### PR TITLE
chore(ci): add --frozen-lockfile to pnpm install in CI

### DIFF
--- a/.github/actions/install/action.yaml
+++ b/.github/actions/install/action.yaml
@@ -33,7 +33,7 @@ runs:
       shell: bash
       run: |
         for attempt in 1 2 3; do
-          pnpm install && break
+          pnpm install --frozen-lockfile && break
           if [ "$attempt" -eq 3 ]; then
             echo "pnpm install failed after 3 attempts"
             exit 1


### PR DESCRIPTION
## Description

Adds `--frozen-lockfile` to the `pnpm install` step in the shared CI install action. This ensures CI fails if `pnpm-lock.yaml` is out of sync with `package.json`, preventing stale cached dependencies from masking broken installs.

## Changes Made

- Added `--frozen-lockfile` flag to `pnpm install` in `.github/actions/install/action.yaml`

## Testing

- [ ] Verify `pnpm-lock.yaml` is currently in sync on `main` (otherwise this will break all CI jobs immediately)

## Reviewer Checklist

- [ ] **Retry interaction**: The existing retry loop (3 attempts) will also retry deterministic `--frozen-lockfile` failures (lockfile mismatch). This is wasteful but not harmful — it'll fail 3 times then exit 1. Consider whether it's worth short-circuiting retries for this specific error class, or if the simplicity of the current approach is fine.

Link to Devin session: https://app.devin.ai/sessions/cd828cad9fdd4eca9d2c89b804e000d3
Requested by: @Swimburger
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/13848" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
