### PR TITLE
fix(generator-cli): add missing version to Gradle dependency in Java README

### DIFF
--- a/packages/generator-cli/src/__test__/__snapshots__/basic-java.md
+++ b/packages/generator-cli/src/__test__/__snapshots__/basic-java.md
@@ -18,7 +18,7 @@ Add the dependency in your `build.gradle` file:
 
 ```groovy
 dependencies {
-  implementation 'io.intercom:intercom-java'
+  implementation 'io.intercom:intercom-java:3.0.0'
 }
 ```
 

--- a/packages/generator-cli/src/__test__/__snapshots__/custom-sections/java/basic.md
+++ b/packages/generator-cli/src/__test__/__snapshots__/custom-sections/java/basic.md
@@ -20,7 +20,7 @@ Add the dependency in your `build.gradle` file:
 
 ```groovy
 dependencies {
-  implementation 'imdb:imdb-java-sdk'
+  implementation 'imdb:imdb-java-sdk:2.0.0'
 }
 ```
 

--- a/packages/generator-cli/src/__test__/__snapshots__/custom-sections/java/invalid-key.md
+++ b/packages/generator-cli/src/__test__/__snapshots__/custom-sections/java/invalid-key.md
@@ -20,7 +20,7 @@ Add the dependency in your `build.gradle` file:
 
 ```groovy
 dependencies {
-  implementation 'imdb:imdb-java-sdk'
+  implementation 'imdb:imdb-java-sdk:2.0.0'
 }
 ```
 

--- a/packages/generator-cli/src/__test__/__snapshots__/custom-sections/java/invalid-language.md
+++ b/packages/generator-cli/src/__test__/__snapshots__/custom-sections/java/invalid-language.md
@@ -19,7 +19,7 @@ Add the dependency in your `build.gradle` file:
 
 ```groovy
 dependencies {
-  implementation 'imdb:imdb-java-sdk'
+  implementation 'imdb:imdb-java-sdk:2.0.0'
 }
 ```
 

--- a/packages/generator-cli/src/__test__/__snapshots__/custom-sections/java/multiple-custom-sections.md
+++ b/packages/generator-cli/src/__test__/__snapshots__/custom-sections/java/multiple-custom-sections.md
@@ -21,7 +21,7 @@ Add the dependency in your `build.gradle` file:
 
 ```groovy
 dependencies {
-  implementation 'imdb:imdb-java-sdk'
+  implementation 'imdb:imdb-java-sdk:2.0.0'
 }
 ```
 

--- a/packages/generator-cli/src/__test__/__snapshots__/custom-sections/java/no-custom-sections.md
+++ b/packages/generator-cli/src/__test__/__snapshots__/custom-sections/java/no-custom-sections.md
@@ -19,7 +19,7 @@ Add the dependency in your `build.gradle` file:
 
 ```groovy
 dependencies {
-  implementation 'imdb:imdb-java-sdk'
+  implementation 'imdb:imdb-java-sdk:2.0.0'
 }
 ```
 

--- a/packages/generator-cli/src/__test__/__snapshots__/custom-sections/java/override-custom-section.md
+++ b/packages/generator-cli/src/__test__/__snapshots__/custom-sections/java/override-custom-section.md
@@ -19,7 +19,7 @@ Add the dependency in your `build.gradle` file:
 
 ```groovy
 dependencies {
-  implementation 'imdb:imdb-java-sdk'
+  implementation 'imdb:imdb-java-sdk:2.0.0'
 }
 ```
 

--- a/packages/generator-cli/src/__test__/fixtures/custom-sections/java.README.md
+++ b/packages/generator-cli/src/__test__/fixtures/custom-sections/java.README.md
@@ -13,7 +13,7 @@ Add the dependency in your `build.gradle` file:
 
 ```groovy
 dependencies {
-  implementation 'imdb:imdb-java-sdk'
+  implementation 'imdb:imdb-java-sdk:1.2.3'
 }
 ```
 

--- a/packages/generator-cli/src/readme/ReadmeGenerator.ts
+++ b/packages/generator-cli/src/readme/ReadmeGenerator.ts
@@ -589,7 +589,7 @@ export class ReadmeGenerator {
         await writer.writeLine();
         await writer.writeLine("```groovy");
         await writer.writeLine("dependencies {");
-        await writer.writeLine(`  implementation '${maven.group}:${maven.artifact}'`);
+        await writer.writeLine(`  implementation '${maven.group}:${maven.artifact}:${maven.version}'`);
         await writer.writeLine("}");
         await writer.writeLine("```");
         await writer.writeLine();


### PR DESCRIPTION
## Description

Refs FER-9148

The generated Java SDK README was missing the version number in the Gradle dependency snippet, while the Maven XML snippet correctly included it. For example, the Gradle section would show `implementation 'io.intercom:intercom-java'` instead of the correct `implementation 'io.intercom:intercom-java:3.0.0'`. This affects all Java SDKs generated by Fern.

## Changes Made

- Fixed `writeInstallationForMaven` in `ReadmeGenerator.ts` to include `${maven.version}` in the Gradle `implementation` string
- Updated all affected test snapshots (7 snapshot files + 1 test fixture)

## Testing

- [x] Unit tests updated (all 83 generator-cli tests pass)
- [ ] Seed test snapshots may need regeneration — `seed/java-sdk/*/README.md` files likely still contain the old format

## Review Checklist

- [ ] Verify `maven.version` is always present when this code path runs (it is — `MavenPublishInfo.version` is a required field, and the `generateInstallation` method is only called when `publishInfo != null`)
- [ ] Check whether CI requires seed snapshot updates for `seed/java-sdk/` README files

Link to Devin session: https://app.devin.ai/sessions/4d4d7ab569924998b1705ac3146ad601
Requested by: @jsklan