### PR TITLE
fix(rust): fix double-pin compilation error in SseStream timeout

### DIFF
--- a/generators/rust/base/src/asIs/sse_stream.rs
+++ b/generators/rust/base/src/asIs/sse_stream.rs
@@ -5,6 +5,7 @@ use reqwest::{header::CONTENT_TYPE, Response};
 use reqwest_sse::{error::EventError, Event, EventSource};
 use serde::de::DeserializeOwned;
 use std::{
+    future::Future,
     marker::PhantomData,
     pin::Pin,
     task::{Context, Poll},
@@ -209,7 +210,7 @@ where
     type Item = Result<T, ApiError>;
 
     fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
-        let this = self.project();
+        let mut this = self.project();
         match this.inner.poll_next(cx) {
             Poll::Ready(Some(Ok(event))) => {
                 // Reset the deadline for the next event
@@ -237,7 +238,7 @@ where
             Poll::Ready(None) => Poll::Ready(None),
             Poll::Pending => {
                 // Check if the per-event timeout has elapsed
-                match this.deadline.poll(cx) {
+                match this.deadline.as_mut().poll(cx) {
                     Poll::Ready(()) => {
                         // Timeout expired — reset deadline and yield a timeout error
                         this.deadline.as_mut().reset(tokio::time::Instant::now() + *this.timeout);
@@ -270,7 +271,7 @@ where
         let this = self.project();
 
         // Access the inner stream's fields through pin projection
-        let inner_pin = this.inner.project();
+        let mut inner_pin = this.inner.project();
 
         match inner_pin.inner.poll_next(cx) {
             Poll::Ready(Some(Ok(event))) => {
@@ -310,7 +311,7 @@ where
             Poll::Ready(None) => Poll::Ready(None),
             Poll::Pending => {
                 // Check if the per-event timeout has elapsed
-                match inner_pin.deadline.poll(cx) {
+                match inner_pin.deadline.as_mut().poll(cx) {
                     Poll::Ready(()) => {
                         // Timeout expired — reset deadline and yield a timeout error
                         inner_pin.deadline.as_mut().reset(tokio::time::Instant::now() + *inner_pin.timeout);

--- a/generators/rust/base/src/asIs/sse_stream.rs
+++ b/generators/rust/base/src/asIs/sse_stream.rs
@@ -104,7 +104,7 @@ pub struct SseStream<T> {
     terminator: Option<String>,
     timeout: Duration,
     #[pin]
-    deadline: Pin<Box<tokio::time::Sleep>>,
+    deadline: tokio::time::Sleep,
     _phantom: PhantomData<T>,
 }
 
@@ -160,7 +160,7 @@ where
             inner: Box::pin(events),
             terminator,
             timeout,
-            deadline: Box::pin(tokio::time::sleep(timeout)),
+            deadline: tokio::time::sleep(timeout),
             _phantom: PhantomData,
         })
     }

--- a/generators/rust/sdk/versions.yml
+++ b/generators/rust/sdk/versions.yml
@@ -1,5 +1,18 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 
+- version: 0.22.1
+  changelogEntry:
+    - summary: |
+        Fix double-pin compilation error in `SseStream` timeout implementation. The `deadline`
+        field was declared as `Pin<Box<tokio::time::Sleep>>` with a `#[pin]` attribute, causing
+        `pin_project` to produce `Pin<&mut Pin<Box<Sleep>>>` which lacks `reset()` and `poll()`
+        methods. Changed the field type to `tokio::time::Sleep` (unpinned, letting `pin_project`
+        handle pinning) so the projected type is `Pin<&mut Sleep>` which correctly exposes
+        the required methods.
+      type: fix
+  createdAt: "2026-03-20"
+  irVersion: 65
+
 - version: 0.22.0
   changelogEntry:
     - summary: |

--- a/seed/rust-sdk/streaming-parameter/src/core/sse_stream.rs
+++ b/seed/rust-sdk/streaming-parameter/src/core/sse_stream.rs
@@ -5,6 +5,7 @@ use reqwest::{header::CONTENT_TYPE, Response};
 use reqwest_sse::{error::EventError, Event, EventSource};
 use serde::de::DeserializeOwned;
 use std::{
+    future::Future,
     marker::PhantomData,
     pin::Pin,
     task::{Context, Poll},
@@ -205,7 +206,7 @@ where
     type Item = Result<T, ApiError>;
 
     fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
-        let this = self.project();
+        let mut this = self.project();
         match this.inner.poll_next(cx) {
             Poll::Ready(Some(Ok(event))) => {
                 // Reset the deadline for the next event
@@ -237,7 +238,7 @@ where
             Poll::Ready(None) => Poll::Ready(None),
             Poll::Pending => {
                 // Check if the per-event timeout has elapsed
-                match this.deadline.poll(cx) {
+                match this.deadline.as_mut().poll(cx) {
                     Poll::Ready(()) => {
                         // Timeout expired — reset deadline and yield a timeout error
                         this.deadline
@@ -272,7 +273,7 @@ where
         let this = self.project();
 
         // Access the inner stream's fields through pin projection
-        let inner_pin = this.inner.project();
+        let mut inner_pin = this.inner.project();
 
         match inner_pin.inner.poll_next(cx) {
             Poll::Ready(Some(Ok(event))) => {
@@ -318,7 +319,7 @@ where
             Poll::Ready(None) => Poll::Ready(None),
             Poll::Pending => {
                 // Check if the per-event timeout has elapsed
-                match inner_pin.deadline.poll(cx) {
+                match inner_pin.deadline.as_mut().poll(cx) {
                     Poll::Ready(()) => {
                         // Timeout expired — reset deadline and yield a timeout error
                         inner_pin

--- a/seed/rust-sdk/streaming-parameter/src/core/sse_stream.rs
+++ b/seed/rust-sdk/streaming-parameter/src/core/sse_stream.rs
@@ -104,7 +104,7 @@ pub struct SseStream<T> {
     terminator: Option<String>,
     timeout: Duration,
     #[pin]
-    deadline: Pin<Box<tokio::time::Sleep>>,
+    deadline: tokio::time::Sleep,
     _phantom: PhantomData<T>,
 }
 
@@ -156,7 +156,7 @@ where
             inner: Box::pin(events),
             terminator,
             timeout,
-            deadline: Box::pin(tokio::time::sleep(timeout)),
+            deadline: tokio::time::sleep(timeout),
             _phantom: PhantomData,
         })
     }

--- a/seed/rust-sdk/streaming/src/core/sse_stream.rs
+++ b/seed/rust-sdk/streaming/src/core/sse_stream.rs
@@ -5,6 +5,7 @@ use reqwest::{header::CONTENT_TYPE, Response};
 use reqwest_sse::{error::EventError, Event, EventSource};
 use serde::de::DeserializeOwned;
 use std::{
+    future::Future,
     marker::PhantomData,
     pin::Pin,
     task::{Context, Poll},
@@ -205,7 +206,7 @@ where
     type Item = Result<T, ApiError>;
 
     fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
-        let this = self.project();
+        let mut this = self.project();
         match this.inner.poll_next(cx) {
             Poll::Ready(Some(Ok(event))) => {
                 // Reset the deadline for the next event
@@ -237,7 +238,7 @@ where
             Poll::Ready(None) => Poll::Ready(None),
             Poll::Pending => {
                 // Check if the per-event timeout has elapsed
-                match this.deadline.poll(cx) {
+                match this.deadline.as_mut().poll(cx) {
                     Poll::Ready(()) => {
                         // Timeout expired — reset deadline and yield a timeout error
                         this.deadline
@@ -272,7 +273,7 @@ where
         let this = self.project();
 
         // Access the inner stream's fields through pin projection
-        let inner_pin = this.inner.project();
+        let mut inner_pin = this.inner.project();
 
         match inner_pin.inner.poll_next(cx) {
             Poll::Ready(Some(Ok(event))) => {
@@ -318,7 +319,7 @@ where
             Poll::Ready(None) => Poll::Ready(None),
             Poll::Pending => {
                 // Check if the per-event timeout has elapsed
-                match inner_pin.deadline.poll(cx) {
+                match inner_pin.deadline.as_mut().poll(cx) {
                     Poll::Ready(()) => {
                         // Timeout expired — reset deadline and yield a timeout error
                         inner_pin

--- a/seed/rust-sdk/streaming/src/core/sse_stream.rs
+++ b/seed/rust-sdk/streaming/src/core/sse_stream.rs
@@ -104,7 +104,7 @@ pub struct SseStream<T> {
     terminator: Option<String>,
     timeout: Duration,
     #[pin]
-    deadline: Pin<Box<tokio::time::Sleep>>,
+    deadline: tokio::time::Sleep,
     _phantom: PhantomData<T>,
 }
 
@@ -156,7 +156,7 @@ where
             inner: Box::pin(events),
             terminator,
             timeout,
-            deadline: Box::pin(tokio::time::sleep(timeout)),
+            deadline: tokio::time::sleep(timeout),
             _phantom: PhantomData,
         })
     }


### PR DESCRIPTION
## Description
Refs [FER-9143](https://linear.app/buildwithfern/issue/FER-9143/rust-sdk-add-timeout-to-sse-stream-methods)

Fixes a compilation error in generated Rust SDKs introduced by #13847. The `SseStream` `deadline` field was declared as `Pin<Box<tokio::time::Sleep>>` with a `#[pin]` attribute, causing `pin_project` to produce the projected type `Pin<&mut Pin<Box<Sleep>>>` — which lacks the `reset()` and `poll()` methods needed for timeout logic. This broke compilation in downstream SDKs (e.g. [xai-rust-internal#16](https://github.com/fern-demo/xai-rust-internal/pull/16)).

## Changes Made
- Changed `deadline` field type from `Pin<Box<tokio::time::Sleep>>` to `tokio::time::Sleep` in the `SseStream` template, letting `pin_project` handle pinning so the projected type is `Pin<&mut Sleep>`
- Removed the `Box::pin()` wrapper at the construction site accordingly
- Added `use std::future::Future` import — required for calling `.poll()` on the projected `Pin<&mut Sleep>`
- Changed `let this` → `let mut this` and `let inner_pin` → `let mut inner_pin` for mutability needed by `.as_mut()` calls
- Changed `.poll(cx)` → `.as_mut().poll(cx)` to reborrow the `Pin` instead of moving it (`Pin<&mut Sleep>` is `!Copy`)
- Regenerated seed snapshots for `streaming` and `streaming-parameter` fixtures
- Added `0.22.1` changelog entry in `versions.yml`

## Review Checklist
- [ ] Verify the `inner` field (`#[pin] inner: Pin<Box<dyn Stream<...>>>`) is unaffected — it works because `Stream` has a blanket impl for `Pin<P>` where `P: DerefMut`, unlike `Sleep::reset()`
- [ ] Confirm `tokio::time::Sleep` is `!Unpin` and therefore correctly requires `#[pin]` for safe projection
- [ ] Verify `Future` import is only needed for the explicit `.poll()` calls in the `Pending` arms (the `Stream::poll_next` calls go through the `Stream` trait which is already imported)

## Testing
- [x] Seed tests pass for `streaming` and `streaming-parameter` fixtures
- [x] `pnpm run check` (Biome lint) passes
- [x] `cargo check` passes on [xai-rust-internal](https://github.com/fern-demo/xai-rust-internal) with the fix applied
- [x] `cargo build` passes on xai-rust-internal with the fix applied

Link to Devin session: https://app.devin.ai/sessions/b80b6af4a7254c84993cd150eb671297
Requested by: @iamnamananand996