### PR TITLE
feat(csharp): conditionally emit System.Text.Json for pre-net8.0 TFMs

### DIFF
--- a/generators/csharp/base/src/project/CsharpProject.ts
+++ b/generators/csharp/base/src/project/CsharpProject.ts
@@ -860,7 +860,6 @@ class CsProj extends WithGeneration {
         const dependencies = this.getDependencies();
         const indent = this.generation.constants.formatting.indent;
         const legacyDeps = this.getLegacyFrameworkDependencies();
-        const modernRefs = this.getModernFrameworkReferences();
         return `
 <Project Sdk="Microsoft.NET.Sdk">
 ${projectGroup.join("\n")}
@@ -891,13 +890,6 @@ ${projectGroup.join("\n")}
     <ItemGroup Condition="${LEGACY_FRAMEWORK_CONDITION}">
         ${legacyDeps.join(`\n${indent}${indent}`)}
     </ItemGroup>
-${
-    modernRefs.length > 0
-        ? `    <ItemGroup Condition="${NET6_COMPATIBLE_CONDITION}">
-        ${modernRefs.join(`\n${indent}${indent}`)}
-    </ItemGroup>\n`
-        : ``
-}\
 ${this.getProtobufDependencies(this.protobufSourceFilePaths).join(`\n${indent}`)}
     <ItemGroup>
         <None Include="${this.readmeRelativePathFromProject}" Pack="true" PackagePath=""/>
@@ -948,32 +940,20 @@ ${this.getAdditionalItemGroups().join(`\n${indent}`)}
     }
 
     /**
-     * Returns package references that should only be emitted for legacy (pre-net6.0) TFMs.
-     * These packages are included in the .NET shared framework starting with net6.0.
+     * Returns package references that should only be emitted for legacy (pre-net8.0) TFMs.
+     * These packages are included in the .NET shared framework starting with net8.0.
      */
     private getLegacyFrameworkDependencies(): string[] {
         const result: string[] = [];
-        for (const pkg of NET6_INBOX_PACKAGES) {
+        for (const pkg of NET8_INBOX_PACKAGES) {
             result.push(`<PackageReference Include="${pkg.name}" Version="${pkg.version}" />`);
         }
         if (this.context.hasWebSocketEndpoints) {
-            for (const pkg of NET6_INBOX_WEBSOCKET_PACKAGES) {
+            for (const pkg of NET8_INBOX_WEBSOCKET_PACKAGES) {
                 result.push(`<PackageReference Include="${pkg.name}" Version="${pkg.version}" />`);
             }
         }
         return result;
-    }
-
-    /**
-     * Returns FrameworkReference entries for modern (net6.0+) TFMs.
-     * Microsoft.AspNetCore.App includes Microsoft.Extensions.* and other packages
-     * that would otherwise need to be referenced individually.
-     */
-    private getModernFrameworkReferences(): string[] {
-        if (!this.context.hasWebSocketEndpoints) {
-            return [];
-        }
-        return ['<FrameworkReference Include="Microsoft.AspNetCore.App" />'];
     }
 
     private getProtobufDependencies(protobufSourceFilePaths: RelativeFilePath[]): string[] {
@@ -1106,23 +1086,23 @@ ${this.getAdditionalItemGroups().join(`\n${indent}`)}
 const EXTERNAL_PROTO_FILE_PREFIXES = ["google/rpc/", "google/api/"];
 
 /**
- * MSBuild condition that matches target frameworks compatible with net6.0 or later.
+ * MSBuild condition that matches target frameworks compatible with net8.0 or later.
  * Uses IsTargetFrameworkCompatible for >= semantics rather than hardcoded TFM equality.
  */
-const NET6_COMPATIBLE_CONDITION = "$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))";
+const NET8_COMPATIBLE_CONDITION = "$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))";
 
 /**
- * MSBuild condition that matches legacy (pre-net6.0) target frameworks.
- * This is the negation of NET6_COMPATIBLE_CONDITION.
+ * MSBuild condition that matches legacy (pre-net8.0) target frameworks.
+ * This is the negation of NET8_COMPATIBLE_CONDITION.
  */
-const LEGACY_FRAMEWORK_CONDITION = `!${NET6_COMPATIBLE_CONDITION}`;
+const LEGACY_FRAMEWORK_CONDITION = `!${NET8_COMPATIBLE_CONDITION}`;
 
 /**
- * Packages that are included in the .NET shared framework for net6.0+ and should
+ * Packages that are included in the .NET shared framework for net8.0+ and should
  * only be emitted as PackageReference when targeting legacy TFMs (netstandard2.0, net462, etc.).
  * Extend this list as more packages become in-box in future .NET versions.
  */
-const NET6_INBOX_PACKAGES: ReadonlyArray<{ name: string; version: string }> = [
+const NET8_INBOX_PACKAGES: ReadonlyArray<{ name: string; version: string }> = [
     { name: "System.Text.Json", version: "8.0.5" },
     { name: "System.Net.Http", version: "[4.3.4,)" },
     { name: "System.Text.RegularExpressions", version: "[4.3.1,)" }
@@ -1130,9 +1110,9 @@ const NET6_INBOX_PACKAGES: ReadonlyArray<{ name: string; version: string }> = [
 
 /**
  * Packages from the websocket dependencies that are included in the .NET shared
- * framework for net6.0+ and should only be emitted as PackageReference for legacy TFMs.
+ * framework for net8.0+ and should only be emitted as PackageReference for legacy TFMs.
  */
-const NET6_INBOX_WEBSOCKET_PACKAGES: ReadonlyArray<{ name: string; version: string }> = [
+const NET8_INBOX_WEBSOCKET_PACKAGES: ReadonlyArray<{ name: string; version: string }> = [
     { name: "Microsoft.Extensions.Logging.Abstractions", version: "8.0.2" },
     { name: "System.Threading.Channels", version: "8.0.0" }
 ];

--- a/generators/csharp/base/src/project/CsharpProject.ts
+++ b/generators/csharp/base/src/project/CsharpProject.ts
@@ -920,15 +920,16 @@ ${this.getAdditionalItemGroups().join(`\n${indent}`)}
         result.push(`${this.generation.constants.formatting.indent}<PrivateAssets>all</PrivateAssets>`);
         result.push("</PackageReference>");
         // When use-undiscriminated-unions is false, we need the OneOf package.
-        // System.Net.Http and System.Text.RegularExpressions are kept unconditional
-        // because OneOf.Extended has unpatched transitive references to vulnerable
-        // versions of these packages — these version-floor overrides apply to all TFMs.
         if (!this.generation.settings.shouldGenerateUndiscriminatedUnions) {
             result.push('<PackageReference Include="OneOf" Version="3.0.271" />');
             result.push('<PackageReference Include="OneOf.Extended" Version="3.0.271" />');
-            result.push('<PackageReference Include="System.Net.Http" Version="[4.3.4,)" />');
-            result.push('<PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />');
         }
+        // System.Net.Http is needed unconditionally: on net462 it provides the
+        // HttpClient / HttpRequestMessage assembly reference, and when OneOf.Extended
+        // is present it acts as a security version-floor override for its unpatched
+        // transitive dependency. System.Text.RegularExpressions is the same for OneOf.
+        result.push('<PackageReference Include="System.Net.Http" Version="[4.3.4,)" />');
+        result.push('<PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />');
         for (const [name, version] of Object.entries(this.generation.settings.extraDependencies)) {
             result.push(`<PackageReference Include="${name}" Version="${version}" />`);
         }

--- a/generators/csharp/base/src/project/CsharpProject.ts
+++ b/generators/csharp/base/src/project/CsharpProject.ts
@@ -858,6 +858,9 @@ class CsProj extends WithGeneration {
     public override toString(): string {
         const projectGroup = this.getProjectGroup();
         const dependencies = this.getDependencies();
+        const indent = this.generation.constants.formatting.indent;
+        const legacyDeps = this.getLegacyFrameworkDependencies();
+        const modernRefs = this.getModernFrameworkReferences();
         return `
 <Project Sdk="Microsoft.NET.Sdk">
 ${projectGroup.join("\n")}
@@ -883,15 +886,23 @@ ${projectGroup.join("\n")}
         <Compile Remove="Core\\DateOnlyConverter.cs" />
     </ItemGroup>
     <ItemGroup>
-        ${dependencies.join(`\n${this.generation.constants.formatting.indent}${this.generation.constants.formatting.indent}`)}
-        ${this.getSseDependencies().join(`\n${this.generation.constants.formatting.indent}`)}
-        ${this.getWebSocketAsyncDependencies().join(`\n${this.generation.constants.formatting.indent}`)}
+        ${dependencies.join(`\n${indent}${indent}`)}
     </ItemGroup>
-${this.getProtobufDependencies(this.protobufSourceFilePaths).join(`\n${this.generation.constants.formatting.indent}`)}
+    <ItemGroup Condition="${LEGACY_FRAMEWORK_CONDITION}">
+        ${legacyDeps.join(`\n${indent}${indent}`)}
+    </ItemGroup>
+${
+    modernRefs.length > 0
+        ? `    <ItemGroup Condition="${NET6_COMPATIBLE_CONDITION}">
+        ${modernRefs.join(`\n${indent}${indent}`)}
+    </ItemGroup>\n`
+        : ``
+}\
+${this.getProtobufDependencies(this.protobufSourceFilePaths).join(`\n${indent}`)}
     <ItemGroup>
         <None Include="${this.readmeRelativePathFromProject}" Pack="true" PackagePath=""/>
     </ItemGroup>
-${this.getAdditionalItemGroups().join(`\n${this.generation.constants.formatting.indent}`)}
+${this.getAdditionalItemGroups().join(`\n${indent}`)}
     <ItemGroup>
         <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
             <_Parameter1>${this.generation.names.files.testProject}</_Parameter1>
@@ -903,6 +914,11 @@ ${this.getAdditionalItemGroups().join(`\n${this.generation.constants.formatting.
 `;
     }
 
+    /**
+     * Returns package references that are needed on all target frameworks.
+     * Packages that ship in-box with net6.0+ are excluded here and emitted
+     * conditionally via {@link getLegacyFrameworkDependencies}.
+     */
     private getDependencies(): string[] {
         const result: string[] = [];
         result.push('<PackageReference Include="PolySharp" Version="1.15.0">');
@@ -916,34 +932,48 @@ ${this.getAdditionalItemGroups().join(`\n${this.generation.constants.formatting.
             result.push('<PackageReference Include="OneOf" Version="3.0.271" />');
             result.push('<PackageReference Include="OneOf.Extended" Version="3.0.271" />');
         }
-        result.push('<PackageReference Include="System.Text.Json" Version="8.0.5" />');
-        result.push('<PackageReference Include="System.Net.Http" Version="[4.3.4,)" />');
-        result.push('<PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />');
         for (const [name, version] of Object.entries(this.generation.settings.extraDependencies)) {
             result.push(`<PackageReference Include="${name}" Version="${version}" />`);
+        }
+        // WebSocket packages that are NOT in-box on net6.0+
+        if (this.context.hasWebSocketEndpoints) {
+            result.push('<PackageReference Include="Microsoft.IO.RecyclableMemoryStream" Version="3.0.1" />');
         }
         return result;
     }
 
     /**
-     * Adds the nuget dependencies for the websocket api client.
-     *
-     * @returns an array of strings that represent the nuget dependencies.
+     * Returns package references that should only be emitted for legacy (pre-net6.0) TFMs.
+     * These packages are included in the .NET shared framework starting with net6.0.
      */
-    private getWebSocketAsyncDependencies(): string[] {
-        return this.context.hasWebSocketEndpoints
-            ? [
-                  '    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.2" />',
-                  '    <PackageReference Include="Microsoft.IO.RecyclableMemoryStream" Version="3.0.1" />',
-                  '    <PackageReference Include="System.Threading.Channels" Version="8.0.0" />'
-              ]
-            : [];
+    private getLegacyFrameworkDependencies(): string[] {
+        const result: string[] = [];
+        for (const pkg of NET6_INBOX_PACKAGES) {
+            result.push(`<PackageReference Include="${pkg.name}" Version="${pkg.version}" />`);
+        }
+        if (this.context.hasWebSocketEndpoints) {
+            for (const pkg of NET6_INBOX_WEBSOCKET_PACKAGES) {
+                result.push(`<PackageReference Include="${pkg.name}" Version="${pkg.version}" />`);
+            }
+        }
+        if (this.context.hasSseEndpoints) {
+            for (const pkg of NET6_INBOX_SSE_PACKAGES) {
+                result.push(`<PackageReference Include="${pkg.name}" Version="${pkg.version}" />`);
+            }
+        }
+        return result;
     }
 
-    private getSseDependencies(): string[] {
-        return this.context.hasSseEndpoints
-            ? ['    <PackageReference Include="System.Net.ServerSentEvents" Version="9.0.9" />']
-            : [];
+    /**
+     * Returns FrameworkReference entries for modern (net6.0+) TFMs.
+     * Microsoft.AspNetCore.App includes Microsoft.Extensions.* and other packages
+     * that would otherwise need to be referenced individually.
+     */
+    private getModernFrameworkReferences(): string[] {
+        if (!this.context.hasWebSocketEndpoints) {
+            return [];
+        }
+        return ['<FrameworkReference Include="Microsoft.AspNetCore.App" />'];
     }
 
     private getProtobufDependencies(protobufSourceFilePaths: RelativeFilePath[]): string[] {
@@ -1074,3 +1104,43 @@ ${this.getAdditionalItemGroups().join(`\n${this.generation.constants.formatting.
  * Grpc.Tools compilation to avoid conflicting type definitions.
  */
 const EXTERNAL_PROTO_FILE_PREFIXES = ["google/rpc/", "google/api/"];
+
+/**
+ * MSBuild condition that matches target frameworks compatible with net6.0 or later.
+ * Uses IsTargetFrameworkCompatible for >= semantics rather than hardcoded TFM equality.
+ */
+const NET6_COMPATIBLE_CONDITION = "$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))";
+
+/**
+ * MSBuild condition that matches legacy (pre-net6.0) target frameworks.
+ * This is the negation of NET6_COMPATIBLE_CONDITION.
+ */
+const LEGACY_FRAMEWORK_CONDITION = `!${NET6_COMPATIBLE_CONDITION}`;
+
+/**
+ * Packages that are included in the .NET shared framework for net6.0+ and should
+ * only be emitted as PackageReference when targeting legacy TFMs (netstandard2.0, net462, etc.).
+ * Extend this list as more packages become in-box in future .NET versions.
+ */
+const NET6_INBOX_PACKAGES: ReadonlyArray<{ name: string; version: string }> = [
+    { name: "System.Text.Json", version: "8.0.5" },
+    { name: "System.Net.Http", version: "[4.3.4,)" },
+    { name: "System.Text.RegularExpressions", version: "[4.3.1,)" }
+];
+
+/**
+ * Packages from the websocket dependencies that are included in the .NET shared
+ * framework for net6.0+ and should only be emitted as PackageReference for legacy TFMs.
+ */
+const NET6_INBOX_WEBSOCKET_PACKAGES: ReadonlyArray<{ name: string; version: string }> = [
+    { name: "Microsoft.Extensions.Logging.Abstractions", version: "8.0.2" },
+    { name: "System.Threading.Channels", version: "8.0.0" }
+];
+
+/**
+ * Packages from the SSE dependencies that are included in the .NET shared
+ * framework for net6.0+ and should only be emitted as PackageReference for legacy TFMs.
+ */
+const NET6_INBOX_SSE_PACKAGES: ReadonlyArray<{ name: string; version: string }> = [
+    { name: "System.Net.ServerSentEvents", version: "9.0.9" }
+];

--- a/generators/csharp/base/src/project/CsharpProject.ts
+++ b/generators/csharp/base/src/project/CsharpProject.ts
@@ -920,16 +920,17 @@ ${this.getAdditionalItemGroups().join(`\n${indent}`)}
         result.push(`${this.generation.constants.formatting.indent}<PrivateAssets>all</PrivateAssets>`);
         result.push("</PackageReference>");
         // When use-undiscriminated-unions is false, we need the OneOf package.
+        // System.Net.Http and System.Text.RegularExpressions are security version-floor
+        // overrides for OneOf.Extended's unpatched transitive dependencies — only needed
+        // when OneOf is present. System.Net.Http is also needed on net462 for the
+        // HttpClient assembly reference, which is handled separately via
+        // getLegacyFrameworkDependencies().
         if (!this.generation.settings.shouldGenerateUndiscriminatedUnions) {
             result.push('<PackageReference Include="OneOf" Version="3.0.271" />');
             result.push('<PackageReference Include="OneOf.Extended" Version="3.0.271" />');
+            result.push('<PackageReference Include="System.Net.Http" Version="[4.3.4,)" />');
+            result.push('<PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />');
         }
-        // System.Net.Http is needed unconditionally: on net462 it provides the
-        // HttpClient / HttpRequestMessage assembly reference, and when OneOf.Extended
-        // is present it acts as a security version-floor override for its unpatched
-        // transitive dependency. System.Text.RegularExpressions is the same for OneOf.
-        result.push('<PackageReference Include="System.Net.Http" Version="[4.3.4,)" />');
-        result.push('<PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />');
         for (const [name, version] of Object.entries(this.generation.settings.extraDependencies)) {
             result.push(`<PackageReference Include="${name}" Version="${version}" />`);
         }
@@ -954,6 +955,13 @@ ${this.getAdditionalItemGroups().join(`\n${indent}`)}
         const result: string[] = [];
         for (const pkg of NET8_INBOX_PACKAGES) {
             result.push(`<PackageReference Include="${pkg.name}" Version="${pkg.version}" />`);
+        }
+        // System.Net.Http is in-box on net8.0+ but needed on legacy TFMs for the
+        // net462 assembly reference. When OneOf is used, it's already in the
+        // unconditional group as a security version-floor override, so skip here
+        // to avoid a duplicate PackageReference.
+        if (this.generation.settings.shouldGenerateUndiscriminatedUnions) {
+            result.push('<PackageReference Include="System.Net.Http" Version="[4.3.4,)" />');
         }
         return result;
     }

--- a/generators/csharp/base/src/project/CsharpProject.ts
+++ b/generators/csharp/base/src/project/CsharpProject.ts
@@ -919,17 +919,23 @@ ${this.getAdditionalItemGroups().join(`\n${indent}`)}
         );
         result.push(`${this.generation.constants.formatting.indent}<PrivateAssets>all</PrivateAssets>`);
         result.push("</PackageReference>");
-        // When use-undiscriminated-unions is false, we need the OneOf package
+        // When use-undiscriminated-unions is false, we need the OneOf package.
+        // System.Net.Http and System.Text.RegularExpressions are kept unconditional
+        // because OneOf.Extended has unpatched transitive references to vulnerable
+        // versions of these packages — these version-floor overrides apply to all TFMs.
         if (!this.generation.settings.shouldGenerateUndiscriminatedUnions) {
             result.push('<PackageReference Include="OneOf" Version="3.0.271" />');
             result.push('<PackageReference Include="OneOf.Extended" Version="3.0.271" />');
+            result.push('<PackageReference Include="System.Net.Http" Version="[4.3.4,)" />');
+            result.push('<PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />');
         }
         for (const [name, version] of Object.entries(this.generation.settings.extraDependencies)) {
             result.push(`<PackageReference Include="${name}" Version="${version}" />`);
         }
-        // WebSocket packages that are NOT in-box on net6.0+
         if (this.context.hasWebSocketEndpoints) {
             result.push('<PackageReference Include="Microsoft.IO.RecyclableMemoryStream" Version="3.0.1" />');
+            result.push('<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.2" />');
+            result.push('<PackageReference Include="System.Threading.Channels" Version="8.0.0" />');
         }
         // SSE package — only in-box starting with net9.0, so keep unconditional for
         // multi-targeted projects that include net8.0
@@ -947,11 +953,6 @@ ${this.getAdditionalItemGroups().join(`\n${indent}`)}
         const result: string[] = [];
         for (const pkg of NET8_INBOX_PACKAGES) {
             result.push(`<PackageReference Include="${pkg.name}" Version="${pkg.version}" />`);
-        }
-        if (this.context.hasWebSocketEndpoints) {
-            for (const pkg of NET8_INBOX_WEBSOCKET_PACKAGES) {
-                result.push(`<PackageReference Include="${pkg.name}" Version="${pkg.version}" />`);
-            }
         }
         return result;
     }
@@ -1103,16 +1104,5 @@ const LEGACY_FRAMEWORK_CONDITION = `!${NET8_COMPATIBLE_CONDITION}`;
  * Extend this list as more packages become in-box in future .NET versions.
  */
 const NET8_INBOX_PACKAGES: ReadonlyArray<{ name: string; version: string }> = [
-    { name: "System.Text.Json", version: "8.0.5" },
-    { name: "System.Net.Http", version: "[4.3.4,)" },
-    { name: "System.Text.RegularExpressions", version: "[4.3.1,)" }
-];
-
-/**
- * Packages from the websocket dependencies that are included in the .NET shared
- * framework for net8.0+ and should only be emitted as PackageReference for legacy TFMs.
- */
-const NET8_INBOX_WEBSOCKET_PACKAGES: ReadonlyArray<{ name: string; version: string }> = [
-    { name: "Microsoft.Extensions.Logging.Abstractions", version: "8.0.2" },
-    { name: "System.Threading.Channels", version: "8.0.0" }
+    { name: "System.Text.Json", version: "8.0.5" }
 ];

--- a/generators/csharp/base/src/project/CsharpProject.ts
+++ b/generators/csharp/base/src/project/CsharpProject.ts
@@ -939,6 +939,11 @@ ${this.getAdditionalItemGroups().join(`\n${indent}`)}
         if (this.context.hasWebSocketEndpoints) {
             result.push('<PackageReference Include="Microsoft.IO.RecyclableMemoryStream" Version="3.0.1" />');
         }
+        // SSE package — only in-box starting with net9.0, so keep unconditional for
+        // multi-targeted projects that include net8.0
+        if (this.context.hasSseEndpoints) {
+            result.push('<PackageReference Include="System.Net.ServerSentEvents" Version="9.0.9" />');
+        }
         return result;
     }
 
@@ -953,11 +958,6 @@ ${this.getAdditionalItemGroups().join(`\n${indent}`)}
         }
         if (this.context.hasWebSocketEndpoints) {
             for (const pkg of NET6_INBOX_WEBSOCKET_PACKAGES) {
-                result.push(`<PackageReference Include="${pkg.name}" Version="${pkg.version}" />`);
-            }
-        }
-        if (this.context.hasSseEndpoints) {
-            for (const pkg of NET6_INBOX_SSE_PACKAGES) {
                 result.push(`<PackageReference Include="${pkg.name}" Version="${pkg.version}" />`);
             }
         }
@@ -1135,12 +1135,4 @@ const NET6_INBOX_PACKAGES: ReadonlyArray<{ name: string; version: string }> = [
 const NET6_INBOX_WEBSOCKET_PACKAGES: ReadonlyArray<{ name: string; version: string }> = [
     { name: "Microsoft.Extensions.Logging.Abstractions", version: "8.0.2" },
     { name: "System.Threading.Channels", version: "8.0.0" }
-];
-
-/**
- * Packages from the SSE dependencies that are included in the .NET shared
- * framework for net6.0+ and should only be emitted as PackageReference for legacy TFMs.
- */
-const NET6_INBOX_SSE_PACKAGES: ReadonlyArray<{ name: string; version: string }> = [
-    { name: "System.Net.ServerSentEvents", version: "9.0.9" }
 ];

--- a/generators/csharp/model/versions.yml
+++ b/generators/csharp/model/versions.yml
@@ -2,11 +2,10 @@
 - version: 0.7.0
   changelogEntry:
     - summary: |
-        Conditionally emit PackageReference entries for packages that ship in-box
-        with net6.0+. Packages like System.Text.Json, System.Net.Http, and
-        System.Text.RegularExpressions are now wrapped in an ItemGroup with an
-        MSBuild condition so they are only referenced when targeting legacy TFMs
-        (netstandard2.0, net462).
+        Conditionally emit System.Text.Json as a PackageReference only when
+        targeting pre-net8.0 TFMs (netstandard2.0, net462). The package is
+        wrapped in an ItemGroup with an MSBuild IsTargetFrameworkCompatible
+        condition so it is skipped for net8.0+ where it ships in-box.
       type: feat
   createdAt: "2026-03-20"
   irVersion: 65

--- a/generators/csharp/model/versions.yml
+++ b/generators/csharp/model/versions.yml
@@ -1,4 +1,16 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 0.6.0
+  changelogEntry:
+    - summary: |
+        Conditionally emit PackageReference entries for packages that ship in-box
+        with net6.0+. Packages like System.Text.Json, System.Net.Http, and
+        System.Text.RegularExpressions are now wrapped in an ItemGroup with an
+        MSBuild condition so they are only referenced when targeting legacy TFMs
+        (netstandard2.0, net462).
+      type: feat
+  createdAt: "2026-03-20"
+  irVersion: 65
+
 - version: 0.5.1
   changelogEntry:
     - summary: |

--- a/generators/csharp/sdk/versions.yml
+++ b/generators/csharp/sdk/versions.yml
@@ -2,14 +2,10 @@
 - version: 2.52.0
   changelogEntry:
     - summary: |
-        Conditionally emit PackageReference entries for packages that ship in-box
-        with net6.0+. Packages like System.Text.Json, System.Net.Http,
-        System.Text.RegularExpressions, Microsoft.Extensions.Logging.Abstractions,
-        and System.Threading.Channels are now wrapped in an ItemGroup with an MSBuild
-        condition so they are only referenced when targeting legacy TFMs
-        (netstandard2.0, net462). For WebSocket-enabled SDKs, a FrameworkReference
-        to Microsoft.AspNetCore.App is emitted for net6.0+ instead of individual
-        Microsoft.Extensions.* package references.
+        Conditionally emit System.Text.Json as a PackageReference only when
+        targeting pre-net8.0 TFMs (netstandard2.0, net462). The package is
+        wrapped in an ItemGroup with an MSBuild IsTargetFrameworkCompatible
+        condition so it is skipped for net8.0+ where it ships in-box.
       type: feat
   createdAt: "2026-03-20"
   irVersion: 65

--- a/generators/csharp/sdk/versions.yml
+++ b/generators/csharp/sdk/versions.yml
@@ -1,4 +1,19 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 2.51.0
+  changelogEntry:
+    - summary: |
+        Conditionally emit PackageReference entries for packages that ship in-box
+        with net6.0+. Packages like System.Text.Json, System.Net.Http,
+        System.Text.RegularExpressions, Microsoft.Extensions.Logging.Abstractions,
+        System.Threading.Channels, and System.Net.ServerSentEvents are now wrapped
+        in an ItemGroup with an MSBuild condition so they are only referenced when
+        targeting legacy TFMs (netstandard2.0, net462). For WebSocket-enabled SDKs,
+        a FrameworkReference to Microsoft.AspNetCore.App is emitted for net6.0+
+        instead of individual Microsoft.Extensions.* package references.
+      type: feat
+  createdAt: "2026-03-20"
+  irVersion: 65
+
 - version: 2.50.0
   changelogEntry:
     - summary: |

--- a/seed/csharp-model/accept-header/src/SeedAccept/SeedAccept.csproj
+++ b/seed/csharp-model/accept-header/src/SeedAccept/SeedAccept.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
   </ItemGroup>
-  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-model/accept-header/src/SeedAccept/SeedAccept.csproj
+++ b/seed/csharp-model/accept-header/src/SeedAccept/SeedAccept.csproj
@@ -39,11 +39,11 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
-    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/accept-header/src/SeedAccept/SeedAccept.csproj
+++ b/seed/csharp-model/accept-header/src/SeedAccept/SeedAccept.csproj
@@ -39,6 +39,8 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+  </ItemGroup>
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-model/alias-extends/src/SeedAliasExtends/SeedAliasExtends.csproj
+++ b/seed/csharp-model/alias-extends/src/SeedAliasExtends/SeedAliasExtends.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
   </ItemGroup>
-  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-model/alias-extends/src/SeedAliasExtends/SeedAliasExtends.csproj
+++ b/seed/csharp-model/alias-extends/src/SeedAliasExtends/SeedAliasExtends.csproj
@@ -39,11 +39,11 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
-    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/alias-extends/src/SeedAliasExtends/SeedAliasExtends.csproj
+++ b/seed/csharp-model/alias-extends/src/SeedAliasExtends/SeedAliasExtends.csproj
@@ -39,6 +39,8 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+  </ItemGroup>
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-model/alias/src/SeedAlias/SeedAlias.csproj
+++ b/seed/csharp-model/alias/src/SeedAlias/SeedAlias.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
   </ItemGroup>
-  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-model/alias/src/SeedAlias/SeedAlias.csproj
+++ b/seed/csharp-model/alias/src/SeedAlias/SeedAlias.csproj
@@ -39,11 +39,11 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
-    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/alias/src/SeedAlias/SeedAlias.csproj
+++ b/seed/csharp-model/alias/src/SeedAlias/SeedAlias.csproj
@@ -39,6 +39,8 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+  </ItemGroup>
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-model/any-auth/src/SeedAnyAuth/SeedAnyAuth.csproj
+++ b/seed/csharp-model/any-auth/src/SeedAnyAuth/SeedAnyAuth.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
   </ItemGroup>
-  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-model/any-auth/src/SeedAnyAuth/SeedAnyAuth.csproj
+++ b/seed/csharp-model/any-auth/src/SeedAnyAuth/SeedAnyAuth.csproj
@@ -39,11 +39,11 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
-    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/any-auth/src/SeedAnyAuth/SeedAnyAuth.csproj
+++ b/seed/csharp-model/any-auth/src/SeedAnyAuth/SeedAnyAuth.csproj
@@ -39,6 +39,8 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+  </ItemGroup>
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-model/api-wide-base-path/src/SeedApiWideBasePath/SeedApiWideBasePath.csproj
+++ b/seed/csharp-model/api-wide-base-path/src/SeedApiWideBasePath/SeedApiWideBasePath.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
   </ItemGroup>
-  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-model/api-wide-base-path/src/SeedApiWideBasePath/SeedApiWideBasePath.csproj
+++ b/seed/csharp-model/api-wide-base-path/src/SeedApiWideBasePath/SeedApiWideBasePath.csproj
@@ -39,11 +39,11 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
-    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/api-wide-base-path/src/SeedApiWideBasePath/SeedApiWideBasePath.csproj
+++ b/seed/csharp-model/api-wide-base-path/src/SeedApiWideBasePath/SeedApiWideBasePath.csproj
@@ -39,6 +39,8 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+  </ItemGroup>
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-model/audiences/src/SeedAudiences/SeedAudiences.csproj
+++ b/seed/csharp-model/audiences/src/SeedAudiences/SeedAudiences.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
   </ItemGroup>
-  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-model/audiences/src/SeedAudiences/SeedAudiences.csproj
+++ b/seed/csharp-model/audiences/src/SeedAudiences/SeedAudiences.csproj
@@ -39,11 +39,11 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
-    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/audiences/src/SeedAudiences/SeedAudiences.csproj
+++ b/seed/csharp-model/audiences/src/SeedAudiences/SeedAudiences.csproj
@@ -39,6 +39,8 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+  </ItemGroup>
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-model/basic-auth-environment-variables/src/SeedBasicAuthEnvironmentVariables/SeedBasicAuthEnvironmentVariables.csproj
+++ b/seed/csharp-model/basic-auth-environment-variables/src/SeedBasicAuthEnvironmentVariables/SeedBasicAuthEnvironmentVariables.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
   </ItemGroup>
-  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-model/basic-auth-environment-variables/src/SeedBasicAuthEnvironmentVariables/SeedBasicAuthEnvironmentVariables.csproj
+++ b/seed/csharp-model/basic-auth-environment-variables/src/SeedBasicAuthEnvironmentVariables/SeedBasicAuthEnvironmentVariables.csproj
@@ -39,11 +39,11 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
-    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/basic-auth-environment-variables/src/SeedBasicAuthEnvironmentVariables/SeedBasicAuthEnvironmentVariables.csproj
+++ b/seed/csharp-model/basic-auth-environment-variables/src/SeedBasicAuthEnvironmentVariables/SeedBasicAuthEnvironmentVariables.csproj
@@ -39,6 +39,8 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+  </ItemGroup>
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-model/basic-auth/src/SeedBasicAuth/SeedBasicAuth.csproj
+++ b/seed/csharp-model/basic-auth/src/SeedBasicAuth/SeedBasicAuth.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
   </ItemGroup>
-  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-model/basic-auth/src/SeedBasicAuth/SeedBasicAuth.csproj
+++ b/seed/csharp-model/basic-auth/src/SeedBasicAuth/SeedBasicAuth.csproj
@@ -39,11 +39,11 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
-    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/basic-auth/src/SeedBasicAuth/SeedBasicAuth.csproj
+++ b/seed/csharp-model/basic-auth/src/SeedBasicAuth/SeedBasicAuth.csproj
@@ -39,6 +39,8 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+  </ItemGroup>
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-model/bearer-token-environment-variable/src/SeedBearerTokenEnvironmentVariable/SeedBearerTokenEnvironmentVariable.csproj
+++ b/seed/csharp-model/bearer-token-environment-variable/src/SeedBearerTokenEnvironmentVariable/SeedBearerTokenEnvironmentVariable.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
   </ItemGroup>
-  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-model/bearer-token-environment-variable/src/SeedBearerTokenEnvironmentVariable/SeedBearerTokenEnvironmentVariable.csproj
+++ b/seed/csharp-model/bearer-token-environment-variable/src/SeedBearerTokenEnvironmentVariable/SeedBearerTokenEnvironmentVariable.csproj
@@ -39,11 +39,11 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
-    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/bearer-token-environment-variable/src/SeedBearerTokenEnvironmentVariable/SeedBearerTokenEnvironmentVariable.csproj
+++ b/seed/csharp-model/bearer-token-environment-variable/src/SeedBearerTokenEnvironmentVariable/SeedBearerTokenEnvironmentVariable.csproj
@@ -39,6 +39,8 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+  </ItemGroup>
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-model/bytes-download/src/SeedBytesDownload/SeedBytesDownload.csproj
+++ b/seed/csharp-model/bytes-download/src/SeedBytesDownload/SeedBytesDownload.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
   </ItemGroup>
-  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-model/bytes-download/src/SeedBytesDownload/SeedBytesDownload.csproj
+++ b/seed/csharp-model/bytes-download/src/SeedBytesDownload/SeedBytesDownload.csproj
@@ -39,11 +39,11 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
-    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/bytes-download/src/SeedBytesDownload/SeedBytesDownload.csproj
+++ b/seed/csharp-model/bytes-download/src/SeedBytesDownload/SeedBytesDownload.csproj
@@ -39,6 +39,8 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+  </ItemGroup>
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-model/bytes-upload/src/SeedBytesUpload/SeedBytesUpload.csproj
+++ b/seed/csharp-model/bytes-upload/src/SeedBytesUpload/SeedBytesUpload.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
   </ItemGroup>
-  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-model/bytes-upload/src/SeedBytesUpload/SeedBytesUpload.csproj
+++ b/seed/csharp-model/bytes-upload/src/SeedBytesUpload/SeedBytesUpload.csproj
@@ -39,11 +39,11 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
-    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/bytes-upload/src/SeedBytesUpload/SeedBytesUpload.csproj
+++ b/seed/csharp-model/bytes-upload/src/SeedBytesUpload/SeedBytesUpload.csproj
@@ -39,6 +39,8 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+  </ItemGroup>
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-model/circular-references-advanced/src/SeedApi/SeedApi.csproj
+++ b/seed/csharp-model/circular-references-advanced/src/SeedApi/SeedApi.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
   </ItemGroup>
-  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-model/circular-references-advanced/src/SeedApi/SeedApi.csproj
+++ b/seed/csharp-model/circular-references-advanced/src/SeedApi/SeedApi.csproj
@@ -39,11 +39,11 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
-    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/circular-references-advanced/src/SeedApi/SeedApi.csproj
+++ b/seed/csharp-model/circular-references-advanced/src/SeedApi/SeedApi.csproj
@@ -39,6 +39,8 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+  </ItemGroup>
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-model/circular-references/src/SeedApi/SeedApi.csproj
+++ b/seed/csharp-model/circular-references/src/SeedApi/SeedApi.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
   </ItemGroup>
-  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-model/circular-references/src/SeedApi/SeedApi.csproj
+++ b/seed/csharp-model/circular-references/src/SeedApi/SeedApi.csproj
@@ -39,11 +39,11 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
-    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/circular-references/src/SeedApi/SeedApi.csproj
+++ b/seed/csharp-model/circular-references/src/SeedApi/SeedApi.csproj
@@ -39,6 +39,8 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+  </ItemGroup>
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-model/client-side-params/src/SeedClientSideParams/SeedClientSideParams.csproj
+++ b/seed/csharp-model/client-side-params/src/SeedClientSideParams/SeedClientSideParams.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
   </ItemGroup>
-  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-model/client-side-params/src/SeedClientSideParams/SeedClientSideParams.csproj
+++ b/seed/csharp-model/client-side-params/src/SeedClientSideParams/SeedClientSideParams.csproj
@@ -39,11 +39,11 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
-    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/client-side-params/src/SeedClientSideParams/SeedClientSideParams.csproj
+++ b/seed/csharp-model/client-side-params/src/SeedClientSideParams/SeedClientSideParams.csproj
@@ -39,6 +39,8 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+  </ItemGroup>
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-model/content-type/src/SeedContentTypes/SeedContentTypes.csproj
+++ b/seed/csharp-model/content-type/src/SeedContentTypes/SeedContentTypes.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
   </ItemGroup>
-  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-model/content-type/src/SeedContentTypes/SeedContentTypes.csproj
+++ b/seed/csharp-model/content-type/src/SeedContentTypes/SeedContentTypes.csproj
@@ -39,11 +39,11 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
-    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/content-type/src/SeedContentTypes/SeedContentTypes.csproj
+++ b/seed/csharp-model/content-type/src/SeedContentTypes/SeedContentTypes.csproj
@@ -39,6 +39,8 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+  </ItemGroup>
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-model/cross-package-type-names/src/SeedCrossPackageTypeNames/SeedCrossPackageTypeNames.csproj
+++ b/seed/csharp-model/cross-package-type-names/src/SeedCrossPackageTypeNames/SeedCrossPackageTypeNames.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
   </ItemGroup>
-  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-model/cross-package-type-names/src/SeedCrossPackageTypeNames/SeedCrossPackageTypeNames.csproj
+++ b/seed/csharp-model/cross-package-type-names/src/SeedCrossPackageTypeNames/SeedCrossPackageTypeNames.csproj
@@ -39,11 +39,11 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
-    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/cross-package-type-names/src/SeedCrossPackageTypeNames/SeedCrossPackageTypeNames.csproj
+++ b/seed/csharp-model/cross-package-type-names/src/SeedCrossPackageTypeNames/SeedCrossPackageTypeNames.csproj
@@ -39,6 +39,8 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+  </ItemGroup>
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-model/csharp-grpc-proto-exhaustive/src/SeedApi/SeedApi.csproj
+++ b/seed/csharp-model/csharp-grpc-proto-exhaustive/src/SeedApi/SeedApi.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
   </ItemGroup>
-  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-model/csharp-grpc-proto-exhaustive/src/SeedApi/SeedApi.csproj
+++ b/seed/csharp-model/csharp-grpc-proto-exhaustive/src/SeedApi/SeedApi.csproj
@@ -39,11 +39,11 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
-    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/csharp-grpc-proto-exhaustive/src/SeedApi/SeedApi.csproj
+++ b/seed/csharp-model/csharp-grpc-proto-exhaustive/src/SeedApi/SeedApi.csproj
@@ -39,6 +39,8 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+  </ItemGroup>
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-model/csharp-grpc-proto/src/SeedApi/SeedApi.csproj
+++ b/seed/csharp-model/csharp-grpc-proto/src/SeedApi/SeedApi.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
   </ItemGroup>
-  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-model/csharp-grpc-proto/src/SeedApi/SeedApi.csproj
+++ b/seed/csharp-model/csharp-grpc-proto/src/SeedApi/SeedApi.csproj
@@ -39,11 +39,11 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
-    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/csharp-grpc-proto/src/SeedApi/SeedApi.csproj
+++ b/seed/csharp-model/csharp-grpc-proto/src/SeedApi/SeedApi.csproj
@@ -39,6 +39,8 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+  </ItemGroup>
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-model/csharp-namespace-collision/src/SeedCsharpNamespaceCollision/SeedCsharpNamespaceCollision.csproj
+++ b/seed/csharp-model/csharp-namespace-collision/src/SeedCsharpNamespaceCollision/SeedCsharpNamespaceCollision.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
   </ItemGroup>
-  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-model/csharp-namespace-collision/src/SeedCsharpNamespaceCollision/SeedCsharpNamespaceCollision.csproj
+++ b/seed/csharp-model/csharp-namespace-collision/src/SeedCsharpNamespaceCollision/SeedCsharpNamespaceCollision.csproj
@@ -39,11 +39,11 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
-    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/csharp-namespace-collision/src/SeedCsharpNamespaceCollision/SeedCsharpNamespaceCollision.csproj
+++ b/seed/csharp-model/csharp-namespace-collision/src/SeedCsharpNamespaceCollision/SeedCsharpNamespaceCollision.csproj
@@ -39,6 +39,8 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+  </ItemGroup>
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-model/csharp-namespace-conflict/src/SeedCsharpNamespaceConflict/SeedCsharpNamespaceConflict.csproj
+++ b/seed/csharp-model/csharp-namespace-conflict/src/SeedCsharpNamespaceConflict/SeedCsharpNamespaceConflict.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
   </ItemGroup>
-  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-model/csharp-namespace-conflict/src/SeedCsharpNamespaceConflict/SeedCsharpNamespaceConflict.csproj
+++ b/seed/csharp-model/csharp-namespace-conflict/src/SeedCsharpNamespaceConflict/SeedCsharpNamespaceConflict.csproj
@@ -39,11 +39,11 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
-    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/csharp-namespace-conflict/src/SeedCsharpNamespaceConflict/SeedCsharpNamespaceConflict.csproj
+++ b/seed/csharp-model/csharp-namespace-conflict/src/SeedCsharpNamespaceConflict/SeedCsharpNamespaceConflict.csproj
@@ -39,6 +39,8 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+  </ItemGroup>
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-model/csharp-readonly-request/src/SeedCsharpReadonlyRequest/SeedCsharpReadonlyRequest.csproj
+++ b/seed/csharp-model/csharp-readonly-request/src/SeedCsharpReadonlyRequest/SeedCsharpReadonlyRequest.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
   </ItemGroup>
-  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-model/csharp-readonly-request/src/SeedCsharpReadonlyRequest/SeedCsharpReadonlyRequest.csproj
+++ b/seed/csharp-model/csharp-readonly-request/src/SeedCsharpReadonlyRequest/SeedCsharpReadonlyRequest.csproj
@@ -39,11 +39,11 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
-    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/csharp-readonly-request/src/SeedCsharpReadonlyRequest/SeedCsharpReadonlyRequest.csproj
+++ b/seed/csharp-model/csharp-readonly-request/src/SeedCsharpReadonlyRequest/SeedCsharpReadonlyRequest.csproj
@@ -39,6 +39,8 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+  </ItemGroup>
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-model/csharp-system-collision/src/SeedCsharpSystemCollision/SeedCsharpSystemCollision.csproj
+++ b/seed/csharp-model/csharp-system-collision/src/SeedCsharpSystemCollision/SeedCsharpSystemCollision.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
   </ItemGroup>
-  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-model/csharp-system-collision/src/SeedCsharpSystemCollision/SeedCsharpSystemCollision.csproj
+++ b/seed/csharp-model/csharp-system-collision/src/SeedCsharpSystemCollision/SeedCsharpSystemCollision.csproj
@@ -39,11 +39,11 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
-    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/csharp-system-collision/src/SeedCsharpSystemCollision/SeedCsharpSystemCollision.csproj
+++ b/seed/csharp-model/csharp-system-collision/src/SeedCsharpSystemCollision/SeedCsharpSystemCollision.csproj
@@ -39,6 +39,8 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+  </ItemGroup>
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-model/csharp-xml-entities/src/SeedCsharpXmlEntities/SeedCsharpXmlEntities.csproj
+++ b/seed/csharp-model/csharp-xml-entities/src/SeedCsharpXmlEntities/SeedCsharpXmlEntities.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
   </ItemGroup>
-  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-model/csharp-xml-entities/src/SeedCsharpXmlEntities/SeedCsharpXmlEntities.csproj
+++ b/seed/csharp-model/csharp-xml-entities/src/SeedCsharpXmlEntities/SeedCsharpXmlEntities.csproj
@@ -39,11 +39,11 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
-    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/csharp-xml-entities/src/SeedCsharpXmlEntities/SeedCsharpXmlEntities.csproj
+++ b/seed/csharp-model/csharp-xml-entities/src/SeedCsharpXmlEntities/SeedCsharpXmlEntities.csproj
@@ -39,6 +39,8 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+  </ItemGroup>
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-model/dollar-string-examples/src/SeedDollarStringExamples/SeedDollarStringExamples.csproj
+++ b/seed/csharp-model/dollar-string-examples/src/SeedDollarStringExamples/SeedDollarStringExamples.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
   </ItemGroup>
-  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-model/dollar-string-examples/src/SeedDollarStringExamples/SeedDollarStringExamples.csproj
+++ b/seed/csharp-model/dollar-string-examples/src/SeedDollarStringExamples/SeedDollarStringExamples.csproj
@@ -39,11 +39,11 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
-    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/dollar-string-examples/src/SeedDollarStringExamples/SeedDollarStringExamples.csproj
+++ b/seed/csharp-model/dollar-string-examples/src/SeedDollarStringExamples/SeedDollarStringExamples.csproj
@@ -39,6 +39,8 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+  </ItemGroup>
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-model/empty-clients/src/SeedEmptyClients/SeedEmptyClients.csproj
+++ b/seed/csharp-model/empty-clients/src/SeedEmptyClients/SeedEmptyClients.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
   </ItemGroup>
-  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-model/empty-clients/src/SeedEmptyClients/SeedEmptyClients.csproj
+++ b/seed/csharp-model/empty-clients/src/SeedEmptyClients/SeedEmptyClients.csproj
@@ -39,11 +39,11 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
-    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/empty-clients/src/SeedEmptyClients/SeedEmptyClients.csproj
+++ b/seed/csharp-model/empty-clients/src/SeedEmptyClients/SeedEmptyClients.csproj
@@ -39,6 +39,8 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+  </ItemGroup>
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-model/endpoint-security-auth/src/SeedEndpointSecurityAuth/SeedEndpointSecurityAuth.csproj
+++ b/seed/csharp-model/endpoint-security-auth/src/SeedEndpointSecurityAuth/SeedEndpointSecurityAuth.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
   </ItemGroup>
-  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-model/endpoint-security-auth/src/SeedEndpointSecurityAuth/SeedEndpointSecurityAuth.csproj
+++ b/seed/csharp-model/endpoint-security-auth/src/SeedEndpointSecurityAuth/SeedEndpointSecurityAuth.csproj
@@ -39,11 +39,11 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
-    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/endpoint-security-auth/src/SeedEndpointSecurityAuth/SeedEndpointSecurityAuth.csproj
+++ b/seed/csharp-model/endpoint-security-auth/src/SeedEndpointSecurityAuth/SeedEndpointSecurityAuth.csproj
@@ -39,6 +39,8 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+  </ItemGroup>
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-model/enum/forward-compatible-enums/src/SeedEnum/SeedEnum.csproj
+++ b/seed/csharp-model/enum/forward-compatible-enums/src/SeedEnum/SeedEnum.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
   </ItemGroup>
-  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-model/enum/forward-compatible-enums/src/SeedEnum/SeedEnum.csproj
+++ b/seed/csharp-model/enum/forward-compatible-enums/src/SeedEnum/SeedEnum.csproj
@@ -39,11 +39,11 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
-    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/enum/forward-compatible-enums/src/SeedEnum/SeedEnum.csproj
+++ b/seed/csharp-model/enum/forward-compatible-enums/src/SeedEnum/SeedEnum.csproj
@@ -39,6 +39,8 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+  </ItemGroup>
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-model/enum/plain-enums/src/SeedEnum/SeedEnum.csproj
+++ b/seed/csharp-model/enum/plain-enums/src/SeedEnum/SeedEnum.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
   </ItemGroup>
-  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-model/enum/plain-enums/src/SeedEnum/SeedEnum.csproj
+++ b/seed/csharp-model/enum/plain-enums/src/SeedEnum/SeedEnum.csproj
@@ -39,11 +39,11 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
-    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/enum/plain-enums/src/SeedEnum/SeedEnum.csproj
+++ b/seed/csharp-model/enum/plain-enums/src/SeedEnum/SeedEnum.csproj
@@ -39,6 +39,8 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+  </ItemGroup>
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-model/error-property/src/SeedErrorProperty/SeedErrorProperty.csproj
+++ b/seed/csharp-model/error-property/src/SeedErrorProperty/SeedErrorProperty.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
   </ItemGroup>
-  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-model/error-property/src/SeedErrorProperty/SeedErrorProperty.csproj
+++ b/seed/csharp-model/error-property/src/SeedErrorProperty/SeedErrorProperty.csproj
@@ -39,11 +39,11 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
-    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/error-property/src/SeedErrorProperty/SeedErrorProperty.csproj
+++ b/seed/csharp-model/error-property/src/SeedErrorProperty/SeedErrorProperty.csproj
@@ -39,6 +39,8 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+  </ItemGroup>
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-model/errors/src/SeedErrors/SeedErrors.csproj
+++ b/seed/csharp-model/errors/src/SeedErrors/SeedErrors.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
   </ItemGroup>
-  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-model/errors/src/SeedErrors/SeedErrors.csproj
+++ b/seed/csharp-model/errors/src/SeedErrors/SeedErrors.csproj
@@ -39,11 +39,11 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
-    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/errors/src/SeedErrors/SeedErrors.csproj
+++ b/seed/csharp-model/errors/src/SeedErrors/SeedErrors.csproj
@@ -39,6 +39,8 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+  </ItemGroup>
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-model/examples/src/SeedExamples/SeedExamples.csproj
+++ b/seed/csharp-model/examples/src/SeedExamples/SeedExamples.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
   </ItemGroup>
-  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-model/examples/src/SeedExamples/SeedExamples.csproj
+++ b/seed/csharp-model/examples/src/SeedExamples/SeedExamples.csproj
@@ -39,11 +39,11 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
-    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/examples/src/SeedExamples/SeedExamples.csproj
+++ b/seed/csharp-model/examples/src/SeedExamples/SeedExamples.csproj
@@ -39,6 +39,8 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+  </ItemGroup>
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-model/exhaustive/src/SeedExhaustive/SeedExhaustive.csproj
+++ b/seed/csharp-model/exhaustive/src/SeedExhaustive/SeedExhaustive.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
   </ItemGroup>
-  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-model/exhaustive/src/SeedExhaustive/SeedExhaustive.csproj
+++ b/seed/csharp-model/exhaustive/src/SeedExhaustive/SeedExhaustive.csproj
@@ -39,11 +39,11 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
-    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/exhaustive/src/SeedExhaustive/SeedExhaustive.csproj
+++ b/seed/csharp-model/exhaustive/src/SeedExhaustive/SeedExhaustive.csproj
@@ -39,6 +39,8 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+  </ItemGroup>
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-model/extends/src/SeedExtends/SeedExtends.csproj
+++ b/seed/csharp-model/extends/src/SeedExtends/SeedExtends.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
   </ItemGroup>
-  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-model/extends/src/SeedExtends/SeedExtends.csproj
+++ b/seed/csharp-model/extends/src/SeedExtends/SeedExtends.csproj
@@ -39,11 +39,11 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
-    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/extends/src/SeedExtends/SeedExtends.csproj
+++ b/seed/csharp-model/extends/src/SeedExtends/SeedExtends.csproj
@@ -39,6 +39,8 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+  </ItemGroup>
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-model/extra-properties/src/SeedExtraProperties/SeedExtraProperties.csproj
+++ b/seed/csharp-model/extra-properties/src/SeedExtraProperties/SeedExtraProperties.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
   </ItemGroup>
-  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-model/extra-properties/src/SeedExtraProperties/SeedExtraProperties.csproj
+++ b/seed/csharp-model/extra-properties/src/SeedExtraProperties/SeedExtraProperties.csproj
@@ -39,11 +39,11 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
-    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/extra-properties/src/SeedExtraProperties/SeedExtraProperties.csproj
+++ b/seed/csharp-model/extra-properties/src/SeedExtraProperties/SeedExtraProperties.csproj
@@ -39,6 +39,8 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+  </ItemGroup>
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-model/file-download/src/SeedFileDownload/SeedFileDownload.csproj
+++ b/seed/csharp-model/file-download/src/SeedFileDownload/SeedFileDownload.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
   </ItemGroup>
-  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-model/file-download/src/SeedFileDownload/SeedFileDownload.csproj
+++ b/seed/csharp-model/file-download/src/SeedFileDownload/SeedFileDownload.csproj
@@ -39,11 +39,11 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
-    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/file-download/src/SeedFileDownload/SeedFileDownload.csproj
+++ b/seed/csharp-model/file-download/src/SeedFileDownload/SeedFileDownload.csproj
@@ -39,6 +39,8 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+  </ItemGroup>
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-model/file-upload-openapi/src/SeedApi/SeedApi.csproj
+++ b/seed/csharp-model/file-upload-openapi/src/SeedApi/SeedApi.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
   </ItemGroup>
-  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-model/file-upload-openapi/src/SeedApi/SeedApi.csproj
+++ b/seed/csharp-model/file-upload-openapi/src/SeedApi/SeedApi.csproj
@@ -39,11 +39,11 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
-    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/file-upload-openapi/src/SeedApi/SeedApi.csproj
+++ b/seed/csharp-model/file-upload-openapi/src/SeedApi/SeedApi.csproj
@@ -39,6 +39,8 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+  </ItemGroup>
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-model/file-upload/src/SeedFileUpload/SeedFileUpload.csproj
+++ b/seed/csharp-model/file-upload/src/SeedFileUpload/SeedFileUpload.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
   </ItemGroup>
-  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-model/file-upload/src/SeedFileUpload/SeedFileUpload.csproj
+++ b/seed/csharp-model/file-upload/src/SeedFileUpload/SeedFileUpload.csproj
@@ -39,11 +39,11 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
-    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/file-upload/src/SeedFileUpload/SeedFileUpload.csproj
+++ b/seed/csharp-model/file-upload/src/SeedFileUpload/SeedFileUpload.csproj
@@ -39,6 +39,8 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+  </ItemGroup>
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-model/folders/src/SeedApi/SeedApi.csproj
+++ b/seed/csharp-model/folders/src/SeedApi/SeedApi.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
   </ItemGroup>
-  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-model/folders/src/SeedApi/SeedApi.csproj
+++ b/seed/csharp-model/folders/src/SeedApi/SeedApi.csproj
@@ -39,11 +39,11 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
-    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/folders/src/SeedApi/SeedApi.csproj
+++ b/seed/csharp-model/folders/src/SeedApi/SeedApi.csproj
@@ -39,6 +39,8 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+  </ItemGroup>
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-model/header-auth-environment-variable/src/SeedHeaderTokenEnvironmentVariable/SeedHeaderTokenEnvironmentVariable.csproj
+++ b/seed/csharp-model/header-auth-environment-variable/src/SeedHeaderTokenEnvironmentVariable/SeedHeaderTokenEnvironmentVariable.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
   </ItemGroup>
-  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-model/header-auth-environment-variable/src/SeedHeaderTokenEnvironmentVariable/SeedHeaderTokenEnvironmentVariable.csproj
+++ b/seed/csharp-model/header-auth-environment-variable/src/SeedHeaderTokenEnvironmentVariable/SeedHeaderTokenEnvironmentVariable.csproj
@@ -39,11 +39,11 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
-    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/header-auth-environment-variable/src/SeedHeaderTokenEnvironmentVariable/SeedHeaderTokenEnvironmentVariable.csproj
+++ b/seed/csharp-model/header-auth-environment-variable/src/SeedHeaderTokenEnvironmentVariable/SeedHeaderTokenEnvironmentVariable.csproj
@@ -39,6 +39,8 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+  </ItemGroup>
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-model/header-auth/src/SeedHeaderToken/SeedHeaderToken.csproj
+++ b/seed/csharp-model/header-auth/src/SeedHeaderToken/SeedHeaderToken.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
   </ItemGroup>
-  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-model/header-auth/src/SeedHeaderToken/SeedHeaderToken.csproj
+++ b/seed/csharp-model/header-auth/src/SeedHeaderToken/SeedHeaderToken.csproj
@@ -39,11 +39,11 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
-    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/header-auth/src/SeedHeaderToken/SeedHeaderToken.csproj
+++ b/seed/csharp-model/header-auth/src/SeedHeaderToken/SeedHeaderToken.csproj
@@ -39,6 +39,8 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+  </ItemGroup>
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-model/http-head/src/SeedHttpHead/SeedHttpHead.csproj
+++ b/seed/csharp-model/http-head/src/SeedHttpHead/SeedHttpHead.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
   </ItemGroup>
-  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-model/http-head/src/SeedHttpHead/SeedHttpHead.csproj
+++ b/seed/csharp-model/http-head/src/SeedHttpHead/SeedHttpHead.csproj
@@ -39,11 +39,11 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
-    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/http-head/src/SeedHttpHead/SeedHttpHead.csproj
+++ b/seed/csharp-model/http-head/src/SeedHttpHead/SeedHttpHead.csproj
@@ -39,6 +39,8 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+  </ItemGroup>
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-model/idempotency-headers/src/SeedIdempotencyHeaders/SeedIdempotencyHeaders.csproj
+++ b/seed/csharp-model/idempotency-headers/src/SeedIdempotencyHeaders/SeedIdempotencyHeaders.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
   </ItemGroup>
-  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-model/idempotency-headers/src/SeedIdempotencyHeaders/SeedIdempotencyHeaders.csproj
+++ b/seed/csharp-model/idempotency-headers/src/SeedIdempotencyHeaders/SeedIdempotencyHeaders.csproj
@@ -39,11 +39,11 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
-    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/idempotency-headers/src/SeedIdempotencyHeaders/SeedIdempotencyHeaders.csproj
+++ b/seed/csharp-model/idempotency-headers/src/SeedIdempotencyHeaders/SeedIdempotencyHeaders.csproj
@@ -39,6 +39,8 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+  </ItemGroup>
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-model/imdb/src/SeedApi/SeedApi.csproj
+++ b/seed/csharp-model/imdb/src/SeedApi/SeedApi.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
   </ItemGroup>
-  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-model/imdb/src/SeedApi/SeedApi.csproj
+++ b/seed/csharp-model/imdb/src/SeedApi/SeedApi.csproj
@@ -39,11 +39,11 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
-    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/imdb/src/SeedApi/SeedApi.csproj
+++ b/seed/csharp-model/imdb/src/SeedApi/SeedApi.csproj
@@ -39,6 +39,8 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+  </ItemGroup>
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-model/inferred-auth-explicit/src/SeedInferredAuthExplicit/SeedInferredAuthExplicit.csproj
+++ b/seed/csharp-model/inferred-auth-explicit/src/SeedInferredAuthExplicit/SeedInferredAuthExplicit.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
   </ItemGroup>
-  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-model/inferred-auth-explicit/src/SeedInferredAuthExplicit/SeedInferredAuthExplicit.csproj
+++ b/seed/csharp-model/inferred-auth-explicit/src/SeedInferredAuthExplicit/SeedInferredAuthExplicit.csproj
@@ -39,11 +39,11 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
-    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/inferred-auth-explicit/src/SeedInferredAuthExplicit/SeedInferredAuthExplicit.csproj
+++ b/seed/csharp-model/inferred-auth-explicit/src/SeedInferredAuthExplicit/SeedInferredAuthExplicit.csproj
@@ -39,6 +39,8 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+  </ItemGroup>
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-model/inferred-auth-implicit-api-key/src/SeedInferredAuthImplicitApiKey/SeedInferredAuthImplicitApiKey.csproj
+++ b/seed/csharp-model/inferred-auth-implicit-api-key/src/SeedInferredAuthImplicitApiKey/SeedInferredAuthImplicitApiKey.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
   </ItemGroup>
-  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-model/inferred-auth-implicit-api-key/src/SeedInferredAuthImplicitApiKey/SeedInferredAuthImplicitApiKey.csproj
+++ b/seed/csharp-model/inferred-auth-implicit-api-key/src/SeedInferredAuthImplicitApiKey/SeedInferredAuthImplicitApiKey.csproj
@@ -39,11 +39,11 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
-    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/inferred-auth-implicit-api-key/src/SeedInferredAuthImplicitApiKey/SeedInferredAuthImplicitApiKey.csproj
+++ b/seed/csharp-model/inferred-auth-implicit-api-key/src/SeedInferredAuthImplicitApiKey/SeedInferredAuthImplicitApiKey.csproj
@@ -39,6 +39,8 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+  </ItemGroup>
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-model/inferred-auth-implicit-no-expiry/src/SeedInferredAuthImplicitNoExpiry/SeedInferredAuthImplicitNoExpiry.csproj
+++ b/seed/csharp-model/inferred-auth-implicit-no-expiry/src/SeedInferredAuthImplicitNoExpiry/SeedInferredAuthImplicitNoExpiry.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
   </ItemGroup>
-  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-model/inferred-auth-implicit-no-expiry/src/SeedInferredAuthImplicitNoExpiry/SeedInferredAuthImplicitNoExpiry.csproj
+++ b/seed/csharp-model/inferred-auth-implicit-no-expiry/src/SeedInferredAuthImplicitNoExpiry/SeedInferredAuthImplicitNoExpiry.csproj
@@ -39,11 +39,11 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
-    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/inferred-auth-implicit-no-expiry/src/SeedInferredAuthImplicitNoExpiry/SeedInferredAuthImplicitNoExpiry.csproj
+++ b/seed/csharp-model/inferred-auth-implicit-no-expiry/src/SeedInferredAuthImplicitNoExpiry/SeedInferredAuthImplicitNoExpiry.csproj
@@ -39,6 +39,8 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+  </ItemGroup>
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-model/inferred-auth-implicit-reference/src/SeedInferredAuthImplicit/SeedInferredAuthImplicit.csproj
+++ b/seed/csharp-model/inferred-auth-implicit-reference/src/SeedInferredAuthImplicit/SeedInferredAuthImplicit.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
   </ItemGroup>
-  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-model/inferred-auth-implicit-reference/src/SeedInferredAuthImplicit/SeedInferredAuthImplicit.csproj
+++ b/seed/csharp-model/inferred-auth-implicit-reference/src/SeedInferredAuthImplicit/SeedInferredAuthImplicit.csproj
@@ -39,11 +39,11 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
-    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/inferred-auth-implicit-reference/src/SeedInferredAuthImplicit/SeedInferredAuthImplicit.csproj
+++ b/seed/csharp-model/inferred-auth-implicit-reference/src/SeedInferredAuthImplicit/SeedInferredAuthImplicit.csproj
@@ -39,6 +39,8 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+  </ItemGroup>
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-model/inferred-auth-implicit/src/SeedInferredAuthImplicit/SeedInferredAuthImplicit.csproj
+++ b/seed/csharp-model/inferred-auth-implicit/src/SeedInferredAuthImplicit/SeedInferredAuthImplicit.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
   </ItemGroup>
-  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-model/inferred-auth-implicit/src/SeedInferredAuthImplicit/SeedInferredAuthImplicit.csproj
+++ b/seed/csharp-model/inferred-auth-implicit/src/SeedInferredAuthImplicit/SeedInferredAuthImplicit.csproj
@@ -39,11 +39,11 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
-    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/inferred-auth-implicit/src/SeedInferredAuthImplicit/SeedInferredAuthImplicit.csproj
+++ b/seed/csharp-model/inferred-auth-implicit/src/SeedInferredAuthImplicit/SeedInferredAuthImplicit.csproj
@@ -39,6 +39,8 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+  </ItemGroup>
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-model/license/src/SeedLicense/SeedLicense.csproj
+++ b/seed/csharp-model/license/src/SeedLicense/SeedLicense.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
   </ItemGroup>
-  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-model/license/src/SeedLicense/SeedLicense.csproj
+++ b/seed/csharp-model/license/src/SeedLicense/SeedLicense.csproj
@@ -39,11 +39,11 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
-    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/license/src/SeedLicense/SeedLicense.csproj
+++ b/seed/csharp-model/license/src/SeedLicense/SeedLicense.csproj
@@ -39,6 +39,8 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+  </ItemGroup>
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-model/literal/src/SeedLiteral/SeedLiteral.csproj
+++ b/seed/csharp-model/literal/src/SeedLiteral/SeedLiteral.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
   </ItemGroup>
-  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-model/literal/src/SeedLiteral/SeedLiteral.csproj
+++ b/seed/csharp-model/literal/src/SeedLiteral/SeedLiteral.csproj
@@ -39,11 +39,11 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
-    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/literal/src/SeedLiteral/SeedLiteral.csproj
+++ b/seed/csharp-model/literal/src/SeedLiteral/SeedLiteral.csproj
@@ -39,6 +39,8 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+  </ItemGroup>
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-model/literals-unions/src/SeedLiteralsUnions/SeedLiteralsUnions.csproj
+++ b/seed/csharp-model/literals-unions/src/SeedLiteralsUnions/SeedLiteralsUnions.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
   </ItemGroup>
-  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-model/literals-unions/src/SeedLiteralsUnions/SeedLiteralsUnions.csproj
+++ b/seed/csharp-model/literals-unions/src/SeedLiteralsUnions/SeedLiteralsUnions.csproj
@@ -39,11 +39,11 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
-    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/literals-unions/src/SeedLiteralsUnions/SeedLiteralsUnions.csproj
+++ b/seed/csharp-model/literals-unions/src/SeedLiteralsUnions/SeedLiteralsUnions.csproj
@@ -39,6 +39,8 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+  </ItemGroup>
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-model/mixed-case/src/SeedMixedCase/SeedMixedCase.csproj
+++ b/seed/csharp-model/mixed-case/src/SeedMixedCase/SeedMixedCase.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
   </ItemGroup>
-  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-model/mixed-case/src/SeedMixedCase/SeedMixedCase.csproj
+++ b/seed/csharp-model/mixed-case/src/SeedMixedCase/SeedMixedCase.csproj
@@ -39,11 +39,11 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
-    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/mixed-case/src/SeedMixedCase/SeedMixedCase.csproj
+++ b/seed/csharp-model/mixed-case/src/SeedMixedCase/SeedMixedCase.csproj
@@ -39,6 +39,8 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+  </ItemGroup>
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-model/mixed-file-directory/src/SeedMixedFileDirectory/SeedMixedFileDirectory.csproj
+++ b/seed/csharp-model/mixed-file-directory/src/SeedMixedFileDirectory/SeedMixedFileDirectory.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
   </ItemGroup>
-  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-model/mixed-file-directory/src/SeedMixedFileDirectory/SeedMixedFileDirectory.csproj
+++ b/seed/csharp-model/mixed-file-directory/src/SeedMixedFileDirectory/SeedMixedFileDirectory.csproj
@@ -39,11 +39,11 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
-    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/mixed-file-directory/src/SeedMixedFileDirectory/SeedMixedFileDirectory.csproj
+++ b/seed/csharp-model/mixed-file-directory/src/SeedMixedFileDirectory/SeedMixedFileDirectory.csproj
@@ -39,6 +39,8 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+  </ItemGroup>
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-model/multi-line-docs/src/SeedMultiLineDocs/SeedMultiLineDocs.csproj
+++ b/seed/csharp-model/multi-line-docs/src/SeedMultiLineDocs/SeedMultiLineDocs.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
   </ItemGroup>
-  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-model/multi-line-docs/src/SeedMultiLineDocs/SeedMultiLineDocs.csproj
+++ b/seed/csharp-model/multi-line-docs/src/SeedMultiLineDocs/SeedMultiLineDocs.csproj
@@ -39,11 +39,11 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
-    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/multi-line-docs/src/SeedMultiLineDocs/SeedMultiLineDocs.csproj
+++ b/seed/csharp-model/multi-line-docs/src/SeedMultiLineDocs/SeedMultiLineDocs.csproj
@@ -39,6 +39,8 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+  </ItemGroup>
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-model/multi-url-environment-no-default/src/SeedMultiUrlEnvironmentNoDefault/SeedMultiUrlEnvironmentNoDefault.csproj
+++ b/seed/csharp-model/multi-url-environment-no-default/src/SeedMultiUrlEnvironmentNoDefault/SeedMultiUrlEnvironmentNoDefault.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
   </ItemGroup>
-  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-model/multi-url-environment-no-default/src/SeedMultiUrlEnvironmentNoDefault/SeedMultiUrlEnvironmentNoDefault.csproj
+++ b/seed/csharp-model/multi-url-environment-no-default/src/SeedMultiUrlEnvironmentNoDefault/SeedMultiUrlEnvironmentNoDefault.csproj
@@ -39,11 +39,11 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
-    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/multi-url-environment-no-default/src/SeedMultiUrlEnvironmentNoDefault/SeedMultiUrlEnvironmentNoDefault.csproj
+++ b/seed/csharp-model/multi-url-environment-no-default/src/SeedMultiUrlEnvironmentNoDefault/SeedMultiUrlEnvironmentNoDefault.csproj
@@ -39,6 +39,8 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+  </ItemGroup>
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-model/multi-url-environment/src/SeedMultiUrlEnvironment/SeedMultiUrlEnvironment.csproj
+++ b/seed/csharp-model/multi-url-environment/src/SeedMultiUrlEnvironment/SeedMultiUrlEnvironment.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
   </ItemGroup>
-  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-model/multi-url-environment/src/SeedMultiUrlEnvironment/SeedMultiUrlEnvironment.csproj
+++ b/seed/csharp-model/multi-url-environment/src/SeedMultiUrlEnvironment/SeedMultiUrlEnvironment.csproj
@@ -39,11 +39,11 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
-    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/multi-url-environment/src/SeedMultiUrlEnvironment/SeedMultiUrlEnvironment.csproj
+++ b/seed/csharp-model/multi-url-environment/src/SeedMultiUrlEnvironment/SeedMultiUrlEnvironment.csproj
@@ -39,6 +39,8 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+  </ItemGroup>
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-model/multiple-request-bodies/src/SeedApi/SeedApi.csproj
+++ b/seed/csharp-model/multiple-request-bodies/src/SeedApi/SeedApi.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
   </ItemGroup>
-  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-model/multiple-request-bodies/src/SeedApi/SeedApi.csproj
+++ b/seed/csharp-model/multiple-request-bodies/src/SeedApi/SeedApi.csproj
@@ -39,11 +39,11 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
-    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/multiple-request-bodies/src/SeedApi/SeedApi.csproj
+++ b/seed/csharp-model/multiple-request-bodies/src/SeedApi/SeedApi.csproj
@@ -39,6 +39,8 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+  </ItemGroup>
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-model/no-environment/src/SeedNoEnvironment/SeedNoEnvironment.csproj
+++ b/seed/csharp-model/no-environment/src/SeedNoEnvironment/SeedNoEnvironment.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
   </ItemGroup>
-  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-model/no-environment/src/SeedNoEnvironment/SeedNoEnvironment.csproj
+++ b/seed/csharp-model/no-environment/src/SeedNoEnvironment/SeedNoEnvironment.csproj
@@ -39,11 +39,11 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
-    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/no-environment/src/SeedNoEnvironment/SeedNoEnvironment.csproj
+++ b/seed/csharp-model/no-environment/src/SeedNoEnvironment/SeedNoEnvironment.csproj
@@ -39,6 +39,8 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+  </ItemGroup>
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-model/no-retries/src/SeedNoRetries/SeedNoRetries.csproj
+++ b/seed/csharp-model/no-retries/src/SeedNoRetries/SeedNoRetries.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
   </ItemGroup>
-  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-model/no-retries/src/SeedNoRetries/SeedNoRetries.csproj
+++ b/seed/csharp-model/no-retries/src/SeedNoRetries/SeedNoRetries.csproj
@@ -39,11 +39,11 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
-    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/no-retries/src/SeedNoRetries/SeedNoRetries.csproj
+++ b/seed/csharp-model/no-retries/src/SeedNoRetries/SeedNoRetries.csproj
@@ -39,6 +39,8 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+  </ItemGroup>
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-model/nullable-allof-extends/src/SeedApi/SeedApi.csproj
+++ b/seed/csharp-model/nullable-allof-extends/src/SeedApi/SeedApi.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
   </ItemGroup>
-  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-model/nullable-allof-extends/src/SeedApi/SeedApi.csproj
+++ b/seed/csharp-model/nullable-allof-extends/src/SeedApi/SeedApi.csproj
@@ -39,11 +39,11 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
-    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/nullable-allof-extends/src/SeedApi/SeedApi.csproj
+++ b/seed/csharp-model/nullable-allof-extends/src/SeedApi/SeedApi.csproj
@@ -39,6 +39,8 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+  </ItemGroup>
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-model/nullable-optional/src/SeedNullableOptional/SeedNullableOptional.csproj
+++ b/seed/csharp-model/nullable-optional/src/SeedNullableOptional/SeedNullableOptional.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
   </ItemGroup>
-  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-model/nullable-optional/src/SeedNullableOptional/SeedNullableOptional.csproj
+++ b/seed/csharp-model/nullable-optional/src/SeedNullableOptional/SeedNullableOptional.csproj
@@ -39,11 +39,11 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
-    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/nullable-optional/src/SeedNullableOptional/SeedNullableOptional.csproj
+++ b/seed/csharp-model/nullable-optional/src/SeedNullableOptional/SeedNullableOptional.csproj
@@ -39,6 +39,8 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+  </ItemGroup>
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-model/nullable-request-body/src/SeedApi/SeedApi.csproj
+++ b/seed/csharp-model/nullable-request-body/src/SeedApi/SeedApi.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
   </ItemGroup>
-  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-model/nullable-request-body/src/SeedApi/SeedApi.csproj
+++ b/seed/csharp-model/nullable-request-body/src/SeedApi/SeedApi.csproj
@@ -39,11 +39,11 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
-    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/nullable-request-body/src/SeedApi/SeedApi.csproj
+++ b/seed/csharp-model/nullable-request-body/src/SeedApi/SeedApi.csproj
@@ -39,6 +39,8 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+  </ItemGroup>
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-model/nullable/src/SeedNullable/SeedNullable.csproj
+++ b/seed/csharp-model/nullable/src/SeedNullable/SeedNullable.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
   </ItemGroup>
-  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-model/nullable/src/SeedNullable/SeedNullable.csproj
+++ b/seed/csharp-model/nullable/src/SeedNullable/SeedNullable.csproj
@@ -39,11 +39,11 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
-    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/nullable/src/SeedNullable/SeedNullable.csproj
+++ b/seed/csharp-model/nullable/src/SeedNullable/SeedNullable.csproj
@@ -39,6 +39,8 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+  </ItemGroup>
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-model/oauth-client-credentials-custom/src/SeedOauthClientCredentials/SeedOauthClientCredentials.csproj
+++ b/seed/csharp-model/oauth-client-credentials-custom/src/SeedOauthClientCredentials/SeedOauthClientCredentials.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
   </ItemGroup>
-  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-model/oauth-client-credentials-custom/src/SeedOauthClientCredentials/SeedOauthClientCredentials.csproj
+++ b/seed/csharp-model/oauth-client-credentials-custom/src/SeedOauthClientCredentials/SeedOauthClientCredentials.csproj
@@ -39,11 +39,11 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
-    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/oauth-client-credentials-custom/src/SeedOauthClientCredentials/SeedOauthClientCredentials.csproj
+++ b/seed/csharp-model/oauth-client-credentials-custom/src/SeedOauthClientCredentials/SeedOauthClientCredentials.csproj
@@ -39,6 +39,8 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+  </ItemGroup>
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-model/oauth-client-credentials-default/src/SeedOauthClientCredentialsDefault/SeedOauthClientCredentialsDefault.csproj
+++ b/seed/csharp-model/oauth-client-credentials-default/src/SeedOauthClientCredentialsDefault/SeedOauthClientCredentialsDefault.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
   </ItemGroup>
-  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-model/oauth-client-credentials-default/src/SeedOauthClientCredentialsDefault/SeedOauthClientCredentialsDefault.csproj
+++ b/seed/csharp-model/oauth-client-credentials-default/src/SeedOauthClientCredentialsDefault/SeedOauthClientCredentialsDefault.csproj
@@ -39,11 +39,11 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
-    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/oauth-client-credentials-default/src/SeedOauthClientCredentialsDefault/SeedOauthClientCredentialsDefault.csproj
+++ b/seed/csharp-model/oauth-client-credentials-default/src/SeedOauthClientCredentialsDefault/SeedOauthClientCredentialsDefault.csproj
@@ -39,6 +39,8 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+  </ItemGroup>
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-model/oauth-client-credentials-environment-variables/src/SeedOauthClientCredentialsEnvironmentVariables/SeedOauthClientCredentialsEnvironmentVariables.csproj
+++ b/seed/csharp-model/oauth-client-credentials-environment-variables/src/SeedOauthClientCredentialsEnvironmentVariables/SeedOauthClientCredentialsEnvironmentVariables.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
   </ItemGroup>
-  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-model/oauth-client-credentials-environment-variables/src/SeedOauthClientCredentialsEnvironmentVariables/SeedOauthClientCredentialsEnvironmentVariables.csproj
+++ b/seed/csharp-model/oauth-client-credentials-environment-variables/src/SeedOauthClientCredentialsEnvironmentVariables/SeedOauthClientCredentialsEnvironmentVariables.csproj
@@ -39,11 +39,11 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
-    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/oauth-client-credentials-environment-variables/src/SeedOauthClientCredentialsEnvironmentVariables/SeedOauthClientCredentialsEnvironmentVariables.csproj
+++ b/seed/csharp-model/oauth-client-credentials-environment-variables/src/SeedOauthClientCredentialsEnvironmentVariables/SeedOauthClientCredentialsEnvironmentVariables.csproj
@@ -39,6 +39,8 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+  </ItemGroup>
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-model/oauth-client-credentials-mandatory-auth/src/SeedOauthClientCredentialsMandatoryAuth/SeedOauthClientCredentialsMandatoryAuth.csproj
+++ b/seed/csharp-model/oauth-client-credentials-mandatory-auth/src/SeedOauthClientCredentialsMandatoryAuth/SeedOauthClientCredentialsMandatoryAuth.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
   </ItemGroup>
-  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-model/oauth-client-credentials-mandatory-auth/src/SeedOauthClientCredentialsMandatoryAuth/SeedOauthClientCredentialsMandatoryAuth.csproj
+++ b/seed/csharp-model/oauth-client-credentials-mandatory-auth/src/SeedOauthClientCredentialsMandatoryAuth/SeedOauthClientCredentialsMandatoryAuth.csproj
@@ -39,11 +39,11 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
-    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/oauth-client-credentials-mandatory-auth/src/SeedOauthClientCredentialsMandatoryAuth/SeedOauthClientCredentialsMandatoryAuth.csproj
+++ b/seed/csharp-model/oauth-client-credentials-mandatory-auth/src/SeedOauthClientCredentialsMandatoryAuth/SeedOauthClientCredentialsMandatoryAuth.csproj
@@ -39,6 +39,8 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+  </ItemGroup>
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-model/oauth-client-credentials-nested-root/src/SeedOauthClientCredentials/SeedOauthClientCredentials.csproj
+++ b/seed/csharp-model/oauth-client-credentials-nested-root/src/SeedOauthClientCredentials/SeedOauthClientCredentials.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
   </ItemGroup>
-  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-model/oauth-client-credentials-nested-root/src/SeedOauthClientCredentials/SeedOauthClientCredentials.csproj
+++ b/seed/csharp-model/oauth-client-credentials-nested-root/src/SeedOauthClientCredentials/SeedOauthClientCredentials.csproj
@@ -39,11 +39,11 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
-    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/oauth-client-credentials-nested-root/src/SeedOauthClientCredentials/SeedOauthClientCredentials.csproj
+++ b/seed/csharp-model/oauth-client-credentials-nested-root/src/SeedOauthClientCredentials/SeedOauthClientCredentials.csproj
@@ -39,6 +39,8 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+  </ItemGroup>
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-model/oauth-client-credentials-reference/src/SeedOauthClientCredentialsReference/SeedOauthClientCredentialsReference.csproj
+++ b/seed/csharp-model/oauth-client-credentials-reference/src/SeedOauthClientCredentialsReference/SeedOauthClientCredentialsReference.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
   </ItemGroup>
-  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-model/oauth-client-credentials-reference/src/SeedOauthClientCredentialsReference/SeedOauthClientCredentialsReference.csproj
+++ b/seed/csharp-model/oauth-client-credentials-reference/src/SeedOauthClientCredentialsReference/SeedOauthClientCredentialsReference.csproj
@@ -39,11 +39,11 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
-    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/oauth-client-credentials-reference/src/SeedOauthClientCredentialsReference/SeedOauthClientCredentialsReference.csproj
+++ b/seed/csharp-model/oauth-client-credentials-reference/src/SeedOauthClientCredentialsReference/SeedOauthClientCredentialsReference.csproj
@@ -39,6 +39,8 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+  </ItemGroup>
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-model/oauth-client-credentials-with-variables/src/SeedOauthClientCredentialsWithVariables/SeedOauthClientCredentialsWithVariables.csproj
+++ b/seed/csharp-model/oauth-client-credentials-with-variables/src/SeedOauthClientCredentialsWithVariables/SeedOauthClientCredentialsWithVariables.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
   </ItemGroup>
-  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-model/oauth-client-credentials-with-variables/src/SeedOauthClientCredentialsWithVariables/SeedOauthClientCredentialsWithVariables.csproj
+++ b/seed/csharp-model/oauth-client-credentials-with-variables/src/SeedOauthClientCredentialsWithVariables/SeedOauthClientCredentialsWithVariables.csproj
@@ -39,11 +39,11 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
-    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/oauth-client-credentials-with-variables/src/SeedOauthClientCredentialsWithVariables/SeedOauthClientCredentialsWithVariables.csproj
+++ b/seed/csharp-model/oauth-client-credentials-with-variables/src/SeedOauthClientCredentialsWithVariables/SeedOauthClientCredentialsWithVariables.csproj
@@ -39,6 +39,8 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+  </ItemGroup>
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-model/oauth-client-credentials/src/SeedOauthClientCredentials/SeedOauthClientCredentials.csproj
+++ b/seed/csharp-model/oauth-client-credentials/src/SeedOauthClientCredentials/SeedOauthClientCredentials.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
   </ItemGroup>
-  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-model/oauth-client-credentials/src/SeedOauthClientCredentials/SeedOauthClientCredentials.csproj
+++ b/seed/csharp-model/oauth-client-credentials/src/SeedOauthClientCredentials/SeedOauthClientCredentials.csproj
@@ -39,11 +39,11 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
-    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/oauth-client-credentials/src/SeedOauthClientCredentials/SeedOauthClientCredentials.csproj
+++ b/seed/csharp-model/oauth-client-credentials/src/SeedOauthClientCredentials/SeedOauthClientCredentials.csproj
@@ -39,6 +39,8 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+  </ItemGroup>
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-model/object/src/SeedObject/SeedObject.csproj
+++ b/seed/csharp-model/object/src/SeedObject/SeedObject.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
   </ItemGroup>
-  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-model/object/src/SeedObject/SeedObject.csproj
+++ b/seed/csharp-model/object/src/SeedObject/SeedObject.csproj
@@ -39,11 +39,11 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
-    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/object/src/SeedObject/SeedObject.csproj
+++ b/seed/csharp-model/object/src/SeedObject/SeedObject.csproj
@@ -39,6 +39,8 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+  </ItemGroup>
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-model/objects-with-imports/src/SeedObjectsWithImports/SeedObjectsWithImports.csproj
+++ b/seed/csharp-model/objects-with-imports/src/SeedObjectsWithImports/SeedObjectsWithImports.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
   </ItemGroup>
-  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-model/objects-with-imports/src/SeedObjectsWithImports/SeedObjectsWithImports.csproj
+++ b/seed/csharp-model/objects-with-imports/src/SeedObjectsWithImports/SeedObjectsWithImports.csproj
@@ -39,11 +39,11 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
-    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/objects-with-imports/src/SeedObjectsWithImports/SeedObjectsWithImports.csproj
+++ b/seed/csharp-model/objects-with-imports/src/SeedObjectsWithImports/SeedObjectsWithImports.csproj
@@ -39,6 +39,8 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+  </ItemGroup>
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-model/optional/src/SeedObjectsWithImports/SeedObjectsWithImports.csproj
+++ b/seed/csharp-model/optional/src/SeedObjectsWithImports/SeedObjectsWithImports.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
   </ItemGroup>
-  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-model/optional/src/SeedObjectsWithImports/SeedObjectsWithImports.csproj
+++ b/seed/csharp-model/optional/src/SeedObjectsWithImports/SeedObjectsWithImports.csproj
@@ -39,11 +39,11 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
-    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/optional/src/SeedObjectsWithImports/SeedObjectsWithImports.csproj
+++ b/seed/csharp-model/optional/src/SeedObjectsWithImports/SeedObjectsWithImports.csproj
@@ -39,6 +39,8 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+  </ItemGroup>
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-model/package-yml/src/SeedPackageYml/SeedPackageYml.csproj
+++ b/seed/csharp-model/package-yml/src/SeedPackageYml/SeedPackageYml.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
   </ItemGroup>
-  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-model/package-yml/src/SeedPackageYml/SeedPackageYml.csproj
+++ b/seed/csharp-model/package-yml/src/SeedPackageYml/SeedPackageYml.csproj
@@ -39,11 +39,11 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
-    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/package-yml/src/SeedPackageYml/SeedPackageYml.csproj
+++ b/seed/csharp-model/package-yml/src/SeedPackageYml/SeedPackageYml.csproj
@@ -39,6 +39,8 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+  </ItemGroup>
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-model/pagination-custom/src/SeedPagination/SeedPagination.csproj
+++ b/seed/csharp-model/pagination-custom/src/SeedPagination/SeedPagination.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
   </ItemGroup>
-  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-model/pagination-custom/src/SeedPagination/SeedPagination.csproj
+++ b/seed/csharp-model/pagination-custom/src/SeedPagination/SeedPagination.csproj
@@ -39,11 +39,11 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
-    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/pagination-custom/src/SeedPagination/SeedPagination.csproj
+++ b/seed/csharp-model/pagination-custom/src/SeedPagination/SeedPagination.csproj
@@ -39,6 +39,8 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+  </ItemGroup>
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-model/pagination-uri-path/src/SeedPaginationUriPath/SeedPaginationUriPath.csproj
+++ b/seed/csharp-model/pagination-uri-path/src/SeedPaginationUriPath/SeedPaginationUriPath.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
   </ItemGroup>
-  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-model/pagination-uri-path/src/SeedPaginationUriPath/SeedPaginationUriPath.csproj
+++ b/seed/csharp-model/pagination-uri-path/src/SeedPaginationUriPath/SeedPaginationUriPath.csproj
@@ -39,11 +39,11 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
-    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/pagination-uri-path/src/SeedPaginationUriPath/SeedPaginationUriPath.csproj
+++ b/seed/csharp-model/pagination-uri-path/src/SeedPaginationUriPath/SeedPaginationUriPath.csproj
@@ -39,6 +39,8 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+  </ItemGroup>
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-model/pagination/src/SeedPagination/SeedPagination.csproj
+++ b/seed/csharp-model/pagination/src/SeedPagination/SeedPagination.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
   </ItemGroup>
-  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-model/pagination/src/SeedPagination/SeedPagination.csproj
+++ b/seed/csharp-model/pagination/src/SeedPagination/SeedPagination.csproj
@@ -39,11 +39,11 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
-    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/pagination/src/SeedPagination/SeedPagination.csproj
+++ b/seed/csharp-model/pagination/src/SeedPagination/SeedPagination.csproj
@@ -39,6 +39,8 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+  </ItemGroup>
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-model/path-parameters/src/SeedPathParameters/SeedPathParameters.csproj
+++ b/seed/csharp-model/path-parameters/src/SeedPathParameters/SeedPathParameters.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
   </ItemGroup>
-  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-model/path-parameters/src/SeedPathParameters/SeedPathParameters.csproj
+++ b/seed/csharp-model/path-parameters/src/SeedPathParameters/SeedPathParameters.csproj
@@ -39,11 +39,11 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
-    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/path-parameters/src/SeedPathParameters/SeedPathParameters.csproj
+++ b/seed/csharp-model/path-parameters/src/SeedPathParameters/SeedPathParameters.csproj
@@ -39,6 +39,8 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+  </ItemGroup>
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-model/plain-text/src/SeedPlainText/SeedPlainText.csproj
+++ b/seed/csharp-model/plain-text/src/SeedPlainText/SeedPlainText.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
   </ItemGroup>
-  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-model/plain-text/src/SeedPlainText/SeedPlainText.csproj
+++ b/seed/csharp-model/plain-text/src/SeedPlainText/SeedPlainText.csproj
@@ -39,11 +39,11 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
-    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/plain-text/src/SeedPlainText/SeedPlainText.csproj
+++ b/seed/csharp-model/plain-text/src/SeedPlainText/SeedPlainText.csproj
@@ -39,6 +39,8 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+  </ItemGroup>
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-model/property-access/src/SeedPropertyAccess/SeedPropertyAccess.csproj
+++ b/seed/csharp-model/property-access/src/SeedPropertyAccess/SeedPropertyAccess.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
   </ItemGroup>
-  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-model/property-access/src/SeedPropertyAccess/SeedPropertyAccess.csproj
+++ b/seed/csharp-model/property-access/src/SeedPropertyAccess/SeedPropertyAccess.csproj
@@ -39,11 +39,11 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
-    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/property-access/src/SeedPropertyAccess/SeedPropertyAccess.csproj
+++ b/seed/csharp-model/property-access/src/SeedPropertyAccess/SeedPropertyAccess.csproj
@@ -39,6 +39,8 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+  </ItemGroup>
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-model/public-object/src/SeedPublicObject/SeedPublicObject.csproj
+++ b/seed/csharp-model/public-object/src/SeedPublicObject/SeedPublicObject.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
   </ItemGroup>
-  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-model/public-object/src/SeedPublicObject/SeedPublicObject.csproj
+++ b/seed/csharp-model/public-object/src/SeedPublicObject/SeedPublicObject.csproj
@@ -39,11 +39,11 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
-    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/public-object/src/SeedPublicObject/SeedPublicObject.csproj
+++ b/seed/csharp-model/public-object/src/SeedPublicObject/SeedPublicObject.csproj
@@ -39,6 +39,8 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+  </ItemGroup>
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-model/query-parameters-openapi-as-objects/src/SeedApi/SeedApi.csproj
+++ b/seed/csharp-model/query-parameters-openapi-as-objects/src/SeedApi/SeedApi.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
   </ItemGroup>
-  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-model/query-parameters-openapi-as-objects/src/SeedApi/SeedApi.csproj
+++ b/seed/csharp-model/query-parameters-openapi-as-objects/src/SeedApi/SeedApi.csproj
@@ -39,11 +39,11 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
-    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/query-parameters-openapi-as-objects/src/SeedApi/SeedApi.csproj
+++ b/seed/csharp-model/query-parameters-openapi-as-objects/src/SeedApi/SeedApi.csproj
@@ -39,6 +39,8 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+  </ItemGroup>
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-model/query-parameters-openapi/src/SeedApi/SeedApi.csproj
+++ b/seed/csharp-model/query-parameters-openapi/src/SeedApi/SeedApi.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
   </ItemGroup>
-  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-model/query-parameters-openapi/src/SeedApi/SeedApi.csproj
+++ b/seed/csharp-model/query-parameters-openapi/src/SeedApi/SeedApi.csproj
@@ -39,11 +39,11 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
-    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/query-parameters-openapi/src/SeedApi/SeedApi.csproj
+++ b/seed/csharp-model/query-parameters-openapi/src/SeedApi/SeedApi.csproj
@@ -39,6 +39,8 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+  </ItemGroup>
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-model/query-parameters/src/SeedQueryParameters/SeedQueryParameters.csproj
+++ b/seed/csharp-model/query-parameters/src/SeedQueryParameters/SeedQueryParameters.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
   </ItemGroup>
-  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-model/query-parameters/src/SeedQueryParameters/SeedQueryParameters.csproj
+++ b/seed/csharp-model/query-parameters/src/SeedQueryParameters/SeedQueryParameters.csproj
@@ -39,11 +39,11 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
-    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/query-parameters/src/SeedQueryParameters/SeedQueryParameters.csproj
+++ b/seed/csharp-model/query-parameters/src/SeedQueryParameters/SeedQueryParameters.csproj
@@ -39,6 +39,8 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+  </ItemGroup>
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-model/request-parameters/src/SeedRequestParameters/SeedRequestParameters.csproj
+++ b/seed/csharp-model/request-parameters/src/SeedRequestParameters/SeedRequestParameters.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
   </ItemGroup>
-  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-model/request-parameters/src/SeedRequestParameters/SeedRequestParameters.csproj
+++ b/seed/csharp-model/request-parameters/src/SeedRequestParameters/SeedRequestParameters.csproj
@@ -39,11 +39,11 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
-    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/request-parameters/src/SeedRequestParameters/SeedRequestParameters.csproj
+++ b/seed/csharp-model/request-parameters/src/SeedRequestParameters/SeedRequestParameters.csproj
@@ -39,6 +39,8 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+  </ItemGroup>
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-model/required-nullable/src/SeedApi/SeedApi.csproj
+++ b/seed/csharp-model/required-nullable/src/SeedApi/SeedApi.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
   </ItemGroup>
-  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-model/required-nullable/src/SeedApi/SeedApi.csproj
+++ b/seed/csharp-model/required-nullable/src/SeedApi/SeedApi.csproj
@@ -39,11 +39,11 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
-    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/required-nullable/src/SeedApi/SeedApi.csproj
+++ b/seed/csharp-model/required-nullable/src/SeedApi/SeedApi.csproj
@@ -39,6 +39,8 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+  </ItemGroup>
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-model/reserved-keywords/src/SeedNurseryApi/SeedNurseryApi.csproj
+++ b/seed/csharp-model/reserved-keywords/src/SeedNurseryApi/SeedNurseryApi.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
   </ItemGroup>
-  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-model/reserved-keywords/src/SeedNurseryApi/SeedNurseryApi.csproj
+++ b/seed/csharp-model/reserved-keywords/src/SeedNurseryApi/SeedNurseryApi.csproj
@@ -39,11 +39,11 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
-    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/reserved-keywords/src/SeedNurseryApi/SeedNurseryApi.csproj
+++ b/seed/csharp-model/reserved-keywords/src/SeedNurseryApi/SeedNurseryApi.csproj
@@ -39,6 +39,8 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+  </ItemGroup>
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-model/response-property/src/SeedResponseProperty/SeedResponseProperty.csproj
+++ b/seed/csharp-model/response-property/src/SeedResponseProperty/SeedResponseProperty.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
   </ItemGroup>
-  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-model/response-property/src/SeedResponseProperty/SeedResponseProperty.csproj
+++ b/seed/csharp-model/response-property/src/SeedResponseProperty/SeedResponseProperty.csproj
@@ -39,11 +39,11 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
-    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/response-property/src/SeedResponseProperty/SeedResponseProperty.csproj
+++ b/seed/csharp-model/response-property/src/SeedResponseProperty/SeedResponseProperty.csproj
@@ -39,6 +39,8 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+  </ItemGroup>
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-model/server-sent-event-examples/src/SeedServerSentEvents/SeedServerSentEvents.csproj
+++ b/seed/csharp-model/server-sent-event-examples/src/SeedServerSentEvents/SeedServerSentEvents.csproj
@@ -41,7 +41,7 @@
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
     <PackageReference Include="System.Net.ServerSentEvents" Version="9.0.9" />
   </ItemGroup>
-  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-model/server-sent-event-examples/src/SeedServerSentEvents/SeedServerSentEvents.csproj
+++ b/seed/csharp-model/server-sent-event-examples/src/SeedServerSentEvents/SeedServerSentEvents.csproj
@@ -39,12 +39,12 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
     <PackageReference Include="System.Net.ServerSentEvents" Version="9.0.9" />
   </ItemGroup>
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
-    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/server-sent-event-examples/src/SeedServerSentEvents/SeedServerSentEvents.csproj
+++ b/seed/csharp-model/server-sent-event-examples/src/SeedServerSentEvents/SeedServerSentEvents.csproj
@@ -39,12 +39,12 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+    <PackageReference Include="System.Net.ServerSentEvents" Version="9.0.9" />
   </ItemGroup>
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
-    <PackageReference Include="System.Net.ServerSentEvents" Version="9.0.9" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/server-sent-event-examples/src/SeedServerSentEvents/SeedServerSentEvents.csproj
+++ b/seed/csharp-model/server-sent-event-examples/src/SeedServerSentEvents/SeedServerSentEvents.csproj
@@ -39,6 +39,8 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+  </ItemGroup>
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-model/server-sent-events/src/SeedServerSentEvents/SeedServerSentEvents.csproj
+++ b/seed/csharp-model/server-sent-events/src/SeedServerSentEvents/SeedServerSentEvents.csproj
@@ -41,7 +41,7 @@
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
     <PackageReference Include="System.Net.ServerSentEvents" Version="9.0.9" />
   </ItemGroup>
-  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-model/server-sent-events/src/SeedServerSentEvents/SeedServerSentEvents.csproj
+++ b/seed/csharp-model/server-sent-events/src/SeedServerSentEvents/SeedServerSentEvents.csproj
@@ -39,12 +39,12 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
     <PackageReference Include="System.Net.ServerSentEvents" Version="9.0.9" />
   </ItemGroup>
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
-    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/server-sent-events/src/SeedServerSentEvents/SeedServerSentEvents.csproj
+++ b/seed/csharp-model/server-sent-events/src/SeedServerSentEvents/SeedServerSentEvents.csproj
@@ -39,12 +39,12 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+    <PackageReference Include="System.Net.ServerSentEvents" Version="9.0.9" />
   </ItemGroup>
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
-    <PackageReference Include="System.Net.ServerSentEvents" Version="9.0.9" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/server-sent-events/src/SeedServerSentEvents/SeedServerSentEvents.csproj
+++ b/seed/csharp-model/server-sent-events/src/SeedServerSentEvents/SeedServerSentEvents.csproj
@@ -39,6 +39,8 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+  </ItemGroup>
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-model/server-url-templating/src/SeedApi/SeedApi.csproj
+++ b/seed/csharp-model/server-url-templating/src/SeedApi/SeedApi.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
   </ItemGroup>
-  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-model/server-url-templating/src/SeedApi/SeedApi.csproj
+++ b/seed/csharp-model/server-url-templating/src/SeedApi/SeedApi.csproj
@@ -39,11 +39,11 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
-    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/server-url-templating/src/SeedApi/SeedApi.csproj
+++ b/seed/csharp-model/server-url-templating/src/SeedApi/SeedApi.csproj
@@ -39,6 +39,8 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+  </ItemGroup>
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-model/simple-api/src/SeedSimpleApi/SeedSimpleApi.csproj
+++ b/seed/csharp-model/simple-api/src/SeedSimpleApi/SeedSimpleApi.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
   </ItemGroup>
-  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-model/simple-api/src/SeedSimpleApi/SeedSimpleApi.csproj
+++ b/seed/csharp-model/simple-api/src/SeedSimpleApi/SeedSimpleApi.csproj
@@ -39,11 +39,11 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
-    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/simple-api/src/SeedSimpleApi/SeedSimpleApi.csproj
+++ b/seed/csharp-model/simple-api/src/SeedSimpleApi/SeedSimpleApi.csproj
@@ -39,6 +39,8 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+  </ItemGroup>
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-model/simple-fhir/src/SeedApi/SeedApi.csproj
+++ b/seed/csharp-model/simple-fhir/src/SeedApi/SeedApi.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
   </ItemGroup>
-  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-model/simple-fhir/src/SeedApi/SeedApi.csproj
+++ b/seed/csharp-model/simple-fhir/src/SeedApi/SeedApi.csproj
@@ -39,11 +39,11 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
-    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/simple-fhir/src/SeedApi/SeedApi.csproj
+++ b/seed/csharp-model/simple-fhir/src/SeedApi/SeedApi.csproj
@@ -39,6 +39,8 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+  </ItemGroup>
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-model/single-url-environment-default/src/SeedSingleUrlEnvironmentDefault/SeedSingleUrlEnvironmentDefault.csproj
+++ b/seed/csharp-model/single-url-environment-default/src/SeedSingleUrlEnvironmentDefault/SeedSingleUrlEnvironmentDefault.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
   </ItemGroup>
-  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-model/single-url-environment-default/src/SeedSingleUrlEnvironmentDefault/SeedSingleUrlEnvironmentDefault.csproj
+++ b/seed/csharp-model/single-url-environment-default/src/SeedSingleUrlEnvironmentDefault/SeedSingleUrlEnvironmentDefault.csproj
@@ -39,11 +39,11 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
-    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/single-url-environment-default/src/SeedSingleUrlEnvironmentDefault/SeedSingleUrlEnvironmentDefault.csproj
+++ b/seed/csharp-model/single-url-environment-default/src/SeedSingleUrlEnvironmentDefault/SeedSingleUrlEnvironmentDefault.csproj
@@ -39,6 +39,8 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+  </ItemGroup>
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-model/single-url-environment-no-default/src/SeedSingleUrlEnvironmentNoDefault/SeedSingleUrlEnvironmentNoDefault.csproj
+++ b/seed/csharp-model/single-url-environment-no-default/src/SeedSingleUrlEnvironmentNoDefault/SeedSingleUrlEnvironmentNoDefault.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
   </ItemGroup>
-  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-model/single-url-environment-no-default/src/SeedSingleUrlEnvironmentNoDefault/SeedSingleUrlEnvironmentNoDefault.csproj
+++ b/seed/csharp-model/single-url-environment-no-default/src/SeedSingleUrlEnvironmentNoDefault/SeedSingleUrlEnvironmentNoDefault.csproj
@@ -39,11 +39,11 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
-    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/single-url-environment-no-default/src/SeedSingleUrlEnvironmentNoDefault/SeedSingleUrlEnvironmentNoDefault.csproj
+++ b/seed/csharp-model/single-url-environment-no-default/src/SeedSingleUrlEnvironmentNoDefault/SeedSingleUrlEnvironmentNoDefault.csproj
@@ -39,6 +39,8 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+  </ItemGroup>
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-model/streaming-parameter/src/SeedStreaming/SeedStreaming.csproj
+++ b/seed/csharp-model/streaming-parameter/src/SeedStreaming/SeedStreaming.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
   </ItemGroup>
-  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-model/streaming-parameter/src/SeedStreaming/SeedStreaming.csproj
+++ b/seed/csharp-model/streaming-parameter/src/SeedStreaming/SeedStreaming.csproj
@@ -39,11 +39,11 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
-    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/streaming-parameter/src/SeedStreaming/SeedStreaming.csproj
+++ b/seed/csharp-model/streaming-parameter/src/SeedStreaming/SeedStreaming.csproj
@@ -39,6 +39,8 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+  </ItemGroup>
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-model/streaming/src/SeedStreaming/SeedStreaming.csproj
+++ b/seed/csharp-model/streaming/src/SeedStreaming/SeedStreaming.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
   </ItemGroup>
-  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-model/streaming/src/SeedStreaming/SeedStreaming.csproj
+++ b/seed/csharp-model/streaming/src/SeedStreaming/SeedStreaming.csproj
@@ -39,11 +39,11 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
-    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/streaming/src/SeedStreaming/SeedStreaming.csproj
+++ b/seed/csharp-model/streaming/src/SeedStreaming/SeedStreaming.csproj
@@ -39,6 +39,8 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+  </ItemGroup>
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-model/trace/src/SeedTrace/SeedTrace.csproj
+++ b/seed/csharp-model/trace/src/SeedTrace/SeedTrace.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
   </ItemGroup>
-  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-model/trace/src/SeedTrace/SeedTrace.csproj
+++ b/seed/csharp-model/trace/src/SeedTrace/SeedTrace.csproj
@@ -39,11 +39,11 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
-    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/trace/src/SeedTrace/SeedTrace.csproj
+++ b/seed/csharp-model/trace/src/SeedTrace/SeedTrace.csproj
@@ -39,6 +39,8 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+  </ItemGroup>
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-model/undiscriminated-union-with-response-property/src/SeedUndiscriminatedUnionWithResponseProperty/SeedUndiscriminatedUnionWithResponseProperty.csproj
+++ b/seed/csharp-model/undiscriminated-union-with-response-property/src/SeedUndiscriminatedUnionWithResponseProperty/SeedUndiscriminatedUnionWithResponseProperty.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
   </ItemGroup>
-  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-model/undiscriminated-union-with-response-property/src/SeedUndiscriminatedUnionWithResponseProperty/SeedUndiscriminatedUnionWithResponseProperty.csproj
+++ b/seed/csharp-model/undiscriminated-union-with-response-property/src/SeedUndiscriminatedUnionWithResponseProperty/SeedUndiscriminatedUnionWithResponseProperty.csproj
@@ -39,11 +39,11 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
-    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/undiscriminated-union-with-response-property/src/SeedUndiscriminatedUnionWithResponseProperty/SeedUndiscriminatedUnionWithResponseProperty.csproj
+++ b/seed/csharp-model/undiscriminated-union-with-response-property/src/SeedUndiscriminatedUnionWithResponseProperty/SeedUndiscriminatedUnionWithResponseProperty.csproj
@@ -39,6 +39,8 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+  </ItemGroup>
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-model/undiscriminated-unions/src/SeedUndiscriminatedUnions/SeedUndiscriminatedUnions.csproj
+++ b/seed/csharp-model/undiscriminated-unions/src/SeedUndiscriminatedUnions/SeedUndiscriminatedUnions.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
   </ItemGroup>
-  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-model/undiscriminated-unions/src/SeedUndiscriminatedUnions/SeedUndiscriminatedUnions.csproj
+++ b/seed/csharp-model/undiscriminated-unions/src/SeedUndiscriminatedUnions/SeedUndiscriminatedUnions.csproj
@@ -39,11 +39,11 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
-    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/undiscriminated-unions/src/SeedUndiscriminatedUnions/SeedUndiscriminatedUnions.csproj
+++ b/seed/csharp-model/undiscriminated-unions/src/SeedUndiscriminatedUnions/SeedUndiscriminatedUnions.csproj
@@ -39,6 +39,8 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+  </ItemGroup>
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-model/unions-with-local-date/src/SeedUnions/SeedUnions.csproj
+++ b/seed/csharp-model/unions-with-local-date/src/SeedUnions/SeedUnions.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
   </ItemGroup>
-  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-model/unions-with-local-date/src/SeedUnions/SeedUnions.csproj
+++ b/seed/csharp-model/unions-with-local-date/src/SeedUnions/SeedUnions.csproj
@@ -39,11 +39,11 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
-    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/unions-with-local-date/src/SeedUnions/SeedUnions.csproj
+++ b/seed/csharp-model/unions-with-local-date/src/SeedUnions/SeedUnions.csproj
@@ -39,6 +39,8 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+  </ItemGroup>
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-model/unions/src/SeedUnions/SeedUnions.csproj
+++ b/seed/csharp-model/unions/src/SeedUnions/SeedUnions.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
   </ItemGroup>
-  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-model/unions/src/SeedUnions/SeedUnions.csproj
+++ b/seed/csharp-model/unions/src/SeedUnions/SeedUnions.csproj
@@ -39,11 +39,11 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
-    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/unions/src/SeedUnions/SeedUnions.csproj
+++ b/seed/csharp-model/unions/src/SeedUnions/SeedUnions.csproj
@@ -39,6 +39,8 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+  </ItemGroup>
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-model/unknown/src/SeedUnknownAsAny/SeedUnknownAsAny.csproj
+++ b/seed/csharp-model/unknown/src/SeedUnknownAsAny/SeedUnknownAsAny.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
   </ItemGroup>
-  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-model/unknown/src/SeedUnknownAsAny/SeedUnknownAsAny.csproj
+++ b/seed/csharp-model/unknown/src/SeedUnknownAsAny/SeedUnknownAsAny.csproj
@@ -39,11 +39,11 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
-    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/unknown/src/SeedUnknownAsAny/SeedUnknownAsAny.csproj
+++ b/seed/csharp-model/unknown/src/SeedUnknownAsAny/SeedUnknownAsAny.csproj
@@ -39,6 +39,8 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+  </ItemGroup>
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-model/url-form-encoded/src/SeedApi/SeedApi.csproj
+++ b/seed/csharp-model/url-form-encoded/src/SeedApi/SeedApi.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
   </ItemGroup>
-  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-model/url-form-encoded/src/SeedApi/SeedApi.csproj
+++ b/seed/csharp-model/url-form-encoded/src/SeedApi/SeedApi.csproj
@@ -39,11 +39,11 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
-    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/url-form-encoded/src/SeedApi/SeedApi.csproj
+++ b/seed/csharp-model/url-form-encoded/src/SeedApi/SeedApi.csproj
@@ -39,6 +39,8 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+  </ItemGroup>
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-model/validation/src/SeedValidation/SeedValidation.csproj
+++ b/seed/csharp-model/validation/src/SeedValidation/SeedValidation.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
   </ItemGroup>
-  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-model/validation/src/SeedValidation/SeedValidation.csproj
+++ b/seed/csharp-model/validation/src/SeedValidation/SeedValidation.csproj
@@ -39,11 +39,11 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
-    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/validation/src/SeedValidation/SeedValidation.csproj
+++ b/seed/csharp-model/validation/src/SeedValidation/SeedValidation.csproj
@@ -39,6 +39,8 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+  </ItemGroup>
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-model/variables/src/SeedVariables/SeedVariables.csproj
+++ b/seed/csharp-model/variables/src/SeedVariables/SeedVariables.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
   </ItemGroup>
-  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-model/variables/src/SeedVariables/SeedVariables.csproj
+++ b/seed/csharp-model/variables/src/SeedVariables/SeedVariables.csproj
@@ -39,11 +39,11 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
-    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/variables/src/SeedVariables/SeedVariables.csproj
+++ b/seed/csharp-model/variables/src/SeedVariables/SeedVariables.csproj
@@ -39,6 +39,8 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+  </ItemGroup>
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-model/version-no-default/src/SeedVersion/SeedVersion.csproj
+++ b/seed/csharp-model/version-no-default/src/SeedVersion/SeedVersion.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
   </ItemGroup>
-  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-model/version-no-default/src/SeedVersion/SeedVersion.csproj
+++ b/seed/csharp-model/version-no-default/src/SeedVersion/SeedVersion.csproj
@@ -39,11 +39,11 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
-    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/version-no-default/src/SeedVersion/SeedVersion.csproj
+++ b/seed/csharp-model/version-no-default/src/SeedVersion/SeedVersion.csproj
@@ -39,6 +39,8 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+  </ItemGroup>
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-model/version/src/SeedVersion/SeedVersion.csproj
+++ b/seed/csharp-model/version/src/SeedVersion/SeedVersion.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
   </ItemGroup>
-  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-model/version/src/SeedVersion/SeedVersion.csproj
+++ b/seed/csharp-model/version/src/SeedVersion/SeedVersion.csproj
@@ -39,11 +39,11 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
-    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/version/src/SeedVersion/SeedVersion.csproj
+++ b/seed/csharp-model/version/src/SeedVersion/SeedVersion.csproj
@@ -39,6 +39,8 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+  </ItemGroup>
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-model/webhook-audience/src/SeedApi/SeedApi.csproj
+++ b/seed/csharp-model/webhook-audience/src/SeedApi/SeedApi.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
   </ItemGroup>
-  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-model/webhook-audience/src/SeedApi/SeedApi.csproj
+++ b/seed/csharp-model/webhook-audience/src/SeedApi/SeedApi.csproj
@@ -39,11 +39,11 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
-    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/webhook-audience/src/SeedApi/SeedApi.csproj
+++ b/seed/csharp-model/webhook-audience/src/SeedApi/SeedApi.csproj
@@ -39,6 +39,8 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+  </ItemGroup>
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-model/webhooks/src/SeedWebhooks/SeedWebhooks.csproj
+++ b/seed/csharp-model/webhooks/src/SeedWebhooks/SeedWebhooks.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
   </ItemGroup>
-  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-model/webhooks/src/SeedWebhooks/SeedWebhooks.csproj
+++ b/seed/csharp-model/webhooks/src/SeedWebhooks/SeedWebhooks.csproj
@@ -39,11 +39,11 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
-    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/webhooks/src/SeedWebhooks/SeedWebhooks.csproj
+++ b/seed/csharp-model/webhooks/src/SeedWebhooks/SeedWebhooks.csproj
@@ -39,6 +39,8 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+  </ItemGroup>
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-model/websocket-bearer-auth/src/SeedWebsocketBearerAuth/SeedWebsocketBearerAuth.csproj
+++ b/seed/csharp-model/websocket-bearer-auth/src/SeedWebsocketBearerAuth/SeedWebsocketBearerAuth.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
   </ItemGroup>
-  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-model/websocket-bearer-auth/src/SeedWebsocketBearerAuth/SeedWebsocketBearerAuth.csproj
+++ b/seed/csharp-model/websocket-bearer-auth/src/SeedWebsocketBearerAuth/SeedWebsocketBearerAuth.csproj
@@ -39,11 +39,11 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
-    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/websocket-bearer-auth/src/SeedWebsocketBearerAuth/SeedWebsocketBearerAuth.csproj
+++ b/seed/csharp-model/websocket-bearer-auth/src/SeedWebsocketBearerAuth/SeedWebsocketBearerAuth.csproj
@@ -39,6 +39,8 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+  </ItemGroup>
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-model/websocket-inferred-auth/src/SeedWebsocketAuth/SeedWebsocketAuth.csproj
+++ b/seed/csharp-model/websocket-inferred-auth/src/SeedWebsocketAuth/SeedWebsocketAuth.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
   </ItemGroup>
-  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-model/websocket-inferred-auth/src/SeedWebsocketAuth/SeedWebsocketAuth.csproj
+++ b/seed/csharp-model/websocket-inferred-auth/src/SeedWebsocketAuth/SeedWebsocketAuth.csproj
@@ -39,11 +39,11 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
-    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/websocket-inferred-auth/src/SeedWebsocketAuth/SeedWebsocketAuth.csproj
+++ b/seed/csharp-model/websocket-inferred-auth/src/SeedWebsocketAuth/SeedWebsocketAuth.csproj
@@ -39,6 +39,8 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+  </ItemGroup>
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-model/websocket/src/SeedWebsocket/SeedWebsocket.csproj
+++ b/seed/csharp-model/websocket/src/SeedWebsocket/SeedWebsocket.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
   </ItemGroup>
-  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-model/websocket/src/SeedWebsocket/SeedWebsocket.csproj
+++ b/seed/csharp-model/websocket/src/SeedWebsocket/SeedWebsocket.csproj
@@ -39,11 +39,11 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
-    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/websocket/src/SeedWebsocket/SeedWebsocket.csproj
+++ b/seed/csharp-model/websocket/src/SeedWebsocket/SeedWebsocket.csproj
@@ -39,6 +39,8 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+  </ItemGroup>
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/accept-header/src/SeedAccept/SeedAccept.csproj
+++ b/seed/csharp-sdk/accept-header/src/SeedAccept/SeedAccept.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
   </ItemGroup>
-  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/accept-header/src/SeedAccept/SeedAccept.csproj
+++ b/seed/csharp-sdk/accept-header/src/SeedAccept/SeedAccept.csproj
@@ -39,11 +39,11 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
-    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/accept-header/src/SeedAccept/SeedAccept.csproj
+++ b/seed/csharp-sdk/accept-header/src/SeedAccept/SeedAccept.csproj
@@ -39,6 +39,8 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+  </ItemGroup>
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/alias-extends/src/SeedAliasExtends/SeedAliasExtends.csproj
+++ b/seed/csharp-sdk/alias-extends/src/SeedAliasExtends/SeedAliasExtends.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
   </ItemGroup>
-  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/alias-extends/src/SeedAliasExtends/SeedAliasExtends.csproj
+++ b/seed/csharp-sdk/alias-extends/src/SeedAliasExtends/SeedAliasExtends.csproj
@@ -39,11 +39,11 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
-    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/alias-extends/src/SeedAliasExtends/SeedAliasExtends.csproj
+++ b/seed/csharp-sdk/alias-extends/src/SeedAliasExtends/SeedAliasExtends.csproj
@@ -39,6 +39,8 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+  </ItemGroup>
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/alias/src/SeedAlias/SeedAlias.csproj
+++ b/seed/csharp-sdk/alias/src/SeedAlias/SeedAlias.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
   </ItemGroup>
-  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/alias/src/SeedAlias/SeedAlias.csproj
+++ b/seed/csharp-sdk/alias/src/SeedAlias/SeedAlias.csproj
@@ -39,11 +39,11 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
-    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/alias/src/SeedAlias/SeedAlias.csproj
+++ b/seed/csharp-sdk/alias/src/SeedAlias/SeedAlias.csproj
@@ -39,6 +39,8 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+  </ItemGroup>
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/any-auth/src/SeedAnyAuth/SeedAnyAuth.csproj
+++ b/seed/csharp-sdk/any-auth/src/SeedAnyAuth/SeedAnyAuth.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
   </ItemGroup>
-  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/any-auth/src/SeedAnyAuth/SeedAnyAuth.csproj
+++ b/seed/csharp-sdk/any-auth/src/SeedAnyAuth/SeedAnyAuth.csproj
@@ -39,11 +39,11 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
-    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/any-auth/src/SeedAnyAuth/SeedAnyAuth.csproj
+++ b/seed/csharp-sdk/any-auth/src/SeedAnyAuth/SeedAnyAuth.csproj
@@ -39,6 +39,8 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+  </ItemGroup>
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/api-wide-base-path/src/SeedApiWideBasePath/SeedApiWideBasePath.csproj
+++ b/seed/csharp-sdk/api-wide-base-path/src/SeedApiWideBasePath/SeedApiWideBasePath.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
   </ItemGroup>
-  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/api-wide-base-path/src/SeedApiWideBasePath/SeedApiWideBasePath.csproj
+++ b/seed/csharp-sdk/api-wide-base-path/src/SeedApiWideBasePath/SeedApiWideBasePath.csproj
@@ -39,11 +39,11 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
-    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/api-wide-base-path/src/SeedApiWideBasePath/SeedApiWideBasePath.csproj
+++ b/seed/csharp-sdk/api-wide-base-path/src/SeedApiWideBasePath/SeedApiWideBasePath.csproj
@@ -39,6 +39,8 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+  </ItemGroup>
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/audiences/src/SeedAudiences/SeedAudiences.csproj
+++ b/seed/csharp-sdk/audiences/src/SeedAudiences/SeedAudiences.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
   </ItemGroup>
-  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/audiences/src/SeedAudiences/SeedAudiences.csproj
+++ b/seed/csharp-sdk/audiences/src/SeedAudiences/SeedAudiences.csproj
@@ -39,11 +39,11 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
-    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/audiences/src/SeedAudiences/SeedAudiences.csproj
+++ b/seed/csharp-sdk/audiences/src/SeedAudiences/SeedAudiences.csproj
@@ -39,6 +39,8 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+  </ItemGroup>
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/basic-auth-environment-variables/src/SeedBasicAuthEnvironmentVariables/SeedBasicAuthEnvironmentVariables.csproj
+++ b/seed/csharp-sdk/basic-auth-environment-variables/src/SeedBasicAuthEnvironmentVariables/SeedBasicAuthEnvironmentVariables.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
   </ItemGroup>
-  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/basic-auth-environment-variables/src/SeedBasicAuthEnvironmentVariables/SeedBasicAuthEnvironmentVariables.csproj
+++ b/seed/csharp-sdk/basic-auth-environment-variables/src/SeedBasicAuthEnvironmentVariables/SeedBasicAuthEnvironmentVariables.csproj
@@ -39,11 +39,11 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
-    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/basic-auth-environment-variables/src/SeedBasicAuthEnvironmentVariables/SeedBasicAuthEnvironmentVariables.csproj
+++ b/seed/csharp-sdk/basic-auth-environment-variables/src/SeedBasicAuthEnvironmentVariables/SeedBasicAuthEnvironmentVariables.csproj
@@ -39,6 +39,8 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+  </ItemGroup>
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/basic-auth/no-custom-config/src/SeedBasicAuth/SeedBasicAuth.csproj
+++ b/seed/csharp-sdk/basic-auth/no-custom-config/src/SeedBasicAuth/SeedBasicAuth.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
   </ItemGroup>
-  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/basic-auth/no-custom-config/src/SeedBasicAuth/SeedBasicAuth.csproj
+++ b/seed/csharp-sdk/basic-auth/no-custom-config/src/SeedBasicAuth/SeedBasicAuth.csproj
@@ -39,11 +39,11 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
-    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/basic-auth/no-custom-config/src/SeedBasicAuth/SeedBasicAuth.csproj
+++ b/seed/csharp-sdk/basic-auth/no-custom-config/src/SeedBasicAuth/SeedBasicAuth.csproj
@@ -39,6 +39,8 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+  </ItemGroup>
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/basic-auth/unified-client-options/src/SeedBasicAuth/SeedBasicAuth.csproj
+++ b/seed/csharp-sdk/basic-auth/unified-client-options/src/SeedBasicAuth/SeedBasicAuth.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
   </ItemGroup>
-  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/basic-auth/unified-client-options/src/SeedBasicAuth/SeedBasicAuth.csproj
+++ b/seed/csharp-sdk/basic-auth/unified-client-options/src/SeedBasicAuth/SeedBasicAuth.csproj
@@ -39,11 +39,11 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
-    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/basic-auth/unified-client-options/src/SeedBasicAuth/SeedBasicAuth.csproj
+++ b/seed/csharp-sdk/basic-auth/unified-client-options/src/SeedBasicAuth/SeedBasicAuth.csproj
@@ -39,6 +39,8 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+  </ItemGroup>
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/bearer-token-environment-variable/no-custom-config/src/SeedBearerTokenEnvironmentVariable/SeedBearerTokenEnvironmentVariable.csproj
+++ b/seed/csharp-sdk/bearer-token-environment-variable/no-custom-config/src/SeedBearerTokenEnvironmentVariable/SeedBearerTokenEnvironmentVariable.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
   </ItemGroup>
-  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/bearer-token-environment-variable/no-custom-config/src/SeedBearerTokenEnvironmentVariable/SeedBearerTokenEnvironmentVariable.csproj
+++ b/seed/csharp-sdk/bearer-token-environment-variable/no-custom-config/src/SeedBearerTokenEnvironmentVariable/SeedBearerTokenEnvironmentVariable.csproj
@@ -39,11 +39,11 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
-    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/bearer-token-environment-variable/no-custom-config/src/SeedBearerTokenEnvironmentVariable/SeedBearerTokenEnvironmentVariable.csproj
+++ b/seed/csharp-sdk/bearer-token-environment-variable/no-custom-config/src/SeedBearerTokenEnvironmentVariable/SeedBearerTokenEnvironmentVariable.csproj
@@ -39,6 +39,8 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+  </ItemGroup>
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/bearer-token-environment-variable/unified-client-options/src/SeedBearerTokenEnvironmentVariable/SeedBearerTokenEnvironmentVariable.csproj
+++ b/seed/csharp-sdk/bearer-token-environment-variable/unified-client-options/src/SeedBearerTokenEnvironmentVariable/SeedBearerTokenEnvironmentVariable.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
   </ItemGroup>
-  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/bearer-token-environment-variable/unified-client-options/src/SeedBearerTokenEnvironmentVariable/SeedBearerTokenEnvironmentVariable.csproj
+++ b/seed/csharp-sdk/bearer-token-environment-variable/unified-client-options/src/SeedBearerTokenEnvironmentVariable/SeedBearerTokenEnvironmentVariable.csproj
@@ -39,11 +39,11 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
-    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/bearer-token-environment-variable/unified-client-options/src/SeedBearerTokenEnvironmentVariable/SeedBearerTokenEnvironmentVariable.csproj
+++ b/seed/csharp-sdk/bearer-token-environment-variable/unified-client-options/src/SeedBearerTokenEnvironmentVariable/SeedBearerTokenEnvironmentVariable.csproj
@@ -39,6 +39,8 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+  </ItemGroup>
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/bytes-download/src/SeedBytesDownload/SeedBytesDownload.csproj
+++ b/seed/csharp-sdk/bytes-download/src/SeedBytesDownload/SeedBytesDownload.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
   </ItemGroup>
-  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/bytes-download/src/SeedBytesDownload/SeedBytesDownload.csproj
+++ b/seed/csharp-sdk/bytes-download/src/SeedBytesDownload/SeedBytesDownload.csproj
@@ -39,11 +39,11 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
-    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/bytes-download/src/SeedBytesDownload/SeedBytesDownload.csproj
+++ b/seed/csharp-sdk/bytes-download/src/SeedBytesDownload/SeedBytesDownload.csproj
@@ -39,6 +39,8 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+  </ItemGroup>
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/bytes-upload/src/SeedBytesUpload/SeedBytesUpload.csproj
+++ b/seed/csharp-sdk/bytes-upload/src/SeedBytesUpload/SeedBytesUpload.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
   </ItemGroup>
-  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/bytes-upload/src/SeedBytesUpload/SeedBytesUpload.csproj
+++ b/seed/csharp-sdk/bytes-upload/src/SeedBytesUpload/SeedBytesUpload.csproj
@@ -39,11 +39,11 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
-    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/bytes-upload/src/SeedBytesUpload/SeedBytesUpload.csproj
+++ b/seed/csharp-sdk/bytes-upload/src/SeedBytesUpload/SeedBytesUpload.csproj
@@ -39,6 +39,8 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+  </ItemGroup>
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/circular-references-advanced/src/SeedApi/SeedApi.csproj
+++ b/seed/csharp-sdk/circular-references-advanced/src/SeedApi/SeedApi.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
   </ItemGroup>
-  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/circular-references-advanced/src/SeedApi/SeedApi.csproj
+++ b/seed/csharp-sdk/circular-references-advanced/src/SeedApi/SeedApi.csproj
@@ -39,11 +39,11 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
-    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/circular-references-advanced/src/SeedApi/SeedApi.csproj
+++ b/seed/csharp-sdk/circular-references-advanced/src/SeedApi/SeedApi.csproj
@@ -39,6 +39,8 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+  </ItemGroup>
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/circular-references/src/SeedApi/SeedApi.csproj
+++ b/seed/csharp-sdk/circular-references/src/SeedApi/SeedApi.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
   </ItemGroup>
-  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/circular-references/src/SeedApi/SeedApi.csproj
+++ b/seed/csharp-sdk/circular-references/src/SeedApi/SeedApi.csproj
@@ -39,11 +39,11 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
-    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/circular-references/src/SeedApi/SeedApi.csproj
+++ b/seed/csharp-sdk/circular-references/src/SeedApi/SeedApi.csproj
@@ -39,6 +39,8 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+  </ItemGroup>
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/client-side-params/src/SeedClientSideParams/SeedClientSideParams.csproj
+++ b/seed/csharp-sdk/client-side-params/src/SeedClientSideParams/SeedClientSideParams.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
   </ItemGroup>
-  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/client-side-params/src/SeedClientSideParams/SeedClientSideParams.csproj
+++ b/seed/csharp-sdk/client-side-params/src/SeedClientSideParams/SeedClientSideParams.csproj
@@ -39,11 +39,11 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
-    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/client-side-params/src/SeedClientSideParams/SeedClientSideParams.csproj
+++ b/seed/csharp-sdk/client-side-params/src/SeedClientSideParams/SeedClientSideParams.csproj
@@ -39,6 +39,8 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+  </ItemGroup>
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/content-type/src/SeedContentTypes/SeedContentTypes.csproj
+++ b/seed/csharp-sdk/content-type/src/SeedContentTypes/SeedContentTypes.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
   </ItemGroup>
-  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/content-type/src/SeedContentTypes/SeedContentTypes.csproj
+++ b/seed/csharp-sdk/content-type/src/SeedContentTypes/SeedContentTypes.csproj
@@ -39,11 +39,11 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
-    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/content-type/src/SeedContentTypes/SeedContentTypes.csproj
+++ b/seed/csharp-sdk/content-type/src/SeedContentTypes/SeedContentTypes.csproj
@@ -39,6 +39,8 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+  </ItemGroup>
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/cross-package-type-names/src/SeedCrossPackageTypeNames/SeedCrossPackageTypeNames.csproj
+++ b/seed/csharp-sdk/cross-package-type-names/src/SeedCrossPackageTypeNames/SeedCrossPackageTypeNames.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
   </ItemGroup>
-  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/cross-package-type-names/src/SeedCrossPackageTypeNames/SeedCrossPackageTypeNames.csproj
+++ b/seed/csharp-sdk/cross-package-type-names/src/SeedCrossPackageTypeNames/SeedCrossPackageTypeNames.csproj
@@ -39,11 +39,11 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
-    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/cross-package-type-names/src/SeedCrossPackageTypeNames/SeedCrossPackageTypeNames.csproj
+++ b/seed/csharp-sdk/cross-package-type-names/src/SeedCrossPackageTypeNames/SeedCrossPackageTypeNames.csproj
@@ -39,6 +39,8 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+  </ItemGroup>
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/csharp-grpc-proto-exhaustive/include-exception-handler/src/SeedApi/SeedApi.csproj
+++ b/seed/csharp-sdk/csharp-grpc-proto-exhaustive/include-exception-handler/src/SeedApi/SeedApi.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
   </ItemGroup>
-  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/csharp-grpc-proto-exhaustive/include-exception-handler/src/SeedApi/SeedApi.csproj
+++ b/seed/csharp-sdk/csharp-grpc-proto-exhaustive/include-exception-handler/src/SeedApi/SeedApi.csproj
@@ -39,11 +39,11 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
-    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/csharp-grpc-proto-exhaustive/include-exception-handler/src/SeedApi/SeedApi.csproj
+++ b/seed/csharp-sdk/csharp-grpc-proto-exhaustive/include-exception-handler/src/SeedApi/SeedApi.csproj
@@ -39,6 +39,8 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+  </ItemGroup>
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/csharp-grpc-proto-exhaustive/no-custom-config/src/SeedApi/SeedApi.csproj
+++ b/seed/csharp-sdk/csharp-grpc-proto-exhaustive/no-custom-config/src/SeedApi/SeedApi.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
   </ItemGroup>
-  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/csharp-grpc-proto-exhaustive/no-custom-config/src/SeedApi/SeedApi.csproj
+++ b/seed/csharp-sdk/csharp-grpc-proto-exhaustive/no-custom-config/src/SeedApi/SeedApi.csproj
@@ -39,11 +39,11 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
-    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/csharp-grpc-proto-exhaustive/no-custom-config/src/SeedApi/SeedApi.csproj
+++ b/seed/csharp-sdk/csharp-grpc-proto-exhaustive/no-custom-config/src/SeedApi/SeedApi.csproj
@@ -39,6 +39,8 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+  </ItemGroup>
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/csharp-grpc-proto-exhaustive/package-id/src/SeedApi/SeedApi.csproj
+++ b/seed/csharp-sdk/csharp-grpc-proto-exhaustive/package-id/src/SeedApi/SeedApi.csproj
@@ -41,7 +41,7 @@
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
   </ItemGroup>
-  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/csharp-grpc-proto-exhaustive/package-id/src/SeedApi/SeedApi.csproj
+++ b/seed/csharp-sdk/csharp-grpc-proto-exhaustive/package-id/src/SeedApi/SeedApi.csproj
@@ -40,11 +40,11 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
-    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/csharp-grpc-proto-exhaustive/package-id/src/SeedApi/SeedApi.csproj
+++ b/seed/csharp-sdk/csharp-grpc-proto-exhaustive/package-id/src/SeedApi/SeedApi.csproj
@@ -40,6 +40,8 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+  </ItemGroup>
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/csharp-grpc-proto-exhaustive/read-only-memory/src/SeedApi/SeedApi.csproj
+++ b/seed/csharp-sdk/csharp-grpc-proto-exhaustive/read-only-memory/src/SeedApi/SeedApi.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
   </ItemGroup>
-  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/csharp-grpc-proto-exhaustive/read-only-memory/src/SeedApi/SeedApi.csproj
+++ b/seed/csharp-sdk/csharp-grpc-proto-exhaustive/read-only-memory/src/SeedApi/SeedApi.csproj
@@ -39,11 +39,11 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
-    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/csharp-grpc-proto-exhaustive/read-only-memory/src/SeedApi/SeedApi.csproj
+++ b/seed/csharp-sdk/csharp-grpc-proto-exhaustive/read-only-memory/src/SeedApi/SeedApi.csproj
@@ -39,6 +39,8 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+  </ItemGroup>
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/csharp-grpc-proto/no-custom-config/src/SeedApi/SeedApi.csproj
+++ b/seed/csharp-sdk/csharp-grpc-proto/no-custom-config/src/SeedApi/SeedApi.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
   </ItemGroup>
-  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/csharp-grpc-proto/no-custom-config/src/SeedApi/SeedApi.csproj
+++ b/seed/csharp-sdk/csharp-grpc-proto/no-custom-config/src/SeedApi/SeedApi.csproj
@@ -39,11 +39,11 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
-    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/csharp-grpc-proto/no-custom-config/src/SeedApi/SeedApi.csproj
+++ b/seed/csharp-sdk/csharp-grpc-proto/no-custom-config/src/SeedApi/SeedApi.csproj
@@ -39,6 +39,8 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+  </ItemGroup>
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/csharp-namespace-collision/fully-qualified-namespaces/src/SeedCsharpNamespaceCollision/SeedCsharpNamespaceCollision.csproj
+++ b/seed/csharp-sdk/csharp-namespace-collision/fully-qualified-namespaces/src/SeedCsharpNamespaceCollision/SeedCsharpNamespaceCollision.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
   </ItemGroup>
-  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/csharp-namespace-collision/fully-qualified-namespaces/src/SeedCsharpNamespaceCollision/SeedCsharpNamespaceCollision.csproj
+++ b/seed/csharp-sdk/csharp-namespace-collision/fully-qualified-namespaces/src/SeedCsharpNamespaceCollision/SeedCsharpNamespaceCollision.csproj
@@ -39,11 +39,11 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
-    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/csharp-namespace-collision/fully-qualified-namespaces/src/SeedCsharpNamespaceCollision/SeedCsharpNamespaceCollision.csproj
+++ b/seed/csharp-sdk/csharp-namespace-collision/fully-qualified-namespaces/src/SeedCsharpNamespaceCollision/SeedCsharpNamespaceCollision.csproj
@@ -39,6 +39,8 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+  </ItemGroup>
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/csharp-namespace-collision/namespace-client-collision/src/Contoso.Net/Contoso.Net.csproj
+++ b/seed/csharp-sdk/csharp-namespace-collision/namespace-client-collision/src/Contoso.Net/Contoso.Net.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
   </ItemGroup>
-  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/csharp-namespace-collision/namespace-client-collision/src/Contoso.Net/Contoso.Net.csproj
+++ b/seed/csharp-sdk/csharp-namespace-collision/namespace-client-collision/src/Contoso.Net/Contoso.Net.csproj
@@ -39,11 +39,11 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
-    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/csharp-namespace-collision/namespace-client-collision/src/Contoso.Net/Contoso.Net.csproj
+++ b/seed/csharp-sdk/csharp-namespace-collision/namespace-client-collision/src/Contoso.Net/Contoso.Net.csproj
@@ -39,6 +39,8 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+  </ItemGroup>
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/csharp-namespace-conflict/client-class-name-matches-namespace-root/src/Seed.CsharpNamespaceConflict/Seed.CsharpNamespaceConflict.csproj
+++ b/seed/csharp-sdk/csharp-namespace-conflict/client-class-name-matches-namespace-root/src/Seed.CsharpNamespaceConflict/Seed.CsharpNamespaceConflict.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
   </ItemGroup>
-  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/csharp-namespace-conflict/client-class-name-matches-namespace-root/src/Seed.CsharpNamespaceConflict/Seed.CsharpNamespaceConflict.csproj
+++ b/seed/csharp-sdk/csharp-namespace-conflict/client-class-name-matches-namespace-root/src/Seed.CsharpNamespaceConflict/Seed.CsharpNamespaceConflict.csproj
@@ -39,11 +39,11 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
-    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/csharp-namespace-conflict/client-class-name-matches-namespace-root/src/Seed.CsharpNamespaceConflict/Seed.CsharpNamespaceConflict.csproj
+++ b/seed/csharp-sdk/csharp-namespace-conflict/client-class-name-matches-namespace-root/src/Seed.CsharpNamespaceConflict/Seed.CsharpNamespaceConflict.csproj
@@ -39,6 +39,8 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+  </ItemGroup>
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/csharp-readonly-request/src/SeedCsharpReadonlyRequest/SeedCsharpReadonlyRequest.csproj
+++ b/seed/csharp-sdk/csharp-readonly-request/src/SeedCsharpReadonlyRequest/SeedCsharpReadonlyRequest.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
   </ItemGroup>
-  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/csharp-readonly-request/src/SeedCsharpReadonlyRequest/SeedCsharpReadonlyRequest.csproj
+++ b/seed/csharp-sdk/csharp-readonly-request/src/SeedCsharpReadonlyRequest/SeedCsharpReadonlyRequest.csproj
@@ -39,11 +39,11 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
-    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/csharp-readonly-request/src/SeedCsharpReadonlyRequest/SeedCsharpReadonlyRequest.csproj
+++ b/seed/csharp-sdk/csharp-readonly-request/src/SeedCsharpReadonlyRequest/SeedCsharpReadonlyRequest.csproj
@@ -39,6 +39,8 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+  </ItemGroup>
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/csharp-system-collision/system-client/src/SeedCsharpSystemCollision/SeedCsharpSystemCollision.csproj
+++ b/seed/csharp-sdk/csharp-system-collision/system-client/src/SeedCsharpSystemCollision/SeedCsharpSystemCollision.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
   </ItemGroup>
-  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/csharp-system-collision/system-client/src/SeedCsharpSystemCollision/SeedCsharpSystemCollision.csproj
+++ b/seed/csharp-sdk/csharp-system-collision/system-client/src/SeedCsharpSystemCollision/SeedCsharpSystemCollision.csproj
@@ -39,11 +39,11 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
-    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/csharp-system-collision/system-client/src/SeedCsharpSystemCollision/SeedCsharpSystemCollision.csproj
+++ b/seed/csharp-sdk/csharp-system-collision/system-client/src/SeedCsharpSystemCollision/SeedCsharpSystemCollision.csproj
@@ -39,6 +39,8 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+  </ItemGroup>
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/csharp-xml-entities/no-custom-config/src/SeedCsharpXmlEntities/SeedCsharpXmlEntities.csproj
+++ b/seed/csharp-sdk/csharp-xml-entities/no-custom-config/src/SeedCsharpXmlEntities/SeedCsharpXmlEntities.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
   </ItemGroup>
-  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/csharp-xml-entities/no-custom-config/src/SeedCsharpXmlEntities/SeedCsharpXmlEntities.csproj
+++ b/seed/csharp-sdk/csharp-xml-entities/no-custom-config/src/SeedCsharpXmlEntities/SeedCsharpXmlEntities.csproj
@@ -39,11 +39,11 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
-    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/csharp-xml-entities/no-custom-config/src/SeedCsharpXmlEntities/SeedCsharpXmlEntities.csproj
+++ b/seed/csharp-sdk/csharp-xml-entities/no-custom-config/src/SeedCsharpXmlEntities/SeedCsharpXmlEntities.csproj
@@ -39,6 +39,8 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+  </ItemGroup>
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/dollar-string-examples/src/SeedDollarStringExamples/SeedDollarStringExamples.csproj
+++ b/seed/csharp-sdk/dollar-string-examples/src/SeedDollarStringExamples/SeedDollarStringExamples.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
   </ItemGroup>
-  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/dollar-string-examples/src/SeedDollarStringExamples/SeedDollarStringExamples.csproj
+++ b/seed/csharp-sdk/dollar-string-examples/src/SeedDollarStringExamples/SeedDollarStringExamples.csproj
@@ -39,11 +39,11 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
-    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/dollar-string-examples/src/SeedDollarStringExamples/SeedDollarStringExamples.csproj
+++ b/seed/csharp-sdk/dollar-string-examples/src/SeedDollarStringExamples/SeedDollarStringExamples.csproj
@@ -39,6 +39,8 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+  </ItemGroup>
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/empty-clients/src/SeedEmptyClients/SeedEmptyClients.csproj
+++ b/seed/csharp-sdk/empty-clients/src/SeedEmptyClients/SeedEmptyClients.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
   </ItemGroup>
-  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/empty-clients/src/SeedEmptyClients/SeedEmptyClients.csproj
+++ b/seed/csharp-sdk/empty-clients/src/SeedEmptyClients/SeedEmptyClients.csproj
@@ -39,11 +39,11 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
-    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/empty-clients/src/SeedEmptyClients/SeedEmptyClients.csproj
+++ b/seed/csharp-sdk/empty-clients/src/SeedEmptyClients/SeedEmptyClients.csproj
@@ -39,6 +39,8 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+  </ItemGroup>
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/endpoint-security-auth/src/SeedEndpointSecurityAuth/SeedEndpointSecurityAuth.csproj
+++ b/seed/csharp-sdk/endpoint-security-auth/src/SeedEndpointSecurityAuth/SeedEndpointSecurityAuth.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
   </ItemGroup>
-  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/endpoint-security-auth/src/SeedEndpointSecurityAuth/SeedEndpointSecurityAuth.csproj
+++ b/seed/csharp-sdk/endpoint-security-auth/src/SeedEndpointSecurityAuth/SeedEndpointSecurityAuth.csproj
@@ -39,11 +39,11 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
-    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/endpoint-security-auth/src/SeedEndpointSecurityAuth/SeedEndpointSecurityAuth.csproj
+++ b/seed/csharp-sdk/endpoint-security-auth/src/SeedEndpointSecurityAuth/SeedEndpointSecurityAuth.csproj
@@ -39,6 +39,8 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+  </ItemGroup>
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/enum/forward-compatible-enums/src/SeedEnum/SeedEnum.csproj
+++ b/seed/csharp-sdk/enum/forward-compatible-enums/src/SeedEnum/SeedEnum.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
   </ItemGroup>
-  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/enum/forward-compatible-enums/src/SeedEnum/SeedEnum.csproj
+++ b/seed/csharp-sdk/enum/forward-compatible-enums/src/SeedEnum/SeedEnum.csproj
@@ -39,11 +39,11 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
-    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/enum/forward-compatible-enums/src/SeedEnum/SeedEnum.csproj
+++ b/seed/csharp-sdk/enum/forward-compatible-enums/src/SeedEnum/SeedEnum.csproj
@@ -39,6 +39,8 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+  </ItemGroup>
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/enum/plain-enums/src/SeedEnum/SeedEnum.csproj
+++ b/seed/csharp-sdk/enum/plain-enums/src/SeedEnum/SeedEnum.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
   </ItemGroup>
-  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/enum/plain-enums/src/SeedEnum/SeedEnum.csproj
+++ b/seed/csharp-sdk/enum/plain-enums/src/SeedEnum/SeedEnum.csproj
@@ -39,11 +39,11 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
-    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/enum/plain-enums/src/SeedEnum/SeedEnum.csproj
+++ b/seed/csharp-sdk/enum/plain-enums/src/SeedEnum/SeedEnum.csproj
@@ -39,6 +39,8 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+  </ItemGroup>
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/error-property/src/SeedErrorProperty/SeedErrorProperty.csproj
+++ b/seed/csharp-sdk/error-property/src/SeedErrorProperty/SeedErrorProperty.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
   </ItemGroup>
-  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/error-property/src/SeedErrorProperty/SeedErrorProperty.csproj
+++ b/seed/csharp-sdk/error-property/src/SeedErrorProperty/SeedErrorProperty.csproj
@@ -39,11 +39,11 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
-    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/error-property/src/SeedErrorProperty/SeedErrorProperty.csproj
+++ b/seed/csharp-sdk/error-property/src/SeedErrorProperty/SeedErrorProperty.csproj
@@ -39,6 +39,8 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+  </ItemGroup>
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/errors/src/SeedErrors/SeedErrors.csproj
+++ b/seed/csharp-sdk/errors/src/SeedErrors/SeedErrors.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
   </ItemGroup>
-  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/errors/src/SeedErrors/SeedErrors.csproj
+++ b/seed/csharp-sdk/errors/src/SeedErrors/SeedErrors.csproj
@@ -39,11 +39,11 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
-    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/errors/src/SeedErrors/SeedErrors.csproj
+++ b/seed/csharp-sdk/errors/src/SeedErrors/SeedErrors.csproj
@@ -39,6 +39,8 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+  </ItemGroup>
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/examples/no-custom-config/src/SeedExamples/SeedExamples.csproj
+++ b/seed/csharp-sdk/examples/no-custom-config/src/SeedExamples/SeedExamples.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
   </ItemGroup>
-  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/examples/no-custom-config/src/SeedExamples/SeedExamples.csproj
+++ b/seed/csharp-sdk/examples/no-custom-config/src/SeedExamples/SeedExamples.csproj
@@ -39,11 +39,11 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
-    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/examples/no-custom-config/src/SeedExamples/SeedExamples.csproj
+++ b/seed/csharp-sdk/examples/no-custom-config/src/SeedExamples/SeedExamples.csproj
@@ -39,6 +39,8 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+  </ItemGroup>
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/examples/readme-config/src/SeedExamples/SeedExamples.csproj
+++ b/seed/csharp-sdk/examples/readme-config/src/SeedExamples/SeedExamples.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
   </ItemGroup>
-  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/examples/readme-config/src/SeedExamples/SeedExamples.csproj
+++ b/seed/csharp-sdk/examples/readme-config/src/SeedExamples/SeedExamples.csproj
@@ -39,11 +39,11 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
-    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/examples/readme-config/src/SeedExamples/SeedExamples.csproj
+++ b/seed/csharp-sdk/examples/readme-config/src/SeedExamples/SeedExamples.csproj
@@ -39,6 +39,8 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+  </ItemGroup>
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/exhaustive/explicit-namespaces/src/SeedExhaustive/SeedExhaustive.csproj
+++ b/seed/csharp-sdk/exhaustive/explicit-namespaces/src/SeedExhaustive/SeedExhaustive.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
   </ItemGroup>
-  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/exhaustive/explicit-namespaces/src/SeedExhaustive/SeedExhaustive.csproj
+++ b/seed/csharp-sdk/exhaustive/explicit-namespaces/src/SeedExhaustive/SeedExhaustive.csproj
@@ -39,11 +39,11 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
-    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/exhaustive/explicit-namespaces/src/SeedExhaustive/SeedExhaustive.csproj
+++ b/seed/csharp-sdk/exhaustive/explicit-namespaces/src/SeedExhaustive/SeedExhaustive.csproj
@@ -39,6 +39,8 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+  </ItemGroup>
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/exhaustive/include-exception-handler/src/SeedExhaustive/SeedExhaustive.csproj
+++ b/seed/csharp-sdk/exhaustive/include-exception-handler/src/SeedExhaustive/SeedExhaustive.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
   </ItemGroup>
-  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/exhaustive/include-exception-handler/src/SeedExhaustive/SeedExhaustive.csproj
+++ b/seed/csharp-sdk/exhaustive/include-exception-handler/src/SeedExhaustive/SeedExhaustive.csproj
@@ -39,11 +39,11 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
-    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/exhaustive/include-exception-handler/src/SeedExhaustive/SeedExhaustive.csproj
+++ b/seed/csharp-sdk/exhaustive/include-exception-handler/src/SeedExhaustive/SeedExhaustive.csproj
@@ -39,6 +39,8 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+  </ItemGroup>
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/exhaustive/no-generate-error-types/src/SeedExhaustive/SeedExhaustive.csproj
+++ b/seed/csharp-sdk/exhaustive/no-generate-error-types/src/SeedExhaustive/SeedExhaustive.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
   </ItemGroup>
-  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/exhaustive/no-generate-error-types/src/SeedExhaustive/SeedExhaustive.csproj
+++ b/seed/csharp-sdk/exhaustive/no-generate-error-types/src/SeedExhaustive/SeedExhaustive.csproj
@@ -39,11 +39,11 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
-    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/exhaustive/no-generate-error-types/src/SeedExhaustive/SeedExhaustive.csproj
+++ b/seed/csharp-sdk/exhaustive/no-generate-error-types/src/SeedExhaustive/SeedExhaustive.csproj
@@ -39,6 +39,8 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+  </ItemGroup>
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/exhaustive/no-root-namespace-for-core-classes/src/SeedExhaustive/SeedExhaustive.csproj
+++ b/seed/csharp-sdk/exhaustive/no-root-namespace-for-core-classes/src/SeedExhaustive/SeedExhaustive.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
   </ItemGroup>
-  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/exhaustive/no-root-namespace-for-core-classes/src/SeedExhaustive/SeedExhaustive.csproj
+++ b/seed/csharp-sdk/exhaustive/no-root-namespace-for-core-classes/src/SeedExhaustive/SeedExhaustive.csproj
@@ -39,11 +39,11 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
-    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/exhaustive/no-root-namespace-for-core-classes/src/SeedExhaustive/SeedExhaustive.csproj
+++ b/seed/csharp-sdk/exhaustive/no-root-namespace-for-core-classes/src/SeedExhaustive/SeedExhaustive.csproj
@@ -39,6 +39,8 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+  </ItemGroup>
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/exhaustive/redact-response-body-on-error/src/SeedExhaustive/SeedExhaustive.csproj
+++ b/seed/csharp-sdk/exhaustive/redact-response-body-on-error/src/SeedExhaustive/SeedExhaustive.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
   </ItemGroup>
-  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/exhaustive/redact-response-body-on-error/src/SeedExhaustive/SeedExhaustive.csproj
+++ b/seed/csharp-sdk/exhaustive/redact-response-body-on-error/src/SeedExhaustive/SeedExhaustive.csproj
@@ -39,11 +39,11 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
-    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/exhaustive/redact-response-body-on-error/src/SeedExhaustive/SeedExhaustive.csproj
+++ b/seed/csharp-sdk/exhaustive/redact-response-body-on-error/src/SeedExhaustive/SeedExhaustive.csproj
@@ -39,6 +39,8 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+  </ItemGroup>
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/exhaustive/use-undiscriminated-unions/src/SeedExhaustive/SeedExhaustive.csproj
+++ b/seed/csharp-sdk/exhaustive/use-undiscriminated-unions/src/SeedExhaustive/SeedExhaustive.csproj
@@ -38,7 +38,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
   </ItemGroup>
-  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/exhaustive/use-undiscriminated-unions/src/SeedExhaustive/SeedExhaustive.csproj
+++ b/seed/csharp-sdk/exhaustive/use-undiscriminated-unions/src/SeedExhaustive/SeedExhaustive.csproj
@@ -37,11 +37,10 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
+    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/exhaustive/use-undiscriminated-unions/src/SeedExhaustive/SeedExhaustive.csproj
+++ b/seed/csharp-sdk/exhaustive/use-undiscriminated-unions/src/SeedExhaustive/SeedExhaustive.csproj
@@ -37,6 +37,8 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
+  </ItemGroup>
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/exhaustive/use-undiscriminated-unions/src/SeedExhaustive/SeedExhaustive.csproj
+++ b/seed/csharp-sdk/exhaustive/use-undiscriminated-unions/src/SeedExhaustive/SeedExhaustive.csproj
@@ -40,8 +40,6 @@
   </ItemGroup>
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
-    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/exhaustive/use-undiscriminated-unions/src/SeedExhaustive/SeedExhaustive.csproj
+++ b/seed/csharp-sdk/exhaustive/use-undiscriminated-unions/src/SeedExhaustive/SeedExhaustive.csproj
@@ -37,6 +37,8 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
+    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />

--- a/seed/csharp-sdk/extends/src/SeedExtends/SeedExtends.csproj
+++ b/seed/csharp-sdk/extends/src/SeedExtends/SeedExtends.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
   </ItemGroup>
-  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/extends/src/SeedExtends/SeedExtends.csproj
+++ b/seed/csharp-sdk/extends/src/SeedExtends/SeedExtends.csproj
@@ -39,11 +39,11 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
-    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/extends/src/SeedExtends/SeedExtends.csproj
+++ b/seed/csharp-sdk/extends/src/SeedExtends/SeedExtends.csproj
@@ -39,6 +39,8 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+  </ItemGroup>
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/extra-properties/src/SeedExtraProperties/SeedExtraProperties.csproj
+++ b/seed/csharp-sdk/extra-properties/src/SeedExtraProperties/SeedExtraProperties.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
   </ItemGroup>
-  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/extra-properties/src/SeedExtraProperties/SeedExtraProperties.csproj
+++ b/seed/csharp-sdk/extra-properties/src/SeedExtraProperties/SeedExtraProperties.csproj
@@ -39,11 +39,11 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
-    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/extra-properties/src/SeedExtraProperties/SeedExtraProperties.csproj
+++ b/seed/csharp-sdk/extra-properties/src/SeedExtraProperties/SeedExtraProperties.csproj
@@ -39,6 +39,8 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+  </ItemGroup>
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/file-download/src/SeedFileDownload/SeedFileDownload.csproj
+++ b/seed/csharp-sdk/file-download/src/SeedFileDownload/SeedFileDownload.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
   </ItemGroup>
-  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/file-download/src/SeedFileDownload/SeedFileDownload.csproj
+++ b/seed/csharp-sdk/file-download/src/SeedFileDownload/SeedFileDownload.csproj
@@ -39,11 +39,11 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
-    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/file-download/src/SeedFileDownload/SeedFileDownload.csproj
+++ b/seed/csharp-sdk/file-download/src/SeedFileDownload/SeedFileDownload.csproj
@@ -39,6 +39,8 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+  </ItemGroup>
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/file-upload-openapi/src/SeedApi/SeedApi.csproj
+++ b/seed/csharp-sdk/file-upload-openapi/src/SeedApi/SeedApi.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
   </ItemGroup>
-  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/file-upload-openapi/src/SeedApi/SeedApi.csproj
+++ b/seed/csharp-sdk/file-upload-openapi/src/SeedApi/SeedApi.csproj
@@ -39,11 +39,11 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
-    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/file-upload-openapi/src/SeedApi/SeedApi.csproj
+++ b/seed/csharp-sdk/file-upload-openapi/src/SeedApi/SeedApi.csproj
@@ -39,6 +39,8 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+  </ItemGroup>
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/file-upload/src/SeedFileUpload/SeedFileUpload.csproj
+++ b/seed/csharp-sdk/file-upload/src/SeedFileUpload/SeedFileUpload.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
   </ItemGroup>
-  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/file-upload/src/SeedFileUpload/SeedFileUpload.csproj
+++ b/seed/csharp-sdk/file-upload/src/SeedFileUpload/SeedFileUpload.csproj
@@ -39,11 +39,11 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
-    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/file-upload/src/SeedFileUpload/SeedFileUpload.csproj
+++ b/seed/csharp-sdk/file-upload/src/SeedFileUpload/SeedFileUpload.csproj
@@ -39,6 +39,8 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+  </ItemGroup>
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/folders/src/SeedApi/SeedApi.csproj
+++ b/seed/csharp-sdk/folders/src/SeedApi/SeedApi.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
   </ItemGroup>
-  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/folders/src/SeedApi/SeedApi.csproj
+++ b/seed/csharp-sdk/folders/src/SeedApi/SeedApi.csproj
@@ -39,11 +39,11 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
-    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/folders/src/SeedApi/SeedApi.csproj
+++ b/seed/csharp-sdk/folders/src/SeedApi/SeedApi.csproj
@@ -39,6 +39,8 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+  </ItemGroup>
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/header-auth-environment-variable/src/SeedHeaderTokenEnvironmentVariable/SeedHeaderTokenEnvironmentVariable.csproj
+++ b/seed/csharp-sdk/header-auth-environment-variable/src/SeedHeaderTokenEnvironmentVariable/SeedHeaderTokenEnvironmentVariable.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
   </ItemGroup>
-  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/header-auth-environment-variable/src/SeedHeaderTokenEnvironmentVariable/SeedHeaderTokenEnvironmentVariable.csproj
+++ b/seed/csharp-sdk/header-auth-environment-variable/src/SeedHeaderTokenEnvironmentVariable/SeedHeaderTokenEnvironmentVariable.csproj
@@ -39,11 +39,11 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
-    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/header-auth-environment-variable/src/SeedHeaderTokenEnvironmentVariable/SeedHeaderTokenEnvironmentVariable.csproj
+++ b/seed/csharp-sdk/header-auth-environment-variable/src/SeedHeaderTokenEnvironmentVariable/SeedHeaderTokenEnvironmentVariable.csproj
@@ -39,6 +39,8 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+  </ItemGroup>
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/header-auth/src/SeedHeaderToken/SeedHeaderToken.csproj
+++ b/seed/csharp-sdk/header-auth/src/SeedHeaderToken/SeedHeaderToken.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
   </ItemGroup>
-  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/header-auth/src/SeedHeaderToken/SeedHeaderToken.csproj
+++ b/seed/csharp-sdk/header-auth/src/SeedHeaderToken/SeedHeaderToken.csproj
@@ -39,11 +39,11 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
-    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/header-auth/src/SeedHeaderToken/SeedHeaderToken.csproj
+++ b/seed/csharp-sdk/header-auth/src/SeedHeaderToken/SeedHeaderToken.csproj
@@ -39,6 +39,8 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+  </ItemGroup>
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/http-head/src/SeedHttpHead/SeedHttpHead.csproj
+++ b/seed/csharp-sdk/http-head/src/SeedHttpHead/SeedHttpHead.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
   </ItemGroup>
-  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/http-head/src/SeedHttpHead/SeedHttpHead.csproj
+++ b/seed/csharp-sdk/http-head/src/SeedHttpHead/SeedHttpHead.csproj
@@ -39,11 +39,11 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
-    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/http-head/src/SeedHttpHead/SeedHttpHead.csproj
+++ b/seed/csharp-sdk/http-head/src/SeedHttpHead/SeedHttpHead.csproj
@@ -39,6 +39,8 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+  </ItemGroup>
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/idempotency-headers/src/SeedIdempotencyHeaders/SeedIdempotencyHeaders.csproj
+++ b/seed/csharp-sdk/idempotency-headers/src/SeedIdempotencyHeaders/SeedIdempotencyHeaders.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
   </ItemGroup>
-  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/idempotency-headers/src/SeedIdempotencyHeaders/SeedIdempotencyHeaders.csproj
+++ b/seed/csharp-sdk/idempotency-headers/src/SeedIdempotencyHeaders/SeedIdempotencyHeaders.csproj
@@ -39,11 +39,11 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
-    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/idempotency-headers/src/SeedIdempotencyHeaders/SeedIdempotencyHeaders.csproj
+++ b/seed/csharp-sdk/idempotency-headers/src/SeedIdempotencyHeaders/SeedIdempotencyHeaders.csproj
@@ -39,6 +39,8 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+  </ItemGroup>
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/imdb/exception-class-names/src/SeedApi/SeedApi.csproj
+++ b/seed/csharp-sdk/imdb/exception-class-names/src/SeedApi/SeedApi.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
   </ItemGroup>
-  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/imdb/exception-class-names/src/SeedApi/SeedApi.csproj
+++ b/seed/csharp-sdk/imdb/exception-class-names/src/SeedApi/SeedApi.csproj
@@ -39,11 +39,11 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
-    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/imdb/exception-class-names/src/SeedApi/SeedApi.csproj
+++ b/seed/csharp-sdk/imdb/exception-class-names/src/SeedApi/SeedApi.csproj
@@ -39,6 +39,8 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+  </ItemGroup>
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/imdb/exported-client-class-name/src/SeedApi/SeedApi.csproj
+++ b/seed/csharp-sdk/imdb/exported-client-class-name/src/SeedApi/SeedApi.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
   </ItemGroup>
-  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/imdb/exported-client-class-name/src/SeedApi/SeedApi.csproj
+++ b/seed/csharp-sdk/imdb/exported-client-class-name/src/SeedApi/SeedApi.csproj
@@ -39,11 +39,11 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
-    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/imdb/exported-client-class-name/src/SeedApi/SeedApi.csproj
+++ b/seed/csharp-sdk/imdb/exported-client-class-name/src/SeedApi/SeedApi.csproj
@@ -39,6 +39,8 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+  </ItemGroup>
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/imdb/extra-dependencies/src/SeedApi/SeedApi.csproj
+++ b/seed/csharp-sdk/imdb/extra-dependencies/src/SeedApi/SeedApi.csproj
@@ -39,11 +39,13 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+    <PackageReference Include="Moq" Version="4.20.70" />
+    <PackageReference Include="Moq.Contrib.HttpClient" Version="1.4.0" />
+  </ItemGroup>
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
-    <PackageReference Include="Moq" Version="4.20.70" />
-    <PackageReference Include="Moq.Contrib.HttpClient" Version="1.4.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/imdb/extra-dependencies/src/SeedApi/SeedApi.csproj
+++ b/seed/csharp-sdk/imdb/extra-dependencies/src/SeedApi/SeedApi.csproj
@@ -39,13 +39,13 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
     <PackageReference Include="Moq" Version="4.20.70" />
     <PackageReference Include="Moq.Contrib.HttpClient" Version="1.4.0" />
   </ItemGroup>
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
-    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/imdb/extra-dependencies/src/SeedApi/SeedApi.csproj
+++ b/seed/csharp-sdk/imdb/extra-dependencies/src/SeedApi/SeedApi.csproj
@@ -42,7 +42,7 @@
     <PackageReference Include="Moq" Version="4.20.70" />
     <PackageReference Include="Moq.Contrib.HttpClient" Version="1.4.0" />
   </ItemGroup>
-  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/imdb/include-exception-handler/src/SeedApi/SeedApi.csproj
+++ b/seed/csharp-sdk/imdb/include-exception-handler/src/SeedApi/SeedApi.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
   </ItemGroup>
-  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/imdb/include-exception-handler/src/SeedApi/SeedApi.csproj
+++ b/seed/csharp-sdk/imdb/include-exception-handler/src/SeedApi/SeedApi.csproj
@@ -39,11 +39,11 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
-    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/imdb/include-exception-handler/src/SeedApi/SeedApi.csproj
+++ b/seed/csharp-sdk/imdb/include-exception-handler/src/SeedApi/SeedApi.csproj
@@ -39,6 +39,8 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+  </ItemGroup>
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/imdb/no-custom-config/src/SeedApi/SeedApi.csproj
+++ b/seed/csharp-sdk/imdb/no-custom-config/src/SeedApi/SeedApi.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
   </ItemGroup>
-  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/imdb/no-custom-config/src/SeedApi/SeedApi.csproj
+++ b/seed/csharp-sdk/imdb/no-custom-config/src/SeedApi/SeedApi.csproj
@@ -39,11 +39,11 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
-    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/imdb/no-custom-config/src/SeedApi/SeedApi.csproj
+++ b/seed/csharp-sdk/imdb/no-custom-config/src/SeedApi/SeedApi.csproj
@@ -39,6 +39,8 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+  </ItemGroup>
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/imdb/omit-fern-headers/src/SeedApi/SeedApi.csproj
+++ b/seed/csharp-sdk/imdb/omit-fern-headers/src/SeedApi/SeedApi.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
   </ItemGroup>
-  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/imdb/omit-fern-headers/src/SeedApi/SeedApi.csproj
+++ b/seed/csharp-sdk/imdb/omit-fern-headers/src/SeedApi/SeedApi.csproj
@@ -39,11 +39,11 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
-    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/imdb/omit-fern-headers/src/SeedApi/SeedApi.csproj
+++ b/seed/csharp-sdk/imdb/omit-fern-headers/src/SeedApi/SeedApi.csproj
@@ -39,6 +39,8 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+  </ItemGroup>
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/inferred-auth-explicit/src/SeedInferredAuthExplicit/SeedInferredAuthExplicit.csproj
+++ b/seed/csharp-sdk/inferred-auth-explicit/src/SeedInferredAuthExplicit/SeedInferredAuthExplicit.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
   </ItemGroup>
-  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/inferred-auth-explicit/src/SeedInferredAuthExplicit/SeedInferredAuthExplicit.csproj
+++ b/seed/csharp-sdk/inferred-auth-explicit/src/SeedInferredAuthExplicit/SeedInferredAuthExplicit.csproj
@@ -39,11 +39,11 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
-    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/inferred-auth-explicit/src/SeedInferredAuthExplicit/SeedInferredAuthExplicit.csproj
+++ b/seed/csharp-sdk/inferred-auth-explicit/src/SeedInferredAuthExplicit/SeedInferredAuthExplicit.csproj
@@ -39,6 +39,8 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+  </ItemGroup>
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/inferred-auth-implicit-api-key/src/SeedInferredAuthImplicitApiKey/SeedInferredAuthImplicitApiKey.csproj
+++ b/seed/csharp-sdk/inferred-auth-implicit-api-key/src/SeedInferredAuthImplicitApiKey/SeedInferredAuthImplicitApiKey.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
   </ItemGroup>
-  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/inferred-auth-implicit-api-key/src/SeedInferredAuthImplicitApiKey/SeedInferredAuthImplicitApiKey.csproj
+++ b/seed/csharp-sdk/inferred-auth-implicit-api-key/src/SeedInferredAuthImplicitApiKey/SeedInferredAuthImplicitApiKey.csproj
@@ -39,11 +39,11 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
-    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/inferred-auth-implicit-api-key/src/SeedInferredAuthImplicitApiKey/SeedInferredAuthImplicitApiKey.csproj
+++ b/seed/csharp-sdk/inferred-auth-implicit-api-key/src/SeedInferredAuthImplicitApiKey/SeedInferredAuthImplicitApiKey.csproj
@@ -39,6 +39,8 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+  </ItemGroup>
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/inferred-auth-implicit-no-expiry/src/SeedInferredAuthImplicitNoExpiry/SeedInferredAuthImplicitNoExpiry.csproj
+++ b/seed/csharp-sdk/inferred-auth-implicit-no-expiry/src/SeedInferredAuthImplicitNoExpiry/SeedInferredAuthImplicitNoExpiry.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
   </ItemGroup>
-  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/inferred-auth-implicit-no-expiry/src/SeedInferredAuthImplicitNoExpiry/SeedInferredAuthImplicitNoExpiry.csproj
+++ b/seed/csharp-sdk/inferred-auth-implicit-no-expiry/src/SeedInferredAuthImplicitNoExpiry/SeedInferredAuthImplicitNoExpiry.csproj
@@ -39,11 +39,11 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
-    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/inferred-auth-implicit-no-expiry/src/SeedInferredAuthImplicitNoExpiry/SeedInferredAuthImplicitNoExpiry.csproj
+++ b/seed/csharp-sdk/inferred-auth-implicit-no-expiry/src/SeedInferredAuthImplicitNoExpiry/SeedInferredAuthImplicitNoExpiry.csproj
@@ -39,6 +39,8 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+  </ItemGroup>
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/inferred-auth-implicit-reference/src/SeedInferredAuthImplicit/SeedInferredAuthImplicit.csproj
+++ b/seed/csharp-sdk/inferred-auth-implicit-reference/src/SeedInferredAuthImplicit/SeedInferredAuthImplicit.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
   </ItemGroup>
-  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/inferred-auth-implicit-reference/src/SeedInferredAuthImplicit/SeedInferredAuthImplicit.csproj
+++ b/seed/csharp-sdk/inferred-auth-implicit-reference/src/SeedInferredAuthImplicit/SeedInferredAuthImplicit.csproj
@@ -39,11 +39,11 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
-    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/inferred-auth-implicit-reference/src/SeedInferredAuthImplicit/SeedInferredAuthImplicit.csproj
+++ b/seed/csharp-sdk/inferred-auth-implicit-reference/src/SeedInferredAuthImplicit/SeedInferredAuthImplicit.csproj
@@ -39,6 +39,8 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+  </ItemGroup>
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/inferred-auth-implicit/src/SeedInferredAuthImplicit/SeedInferredAuthImplicit.csproj
+++ b/seed/csharp-sdk/inferred-auth-implicit/src/SeedInferredAuthImplicit/SeedInferredAuthImplicit.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
   </ItemGroup>
-  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/inferred-auth-implicit/src/SeedInferredAuthImplicit/SeedInferredAuthImplicit.csproj
+++ b/seed/csharp-sdk/inferred-auth-implicit/src/SeedInferredAuthImplicit/SeedInferredAuthImplicit.csproj
@@ -39,11 +39,11 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
-    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/inferred-auth-implicit/src/SeedInferredAuthImplicit/SeedInferredAuthImplicit.csproj
+++ b/seed/csharp-sdk/inferred-auth-implicit/src/SeedInferredAuthImplicit/SeedInferredAuthImplicit.csproj
@@ -39,6 +39,8 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+  </ItemGroup>
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/license/custom-license/src/SeedLicense/SeedLicense.csproj
+++ b/seed/csharp-sdk/license/custom-license/src/SeedLicense/SeedLicense.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
   </ItemGroup>
-  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/license/custom-license/src/SeedLicense/SeedLicense.csproj
+++ b/seed/csharp-sdk/license/custom-license/src/SeedLicense/SeedLicense.csproj
@@ -39,11 +39,11 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
-    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/license/custom-license/src/SeedLicense/SeedLicense.csproj
+++ b/seed/csharp-sdk/license/custom-license/src/SeedLicense/SeedLicense.csproj
@@ -39,6 +39,8 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+  </ItemGroup>
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/license/mit-license/src/SeedLicense/SeedLicense.csproj
+++ b/seed/csharp-sdk/license/mit-license/src/SeedLicense/SeedLicense.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
   </ItemGroup>
-  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/license/mit-license/src/SeedLicense/SeedLicense.csproj
+++ b/seed/csharp-sdk/license/mit-license/src/SeedLicense/SeedLicense.csproj
@@ -39,11 +39,11 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
-    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/license/mit-license/src/SeedLicense/SeedLicense.csproj
+++ b/seed/csharp-sdk/license/mit-license/src/SeedLicense/SeedLicense.csproj
@@ -39,6 +39,8 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+  </ItemGroup>
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/literal/no-custom-config/src/SeedLiteral/SeedLiteral.csproj
+++ b/seed/csharp-sdk/literal/no-custom-config/src/SeedLiteral/SeedLiteral.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
   </ItemGroup>
-  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/literal/no-custom-config/src/SeedLiteral/SeedLiteral.csproj
+++ b/seed/csharp-sdk/literal/no-custom-config/src/SeedLiteral/SeedLiteral.csproj
@@ -39,11 +39,11 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
-    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/literal/no-custom-config/src/SeedLiteral/SeedLiteral.csproj
+++ b/seed/csharp-sdk/literal/no-custom-config/src/SeedLiteral/SeedLiteral.csproj
@@ -39,6 +39,8 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+  </ItemGroup>
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/literal/readonly-constants/src/SeedLiteral/SeedLiteral.csproj
+++ b/seed/csharp-sdk/literal/readonly-constants/src/SeedLiteral/SeedLiteral.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
   </ItemGroup>
-  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/literal/readonly-constants/src/SeedLiteral/SeedLiteral.csproj
+++ b/seed/csharp-sdk/literal/readonly-constants/src/SeedLiteral/SeedLiteral.csproj
@@ -39,11 +39,11 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
-    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/literal/readonly-constants/src/SeedLiteral/SeedLiteral.csproj
+++ b/seed/csharp-sdk/literal/readonly-constants/src/SeedLiteral/SeedLiteral.csproj
@@ -39,6 +39,8 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+  </ItemGroup>
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/literals-unions/src/SeedLiteralsUnions/SeedLiteralsUnions.csproj
+++ b/seed/csharp-sdk/literals-unions/src/SeedLiteralsUnions/SeedLiteralsUnions.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
   </ItemGroup>
-  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/literals-unions/src/SeedLiteralsUnions/SeedLiteralsUnions.csproj
+++ b/seed/csharp-sdk/literals-unions/src/SeedLiteralsUnions/SeedLiteralsUnions.csproj
@@ -39,11 +39,11 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
-    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/literals-unions/src/SeedLiteralsUnions/SeedLiteralsUnions.csproj
+++ b/seed/csharp-sdk/literals-unions/src/SeedLiteralsUnions/SeedLiteralsUnions.csproj
@@ -39,6 +39,8 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+  </ItemGroup>
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/mixed-case/src/SeedMixedCase/SeedMixedCase.csproj
+++ b/seed/csharp-sdk/mixed-case/src/SeedMixedCase/SeedMixedCase.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
   </ItemGroup>
-  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/mixed-case/src/SeedMixedCase/SeedMixedCase.csproj
+++ b/seed/csharp-sdk/mixed-case/src/SeedMixedCase/SeedMixedCase.csproj
@@ -39,11 +39,11 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
-    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/mixed-case/src/SeedMixedCase/SeedMixedCase.csproj
+++ b/seed/csharp-sdk/mixed-case/src/SeedMixedCase/SeedMixedCase.csproj
@@ -39,6 +39,8 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+  </ItemGroup>
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/mixed-file-directory/src/SeedMixedFileDirectory/SeedMixedFileDirectory.csproj
+++ b/seed/csharp-sdk/mixed-file-directory/src/SeedMixedFileDirectory/SeedMixedFileDirectory.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
   </ItemGroup>
-  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/mixed-file-directory/src/SeedMixedFileDirectory/SeedMixedFileDirectory.csproj
+++ b/seed/csharp-sdk/mixed-file-directory/src/SeedMixedFileDirectory/SeedMixedFileDirectory.csproj
@@ -39,11 +39,11 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
-    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/mixed-file-directory/src/SeedMixedFileDirectory/SeedMixedFileDirectory.csproj
+++ b/seed/csharp-sdk/mixed-file-directory/src/SeedMixedFileDirectory/SeedMixedFileDirectory.csproj
@@ -39,6 +39,8 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+  </ItemGroup>
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/multi-line-docs/src/SeedMultiLineDocs/SeedMultiLineDocs.csproj
+++ b/seed/csharp-sdk/multi-line-docs/src/SeedMultiLineDocs/SeedMultiLineDocs.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
   </ItemGroup>
-  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/multi-line-docs/src/SeedMultiLineDocs/SeedMultiLineDocs.csproj
+++ b/seed/csharp-sdk/multi-line-docs/src/SeedMultiLineDocs/SeedMultiLineDocs.csproj
@@ -39,11 +39,11 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
-    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/multi-line-docs/src/SeedMultiLineDocs/SeedMultiLineDocs.csproj
+++ b/seed/csharp-sdk/multi-line-docs/src/SeedMultiLineDocs/SeedMultiLineDocs.csproj
@@ -39,6 +39,8 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+  </ItemGroup>
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/multi-url-environment-no-default/src/SeedMultiUrlEnvironmentNoDefault/SeedMultiUrlEnvironmentNoDefault.csproj
+++ b/seed/csharp-sdk/multi-url-environment-no-default/src/SeedMultiUrlEnvironmentNoDefault/SeedMultiUrlEnvironmentNoDefault.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
   </ItemGroup>
-  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/multi-url-environment-no-default/src/SeedMultiUrlEnvironmentNoDefault/SeedMultiUrlEnvironmentNoDefault.csproj
+++ b/seed/csharp-sdk/multi-url-environment-no-default/src/SeedMultiUrlEnvironmentNoDefault/SeedMultiUrlEnvironmentNoDefault.csproj
@@ -39,11 +39,11 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
-    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/multi-url-environment-no-default/src/SeedMultiUrlEnvironmentNoDefault/SeedMultiUrlEnvironmentNoDefault.csproj
+++ b/seed/csharp-sdk/multi-url-environment-no-default/src/SeedMultiUrlEnvironmentNoDefault/SeedMultiUrlEnvironmentNoDefault.csproj
@@ -39,6 +39,8 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+  </ItemGroup>
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/multi-url-environment/environment-class-name/src/SeedMultiUrlEnvironment/SeedMultiUrlEnvironment.csproj
+++ b/seed/csharp-sdk/multi-url-environment/environment-class-name/src/SeedMultiUrlEnvironment/SeedMultiUrlEnvironment.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
   </ItemGroup>
-  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/multi-url-environment/environment-class-name/src/SeedMultiUrlEnvironment/SeedMultiUrlEnvironment.csproj
+++ b/seed/csharp-sdk/multi-url-environment/environment-class-name/src/SeedMultiUrlEnvironment/SeedMultiUrlEnvironment.csproj
@@ -39,11 +39,11 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
-    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/multi-url-environment/environment-class-name/src/SeedMultiUrlEnvironment/SeedMultiUrlEnvironment.csproj
+++ b/seed/csharp-sdk/multi-url-environment/environment-class-name/src/SeedMultiUrlEnvironment/SeedMultiUrlEnvironment.csproj
@@ -39,6 +39,8 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+  </ItemGroup>
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/multi-url-environment/no-pascal-case-environments/src/SeedMultiUrlEnvironment/SeedMultiUrlEnvironment.csproj
+++ b/seed/csharp-sdk/multi-url-environment/no-pascal-case-environments/src/SeedMultiUrlEnvironment/SeedMultiUrlEnvironment.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
   </ItemGroup>
-  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/multi-url-environment/no-pascal-case-environments/src/SeedMultiUrlEnvironment/SeedMultiUrlEnvironment.csproj
+++ b/seed/csharp-sdk/multi-url-environment/no-pascal-case-environments/src/SeedMultiUrlEnvironment/SeedMultiUrlEnvironment.csproj
@@ -39,11 +39,11 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
-    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/multi-url-environment/no-pascal-case-environments/src/SeedMultiUrlEnvironment/SeedMultiUrlEnvironment.csproj
+++ b/seed/csharp-sdk/multi-url-environment/no-pascal-case-environments/src/SeedMultiUrlEnvironment/SeedMultiUrlEnvironment.csproj
@@ -39,6 +39,8 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+  </ItemGroup>
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/multiple-request-bodies/src/SeedApi/SeedApi.csproj
+++ b/seed/csharp-sdk/multiple-request-bodies/src/SeedApi/SeedApi.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
   </ItemGroup>
-  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/multiple-request-bodies/src/SeedApi/SeedApi.csproj
+++ b/seed/csharp-sdk/multiple-request-bodies/src/SeedApi/SeedApi.csproj
@@ -39,11 +39,11 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
-    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/multiple-request-bodies/src/SeedApi/SeedApi.csproj
+++ b/seed/csharp-sdk/multiple-request-bodies/src/SeedApi/SeedApi.csproj
@@ -39,6 +39,8 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+  </ItemGroup>
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/no-environment/src/SeedNoEnvironment/SeedNoEnvironment.csproj
+++ b/seed/csharp-sdk/no-environment/src/SeedNoEnvironment/SeedNoEnvironment.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
   </ItemGroup>
-  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/no-environment/src/SeedNoEnvironment/SeedNoEnvironment.csproj
+++ b/seed/csharp-sdk/no-environment/src/SeedNoEnvironment/SeedNoEnvironment.csproj
@@ -39,11 +39,11 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
-    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/no-environment/src/SeedNoEnvironment/SeedNoEnvironment.csproj
+++ b/seed/csharp-sdk/no-environment/src/SeedNoEnvironment/SeedNoEnvironment.csproj
@@ -39,6 +39,8 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+  </ItemGroup>
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/no-retries/src/SeedNoRetries/SeedNoRetries.csproj
+++ b/seed/csharp-sdk/no-retries/src/SeedNoRetries/SeedNoRetries.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
   </ItemGroup>
-  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/no-retries/src/SeedNoRetries/SeedNoRetries.csproj
+++ b/seed/csharp-sdk/no-retries/src/SeedNoRetries/SeedNoRetries.csproj
@@ -39,11 +39,11 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
-    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/no-retries/src/SeedNoRetries/SeedNoRetries.csproj
+++ b/seed/csharp-sdk/no-retries/src/SeedNoRetries/SeedNoRetries.csproj
@@ -39,6 +39,8 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+  </ItemGroup>
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/nullable-allof-extends/src/SeedApi/SeedApi.csproj
+++ b/seed/csharp-sdk/nullable-allof-extends/src/SeedApi/SeedApi.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
   </ItemGroup>
-  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/nullable-allof-extends/src/SeedApi/SeedApi.csproj
+++ b/seed/csharp-sdk/nullable-allof-extends/src/SeedApi/SeedApi.csproj
@@ -39,11 +39,11 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
-    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/nullable-allof-extends/src/SeedApi/SeedApi.csproj
+++ b/seed/csharp-sdk/nullable-allof-extends/src/SeedApi/SeedApi.csproj
@@ -39,6 +39,8 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+  </ItemGroup>
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/nullable-optional/explicit-nullable-optional/src/SeedNullableOptional/SeedNullableOptional.csproj
+++ b/seed/csharp-sdk/nullable-optional/explicit-nullable-optional/src/SeedNullableOptional/SeedNullableOptional.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
   </ItemGroup>
-  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/nullable-optional/explicit-nullable-optional/src/SeedNullableOptional/SeedNullableOptional.csproj
+++ b/seed/csharp-sdk/nullable-optional/explicit-nullable-optional/src/SeedNullableOptional/SeedNullableOptional.csproj
@@ -39,11 +39,11 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
-    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/nullable-optional/explicit-nullable-optional/src/SeedNullableOptional/SeedNullableOptional.csproj
+++ b/seed/csharp-sdk/nullable-optional/explicit-nullable-optional/src/SeedNullableOptional/SeedNullableOptional.csproj
@@ -39,6 +39,8 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+  </ItemGroup>
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/nullable-optional/no-custom-config/src/SeedNullableOptional/SeedNullableOptional.csproj
+++ b/seed/csharp-sdk/nullable-optional/no-custom-config/src/SeedNullableOptional/SeedNullableOptional.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
   </ItemGroup>
-  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/nullable-optional/no-custom-config/src/SeedNullableOptional/SeedNullableOptional.csproj
+++ b/seed/csharp-sdk/nullable-optional/no-custom-config/src/SeedNullableOptional/SeedNullableOptional.csproj
@@ -39,11 +39,11 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
-    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/nullable-optional/no-custom-config/src/SeedNullableOptional/SeedNullableOptional.csproj
+++ b/seed/csharp-sdk/nullable-optional/no-custom-config/src/SeedNullableOptional/SeedNullableOptional.csproj
@@ -39,6 +39,8 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+  </ItemGroup>
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/nullable-request-body/src/SeedApi/SeedApi.csproj
+++ b/seed/csharp-sdk/nullable-request-body/src/SeedApi/SeedApi.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
   </ItemGroup>
-  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/nullable-request-body/src/SeedApi/SeedApi.csproj
+++ b/seed/csharp-sdk/nullable-request-body/src/SeedApi/SeedApi.csproj
@@ -39,11 +39,11 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
-    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/nullable-request-body/src/SeedApi/SeedApi.csproj
+++ b/seed/csharp-sdk/nullable-request-body/src/SeedApi/SeedApi.csproj
@@ -39,6 +39,8 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+  </ItemGroup>
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/nullable/explicit-nullable-optional/src/SeedNullable/SeedNullable.csproj
+++ b/seed/csharp-sdk/nullable/explicit-nullable-optional/src/SeedNullable/SeedNullable.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
   </ItemGroup>
-  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/nullable/explicit-nullable-optional/src/SeedNullable/SeedNullable.csproj
+++ b/seed/csharp-sdk/nullable/explicit-nullable-optional/src/SeedNullable/SeedNullable.csproj
@@ -39,11 +39,11 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
-    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/nullable/explicit-nullable-optional/src/SeedNullable/SeedNullable.csproj
+++ b/seed/csharp-sdk/nullable/explicit-nullable-optional/src/SeedNullable/SeedNullable.csproj
@@ -39,6 +39,8 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+  </ItemGroup>
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/nullable/no-custom-config/src/SeedNullable/SeedNullable.csproj
+++ b/seed/csharp-sdk/nullable/no-custom-config/src/SeedNullable/SeedNullable.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
   </ItemGroup>
-  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/nullable/no-custom-config/src/SeedNullable/SeedNullable.csproj
+++ b/seed/csharp-sdk/nullable/no-custom-config/src/SeedNullable/SeedNullable.csproj
@@ -39,11 +39,11 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
-    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/nullable/no-custom-config/src/SeedNullable/SeedNullable.csproj
+++ b/seed/csharp-sdk/nullable/no-custom-config/src/SeedNullable/SeedNullable.csproj
@@ -39,6 +39,8 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+  </ItemGroup>
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/oauth-client-credentials-custom/src/SeedOauthClientCredentials/SeedOauthClientCredentials.csproj
+++ b/seed/csharp-sdk/oauth-client-credentials-custom/src/SeedOauthClientCredentials/SeedOauthClientCredentials.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
   </ItemGroup>
-  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/oauth-client-credentials-custom/src/SeedOauthClientCredentials/SeedOauthClientCredentials.csproj
+++ b/seed/csharp-sdk/oauth-client-credentials-custom/src/SeedOauthClientCredentials/SeedOauthClientCredentials.csproj
@@ -39,11 +39,11 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
-    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/oauth-client-credentials-custom/src/SeedOauthClientCredentials/SeedOauthClientCredentials.csproj
+++ b/seed/csharp-sdk/oauth-client-credentials-custom/src/SeedOauthClientCredentials/SeedOauthClientCredentials.csproj
@@ -39,6 +39,8 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+  </ItemGroup>
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/oauth-client-credentials-default/src/SeedOauthClientCredentialsDefault/SeedOauthClientCredentialsDefault.csproj
+++ b/seed/csharp-sdk/oauth-client-credentials-default/src/SeedOauthClientCredentialsDefault/SeedOauthClientCredentialsDefault.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
   </ItemGroup>
-  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/oauth-client-credentials-default/src/SeedOauthClientCredentialsDefault/SeedOauthClientCredentialsDefault.csproj
+++ b/seed/csharp-sdk/oauth-client-credentials-default/src/SeedOauthClientCredentialsDefault/SeedOauthClientCredentialsDefault.csproj
@@ -39,11 +39,11 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
-    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/oauth-client-credentials-default/src/SeedOauthClientCredentialsDefault/SeedOauthClientCredentialsDefault.csproj
+++ b/seed/csharp-sdk/oauth-client-credentials-default/src/SeedOauthClientCredentialsDefault/SeedOauthClientCredentialsDefault.csproj
@@ -39,6 +39,8 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+  </ItemGroup>
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/oauth-client-credentials-environment-variables/src/SeedOauthClientCredentialsEnvironmentVariables/SeedOauthClientCredentialsEnvironmentVariables.csproj
+++ b/seed/csharp-sdk/oauth-client-credentials-environment-variables/src/SeedOauthClientCredentialsEnvironmentVariables/SeedOauthClientCredentialsEnvironmentVariables.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
   </ItemGroup>
-  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/oauth-client-credentials-environment-variables/src/SeedOauthClientCredentialsEnvironmentVariables/SeedOauthClientCredentialsEnvironmentVariables.csproj
+++ b/seed/csharp-sdk/oauth-client-credentials-environment-variables/src/SeedOauthClientCredentialsEnvironmentVariables/SeedOauthClientCredentialsEnvironmentVariables.csproj
@@ -39,11 +39,11 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
-    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/oauth-client-credentials-environment-variables/src/SeedOauthClientCredentialsEnvironmentVariables/SeedOauthClientCredentialsEnvironmentVariables.csproj
+++ b/seed/csharp-sdk/oauth-client-credentials-environment-variables/src/SeedOauthClientCredentialsEnvironmentVariables/SeedOauthClientCredentialsEnvironmentVariables.csproj
@@ -39,6 +39,8 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+  </ItemGroup>
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/oauth-client-credentials-mandatory-auth/no-custom-config/src/SeedOauthClientCredentialsMandatoryAuth/SeedOauthClientCredentialsMandatoryAuth.csproj
+++ b/seed/csharp-sdk/oauth-client-credentials-mandatory-auth/no-custom-config/src/SeedOauthClientCredentialsMandatoryAuth/SeedOauthClientCredentialsMandatoryAuth.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
   </ItemGroup>
-  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/oauth-client-credentials-mandatory-auth/no-custom-config/src/SeedOauthClientCredentialsMandatoryAuth/SeedOauthClientCredentialsMandatoryAuth.csproj
+++ b/seed/csharp-sdk/oauth-client-credentials-mandatory-auth/no-custom-config/src/SeedOauthClientCredentialsMandatoryAuth/SeedOauthClientCredentialsMandatoryAuth.csproj
@@ -39,11 +39,11 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
-    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/oauth-client-credentials-mandatory-auth/no-custom-config/src/SeedOauthClientCredentialsMandatoryAuth/SeedOauthClientCredentialsMandatoryAuth.csproj
+++ b/seed/csharp-sdk/oauth-client-credentials-mandatory-auth/no-custom-config/src/SeedOauthClientCredentialsMandatoryAuth/SeedOauthClientCredentialsMandatoryAuth.csproj
@@ -39,6 +39,8 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+  </ItemGroup>
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/oauth-client-credentials-mandatory-auth/unified-client-options/src/SeedOauthClientCredentialsMandatoryAuth/SeedOauthClientCredentialsMandatoryAuth.csproj
+++ b/seed/csharp-sdk/oauth-client-credentials-mandatory-auth/unified-client-options/src/SeedOauthClientCredentialsMandatoryAuth/SeedOauthClientCredentialsMandatoryAuth.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
   </ItemGroup>
-  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/oauth-client-credentials-mandatory-auth/unified-client-options/src/SeedOauthClientCredentialsMandatoryAuth/SeedOauthClientCredentialsMandatoryAuth.csproj
+++ b/seed/csharp-sdk/oauth-client-credentials-mandatory-auth/unified-client-options/src/SeedOauthClientCredentialsMandatoryAuth/SeedOauthClientCredentialsMandatoryAuth.csproj
@@ -39,11 +39,11 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
-    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/oauth-client-credentials-mandatory-auth/unified-client-options/src/SeedOauthClientCredentialsMandatoryAuth/SeedOauthClientCredentialsMandatoryAuth.csproj
+++ b/seed/csharp-sdk/oauth-client-credentials-mandatory-auth/unified-client-options/src/SeedOauthClientCredentialsMandatoryAuth/SeedOauthClientCredentialsMandatoryAuth.csproj
@@ -39,6 +39,8 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+  </ItemGroup>
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/oauth-client-credentials-nested-root/src/SeedOauthClientCredentials/SeedOauthClientCredentials.csproj
+++ b/seed/csharp-sdk/oauth-client-credentials-nested-root/src/SeedOauthClientCredentials/SeedOauthClientCredentials.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
   </ItemGroup>
-  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/oauth-client-credentials-nested-root/src/SeedOauthClientCredentials/SeedOauthClientCredentials.csproj
+++ b/seed/csharp-sdk/oauth-client-credentials-nested-root/src/SeedOauthClientCredentials/SeedOauthClientCredentials.csproj
@@ -39,11 +39,11 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
-    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/oauth-client-credentials-nested-root/src/SeedOauthClientCredentials/SeedOauthClientCredentials.csproj
+++ b/seed/csharp-sdk/oauth-client-credentials-nested-root/src/SeedOauthClientCredentials/SeedOauthClientCredentials.csproj
@@ -39,6 +39,8 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+  </ItemGroup>
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/oauth-client-credentials-reference/src/SeedOauthClientCredentialsReference/SeedOauthClientCredentialsReference.csproj
+++ b/seed/csharp-sdk/oauth-client-credentials-reference/src/SeedOauthClientCredentialsReference/SeedOauthClientCredentialsReference.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
   </ItemGroup>
-  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/oauth-client-credentials-reference/src/SeedOauthClientCredentialsReference/SeedOauthClientCredentialsReference.csproj
+++ b/seed/csharp-sdk/oauth-client-credentials-reference/src/SeedOauthClientCredentialsReference/SeedOauthClientCredentialsReference.csproj
@@ -39,11 +39,11 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
-    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/oauth-client-credentials-reference/src/SeedOauthClientCredentialsReference/SeedOauthClientCredentialsReference.csproj
+++ b/seed/csharp-sdk/oauth-client-credentials-reference/src/SeedOauthClientCredentialsReference/SeedOauthClientCredentialsReference.csproj
@@ -39,6 +39,8 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+  </ItemGroup>
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/oauth-client-credentials-with-variables/src/SeedOauthClientCredentialsWithVariables/SeedOauthClientCredentialsWithVariables.csproj
+++ b/seed/csharp-sdk/oauth-client-credentials-with-variables/src/SeedOauthClientCredentialsWithVariables/SeedOauthClientCredentialsWithVariables.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
   </ItemGroup>
-  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/oauth-client-credentials-with-variables/src/SeedOauthClientCredentialsWithVariables/SeedOauthClientCredentialsWithVariables.csproj
+++ b/seed/csharp-sdk/oauth-client-credentials-with-variables/src/SeedOauthClientCredentialsWithVariables/SeedOauthClientCredentialsWithVariables.csproj
@@ -39,11 +39,11 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
-    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/oauth-client-credentials-with-variables/src/SeedOauthClientCredentialsWithVariables/SeedOauthClientCredentialsWithVariables.csproj
+++ b/seed/csharp-sdk/oauth-client-credentials-with-variables/src/SeedOauthClientCredentialsWithVariables/SeedOauthClientCredentialsWithVariables.csproj
@@ -39,6 +39,8 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+  </ItemGroup>
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/oauth-client-credentials/include-exception-handler/src/SeedOauthClientCredentials/SeedOauthClientCredentials.csproj
+++ b/seed/csharp-sdk/oauth-client-credentials/include-exception-handler/src/SeedOauthClientCredentials/SeedOauthClientCredentials.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
   </ItemGroup>
-  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/oauth-client-credentials/include-exception-handler/src/SeedOauthClientCredentials/SeedOauthClientCredentials.csproj
+++ b/seed/csharp-sdk/oauth-client-credentials/include-exception-handler/src/SeedOauthClientCredentials/SeedOauthClientCredentials.csproj
@@ -39,11 +39,11 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
-    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/oauth-client-credentials/include-exception-handler/src/SeedOauthClientCredentials/SeedOauthClientCredentials.csproj
+++ b/seed/csharp-sdk/oauth-client-credentials/include-exception-handler/src/SeedOauthClientCredentials/SeedOauthClientCredentials.csproj
@@ -39,6 +39,8 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+  </ItemGroup>
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/oauth-client-credentials/no-custom-config/src/SeedOauthClientCredentials/SeedOauthClientCredentials.csproj
+++ b/seed/csharp-sdk/oauth-client-credentials/no-custom-config/src/SeedOauthClientCredentials/SeedOauthClientCredentials.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
   </ItemGroup>
-  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/oauth-client-credentials/no-custom-config/src/SeedOauthClientCredentials/SeedOauthClientCredentials.csproj
+++ b/seed/csharp-sdk/oauth-client-credentials/no-custom-config/src/SeedOauthClientCredentials/SeedOauthClientCredentials.csproj
@@ -39,11 +39,11 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
-    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/oauth-client-credentials/no-custom-config/src/SeedOauthClientCredentials/SeedOauthClientCredentials.csproj
+++ b/seed/csharp-sdk/oauth-client-credentials/no-custom-config/src/SeedOauthClientCredentials/SeedOauthClientCredentials.csproj
@@ -39,6 +39,8 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+  </ItemGroup>
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/object/src/SeedObject/SeedObject.csproj
+++ b/seed/csharp-sdk/object/src/SeedObject/SeedObject.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
   </ItemGroup>
-  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/object/src/SeedObject/SeedObject.csproj
+++ b/seed/csharp-sdk/object/src/SeedObject/SeedObject.csproj
@@ -39,11 +39,11 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
-    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/object/src/SeedObject/SeedObject.csproj
+++ b/seed/csharp-sdk/object/src/SeedObject/SeedObject.csproj
@@ -39,6 +39,8 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+  </ItemGroup>
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/objects-with-imports/src/SeedObjectsWithImports/SeedObjectsWithImports.csproj
+++ b/seed/csharp-sdk/objects-with-imports/src/SeedObjectsWithImports/SeedObjectsWithImports.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
   </ItemGroup>
-  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/objects-with-imports/src/SeedObjectsWithImports/SeedObjectsWithImports.csproj
+++ b/seed/csharp-sdk/objects-with-imports/src/SeedObjectsWithImports/SeedObjectsWithImports.csproj
@@ -39,11 +39,11 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
-    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/objects-with-imports/src/SeedObjectsWithImports/SeedObjectsWithImports.csproj
+++ b/seed/csharp-sdk/objects-with-imports/src/SeedObjectsWithImports/SeedObjectsWithImports.csproj
@@ -39,6 +39,8 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+  </ItemGroup>
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/optional/no-custom-config/src/SeedObjectsWithImports/SeedObjectsWithImports.csproj
+++ b/seed/csharp-sdk/optional/no-custom-config/src/SeedObjectsWithImports/SeedObjectsWithImports.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
   </ItemGroup>
-  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/optional/no-custom-config/src/SeedObjectsWithImports/SeedObjectsWithImports.csproj
+++ b/seed/csharp-sdk/optional/no-custom-config/src/SeedObjectsWithImports/SeedObjectsWithImports.csproj
@@ -39,11 +39,11 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
-    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/optional/no-custom-config/src/SeedObjectsWithImports/SeedObjectsWithImports.csproj
+++ b/seed/csharp-sdk/optional/no-custom-config/src/SeedObjectsWithImports/SeedObjectsWithImports.csproj
@@ -39,6 +39,8 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+  </ItemGroup>
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/optional/simplify-object-dictionaries/src/SeedObjectsWithImports/SeedObjectsWithImports.csproj
+++ b/seed/csharp-sdk/optional/simplify-object-dictionaries/src/SeedObjectsWithImports/SeedObjectsWithImports.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
   </ItemGroup>
-  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/optional/simplify-object-dictionaries/src/SeedObjectsWithImports/SeedObjectsWithImports.csproj
+++ b/seed/csharp-sdk/optional/simplify-object-dictionaries/src/SeedObjectsWithImports/SeedObjectsWithImports.csproj
@@ -39,11 +39,11 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
-    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/optional/simplify-object-dictionaries/src/SeedObjectsWithImports/SeedObjectsWithImports.csproj
+++ b/seed/csharp-sdk/optional/simplify-object-dictionaries/src/SeedObjectsWithImports/SeedObjectsWithImports.csproj
@@ -39,6 +39,8 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+  </ItemGroup>
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/package-yml/src/SeedPackageYml/SeedPackageYml.csproj
+++ b/seed/csharp-sdk/package-yml/src/SeedPackageYml/SeedPackageYml.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
   </ItemGroup>
-  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/package-yml/src/SeedPackageYml/SeedPackageYml.csproj
+++ b/seed/csharp-sdk/package-yml/src/SeedPackageYml/SeedPackageYml.csproj
@@ -39,11 +39,11 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
-    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/package-yml/src/SeedPackageYml/SeedPackageYml.csproj
+++ b/seed/csharp-sdk/package-yml/src/SeedPackageYml/SeedPackageYml.csproj
@@ -39,6 +39,8 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+  </ItemGroup>
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/pagination-custom/src/SeedPagination/SeedPagination.csproj
+++ b/seed/csharp-sdk/pagination-custom/src/SeedPagination/SeedPagination.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
   </ItemGroup>
-  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/pagination-custom/src/SeedPagination/SeedPagination.csproj
+++ b/seed/csharp-sdk/pagination-custom/src/SeedPagination/SeedPagination.csproj
@@ -39,11 +39,11 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
-    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/pagination-custom/src/SeedPagination/SeedPagination.csproj
+++ b/seed/csharp-sdk/pagination-custom/src/SeedPagination/SeedPagination.csproj
@@ -39,6 +39,8 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+  </ItemGroup>
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/pagination/custom-pager-with-exception-handler/src/SeedPagination/SeedPagination.csproj
+++ b/seed/csharp-sdk/pagination/custom-pager-with-exception-handler/src/SeedPagination/SeedPagination.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
   </ItemGroup>
-  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/pagination/custom-pager-with-exception-handler/src/SeedPagination/SeedPagination.csproj
+++ b/seed/csharp-sdk/pagination/custom-pager-with-exception-handler/src/SeedPagination/SeedPagination.csproj
@@ -39,11 +39,11 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
-    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/pagination/custom-pager-with-exception-handler/src/SeedPagination/SeedPagination.csproj
+++ b/seed/csharp-sdk/pagination/custom-pager-with-exception-handler/src/SeedPagination/SeedPagination.csproj
@@ -39,6 +39,8 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+  </ItemGroup>
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/pagination/custom-pager/src/SeedPagination/SeedPagination.csproj
+++ b/seed/csharp-sdk/pagination/custom-pager/src/SeedPagination/SeedPagination.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
   </ItemGroup>
-  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/pagination/custom-pager/src/SeedPagination/SeedPagination.csproj
+++ b/seed/csharp-sdk/pagination/custom-pager/src/SeedPagination/SeedPagination.csproj
@@ -39,11 +39,11 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
-    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/pagination/custom-pager/src/SeedPagination/SeedPagination.csproj
+++ b/seed/csharp-sdk/pagination/custom-pager/src/SeedPagination/SeedPagination.csproj
@@ -39,6 +39,8 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+  </ItemGroup>
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/pagination/no-custom-config/src/SeedPagination/SeedPagination.csproj
+++ b/seed/csharp-sdk/pagination/no-custom-config/src/SeedPagination/SeedPagination.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
   </ItemGroup>
-  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/pagination/no-custom-config/src/SeedPagination/SeedPagination.csproj
+++ b/seed/csharp-sdk/pagination/no-custom-config/src/SeedPagination/SeedPagination.csproj
@@ -39,11 +39,11 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
-    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/pagination/no-custom-config/src/SeedPagination/SeedPagination.csproj
+++ b/seed/csharp-sdk/pagination/no-custom-config/src/SeedPagination/SeedPagination.csproj
@@ -39,6 +39,8 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+  </ItemGroup>
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/path-parameters/no-custom-config/src/SeedPathParameters/SeedPathParameters.csproj
+++ b/seed/csharp-sdk/path-parameters/no-custom-config/src/SeedPathParameters/SeedPathParameters.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
   </ItemGroup>
-  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/path-parameters/no-custom-config/src/SeedPathParameters/SeedPathParameters.csproj
+++ b/seed/csharp-sdk/path-parameters/no-custom-config/src/SeedPathParameters/SeedPathParameters.csproj
@@ -39,11 +39,11 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
-    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/path-parameters/no-custom-config/src/SeedPathParameters/SeedPathParameters.csproj
+++ b/seed/csharp-sdk/path-parameters/no-custom-config/src/SeedPathParameters/SeedPathParameters.csproj
@@ -39,6 +39,8 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+  </ItemGroup>
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/path-parameters/no-inline-path-parameters/src/SeedPathParameters/SeedPathParameters.csproj
+++ b/seed/csharp-sdk/path-parameters/no-inline-path-parameters/src/SeedPathParameters/SeedPathParameters.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
   </ItemGroup>
-  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/path-parameters/no-inline-path-parameters/src/SeedPathParameters/SeedPathParameters.csproj
+++ b/seed/csharp-sdk/path-parameters/no-inline-path-parameters/src/SeedPathParameters/SeedPathParameters.csproj
@@ -39,11 +39,11 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
-    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/path-parameters/no-inline-path-parameters/src/SeedPathParameters/SeedPathParameters.csproj
+++ b/seed/csharp-sdk/path-parameters/no-inline-path-parameters/src/SeedPathParameters/SeedPathParameters.csproj
@@ -39,6 +39,8 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+  </ItemGroup>
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/plain-text/src/SeedPlainText/SeedPlainText.csproj
+++ b/seed/csharp-sdk/plain-text/src/SeedPlainText/SeedPlainText.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
   </ItemGroup>
-  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/plain-text/src/SeedPlainText/SeedPlainText.csproj
+++ b/seed/csharp-sdk/plain-text/src/SeedPlainText/SeedPlainText.csproj
@@ -39,11 +39,11 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
-    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/plain-text/src/SeedPlainText/SeedPlainText.csproj
+++ b/seed/csharp-sdk/plain-text/src/SeedPlainText/SeedPlainText.csproj
@@ -39,6 +39,8 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+  </ItemGroup>
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/property-access/src/SeedPropertyAccess/SeedPropertyAccess.csproj
+++ b/seed/csharp-sdk/property-access/src/SeedPropertyAccess/SeedPropertyAccess.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
   </ItemGroup>
-  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/property-access/src/SeedPropertyAccess/SeedPropertyAccess.csproj
+++ b/seed/csharp-sdk/property-access/src/SeedPropertyAccess/SeedPropertyAccess.csproj
@@ -39,11 +39,11 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
-    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/property-access/src/SeedPropertyAccess/SeedPropertyAccess.csproj
+++ b/seed/csharp-sdk/property-access/src/SeedPropertyAccess/SeedPropertyAccess.csproj
@@ -39,6 +39,8 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+  </ItemGroup>
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/public-object/src/SeedPublicObject/SeedPublicObject.csproj
+++ b/seed/csharp-sdk/public-object/src/SeedPublicObject/SeedPublicObject.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
   </ItemGroup>
-  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/public-object/src/SeedPublicObject/SeedPublicObject.csproj
+++ b/seed/csharp-sdk/public-object/src/SeedPublicObject/SeedPublicObject.csproj
@@ -39,11 +39,11 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
-    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/public-object/src/SeedPublicObject/SeedPublicObject.csproj
+++ b/seed/csharp-sdk/public-object/src/SeedPublicObject/SeedPublicObject.csproj
@@ -39,6 +39,8 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+  </ItemGroup>
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/query-parameters-openapi-as-objects/src/SeedApi/SeedApi.csproj
+++ b/seed/csharp-sdk/query-parameters-openapi-as-objects/src/SeedApi/SeedApi.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
   </ItemGroup>
-  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/query-parameters-openapi-as-objects/src/SeedApi/SeedApi.csproj
+++ b/seed/csharp-sdk/query-parameters-openapi-as-objects/src/SeedApi/SeedApi.csproj
@@ -39,11 +39,11 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
-    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/query-parameters-openapi-as-objects/src/SeedApi/SeedApi.csproj
+++ b/seed/csharp-sdk/query-parameters-openapi-as-objects/src/SeedApi/SeedApi.csproj
@@ -39,6 +39,8 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+  </ItemGroup>
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/query-parameters-openapi/src/SeedApi/SeedApi.csproj
+++ b/seed/csharp-sdk/query-parameters-openapi/src/SeedApi/SeedApi.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
   </ItemGroup>
-  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/query-parameters-openapi/src/SeedApi/SeedApi.csproj
+++ b/seed/csharp-sdk/query-parameters-openapi/src/SeedApi/SeedApi.csproj
@@ -39,11 +39,11 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
-    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/query-parameters-openapi/src/SeedApi/SeedApi.csproj
+++ b/seed/csharp-sdk/query-parameters-openapi/src/SeedApi/SeedApi.csproj
@@ -39,6 +39,8 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+  </ItemGroup>
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/query-parameters/src/SeedQueryParameters/SeedQueryParameters.csproj
+++ b/seed/csharp-sdk/query-parameters/src/SeedQueryParameters/SeedQueryParameters.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
   </ItemGroup>
-  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/query-parameters/src/SeedQueryParameters/SeedQueryParameters.csproj
+++ b/seed/csharp-sdk/query-parameters/src/SeedQueryParameters/SeedQueryParameters.csproj
@@ -39,11 +39,11 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
-    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/query-parameters/src/SeedQueryParameters/SeedQueryParameters.csproj
+++ b/seed/csharp-sdk/query-parameters/src/SeedQueryParameters/SeedQueryParameters.csproj
@@ -39,6 +39,8 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+  </ItemGroup>
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/request-parameters/no-custom-config/src/SeedRequestParameters/SeedRequestParameters.csproj
+++ b/seed/csharp-sdk/request-parameters/no-custom-config/src/SeedRequestParameters/SeedRequestParameters.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
   </ItemGroup>
-  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/request-parameters/no-custom-config/src/SeedRequestParameters/SeedRequestParameters.csproj
+++ b/seed/csharp-sdk/request-parameters/no-custom-config/src/SeedRequestParameters/SeedRequestParameters.csproj
@@ -39,11 +39,11 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
-    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/request-parameters/no-custom-config/src/SeedRequestParameters/SeedRequestParameters.csproj
+++ b/seed/csharp-sdk/request-parameters/no-custom-config/src/SeedRequestParameters/SeedRequestParameters.csproj
@@ -39,6 +39,8 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+  </ItemGroup>
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/request-parameters/with-defaults/src/SeedRequestParameters/SeedRequestParameters.csproj
+++ b/seed/csharp-sdk/request-parameters/with-defaults/src/SeedRequestParameters/SeedRequestParameters.csproj
@@ -38,7 +38,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
   </ItemGroup>
-  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/request-parameters/with-defaults/src/SeedRequestParameters/SeedRequestParameters.csproj
+++ b/seed/csharp-sdk/request-parameters/with-defaults/src/SeedRequestParameters/SeedRequestParameters.csproj
@@ -37,11 +37,10 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
+    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/request-parameters/with-defaults/src/SeedRequestParameters/SeedRequestParameters.csproj
+++ b/seed/csharp-sdk/request-parameters/with-defaults/src/SeedRequestParameters/SeedRequestParameters.csproj
@@ -37,6 +37,8 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
+  </ItemGroup>
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/request-parameters/with-defaults/src/SeedRequestParameters/SeedRequestParameters.csproj
+++ b/seed/csharp-sdk/request-parameters/with-defaults/src/SeedRequestParameters/SeedRequestParameters.csproj
@@ -40,8 +40,6 @@
   </ItemGroup>
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
-    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/request-parameters/with-defaults/src/SeedRequestParameters/SeedRequestParameters.csproj
+++ b/seed/csharp-sdk/request-parameters/with-defaults/src/SeedRequestParameters/SeedRequestParameters.csproj
@@ -37,6 +37,8 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
+    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />

--- a/seed/csharp-sdk/required-nullable/explicit-nullable-optional/src/SeedApi/SeedApi.csproj
+++ b/seed/csharp-sdk/required-nullable/explicit-nullable-optional/src/SeedApi/SeedApi.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
   </ItemGroup>
-  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/required-nullable/explicit-nullable-optional/src/SeedApi/SeedApi.csproj
+++ b/seed/csharp-sdk/required-nullable/explicit-nullable-optional/src/SeedApi/SeedApi.csproj
@@ -39,11 +39,11 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
-    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/required-nullable/explicit-nullable-optional/src/SeedApi/SeedApi.csproj
+++ b/seed/csharp-sdk/required-nullable/explicit-nullable-optional/src/SeedApi/SeedApi.csproj
@@ -39,6 +39,8 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+  </ItemGroup>
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/required-nullable/no-custom-config/src/SeedApi/SeedApi.csproj
+++ b/seed/csharp-sdk/required-nullable/no-custom-config/src/SeedApi/SeedApi.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
   </ItemGroup>
-  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/required-nullable/no-custom-config/src/SeedApi/SeedApi.csproj
+++ b/seed/csharp-sdk/required-nullable/no-custom-config/src/SeedApi/SeedApi.csproj
@@ -39,11 +39,11 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
-    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/required-nullable/no-custom-config/src/SeedApi/SeedApi.csproj
+++ b/seed/csharp-sdk/required-nullable/no-custom-config/src/SeedApi/SeedApi.csproj
@@ -39,6 +39,8 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+  </ItemGroup>
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/reserved-keywords/src/SeedNurseryApi/SeedNurseryApi.csproj
+++ b/seed/csharp-sdk/reserved-keywords/src/SeedNurseryApi/SeedNurseryApi.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
   </ItemGroup>
-  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/reserved-keywords/src/SeedNurseryApi/SeedNurseryApi.csproj
+++ b/seed/csharp-sdk/reserved-keywords/src/SeedNurseryApi/SeedNurseryApi.csproj
@@ -39,11 +39,11 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
-    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/reserved-keywords/src/SeedNurseryApi/SeedNurseryApi.csproj
+++ b/seed/csharp-sdk/reserved-keywords/src/SeedNurseryApi/SeedNurseryApi.csproj
@@ -39,6 +39,8 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+  </ItemGroup>
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/response-property/src/SeedResponseProperty/SeedResponseProperty.csproj
+++ b/seed/csharp-sdk/response-property/src/SeedResponseProperty/SeedResponseProperty.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
   </ItemGroup>
-  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/response-property/src/SeedResponseProperty/SeedResponseProperty.csproj
+++ b/seed/csharp-sdk/response-property/src/SeedResponseProperty/SeedResponseProperty.csproj
@@ -39,11 +39,11 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
-    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/response-property/src/SeedResponseProperty/SeedResponseProperty.csproj
+++ b/seed/csharp-sdk/response-property/src/SeedResponseProperty/SeedResponseProperty.csproj
@@ -39,6 +39,8 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+  </ItemGroup>
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/server-sent-event-examples/src/SeedServerSentEvents/SeedServerSentEvents.csproj
+++ b/seed/csharp-sdk/server-sent-event-examples/src/SeedServerSentEvents/SeedServerSentEvents.csproj
@@ -41,7 +41,7 @@
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
     <PackageReference Include="System.Net.ServerSentEvents" Version="9.0.9" />
   </ItemGroup>
-  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/server-sent-event-examples/src/SeedServerSentEvents/SeedServerSentEvents.csproj
+++ b/seed/csharp-sdk/server-sent-event-examples/src/SeedServerSentEvents/SeedServerSentEvents.csproj
@@ -39,12 +39,12 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
     <PackageReference Include="System.Net.ServerSentEvents" Version="9.0.9" />
   </ItemGroup>
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
-    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/server-sent-event-examples/src/SeedServerSentEvents/SeedServerSentEvents.csproj
+++ b/seed/csharp-sdk/server-sent-event-examples/src/SeedServerSentEvents/SeedServerSentEvents.csproj
@@ -39,12 +39,12 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+    <PackageReference Include="System.Net.ServerSentEvents" Version="9.0.9" />
   </ItemGroup>
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
-    <PackageReference Include="System.Net.ServerSentEvents" Version="9.0.9" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/server-sent-event-examples/src/SeedServerSentEvents/SeedServerSentEvents.csproj
+++ b/seed/csharp-sdk/server-sent-event-examples/src/SeedServerSentEvents/SeedServerSentEvents.csproj
@@ -39,6 +39,8 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+  </ItemGroup>
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/server-sent-events/src/SeedServerSentEvents/SeedServerSentEvents.csproj
+++ b/seed/csharp-sdk/server-sent-events/src/SeedServerSentEvents/SeedServerSentEvents.csproj
@@ -41,7 +41,7 @@
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
     <PackageReference Include="System.Net.ServerSentEvents" Version="9.0.9" />
   </ItemGroup>
-  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/server-sent-events/src/SeedServerSentEvents/SeedServerSentEvents.csproj
+++ b/seed/csharp-sdk/server-sent-events/src/SeedServerSentEvents/SeedServerSentEvents.csproj
@@ -39,12 +39,12 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
     <PackageReference Include="System.Net.ServerSentEvents" Version="9.0.9" />
   </ItemGroup>
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
-    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/server-sent-events/src/SeedServerSentEvents/SeedServerSentEvents.csproj
+++ b/seed/csharp-sdk/server-sent-events/src/SeedServerSentEvents/SeedServerSentEvents.csproj
@@ -39,12 +39,12 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+    <PackageReference Include="System.Net.ServerSentEvents" Version="9.0.9" />
   </ItemGroup>
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
-    <PackageReference Include="System.Net.ServerSentEvents" Version="9.0.9" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/server-sent-events/src/SeedServerSentEvents/SeedServerSentEvents.csproj
+++ b/seed/csharp-sdk/server-sent-events/src/SeedServerSentEvents/SeedServerSentEvents.csproj
@@ -39,6 +39,8 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+  </ItemGroup>
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/server-url-templating/src/SeedApi/SeedApi.csproj
+++ b/seed/csharp-sdk/server-url-templating/src/SeedApi/SeedApi.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
   </ItemGroup>
-  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/server-url-templating/src/SeedApi/SeedApi.csproj
+++ b/seed/csharp-sdk/server-url-templating/src/SeedApi/SeedApi.csproj
@@ -39,11 +39,11 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
-    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/server-url-templating/src/SeedApi/SeedApi.csproj
+++ b/seed/csharp-sdk/server-url-templating/src/SeedApi/SeedApi.csproj
@@ -39,6 +39,8 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+  </ItemGroup>
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/simple-api/custom-output-path-object/lib/SeedApi/SeedSimpleApi/SeedSimpleApi.csproj
+++ b/seed/csharp-sdk/simple-api/custom-output-path-object/lib/SeedApi/SeedSimpleApi/SeedSimpleApi.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
   </ItemGroup>
-  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/simple-api/custom-output-path-object/lib/SeedApi/SeedSimpleApi/SeedSimpleApi.csproj
+++ b/seed/csharp-sdk/simple-api/custom-output-path-object/lib/SeedApi/SeedSimpleApi/SeedSimpleApi.csproj
@@ -39,11 +39,11 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
-    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/simple-api/custom-output-path-object/lib/SeedApi/SeedSimpleApi/SeedSimpleApi.csproj
+++ b/seed/csharp-sdk/simple-api/custom-output-path-object/lib/SeedApi/SeedSimpleApi/SeedSimpleApi.csproj
@@ -39,6 +39,8 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+  </ItemGroup>
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/simple-api/custom-output-path/custom-src/SeedSimpleApi/SeedSimpleApi.csproj
+++ b/seed/csharp-sdk/simple-api/custom-output-path/custom-src/SeedSimpleApi/SeedSimpleApi.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
   </ItemGroup>
-  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/simple-api/custom-output-path/custom-src/SeedSimpleApi/SeedSimpleApi.csproj
+++ b/seed/csharp-sdk/simple-api/custom-output-path/custom-src/SeedSimpleApi/SeedSimpleApi.csproj
@@ -39,11 +39,11 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
-    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/simple-api/custom-output-path/custom-src/SeedSimpleApi/SeedSimpleApi.csproj
+++ b/seed/csharp-sdk/simple-api/custom-output-path/custom-src/SeedSimpleApi/SeedSimpleApi.csproj
@@ -39,6 +39,8 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+  </ItemGroup>
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/simple-api/no-custom-config/src/SeedSimpleApi/SeedSimpleApi.csproj
+++ b/seed/csharp-sdk/simple-api/no-custom-config/src/SeedSimpleApi/SeedSimpleApi.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
   </ItemGroup>
-  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/simple-api/no-custom-config/src/SeedSimpleApi/SeedSimpleApi.csproj
+++ b/seed/csharp-sdk/simple-api/no-custom-config/src/SeedSimpleApi/SeedSimpleApi.csproj
@@ -39,11 +39,11 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
-    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/simple-api/no-custom-config/src/SeedSimpleApi/SeedSimpleApi.csproj
+++ b/seed/csharp-sdk/simple-api/no-custom-config/src/SeedSimpleApi/SeedSimpleApi.csproj
@@ -39,6 +39,8 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+  </ItemGroup>
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/simple-api/use-sln-format/src/SeedSimpleApi/SeedSimpleApi.csproj
+++ b/seed/csharp-sdk/simple-api/use-sln-format/src/SeedSimpleApi/SeedSimpleApi.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
   </ItemGroup>
-  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/simple-api/use-sln-format/src/SeedSimpleApi/SeedSimpleApi.csproj
+++ b/seed/csharp-sdk/simple-api/use-sln-format/src/SeedSimpleApi/SeedSimpleApi.csproj
@@ -39,11 +39,11 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
-    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/simple-api/use-sln-format/src/SeedSimpleApi/SeedSimpleApi.csproj
+++ b/seed/csharp-sdk/simple-api/use-sln-format/src/SeedSimpleApi/SeedSimpleApi.csproj
@@ -39,6 +39,8 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+  </ItemGroup>
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/simple-fhir/src/SeedApi/SeedApi.csproj
+++ b/seed/csharp-sdk/simple-fhir/src/SeedApi/SeedApi.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
   </ItemGroup>
-  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/simple-fhir/src/SeedApi/SeedApi.csproj
+++ b/seed/csharp-sdk/simple-fhir/src/SeedApi/SeedApi.csproj
@@ -39,11 +39,11 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
-    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/simple-fhir/src/SeedApi/SeedApi.csproj
+++ b/seed/csharp-sdk/simple-fhir/src/SeedApi/SeedApi.csproj
@@ -39,6 +39,8 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+  </ItemGroup>
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/single-url-environment-default/src/SeedSingleUrlEnvironmentDefault/SeedSingleUrlEnvironmentDefault.csproj
+++ b/seed/csharp-sdk/single-url-environment-default/src/SeedSingleUrlEnvironmentDefault/SeedSingleUrlEnvironmentDefault.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
   </ItemGroup>
-  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/single-url-environment-default/src/SeedSingleUrlEnvironmentDefault/SeedSingleUrlEnvironmentDefault.csproj
+++ b/seed/csharp-sdk/single-url-environment-default/src/SeedSingleUrlEnvironmentDefault/SeedSingleUrlEnvironmentDefault.csproj
@@ -39,11 +39,11 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
-    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/single-url-environment-default/src/SeedSingleUrlEnvironmentDefault/SeedSingleUrlEnvironmentDefault.csproj
+++ b/seed/csharp-sdk/single-url-environment-default/src/SeedSingleUrlEnvironmentDefault/SeedSingleUrlEnvironmentDefault.csproj
@@ -39,6 +39,8 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+  </ItemGroup>
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/single-url-environment-no-default/src/SeedSingleUrlEnvironmentNoDefault/SeedSingleUrlEnvironmentNoDefault.csproj
+++ b/seed/csharp-sdk/single-url-environment-no-default/src/SeedSingleUrlEnvironmentNoDefault/SeedSingleUrlEnvironmentNoDefault.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
   </ItemGroup>
-  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/single-url-environment-no-default/src/SeedSingleUrlEnvironmentNoDefault/SeedSingleUrlEnvironmentNoDefault.csproj
+++ b/seed/csharp-sdk/single-url-environment-no-default/src/SeedSingleUrlEnvironmentNoDefault/SeedSingleUrlEnvironmentNoDefault.csproj
@@ -39,11 +39,11 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
-    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/single-url-environment-no-default/src/SeedSingleUrlEnvironmentNoDefault/SeedSingleUrlEnvironmentNoDefault.csproj
+++ b/seed/csharp-sdk/single-url-environment-no-default/src/SeedSingleUrlEnvironmentNoDefault/SeedSingleUrlEnvironmentNoDefault.csproj
@@ -39,6 +39,8 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+  </ItemGroup>
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/streaming-parameter/src/SeedStreaming/SeedStreaming.csproj
+++ b/seed/csharp-sdk/streaming-parameter/src/SeedStreaming/SeedStreaming.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
   </ItemGroup>
-  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/streaming-parameter/src/SeedStreaming/SeedStreaming.csproj
+++ b/seed/csharp-sdk/streaming-parameter/src/SeedStreaming/SeedStreaming.csproj
@@ -39,11 +39,11 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
-    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/streaming-parameter/src/SeedStreaming/SeedStreaming.csproj
+++ b/seed/csharp-sdk/streaming-parameter/src/SeedStreaming/SeedStreaming.csproj
@@ -39,6 +39,8 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+  </ItemGroup>
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/streaming/no-custom-config/src/SeedStreaming/SeedStreaming.csproj
+++ b/seed/csharp-sdk/streaming/no-custom-config/src/SeedStreaming/SeedStreaming.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
   </ItemGroup>
-  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/streaming/no-custom-config/src/SeedStreaming/SeedStreaming.csproj
+++ b/seed/csharp-sdk/streaming/no-custom-config/src/SeedStreaming/SeedStreaming.csproj
@@ -39,11 +39,11 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
-    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/streaming/no-custom-config/src/SeedStreaming/SeedStreaming.csproj
+++ b/seed/csharp-sdk/streaming/no-custom-config/src/SeedStreaming/SeedStreaming.csproj
@@ -39,6 +39,8 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+  </ItemGroup>
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/streaming/redact-response-body-on-error/src/SeedStreaming/SeedStreaming.csproj
+++ b/seed/csharp-sdk/streaming/redact-response-body-on-error/src/SeedStreaming/SeedStreaming.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
   </ItemGroup>
-  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/streaming/redact-response-body-on-error/src/SeedStreaming/SeedStreaming.csproj
+++ b/seed/csharp-sdk/streaming/redact-response-body-on-error/src/SeedStreaming/SeedStreaming.csproj
@@ -39,11 +39,11 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
-    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/streaming/redact-response-body-on-error/src/SeedStreaming/SeedStreaming.csproj
+++ b/seed/csharp-sdk/streaming/redact-response-body-on-error/src/SeedStreaming/SeedStreaming.csproj
@@ -39,6 +39,8 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+  </ItemGroup>
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/trace/src/SeedTrace/SeedTrace.csproj
+++ b/seed/csharp-sdk/trace/src/SeedTrace/SeedTrace.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
   </ItemGroup>
-  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/trace/src/SeedTrace/SeedTrace.csproj
+++ b/seed/csharp-sdk/trace/src/SeedTrace/SeedTrace.csproj
@@ -39,11 +39,11 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
-    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/trace/src/SeedTrace/SeedTrace.csproj
+++ b/seed/csharp-sdk/trace/src/SeedTrace/SeedTrace.csproj
@@ -39,6 +39,8 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+  </ItemGroup>
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/undiscriminated-union-with-response-property/src/SeedUndiscriminatedUnionWithResponseProperty/SeedUndiscriminatedUnionWithResponseProperty.csproj
+++ b/seed/csharp-sdk/undiscriminated-union-with-response-property/src/SeedUndiscriminatedUnionWithResponseProperty/SeedUndiscriminatedUnionWithResponseProperty.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
   </ItemGroup>
-  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/undiscriminated-union-with-response-property/src/SeedUndiscriminatedUnionWithResponseProperty/SeedUndiscriminatedUnionWithResponseProperty.csproj
+++ b/seed/csharp-sdk/undiscriminated-union-with-response-property/src/SeedUndiscriminatedUnionWithResponseProperty/SeedUndiscriminatedUnionWithResponseProperty.csproj
@@ -39,11 +39,11 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
-    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/undiscriminated-union-with-response-property/src/SeedUndiscriminatedUnionWithResponseProperty/SeedUndiscriminatedUnionWithResponseProperty.csproj
+++ b/seed/csharp-sdk/undiscriminated-union-with-response-property/src/SeedUndiscriminatedUnionWithResponseProperty/SeedUndiscriminatedUnionWithResponseProperty.csproj
@@ -39,6 +39,8 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+  </ItemGroup>
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/undiscriminated-unions/no-custom-config/src/SeedUndiscriminatedUnions/SeedUndiscriminatedUnions.csproj
+++ b/seed/csharp-sdk/undiscriminated-unions/no-custom-config/src/SeedUndiscriminatedUnions/SeedUndiscriminatedUnions.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
   </ItemGroup>
-  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/undiscriminated-unions/no-custom-config/src/SeedUndiscriminatedUnions/SeedUndiscriminatedUnions.csproj
+++ b/seed/csharp-sdk/undiscriminated-unions/no-custom-config/src/SeedUndiscriminatedUnions/SeedUndiscriminatedUnions.csproj
@@ -39,11 +39,11 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
-    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/undiscriminated-unions/no-custom-config/src/SeedUndiscriminatedUnions/SeedUndiscriminatedUnions.csproj
+++ b/seed/csharp-sdk/undiscriminated-unions/no-custom-config/src/SeedUndiscriminatedUnions/SeedUndiscriminatedUnions.csproj
@@ -39,6 +39,8 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+  </ItemGroup>
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/undiscriminated-unions/with-undiscriminated-unions/src/SeedUndiscriminatedUnions/SeedUndiscriminatedUnions.csproj
+++ b/seed/csharp-sdk/undiscriminated-unions/with-undiscriminated-unions/src/SeedUndiscriminatedUnions/SeedUndiscriminatedUnions.csproj
@@ -38,7 +38,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
   </ItemGroup>
-  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/undiscriminated-unions/with-undiscriminated-unions/src/SeedUndiscriminatedUnions/SeedUndiscriminatedUnions.csproj
+++ b/seed/csharp-sdk/undiscriminated-unions/with-undiscriminated-unions/src/SeedUndiscriminatedUnions/SeedUndiscriminatedUnions.csproj
@@ -37,11 +37,10 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
+    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/undiscriminated-unions/with-undiscriminated-unions/src/SeedUndiscriminatedUnions/SeedUndiscriminatedUnions.csproj
+++ b/seed/csharp-sdk/undiscriminated-unions/with-undiscriminated-unions/src/SeedUndiscriminatedUnions/SeedUndiscriminatedUnions.csproj
@@ -37,6 +37,8 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
+  </ItemGroup>
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/undiscriminated-unions/with-undiscriminated-unions/src/SeedUndiscriminatedUnions/SeedUndiscriminatedUnions.csproj
+++ b/seed/csharp-sdk/undiscriminated-unions/with-undiscriminated-unions/src/SeedUndiscriminatedUnions/SeedUndiscriminatedUnions.csproj
@@ -40,8 +40,6 @@
   </ItemGroup>
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
-    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/undiscriminated-unions/with-undiscriminated-unions/src/SeedUndiscriminatedUnions/SeedUndiscriminatedUnions.csproj
+++ b/seed/csharp-sdk/undiscriminated-unions/with-undiscriminated-unions/src/SeedUndiscriminatedUnions/SeedUndiscriminatedUnions.csproj
@@ -37,6 +37,8 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
+    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />

--- a/seed/csharp-sdk/unions-with-local-date/src/SeedUnions/SeedUnions.csproj
+++ b/seed/csharp-sdk/unions-with-local-date/src/SeedUnions/SeedUnions.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
   </ItemGroup>
-  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/unions-with-local-date/src/SeedUnions/SeedUnions.csproj
+++ b/seed/csharp-sdk/unions-with-local-date/src/SeedUnions/SeedUnions.csproj
@@ -39,11 +39,11 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
-    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/unions-with-local-date/src/SeedUnions/SeedUnions.csproj
+++ b/seed/csharp-sdk/unions-with-local-date/src/SeedUnions/SeedUnions.csproj
@@ -39,6 +39,8 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+  </ItemGroup>
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/unions/no-custom-config/src/SeedUnions/SeedUnions.csproj
+++ b/seed/csharp-sdk/unions/no-custom-config/src/SeedUnions/SeedUnions.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
   </ItemGroup>
-  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/unions/no-custom-config/src/SeedUnions/SeedUnions.csproj
+++ b/seed/csharp-sdk/unions/no-custom-config/src/SeedUnions/SeedUnions.csproj
@@ -39,11 +39,11 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
-    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/unions/no-custom-config/src/SeedUnions/SeedUnions.csproj
+++ b/seed/csharp-sdk/unions/no-custom-config/src/SeedUnions/SeedUnions.csproj
@@ -39,6 +39,8 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+  </ItemGroup>
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/unions/no-discriminated-unions/src/SeedUnions/SeedUnions.csproj
+++ b/seed/csharp-sdk/unions/no-discriminated-unions/src/SeedUnions/SeedUnions.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
   </ItemGroup>
-  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/unions/no-discriminated-unions/src/SeedUnions/SeedUnions.csproj
+++ b/seed/csharp-sdk/unions/no-discriminated-unions/src/SeedUnions/SeedUnions.csproj
@@ -39,11 +39,11 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
-    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/unions/no-discriminated-unions/src/SeedUnions/SeedUnions.csproj
+++ b/seed/csharp-sdk/unions/no-discriminated-unions/src/SeedUnions/SeedUnions.csproj
@@ -39,6 +39,8 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+  </ItemGroup>
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/unknown/src/SeedUnknownAsAny/SeedUnknownAsAny.csproj
+++ b/seed/csharp-sdk/unknown/src/SeedUnknownAsAny/SeedUnknownAsAny.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
   </ItemGroup>
-  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/unknown/src/SeedUnknownAsAny/SeedUnknownAsAny.csproj
+++ b/seed/csharp-sdk/unknown/src/SeedUnknownAsAny/SeedUnknownAsAny.csproj
@@ -39,11 +39,11 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
-    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/unknown/src/SeedUnknownAsAny/SeedUnknownAsAny.csproj
+++ b/seed/csharp-sdk/unknown/src/SeedUnknownAsAny/SeedUnknownAsAny.csproj
@@ -39,6 +39,8 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+  </ItemGroup>
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/url-form-encoded/no-custom-config/src/SeedApi/SeedApi.csproj
+++ b/seed/csharp-sdk/url-form-encoded/no-custom-config/src/SeedApi/SeedApi.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
   </ItemGroup>
-  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/url-form-encoded/no-custom-config/src/SeedApi/SeedApi.csproj
+++ b/seed/csharp-sdk/url-form-encoded/no-custom-config/src/SeedApi/SeedApi.csproj
@@ -39,11 +39,11 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
-    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/url-form-encoded/no-custom-config/src/SeedApi/SeedApi.csproj
+++ b/seed/csharp-sdk/url-form-encoded/no-custom-config/src/SeedApi/SeedApi.csproj
@@ -39,6 +39,8 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+  </ItemGroup>
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/validation/src/SeedValidation/SeedValidation.csproj
+++ b/seed/csharp-sdk/validation/src/SeedValidation/SeedValidation.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
   </ItemGroup>
-  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/validation/src/SeedValidation/SeedValidation.csproj
+++ b/seed/csharp-sdk/validation/src/SeedValidation/SeedValidation.csproj
@@ -39,11 +39,11 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
-    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/validation/src/SeedValidation/SeedValidation.csproj
+++ b/seed/csharp-sdk/validation/src/SeedValidation/SeedValidation.csproj
@@ -39,6 +39,8 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+  </ItemGroup>
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/variables/src/SeedVariables/SeedVariables.csproj
+++ b/seed/csharp-sdk/variables/src/SeedVariables/SeedVariables.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
   </ItemGroup>
-  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/variables/src/SeedVariables/SeedVariables.csproj
+++ b/seed/csharp-sdk/variables/src/SeedVariables/SeedVariables.csproj
@@ -39,11 +39,11 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
-    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/variables/src/SeedVariables/SeedVariables.csproj
+++ b/seed/csharp-sdk/variables/src/SeedVariables/SeedVariables.csproj
@@ -39,6 +39,8 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+  </ItemGroup>
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/version-no-default/src/SeedVersion/SeedVersion.csproj
+++ b/seed/csharp-sdk/version-no-default/src/SeedVersion/SeedVersion.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
   </ItemGroup>
-  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/version-no-default/src/SeedVersion/SeedVersion.csproj
+++ b/seed/csharp-sdk/version-no-default/src/SeedVersion/SeedVersion.csproj
@@ -39,11 +39,11 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
-    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/version-no-default/src/SeedVersion/SeedVersion.csproj
+++ b/seed/csharp-sdk/version-no-default/src/SeedVersion/SeedVersion.csproj
@@ -39,6 +39,8 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+  </ItemGroup>
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/version/src/SeedVersion/SeedVersion.csproj
+++ b/seed/csharp-sdk/version/src/SeedVersion/SeedVersion.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
   </ItemGroup>
-  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/version/src/SeedVersion/SeedVersion.csproj
+++ b/seed/csharp-sdk/version/src/SeedVersion/SeedVersion.csproj
@@ -39,11 +39,11 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
-    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/version/src/SeedVersion/SeedVersion.csproj
+++ b/seed/csharp-sdk/version/src/SeedVersion/SeedVersion.csproj
@@ -39,6 +39,8 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+  </ItemGroup>
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/webhook-audience/src/SeedApi/SeedApi.csproj
+++ b/seed/csharp-sdk/webhook-audience/src/SeedApi/SeedApi.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
   </ItemGroup>
-  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/webhook-audience/src/SeedApi/SeedApi.csproj
+++ b/seed/csharp-sdk/webhook-audience/src/SeedApi/SeedApi.csproj
@@ -39,11 +39,11 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
-    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/webhook-audience/src/SeedApi/SeedApi.csproj
+++ b/seed/csharp-sdk/webhook-audience/src/SeedApi/SeedApi.csproj
@@ -39,6 +39,8 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+  </ItemGroup>
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/webhooks/src/SeedWebhooks/SeedWebhooks.csproj
+++ b/seed/csharp-sdk/webhooks/src/SeedWebhooks/SeedWebhooks.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
   </ItemGroup>
-  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/webhooks/src/SeedWebhooks/SeedWebhooks.csproj
+++ b/seed/csharp-sdk/webhooks/src/SeedWebhooks/SeedWebhooks.csproj
@@ -39,11 +39,11 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
-    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/webhooks/src/SeedWebhooks/SeedWebhooks.csproj
+++ b/seed/csharp-sdk/webhooks/src/SeedWebhooks/SeedWebhooks.csproj
@@ -39,6 +39,8 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+  </ItemGroup>
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/websocket-bearer-auth/src/SeedWebsocketBearerAuth/SeedWebsocketBearerAuth.csproj
+++ b/seed/csharp-sdk/websocket-bearer-auth/src/SeedWebsocketBearerAuth/SeedWebsocketBearerAuth.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
   </ItemGroup>
-  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/websocket-bearer-auth/src/SeedWebsocketBearerAuth/SeedWebsocketBearerAuth.csproj
+++ b/seed/csharp-sdk/websocket-bearer-auth/src/SeedWebsocketBearerAuth/SeedWebsocketBearerAuth.csproj
@@ -39,11 +39,11 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
-    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/websocket-bearer-auth/src/SeedWebsocketBearerAuth/SeedWebsocketBearerAuth.csproj
+++ b/seed/csharp-sdk/websocket-bearer-auth/src/SeedWebsocketBearerAuth/SeedWebsocketBearerAuth.csproj
@@ -39,6 +39,8 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+  </ItemGroup>
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/websocket-inferred-auth/src/SeedWebsocketAuth/SeedWebsocketAuth.csproj
+++ b/seed/csharp-sdk/websocket-inferred-auth/src/SeedWebsocketAuth/SeedWebsocketAuth.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
   </ItemGroup>
-  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/websocket-inferred-auth/src/SeedWebsocketAuth/SeedWebsocketAuth.csproj
+++ b/seed/csharp-sdk/websocket-inferred-auth/src/SeedWebsocketAuth/SeedWebsocketAuth.csproj
@@ -39,11 +39,11 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
-    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/websocket-inferred-auth/src/SeedWebsocketAuth/SeedWebsocketAuth.csproj
+++ b/seed/csharp-sdk/websocket-inferred-auth/src/SeedWebsocketAuth/SeedWebsocketAuth.csproj
@@ -39,6 +39,8 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+  </ItemGroup>
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/websocket/no-custom-config/src/SeedWebsocket/SeedWebsocket.csproj
+++ b/seed/csharp-sdk/websocket/no-custom-config/src/SeedWebsocket/SeedWebsocket.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
   </ItemGroup>
-  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/websocket/no-custom-config/src/SeedWebsocket/SeedWebsocket.csproj
+++ b/seed/csharp-sdk/websocket/no-custom-config/src/SeedWebsocket/SeedWebsocket.csproj
@@ -39,11 +39,11 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
-    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/websocket/no-custom-config/src/SeedWebsocket/SeedWebsocket.csproj
+++ b/seed/csharp-sdk/websocket/no-custom-config/src/SeedWebsocket/SeedWebsocket.csproj
@@ -39,6 +39,8 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+  </ItemGroup>
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />

--- a/seed/csharp-sdk/websocket/with-websockets/src/SeedWebsocket/SeedWebsocket.csproj
+++ b/seed/csharp-sdk/websocket/with-websockets/src/SeedWebsocket/SeedWebsocket.csproj
@@ -39,13 +39,17 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+    <PackageReference Include="Microsoft.IO.RecyclableMemoryStream" Version="3.0.1" />
+  </ItemGroup>
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
-
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.2" />
-    <PackageReference Include="Microsoft.IO.RecyclableMemoryStream" Version="3.0.1" />
     <PackageReference Include="System.Threading.Channels" Version="8.0.0" />
+  </ItemGroup>
+  <ItemGroup Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/websocket/with-websockets/src/SeedWebsocket/SeedWebsocket.csproj
+++ b/seed/csharp-sdk/websocket/with-websockets/src/SeedWebsocket/SeedWebsocket.csproj
@@ -41,15 +41,12 @@
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
     <PackageReference Include="Microsoft.IO.RecyclableMemoryStream" Version="3.0.1" />
   </ItemGroup>
-  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
     <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.2" />
     <PackageReference Include="System.Threading.Channels" Version="8.0.0" />
-  </ItemGroup>
-  <ItemGroup Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">
-    <FrameworkReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/websocket/with-websockets/src/SeedWebsocket/SeedWebsocket.csproj
+++ b/seed/csharp-sdk/websocket/with-websockets/src/SeedWebsocket/SeedWebsocket.csproj
@@ -39,14 +39,14 @@
     </PackageReference>
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.Extended" Version="3.0.271" />
+    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
     <PackageReference Include="Microsoft.IO.RecyclableMemoryStream" Version="3.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.2" />
+    <PackageReference Include="System.Threading.Channels" Version="8.0.0" />
   </ItemGroup>
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
-    <PackageReference Include="System.Net.Http" Version="[4.3.4,)" />
-    <PackageReference Include="System.Text.RegularExpressions" Version="[4.3.1,)" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.2" />
-    <PackageReference Include="System.Threading.Channels" Version="8.0.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Description

Updates the C# `.csproj` generation logic so that packages shipping in-box with net8.0+ are only emitted as `<PackageReference>` for legacy TFMs (`netstandard2.0`, `net462`). These packages are wrapped in a separate `<ItemGroup>` gated by an MSBuild `IsTargetFrameworkCompatible` condition.

## Changes Made

- **New named constants** in `generators/csharp/base/src/project/CsharpProject.ts`:
  - `NET8_COMPATIBLE_CONDITION` / `LEGACY_FRAMEWORK_CONDITION` — MSBuild condition using `IsTargetFrameworkCompatible` for `>=` semantics
  - `NET8_INBOX_PACKAGES` — centralized list (currently just `System.Text.Json`), easy to extend
- **`getDependencies()`** now emits all unconditional packages: PolySharp, OneOf (when used), extra deps, WebSocket packages, and SSE package
- **New `getLegacyFrameworkDependencies()`** emits packages gated with `!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))`
- **Removed** `getWebSocketAsyncDependencies()` and `getSseDependencies()` — their contents moved into `getDependencies()`
- **`System.Net.Http` and `System.Text.RegularExpressions` scoped to OneOf** — when OneOf.Extended is present, both are emitted unconditionally as security version-floor overrides for its unpatched transitive dependencies. When OneOf is absent, `System.Net.Http` is emitted only in the legacy conditional group (for net462 assembly reference) and `System.Text.RegularExpressions` is omitted entirely.
- **WebSocket packages kept unconditional** — `Microsoft.Extensions.Logging.Abstractions`, `Microsoft.IO.RecyclableMemoryStream`, and `System.Threading.Channels` are needed on all TFMs
- **`System.Net.ServerSentEvents` kept unconditional** — only in-box starting with net9.0, must remain a `<PackageReference>` for net8.0 targets
- **Updated versions.yml** for both `csharp-sdk` (→ 2.52.0) and `csharp-model` (→ 0.7.0)
- **Updated ~265 seed snapshot `.csproj` files** across `csharp-sdk` and `csharp-model`

## Human Review Checklist

- [ ] Confirm the negated `IsTargetFrameworkCompatible` condition works correctly for `net462` (not a `netX.Y`-style TFM) — MSBuild docs say it returns `false` for non-.NET 5+ TFMs, so the negation correctly includes `net462` in the legacy group
- [ ] Verify `System.Net.Http` dual-path logic: emitted unconditionally when OneOf is present (security override), and in the legacy `<ItemGroup>` only when OneOf is absent (net462 assembly reference). No duplicates in either case.
- [ ] Spot-check a WebSocket `.csproj` snapshot (e.g. `seed/csharp-sdk/websocket/with-websockets/`) to confirm `Microsoft.Extensions.Logging.Abstractions` and `System.Threading.Channels` are in the unconditional `<ItemGroup>`, not the legacy-conditional one
- [ ] Spot-check an undiscriminated-unions `.csproj` snapshot (e.g. `seed/csharp-sdk/undiscriminated-unions/with-undiscriminated-unions/`) to confirm `System.Net.Http` is in the **legacy conditional** `<ItemGroup>` (not unconditional), and that `System.Text.RegularExpressions` is absent (no OneOf = no security override needed)
- [ ] Note: `shouldGenerateUndiscriminatedUnions` is `true` when OneOf is **not** used — the boolean reads counterintuitively in the condition checks

## Testing

- [x] `pnpm seed test --generator csharp-sdk --skip-scripts` — 150/151 passed (1 expected failure)
- [x] `pnpm seed test --generator csharp-model --skip-scripts` — 114/114 passed
- [x] `pnpm run check` (biome lint) passes
- [ ] Not tested locally: actual `dotnet build` of a generated multi-targeted SDK — relying on CI seed-with-scripts checks

Link to Devin session: https://app.devin.ai/sessions/aa7cf09822fe4797bf65b2726a1b5dd7
Requested by: @Swimburger
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/13846" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
