### PR TITLE
feat(rust): add per-event timeout to SSE stream methods

### DIFF
--- a/generators/rust/base/src/asIs/sse_stream.rs
+++ b/generators/rust/base/src/asIs/sse_stream.rs
@@ -8,6 +8,7 @@ use std::{
     marker::PhantomData,
     pin::Pin,
     task::{Context, Poll},
+    time::Duration,
 };
 
 /// Metadata from a Server-Sent Event
@@ -101,6 +102,9 @@ pub struct SseStream<T> {
     #[pin]
     inner: Pin<Box<dyn Stream<Item = Result<Event, EventError>> + Send>>,
     terminator: Option<String>,
+    timeout: Duration,
+    #[pin]
+    deadline: Pin<Box<tokio::time::Sleep>>,
     _phantom: PhantomData<T>,
 }
 
@@ -113,12 +117,18 @@ where
     /// # Arguments
     /// * `response` - The HTTP response to parse as SSE
     /// * `terminator` - Optional terminator string (e.g., `"[DONE]"`) that signals end of stream
+    /// * `timeout` - Per-event timeout duration. If no event is received within this duration,
+    ///   the stream yields `ApiError::StreamTimeout`.
     ///
     /// # Errors
     /// Returns `ApiError::SseParseError` if:
     /// - Response Content-Type is not `text/event-stream`
     /// - SSE stream cannot be created from response
-    pub(crate) async fn new(response: Response, terminator: Option<String>) -> Result<Self, ApiError> {
+    pub(crate) async fn new(
+        response: Response,
+        terminator: Option<String>,
+        timeout: Duration,
+    ) -> Result<Self, ApiError> {
         // Validate Content-Type header (case-insensitive, handles parameters)
         let content_type = response
             .headers()
@@ -149,6 +159,8 @@ where
         Ok(Self {
             inner: Box::pin(events),
             terminator,
+            timeout,
+            deadline: Box::pin(tokio::time::sleep(timeout)),
             _phantom: PhantomData,
         })
     }
@@ -200,6 +212,9 @@ where
         let this = self.project();
         match this.inner.poll_next(cx) {
             Poll::Ready(Some(Ok(event))) => {
+                // Reset the deadline for the next event
+                this.deadline.as_mut().reset(tokio::time::Instant::now() + *this.timeout);
+
                 // Check for terminator before parsing
                 if let Some(ref terminator) = this.terminator {
                     if event.data == *terminator {
@@ -215,10 +230,22 @@ where
                 }
             }
             Poll::Ready(Some(Err(e))) => {
+                // Reset the deadline on error events too
+                this.deadline.as_mut().reset(tokio::time::Instant::now() + *this.timeout);
                 Poll::Ready(Some(Err(ApiError::SseParseError(e.to_string()))))
             }
             Poll::Ready(None) => Poll::Ready(None),
-            Poll::Pending => Poll::Pending,
+            Poll::Pending => {
+                // Check if the per-event timeout has elapsed
+                match this.deadline.poll(cx) {
+                    Poll::Ready(()) => {
+                        // Timeout expired — reset deadline and yield a timeout error
+                        this.deadline.as_mut().reset(tokio::time::Instant::now() + *this.timeout);
+                        Poll::Ready(Some(Err(ApiError::StreamTimeout)))
+                    }
+                    Poll::Pending => Poll::Pending,
+                }
+            }
         }
     }
 }
@@ -247,6 +274,9 @@ where
 
         match inner_pin.inner.poll_next(cx) {
             Poll::Ready(Some(Ok(event))) => {
+                // Reset the deadline for the next event
+                inner_pin.deadline.as_mut().reset(tokio::time::Instant::now() + *inner_pin.timeout);
+
                 // Check for terminator
                 if let Some(ref terminator) = inner_pin.terminator {
                     if event.data == *terminator {
@@ -273,10 +303,22 @@ where
                 }
             }
             Poll::Ready(Some(Err(e))) => {
+                // Reset the deadline on error events too
+                inner_pin.deadline.as_mut().reset(tokio::time::Instant::now() + *inner_pin.timeout);
                 Poll::Ready(Some(Err(ApiError::SseParseError(e.to_string()))))
             }
             Poll::Ready(None) => Poll::Ready(None),
-            Poll::Pending => Poll::Pending,
+            Poll::Pending => {
+                // Check if the per-event timeout has elapsed
+                match inner_pin.deadline.poll(cx) {
+                    Poll::Ready(()) => {
+                        // Timeout expired — reset deadline and yield a timeout error
+                        inner_pin.deadline.as_mut().reset(tokio::time::Instant::now() + *inner_pin.timeout);
+                        Poll::Ready(Some(Err(ApiError::StreamTimeout)))
+                    }
+                    Poll::Pending => Poll::Pending,
+                }
+            }
         }
     }
 }

--- a/generators/rust/base/src/project/RustProject.ts
+++ b/generators/rust/base/src/project/RustProject.ts
@@ -320,11 +320,18 @@ export class RustProject extends AbstractProject<AbstractRustGeneratorContext<Ba
                 .map_err(|_| ApiError::InvalidHeader)?,
         );
 
+        // Determine per-event timeout: request-level overrides client-level
+        let timeout = options
+            .as_ref()
+            .and_then(|opts| opts.timeout_seconds)
+            .map(std::time::Duration::from_secs)
+            .unwrap_or(self.config.timeout);
+
         // Execute with retries
         let response = self.execute_with_retries(req, &options).await?;
 
-        // Return SSE stream
-        crate::SseStream::new(response, terminator).await
+        // Return SSE stream with per-event timeout
+        crate::SseStream::new(response, terminator, timeout).await
     }
 
 `

--- a/generators/rust/sdk/src/__test__/snapshots/api-specific-variants.rs
+++ b/generators/rust/sdk/src/__test__/snapshots/api-specific-variants.rs
@@ -22,6 +22,8 @@ pub enum ApiError {
     RequestClone,
     #[error("SSE stream terminated")]
     StreamTerminated,
+    #[error("SSE stream timed out waiting for next event")]
+    StreamTimeout,
     #[error("SSE parse error: {0}")]
     SseParseError(String),
 }

--- a/generators/rust/sdk/src/__test__/snapshots/basic-error-enum.rs
+++ b/generators/rust/sdk/src/__test__/snapshots/basic-error-enum.rs
@@ -20,6 +20,8 @@ pub enum ApiError {
     RequestClone,
     #[error("SSE stream terminated")]
     StreamTerminated,
+    #[error("SSE stream timed out waiting for next event")]
+    StreamTimeout,
     #[error("SSE parse error: {0}")]
     SseParseError(String),
 }

--- a/generators/rust/sdk/src/__test__/snapshots/context-rich-fields.rs
+++ b/generators/rust/sdk/src/__test__/snapshots/context-rich-fields.rs
@@ -26,6 +26,8 @@ pub enum ApiError {
     RequestClone,
     #[error("SSE stream terminated")]
     StreamTerminated,
+    #[error("SSE stream timed out waiting for next event")]
+    StreamTimeout,
     #[error("SSE parse error: {0}")]
     SseParseError(String),
 }

--- a/generators/rust/sdk/src/__test__/snapshots/default-field-values.rs
+++ b/generators/rust/sdk/src/__test__/snapshots/default-field-values.rs
@@ -20,6 +20,8 @@ pub enum ApiError {
     RequestClone,
     #[error("SSE stream terminated")]
     StreamTerminated,
+    #[error("SSE stream timed out waiting for next event")]
+    StreamTimeout,
     #[error("SSE parse error: {0}")]
     SseParseError(String),
 }

--- a/generators/rust/sdk/src/__test__/snapshots/different-error-messages.rs
+++ b/generators/rust/sdk/src/__test__/snapshots/different-error-messages.rs
@@ -26,6 +26,8 @@ pub enum ApiError {
     RequestClone,
     #[error("SSE stream terminated")]
     StreamTerminated,
+    #[error("SSE stream timed out waiting for next event")]
+    StreamTimeout,
     #[error("SSE parse error: {0}")]
     SseParseError(String),
 }

--- a/generators/rust/sdk/src/__test__/snapshots/empty-errors.rs
+++ b/generators/rust/sdk/src/__test__/snapshots/empty-errors.rs
@@ -16,6 +16,8 @@ pub enum ApiError {
     RequestClone,
     #[error("SSE stream terminated")]
     StreamTerminated,
+    #[error("SSE stream timed out waiting for next event")]
+    StreamTimeout,
     #[error("SSE parse error: {0}")]
     SseParseError(String),
 }

--- a/generators/rust/sdk/src/__test__/snapshots/json-parsing.rs
+++ b/generators/rust/sdk/src/__test__/snapshots/json-parsing.rs
@@ -20,6 +20,8 @@ pub enum ApiError {
     RequestClone,
     #[error("SSE stream terminated")]
     StreamTerminated,
+    #[error("SSE stream timed out waiting for next event")]
+    StreamTimeout,
     #[error("SSE parse error: {0}")]
     SseParseError(String),
 }

--- a/generators/rust/sdk/src/__test__/snapshots/status-code-mapping.rs
+++ b/generators/rust/sdk/src/__test__/snapshots/status-code-mapping.rs
@@ -24,6 +24,8 @@ pub enum ApiError {
     RequestClone,
     #[error("SSE stream terminated")]
     StreamTerminated,
+    #[error("SSE stream timed out waiting for next event")]
+    StreamTimeout,
     #[error("SSE parse error: {0}")]
     SseParseError(String),
 }

--- a/generators/rust/sdk/src/__test__/snapshots/text-only-errors.rs
+++ b/generators/rust/sdk/src/__test__/snapshots/text-only-errors.rs
@@ -20,6 +20,8 @@ pub enum ApiError {
     RequestClone,
     #[error("SSE stream terminated")]
     StreamTerminated,
+    #[error("SSE stream timed out waiting for next event")]
+    StreamTimeout,
     #[error("SSE parse error: {0}")]
     SseParseError(String),
 }

--- a/generators/rust/sdk/src/error/ErrorGenerator.ts
+++ b/generators/rust/sdk/src/error/ErrorGenerator.ts
@@ -90,6 +90,7 @@ export class ErrorGenerator {
             this.buildStandardVariant("InvalidHeader", "Invalid header value"),
             this.buildStandardVariant("RequestClone", "Could not clone request for retry"),
             this.buildStandardVariant("StreamTerminated", "SSE stream terminated"),
+            this.buildStandardVariant("StreamTimeout", "SSE stream timed out waiting for next event"),
             this.buildStandardVariant("SseParseError", "SSE parse error: {0}", undefined, [Type.string()])
         ];
 

--- a/generators/rust/sdk/versions.yml
+++ b/generators/rust/sdk/versions.yml
@@ -1,6 +1,6 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 
-- version: 0.21.1
+- version: 0.22.0
   changelogEntry:
     - summary: |
         Add per-event timeout to SSE stream methods. The `SseStream` now accepts a timeout

--- a/generators/rust/sdk/versions.yml
+++ b/generators/rust/sdk/versions.yml
@@ -1,5 +1,17 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 
+- version: 0.21.1
+  changelogEntry:
+    - summary: |
+        Add per-event timeout to SSE stream methods. The `SseStream` now accepts a timeout
+        duration and yields `ApiError::StreamTimeout` if no event is received within that
+        period. The timeout is derived from `RequestOptions.timeout_seconds` (per-request)
+        or `ClientConfig.timeout` (client-level), preventing indefinite blocking when the
+        server stops sending events.
+      type: feat
+  createdAt: "2026-03-20"
+  irVersion: 65
+
 - version: 0.21.0
   changelogEntry:
     - summary: |

--- a/seed/rust-sdk/exhaustive/src/error.rs
+++ b/seed/rust-sdk/exhaustive/src/error.rs
@@ -58,6 +58,8 @@ pub enum ApiError {
     RequestClone,
     #[error("SSE stream terminated")]
     StreamTerminated,
+    #[error("SSE stream timed out waiting for next event")]
+    StreamTimeout,
     #[error("SSE parse error: {0}")]
     SseParseError(String),
 }

--- a/seed/rust-sdk/streaming-parameter/src/core/http_client.rs
+++ b/seed/rust-sdk/streaming-parameter/src/core/http_client.rs
@@ -559,10 +559,17 @@ impl HttpClient {
             "no-store".parse().map_err(|_| ApiError::InvalidHeader)?,
         );
 
+        // Determine per-event timeout: request-level overrides client-level
+        let timeout = options
+            .as_ref()
+            .and_then(|opts| opts.timeout_seconds)
+            .map(std::time::Duration::from_secs)
+            .unwrap_or(self.config.timeout);
+
         // Execute with retries
         let response = self.execute_with_retries(req, &options).await?;
 
-        // Return SSE stream
-        crate::SseStream::new(response, terminator).await
+        // Return SSE stream with per-event timeout
+        crate::SseStream::new(response, terminator, timeout).await
     }
 }

--- a/seed/rust-sdk/streaming-parameter/src/core/sse_stream.rs
+++ b/seed/rust-sdk/streaming-parameter/src/core/sse_stream.rs
@@ -8,6 +8,7 @@ use std::{
     marker::PhantomData,
     pin::Pin,
     task::{Context, Poll},
+    time::Duration,
 };
 
 /// Metadata from a Server-Sent Event
@@ -101,6 +102,9 @@ pub struct SseStream<T> {
     #[pin]
     inner: Pin<Box<dyn Stream<Item = Result<Event, EventError>> + Send>>,
     terminator: Option<String>,
+    timeout: Duration,
+    #[pin]
+    deadline: Pin<Box<tokio::time::Sleep>>,
     _phantom: PhantomData<T>,
 }
 
@@ -113,6 +117,8 @@ where
     /// # Arguments
     /// * `response` - The HTTP response to parse as SSE
     /// * `terminator` - Optional terminator string (e.g., `"[DONE]"`) that signals end of stream
+    /// * `timeout` - Per-event timeout duration. If no event is received within this duration,
+    ///   the stream yields `ApiError::StreamTimeout`.
     ///
     /// # Errors
     /// Returns `ApiError::SseParseError` if:
@@ -121,6 +127,7 @@ where
     pub(crate) async fn new(
         response: Response,
         terminator: Option<String>,
+        timeout: Duration,
     ) -> Result<Self, ApiError> {
         // Validate Content-Type header (case-insensitive, handles parameters)
         let content_type = response
@@ -148,6 +155,8 @@ where
         Ok(Self {
             inner: Box::pin(events),
             terminator,
+            timeout,
+            deadline: Box::pin(tokio::time::sleep(timeout)),
             _phantom: PhantomData,
         })
     }
@@ -199,6 +208,11 @@ where
         let this = self.project();
         match this.inner.poll_next(cx) {
             Poll::Ready(Some(Ok(event))) => {
+                // Reset the deadline for the next event
+                this.deadline
+                    .as_mut()
+                    .reset(tokio::time::Instant::now() + *this.timeout);
+
                 // Check for terminator before parsing
                 if let Some(ref terminator) = this.terminator {
                     if event.data == *terminator {
@@ -214,10 +228,26 @@ where
                 }
             }
             Poll::Ready(Some(Err(e))) => {
+                // Reset the deadline on error events too
+                this.deadline
+                    .as_mut()
+                    .reset(tokio::time::Instant::now() + *this.timeout);
                 Poll::Ready(Some(Err(ApiError::SseParseError(e.to_string()))))
             }
             Poll::Ready(None) => Poll::Ready(None),
-            Poll::Pending => Poll::Pending,
+            Poll::Pending => {
+                // Check if the per-event timeout has elapsed
+                match this.deadline.poll(cx) {
+                    Poll::Ready(()) => {
+                        // Timeout expired — reset deadline and yield a timeout error
+                        this.deadline
+                            .as_mut()
+                            .reset(tokio::time::Instant::now() + *this.timeout);
+                        Poll::Ready(Some(Err(ApiError::StreamTimeout)))
+                    }
+                    Poll::Pending => Poll::Pending,
+                }
+            }
         }
     }
 }
@@ -246,6 +276,12 @@ where
 
         match inner_pin.inner.poll_next(cx) {
             Poll::Ready(Some(Ok(event))) => {
+                // Reset the deadline for the next event
+                inner_pin
+                    .deadline
+                    .as_mut()
+                    .reset(tokio::time::Instant::now() + *inner_pin.timeout);
+
                 // Check for terminator
                 if let Some(ref terminator) = inner_pin.terminator {
                     if event.data == *terminator {
@@ -272,10 +308,28 @@ where
                 }
             }
             Poll::Ready(Some(Err(e))) => {
+                // Reset the deadline on error events too
+                inner_pin
+                    .deadline
+                    .as_mut()
+                    .reset(tokio::time::Instant::now() + *inner_pin.timeout);
                 Poll::Ready(Some(Err(ApiError::SseParseError(e.to_string()))))
             }
             Poll::Ready(None) => Poll::Ready(None),
-            Poll::Pending => Poll::Pending,
+            Poll::Pending => {
+                // Check if the per-event timeout has elapsed
+                match inner_pin.deadline.poll(cx) {
+                    Poll::Ready(()) => {
+                        // Timeout expired — reset deadline and yield a timeout error
+                        inner_pin
+                            .deadline
+                            .as_mut()
+                            .reset(tokio::time::Instant::now() + *inner_pin.timeout);
+                        Poll::Ready(Some(Err(ApiError::StreamTimeout)))
+                    }
+                    Poll::Pending => Poll::Pending,
+                }
+            }
         }
     }
 }

--- a/seed/rust-sdk/streaming-parameter/src/error.rs
+++ b/seed/rust-sdk/streaming-parameter/src/error.rs
@@ -16,6 +16,8 @@ pub enum ApiError {
     RequestClone,
     #[error("SSE stream terminated")]
     StreamTerminated,
+    #[error("SSE stream timed out waiting for next event")]
+    StreamTimeout,
     #[error("SSE parse error: {0}")]
     SseParseError(String),
 }

--- a/seed/rust-sdk/streaming/src/core/http_client.rs
+++ b/seed/rust-sdk/streaming/src/core/http_client.rs
@@ -559,10 +559,17 @@ impl HttpClient {
             "no-store".parse().map_err(|_| ApiError::InvalidHeader)?,
         );
 
+        // Determine per-event timeout: request-level overrides client-level
+        let timeout = options
+            .as_ref()
+            .and_then(|opts| opts.timeout_seconds)
+            .map(std::time::Duration::from_secs)
+            .unwrap_or(self.config.timeout);
+
         // Execute with retries
         let response = self.execute_with_retries(req, &options).await?;
 
-        // Return SSE stream
-        crate::SseStream::new(response, terminator).await
+        // Return SSE stream with per-event timeout
+        crate::SseStream::new(response, terminator, timeout).await
     }
 }

--- a/seed/rust-sdk/streaming/src/core/sse_stream.rs
+++ b/seed/rust-sdk/streaming/src/core/sse_stream.rs
@@ -8,6 +8,7 @@ use std::{
     marker::PhantomData,
     pin::Pin,
     task::{Context, Poll},
+    time::Duration,
 };
 
 /// Metadata from a Server-Sent Event
@@ -101,6 +102,9 @@ pub struct SseStream<T> {
     #[pin]
     inner: Pin<Box<dyn Stream<Item = Result<Event, EventError>> + Send>>,
     terminator: Option<String>,
+    timeout: Duration,
+    #[pin]
+    deadline: Pin<Box<tokio::time::Sleep>>,
     _phantom: PhantomData<T>,
 }
 
@@ -113,6 +117,8 @@ where
     /// # Arguments
     /// * `response` - The HTTP response to parse as SSE
     /// * `terminator` - Optional terminator string (e.g., `"[DONE]"`) that signals end of stream
+    /// * `timeout` - Per-event timeout duration. If no event is received within this duration,
+    ///   the stream yields `ApiError::StreamTimeout`.
     ///
     /// # Errors
     /// Returns `ApiError::SseParseError` if:
@@ -121,6 +127,7 @@ where
     pub(crate) async fn new(
         response: Response,
         terminator: Option<String>,
+        timeout: Duration,
     ) -> Result<Self, ApiError> {
         // Validate Content-Type header (case-insensitive, handles parameters)
         let content_type = response
@@ -148,6 +155,8 @@ where
         Ok(Self {
             inner: Box::pin(events),
             terminator,
+            timeout,
+            deadline: Box::pin(tokio::time::sleep(timeout)),
             _phantom: PhantomData,
         })
     }
@@ -199,6 +208,11 @@ where
         let this = self.project();
         match this.inner.poll_next(cx) {
             Poll::Ready(Some(Ok(event))) => {
+                // Reset the deadline for the next event
+                this.deadline
+                    .as_mut()
+                    .reset(tokio::time::Instant::now() + *this.timeout);
+
                 // Check for terminator before parsing
                 if let Some(ref terminator) = this.terminator {
                     if event.data == *terminator {
@@ -214,10 +228,26 @@ where
                 }
             }
             Poll::Ready(Some(Err(e))) => {
+                // Reset the deadline on error events too
+                this.deadline
+                    .as_mut()
+                    .reset(tokio::time::Instant::now() + *this.timeout);
                 Poll::Ready(Some(Err(ApiError::SseParseError(e.to_string()))))
             }
             Poll::Ready(None) => Poll::Ready(None),
-            Poll::Pending => Poll::Pending,
+            Poll::Pending => {
+                // Check if the per-event timeout has elapsed
+                match this.deadline.poll(cx) {
+                    Poll::Ready(()) => {
+                        // Timeout expired — reset deadline and yield a timeout error
+                        this.deadline
+                            .as_mut()
+                            .reset(tokio::time::Instant::now() + *this.timeout);
+                        Poll::Ready(Some(Err(ApiError::StreamTimeout)))
+                    }
+                    Poll::Pending => Poll::Pending,
+                }
+            }
         }
     }
 }
@@ -246,6 +276,12 @@ where
 
         match inner_pin.inner.poll_next(cx) {
             Poll::Ready(Some(Ok(event))) => {
+                // Reset the deadline for the next event
+                inner_pin
+                    .deadline
+                    .as_mut()
+                    .reset(tokio::time::Instant::now() + *inner_pin.timeout);
+
                 // Check for terminator
                 if let Some(ref terminator) = inner_pin.terminator {
                     if event.data == *terminator {
@@ -272,10 +308,28 @@ where
                 }
             }
             Poll::Ready(Some(Err(e))) => {
+                // Reset the deadline on error events too
+                inner_pin
+                    .deadline
+                    .as_mut()
+                    .reset(tokio::time::Instant::now() + *inner_pin.timeout);
                 Poll::Ready(Some(Err(ApiError::SseParseError(e.to_string()))))
             }
             Poll::Ready(None) => Poll::Ready(None),
-            Poll::Pending => Poll::Pending,
+            Poll::Pending => {
+                // Check if the per-event timeout has elapsed
+                match inner_pin.deadline.poll(cx) {
+                    Poll::Ready(()) => {
+                        // Timeout expired — reset deadline and yield a timeout error
+                        inner_pin
+                            .deadline
+                            .as_mut()
+                            .reset(tokio::time::Instant::now() + *inner_pin.timeout);
+                        Poll::Ready(Some(Err(ApiError::StreamTimeout)))
+                    }
+                    Poll::Pending => Poll::Pending,
+                }
+            }
         }
     }
 }

--- a/seed/rust-sdk/streaming/src/error.rs
+++ b/seed/rust-sdk/streaming/src/error.rs
@@ -16,6 +16,8 @@ pub enum ApiError {
     RequestClone,
     #[error("SSE stream terminated")]
     StreamTerminated,
+    #[error("SSE stream timed out waiting for next event")]
+    StreamTimeout,
     #[error("SSE parse error: {0}")]
     SseParseError(String),
 }


### PR DESCRIPTION
## Description
Closes [FER-9143](https://linear.app/buildwithfern/issue/FER-9143/rust-sdk-add-timeout-to-sse-stream-methods)

Adds a per-event timeout to SSE streams in the generated Rust SDK. Previously, if a server stopped sending events, `SseStream` would block indefinitely. Now the stream yields `ApiError::StreamTimeout` if no event arrives within the configured timeout period.

## Changes Made
- Added `StreamTimeout` error variant to the generated `ApiError` enum (`ErrorGenerator.ts`)
- Added `timeout` + `deadline` (pinned `tokio::time::Sleep`) fields to `SseStream` struct (`sse_stream.rs` template)
- Updated `SseStream::new()` to accept a `Duration` timeout parameter
- Both `SseStream` and `SseStreamWithMetadata` `poll_next` implementations now check the deadline when the inner stream returns `Pending`
- Updated `execute_sse_request` template (`RustProject.ts`) to resolve timeout from `RequestOptions.timeout_seconds` → `ClientConfig.timeout` fallback, and pass it to `SseStream::new`
- Updated `versions.yml` with `0.22.0` changelog entry (minor bump for `feat`)
- Updated ErrorGenerator snapshot tests to include the new `StreamTimeout` variant
- Regenerated seed outputs for `streaming`, `streaming-parameter`, and `exhaustive` fixtures

## Key review points
1. **Timeout is mandatory, not optional** — `SseStream::new` requires a `Duration`, always applying a per-event timeout. The default comes from `ClientConfig.timeout` (60s). APIs with legitimately long gaps between SSE events may need users to set a longer timeout. Should this be `Option<Duration>` instead?
2. **Timeout yields an error but does not terminate the stream** — on timeout, the deadline resets and the stream continues. The consumer receives `Err(ApiError::StreamTimeout)` for that poll cycle. This is consistent with how `SseParseError` is handled (non-fatal), but worth confirming this is the desired semantics vs. terminating the stream.
3. **Reuses HTTP request timeout for SSE event intervals** — there's no separate SSE-specific timeout config; it piggybacks on `timeout_seconds` / `ClientConfig.timeout`. This keeps the API simple but conflates two different timeout semantics.
4. **Pin projection on `deadline` field** — The `Pin<Box<tokio::time::Sleep>>` field uses `#[pin]` in the `pin_project` struct. The compiler accepts this and seed tests compile, but the nested pin pattern (`Pin<&mut Pin<Box<Sleep>>>`) is non-trivial — worth a glance to confirm correctness.

## Testing
- [x] `pnpm run check` (Biome lint) — passes
- [x] ErrorGenerator snapshot tests — updated and passing (9 snapshots)
- [x] Seed tests: `streaming`, `streaming-parameter`, `exhaustive` — all pass
- [ ] No runtime unit tests for timeout behavior (would require a mock SSE server with delayed events)

Link to Devin session: https://app.devin.ai/sessions/b80b6af4a7254c84993cd150eb671297
Requested by: @iamnamananand996