### PR TITLE
fix(cli): use parseRepository() for GitHub URI parsing in publish config

### DIFF
--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -1,5 +1,20 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 
+- version: 4.38.1
+  changelogEntry:
+    - summary: |
+        Fix incorrect repository URL in generated package metadata when the
+        GitHub `uri` in `generators.yml` is a full URL (e.g.
+        `https://github.com/owner/repo`). The naive `split("/")` produced
+        `owner = "https:"` and `repo = ""`, generating broken URLs like
+        `git+https://github.com/https:/`. Both `getPublishConfig()` and
+        `newDummyPublishOutputConfig()` now use the existing `parseRepository()`
+        utility, which correctly handles full URLs, shorthand `owner/repo`,
+        and custom GitHub domains.
+      type: fix
+  createdAt: "2026-03-20"
+  irVersion: 65
+
 - version: 4.38.0
   changelogEntry:
     - summary: |

--- a/packages/cli/generation/local-generation/local-workspace-runner/src/getGeneratorConfig.ts
+++ b/packages/cli/generation/local-generation/local-workspace-runner/src/getGeneratorConfig.ts
@@ -1,6 +1,7 @@
 import { GeneratorInvocation, generatorsYml } from "@fern-api/configuration";
 import { isGithubSelfhosted } from "@fern-api/configuration-loader";
 import { AbsoluteFilePath } from "@fern-api/fs-utils";
+import { parseRepository } from "@fern-api/github";
 import {
     CratesOutput,
     GithubPublishInfo as FiddleGithubPublishInfo,
@@ -326,8 +327,8 @@ function newDummyPublishOutputConfig(
     let repoUrl = "";
     if (generatorInvocation.raw?.github != null) {
         if (isGithubSelfhosted(generatorInvocation.raw.github)) {
-            // Convert shorthand uri (owner/repo) to full URL format to match Fiddle's behavior
-            repoUrl = `https://github.com/${generatorInvocation.raw.github.uri}`;
+            const parsed = parseRepository(generatorInvocation.raw.github.uri);
+            repoUrl = parsed.repoUrl;
         } else {
             repoUrl = generatorInvocation.raw?.github.repository;
         }

--- a/packages/cli/generation/local-generation/local-workspace-runner/src/runLocalGenerationForWorkspace.ts
+++ b/packages/cli/generation/local-generation/local-workspace-runner/src/runLocalGenerationForWorkspace.ts
@@ -433,18 +433,13 @@ function getPublishConfig({
     context: TaskContext;
 }): FernIr.PublishingConfig | undefined {
     if (generatorInvocation.raw?.github != null && isGithubSelfhosted(generatorInvocation.raw.github)) {
-        const [owner, repo] = generatorInvocation.raw.github.uri.split("/");
-        if (owner == null || repo == null) {
-            return context.failAndThrow(
-                `Invalid GitHub repository URI: ${generatorInvocation.raw.github.uri}. Expected format: owner/repo`
-            );
-        }
+        const parsed = parseRepository(generatorInvocation.raw.github.uri);
 
         const irMode = generatorInvocation.raw.github.mode === "pull-request" ? "pull-request" : undefined;
 
         return FernIr.PublishingConfig.github({
-            owner,
-            repo,
+            owner: parsed.owner,
+            repo: parsed.repo,
             uri: generatorInvocation.raw.github.uri,
             token: generatorInvocation.raw.github.token,
             mode: irMode,

--- a/packages/commons/github/src/__test__/parseRepository.test.ts
+++ b/packages/commons/github/src/__test__/parseRepository.test.ts
@@ -29,6 +29,15 @@ describe("parseRepository", () => {
         }).toThrow(Error);
     });
 
+    it("full URL produces correct owner and repo (FER-9146)", async () => {
+        // Previously, code used uri.split("/") which would produce
+        // owner = "https:" and repo = "" for full URLs.
+        const reference = parseRepository("https://github.com/anduril/lattice-sdk-javascript");
+        expect(reference.owner).toBe("anduril");
+        expect(reference.repo).toBe("lattice-sdk-javascript");
+        expect(reference.repoUrl).toBe("https://github.com/anduril/lattice-sdk-javascript");
+    });
+
     it("custom github domain", async () => {
         const test = "https://github.acme.com/engineering/api-client-sdk.git";
         const reference = parseRepository(test);


### PR DESCRIPTION
## Description

Closes FER-9146

When `generators.yml` specifies a full GitHub URL as the `uri` (e.g. `https://github.com/anduril/lattice-sdk-javascript`), the naive `uri.split("/")` in `getPublishConfig()` produced `owner = "https:"` and `repo = ""`, generating broken repository URLs in package metadata (e.g. `git+https://github.com/https:/`).

## Changes Made

- **`runLocalGenerationForWorkspace.ts`** — Replace `uri.split("/")` in `getPublishConfig()` with the existing `parseRepository()` utility from `@fern-api/github`, which correctly handles full URLs, `owner/repo` shorthand, and custom GitHub domains.
- **`getGeneratorConfig.ts`** — Same fix in `newDummyPublishOutputConfig()`. The old code also hardcoded `https://github.com/` which would break for custom GitHub Enterprise domains; `parsed.repoUrl` handles this correctly.
- **`parseRepository.test.ts`** — Added regression test documenting the exact FER-9146 scenario (full URL → correct owner/repo).
- **`versions.yml`** — Added v4.38.1 changelog entry.

## Testing

- [x] Unit tests added (regression test for full URL parsing)
- [x] Existing `parseRepository` test suite passes (18/18)
- [x] `biome check` passes

## Review Checklist

- ⚠️ **Error handling change in `getPublishConfig()`**: The old code had an explicit `context.failAndThrow()` with a descriptive message for invalid URIs. The new code relies on `parseRepository()` throwing a bare `Error("Failed to parse GitHub repository ...")`. Verify this is acceptable — the error will propagate as an unhandled exception rather than going through the task context's structured error reporting.
- Confirm `@fern-api/github` is a valid dependency for the `getGeneratorConfig.ts` package (it's already used in `runLocalGenerationForWorkspace.ts` in the same package).

Link to Devin session: https://app.devin.ai/sessions/50773b13bff241b0a548d83e39d8fc5a
Requested by: @jsklan
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/13854" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
