### PR TITLE
fix(java): fix incorrect license name in generated build.gradle

### DIFF
--- a/generators/java/generator-utils/src/main/java/com/fern/java/output/GeneratedBuildGradle.java
+++ b/generators/java/generator-utils/src/main/java/com/fern/java/output/GeneratedBuildGradle.java
@@ -179,7 +179,7 @@ public abstract class GeneratedBuildGradle extends GeneratedFile {
 
     /**
      * Reads a license file and extracts the license name. For standard licenses (Apache, MIT, etc.), returns the SPDX
-     * identifier. For custom licenses, returns the first line of the file as the license name.
+     * identifier. For unrecognized licenses, returns "Custom License".
      */
     private String extractLicenseFromFile(String filename) {
         try {
@@ -191,6 +191,8 @@ public abstract class GeneratedBuildGradle extends GeneratedFile {
             }
 
             String content = Files.readString(licensePath);
+            // Strip leading markdown heading markers for safety
+            content = content.replaceAll("(?m)^#{1,6}\\s+", "");
             String contentLower = content.toLowerCase();
 
             if (contentLower.contains("apache license") && contentLower.contains("version 2.0")) {
@@ -210,16 +212,7 @@ public abstract class GeneratedBuildGradle extends GeneratedFile {
             } else if (contentLower.contains("isc license")) {
                 return "ISC";
             } else {
-                String firstLine = content.lines()
-                        .filter(line -> !line.trim().isEmpty())
-                        .findFirst()
-                        .orElse("Custom License");
-
-                firstLine = firstLine.trim().replaceAll("[.:;]+$", "").replaceAll("\\s+", " ");
-
-                firstLine = firstLine.replace("'", "\\'");
-
-                return firstLine;
+                return "Custom License";
             }
         } catch (IOException e) {
             // Return a descriptive name instead of null
@@ -242,39 +235,6 @@ public abstract class GeneratedBuildGradle extends GeneratedFile {
 
                     @Override
                     public String visitCustom(CustomLicense customLicense) {
-
-                        // First check if we have a license name passed from the CLI in custom config
-                        if (generatorConfig().isPresent()
-                                && generatorConfig().get().getCustomConfig().isPresent()) {
-                            Object customConfig =
-                                    generatorConfig().get().getCustomConfig().get();
-
-                            // Check if customConfig is a Map (which it usually is when coming from JSON)
-                            if (customConfig instanceof java.util.Map) {
-                                @SuppressWarnings("unchecked")
-                                java.util.Map<String, Object> configMap = (java.util.Map<String, Object>) customConfig;
-                                Object licenseNameObj = configMap.get("_fernLicenseName");
-                                if (licenseNameObj != null) {
-                                    String licenseName = licenseNameObj.toString();
-                                    return licenseName;
-                                }
-                            } else {
-                                // Fallback to reflection for non-Map types
-                                try {
-                                    java.lang.reflect.Field fernLicenseNameField =
-                                            customConfig.getClass().getDeclaredField("_fernLicenseName");
-                                    fernLicenseNameField.setAccessible(true);
-                                    Object value = fernLicenseNameField.get(customConfig);
-                                    if (value instanceof String && !((String) value).isEmpty()) {
-                                        return (String) value;
-                                    }
-                                } catch (Exception e) {
-                                    // Silently fall back to file extraction
-                                }
-                            }
-                        }
-
-                        // Fallback to extracting from file
                         return extractLicenseFromFile(customLicense.getFilename());
                     }
 
@@ -283,19 +243,6 @@ public abstract class GeneratedBuildGradle extends GeneratedFile {
                         return null;
                     }
                 }));
-
-        // Workaround: If license is not present but publishMetadata indicates custom license,
-        // extract from description
-        if (!license.isPresent()) {
-            Optional<PublishingMetadata> pm = config.getOutput().getPublishingMetadata();
-            if (pm.isPresent() && pm.get().getPackageDescription().isPresent()) {
-                String description = pm.get().getPackageDescription().get();
-                if (description.toLowerCase().contains("custom license")) {
-                    // Look for LICENSE file in standard locations
-                    license = Optional.of(extractLicenseFromFile("LICENSE"));
-                }
-            }
-        }
 
         Optional<PublishingMetadata> pm = config.getOutput().getPublishingMetadata();
         String organizationName = config.getOrganization();

--- a/generators/java/generator-utils/src/test/java/com/fern/java/output/GeneratedBuildGradleTest.java
+++ b/generators/java/generator-utils/src/test/java/com/fern/java/output/GeneratedBuildGradleTest.java
@@ -62,9 +62,8 @@ public class GeneratedBuildGradleTest {
     Path tempDir;
 
     private String invokeExtractLicenseFromFile(String filename) throws Exception {
-        GeneratedBuildGradle instance = GeneratedBuildGradle.builder()
-                .shouldSignPackage(false)
-                .build();
+        GeneratedBuildGradle instance =
+                GeneratedBuildGradle.builder().shouldSignPackage(false).build();
         Method method = GeneratedBuildGradle.class.getDeclaredMethod("extractLicenseFromFile", String.class);
         method.setAccessible(true);
         return (String) method.invoke(instance, filename);
@@ -80,8 +79,7 @@ public class GeneratedBuildGradleTest {
     @Test
     public void test_extractLicense_apacheLicense() throws Exception {
         Path licenseFile = tempDir.resolve("LICENSE");
-        Files.writeString(
-                licenseFile, "Apache License\nVersion 2.0, January 2004\nhttp://www.apache.org/licenses/\n");
+        Files.writeString(licenseFile, "Apache License\nVersion 2.0, January 2004\nhttp://www.apache.org/licenses/\n");
         assertThat(invokeExtractLicenseFromFile(licenseFile.toString())).isEqualTo("Apache-2.0");
     }
 
@@ -108,8 +106,7 @@ public class GeneratedBuildGradleTest {
 
     @Test
     public void test_extractLicense_fileNotFound() throws Exception {
-        assertThat(invokeExtractLicenseFromFile("/nonexistent/path/LICENSE"))
-                .isEqualTo("Custom License (LICENSE)");
+        assertThat(invokeExtractLicenseFromFile("/nonexistent/path/LICENSE")).isEqualTo("Custom License (LICENSE)");
     }
 
     @Test

--- a/generators/java/generator-utils/src/test/java/com/fern/java/output/GeneratedBuildGradleTest.java
+++ b/generators/java/generator-utils/src/test/java/com/fern/java/output/GeneratedBuildGradleTest.java
@@ -1,5 +1,7 @@
 package com.fern.java.output;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import com.fern.generator.exec.model.logging.MavenCoordinate;
 import com.fern.java.output.gradle.AbstractGradleDependency;
 import com.fern.java.output.gradle.GradleDependencyType;
@@ -8,8 +10,12 @@ import com.fern.java.output.gradle.GradlePublishingConfig;
 import com.fern.java.output.gradle.GradleRepository;
 import com.fern.java.output.gradle.ParsedGradleDependency;
 import com.fern.java.output.gradle.RootProjectGradleDependency;
+import java.lang.reflect.Method;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.List;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 public class GeneratedBuildGradleTest {
 
@@ -50,5 +56,73 @@ public class GeneratedBuildGradleTest {
                 .build();
 
         System.out.println(buildGradle.getContents());
+    }
+
+    @TempDir
+    Path tempDir;
+
+    private String invokeExtractLicenseFromFile(String filename) throws Exception {
+        GeneratedBuildGradle instance = GeneratedBuildGradle.builder()
+                .shouldSignPackage(false)
+                .build();
+        Method method = GeneratedBuildGradle.class.getDeclaredMethod("extractLicenseFromFile", String.class);
+        method.setAccessible(true);
+        return (String) method.invoke(instance, filename);
+    }
+
+    @Test
+    public void test_extractLicense_mitLicense() throws Exception {
+        Path licenseFile = tempDir.resolve("LICENSE");
+        Files.writeString(licenseFile, "MIT License\n\nCopyright (c) 2024 Example Corp\n");
+        assertThat(invokeExtractLicenseFromFile(licenseFile.toString())).isEqualTo("MIT");
+    }
+
+    @Test
+    public void test_extractLicense_apacheLicense() throws Exception {
+        Path licenseFile = tempDir.resolve("LICENSE");
+        Files.writeString(
+                licenseFile, "Apache License\nVersion 2.0, January 2004\nhttp://www.apache.org/licenses/\n");
+        assertThat(invokeExtractLicenseFromFile(licenseFile.toString())).isEqualTo("Apache-2.0");
+    }
+
+    @Test
+    public void test_extractLicense_unknownLicenseReturnsCustomLicense() throws Exception {
+        Path licenseFile = tempDir.resolve("LICENSE");
+        Files.writeString(licenseFile, "Anduril Technologies Proprietary License\nAll rights reserved.\n");
+        assertThat(invokeExtractLicenseFromFile(licenseFile.toString())).isEqualTo("Custom License");
+    }
+
+    @Test
+    public void test_extractLicense_markdownHeadingStripped() throws Exception {
+        Path licenseFile = tempDir.resolve("LICENSE");
+        Files.writeString(licenseFile, "# MIT License\n\nCopyright (c) 2024 Example Corp\n");
+        assertThat(invokeExtractLicenseFromFile(licenseFile.toString())).isEqualTo("MIT");
+    }
+
+    @Test
+    public void test_extractLicense_markdownHeadingWithUnknownLicense() throws Exception {
+        Path licenseFile = tempDir.resolve("LICENSE");
+        Files.writeString(licenseFile, "# Anduril Custom License\n\nSome proprietary terms.\n");
+        assertThat(invokeExtractLicenseFromFile(licenseFile.toString())).isEqualTo("Custom License");
+    }
+
+    @Test
+    public void test_extractLicense_fileNotFound() throws Exception {
+        assertThat(invokeExtractLicenseFromFile("/nonexistent/path/LICENSE"))
+                .isEqualTo("Custom License (LICENSE)");
+    }
+
+    @Test
+    public void test_extractLicense_bsd3Clause() throws Exception {
+        Path licenseFile = tempDir.resolve("LICENSE");
+        Files.writeString(licenseFile, "BSD 3-Clause License\n\nCopyright...\n");
+        assertThat(invokeExtractLicenseFromFile(licenseFile.toString())).isEqualTo("BSD-3-Clause");
+    }
+
+    @Test
+    public void test_extractLicense_multipleMarkdownHeadings() throws Exception {
+        Path licenseFile = tempDir.resolve("LICENSE");
+        Files.writeString(licenseFile, "## Apache License\n## Version 2.0\nSome text\n");
+        assertThat(invokeExtractLicenseFromFile(licenseFile.toString())).isEqualTo("Apache-2.0");
     }
 }

--- a/generators/java/sdk/versions.yml
+++ b/generators/java/sdk/versions.yml
@@ -1,4 +1,18 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 4.0.4
+  changelogEntry:
+    - summary: |
+        Fix incorrect license name in generated `build.gradle`. When a LICENSE
+        file contained an unrecognized license, the generator extracted the first
+        line of the file as the license name instead of using `"Custom License"`.
+        This caused issues when the LICENSE file started with markdown heading
+        markers (e.g. `# Anduril ...`), leaking the `#` into `build.gradle`.
+        The else branch now returns `"Custom License"` and markdown heading
+        markers are stripped before license detection for safety.
+      type: fix
+  createdAt: "2026-03-20"
+  irVersion: 65
+
 - version: 4.0.3
   changelogEntry:
     - summary: |


### PR DESCRIPTION
## Description

Linear ticket: Closes FER-9147

Fixes two bugs in `GeneratedBuildGradle.java`'s `extractLicenseFromFile()` method that caused incorrect license names in generated `build.gradle` files:

1. **Wrong license name for unrecognized licenses**: The else branch extracted the first line of the LICENSE file as the license name instead of returning `"Custom License"`. For files starting with `# Anduril ...`, the `#` leaked into `build.gradle`.
2. **Dead `_fernLicenseName` config code path**: The custom config mechanism added in v2.43.2 was never wired up, so the fallback always ran.

## Changes Made

- Reverted the else branch of `extractLicenseFromFile()` to return `"Custom License"` for unrecognized licenses
- Added markdown heading marker (`#`) stripping before license detection so that `# MIT License` still correctly resolves to `"MIT"`
- Removed dead `_fernLicenseName` custom config lookup in `visitCustom()` (reflection-based code that was never populated)
- Removed unreachable publishMetadata-based license extraction workaround
- [x] Updated `versions.yml` with v4.0.4 changelog entry

## Testing

- [x] Unit tests added — 8 new tests covering standard licenses, markdown headings, unknown licenses, and missing files
- [x] All 9 tests pass locally (`./gradlew :generator-utils:test`)
- [x] `pnpm run check` passes

## Review Checklist

- [ ] Verify the markdown-stripping regex `(?m)^#{1,6}\\s+` doesn't have unintended side effects on license content matching
- [ ] Confirm removing the `_fernLicenseName` and publishMetadata workaround code paths is safe (ticket states they were never wired up)

Link to Devin session: https://app.devin.ai/sessions/5a8e906cad394df889c6b64902349ba9
Requested by: @jsklan