### PR TITLE
feat(cli): add --require-env-vars flag to fern generate

### DIFF
--- a/packages/cli/cli-v2/src/sdk/generator/LegacyRemoteGenerationRunner.ts
+++ b/packages/cli/cli-v2/src/sdk/generator/LegacyRemoteGenerationRunner.ts
@@ -126,7 +126,8 @@ export class LegacyRemoteGenerationRunner {
                 absolutePathToPreview,
                 whitelabel: undefined,
                 dynamicIrOnly: false,
-                retryRateLimited: false
+                retryRateLimited: false,
+                requireEnvVars: true
             });
 
             if (this.isLocalGitCombo(args) && absolutePathToPreview != null) {

--- a/packages/cli/cli/src/cli.ts
+++ b/packages/cli/cli/src/cli.ts
@@ -743,6 +743,12 @@ function addGenerateCommand(cli: Argv<GlobalCliOptions>, cliContext: CliContext)
                     default: false,
                     description:
                         "Automatically retry with exponential backoff when receiving 429 Too Many Requests responses"
+                })
+                .option("require-env-vars", {
+                    boolean: true,
+                    default: true,
+                    description:
+                        "Require all referenced environment variables to be defined. Use --require-env-vars false to substitute empty strings for missing variables."
                 }),
         async (argv) => {
             if (argv.api != null && argv.docs != null) {
@@ -811,7 +817,8 @@ function addGenerateCommand(cli: Argv<GlobalCliOptions>, cliContext: CliContext)
                     dynamicIrOnly: argv["dynamic-ir-only"],
                     outputDir: argv.output,
                     noReplay: !argv.replay,
-                    retryRateLimited: argv["retry-rate-limited"]
+                    retryRateLimited: argv["retry-rate-limited"],
+                    requireEnvVars: argv["require-env-vars"]
                 });
             }
             if (argv.docs != null) {
@@ -868,7 +875,8 @@ function addGenerateCommand(cli: Argv<GlobalCliOptions>, cliContext: CliContext)
                 dynamicIrOnly: argv["dynamic-ir-only"],
                 outputDir: argv.output,
                 noReplay: !argv.replay,
-                retryRateLimited: argv["retry-rate-limited"]
+                retryRateLimited: argv["retry-rate-limited"],
+                requireEnvVars: argv["require-env-vars"]
             });
         }
     );

--- a/packages/cli/cli/src/cli.ts
+++ b/packages/cli/cli/src/cli.ts
@@ -748,7 +748,7 @@ function addGenerateCommand(cli: Argv<GlobalCliOptions>, cliContext: CliContext)
                     boolean: true,
                     default: true,
                     description:
-                        "Require all referenced environment variables to be defined. Use --require-env-vars false to substitute empty strings for missing variables."
+                        "Require all referenced environment variables to be defined (use --no-require-env-vars to substitute empty strings for missing variables)"
                 }),
         async (argv) => {
             if (argv.api != null && argv.docs != null) {

--- a/packages/cli/cli/src/commands/generate/generateAPIWorkspace.ts
+++ b/packages/cli/cli/src/commands/generate/generateAPIWorkspace.ts
@@ -37,7 +37,8 @@ export async function generateWorkspace({
     fernignorePath,
     dynamicIrOnly,
     noReplay,
-    retryRateLimited
+    retryRateLimited,
+    requireEnvVars
 }: {
     organization: string;
     workspace: AbstractAPIWorkspace<unknown>;
@@ -59,6 +60,7 @@ export async function generateWorkspace({
     dynamicIrOnly: boolean;
     noReplay: boolean;
     retryRateLimited: boolean;
+    requireEnvVars: boolean;
 }): Promise<void> {
     if (workspace.generatorsConfiguration == null) {
         context.logger.warn("This workspaces has no generators.yml");
@@ -148,7 +150,8 @@ export async function generateWorkspace({
                     ai,
                     replay,
                     noReplay,
-                    validateWorkspace: true
+                    validateWorkspace: true,
+                    requireEnvVars
                 });
             } else if (token != null) {
                 await runRemoteGenerationForAPIWorkspace({
@@ -166,7 +169,8 @@ export async function generateWorkspace({
                     fernignorePath,
                     dynamicIrOnly,
                     validateWorkspace: true,
-                    retryRateLimited
+                    retryRateLimited,
+                    requireEnvVars
                 });
             }
         })

--- a/packages/cli/cli/src/commands/generate/generateAPIWorkspaces.ts
+++ b/packages/cli/cli/src/commands/generate/generateAPIWorkspaces.ts
@@ -35,7 +35,8 @@ export async function generateAPIWorkspaces({
     dynamicIrOnly,
     outputDir,
     noReplay,
-    retryRateLimited
+    retryRateLimited,
+    requireEnvVars
 }: {
     project: Project;
     cliContext: CliContext;
@@ -56,6 +57,7 @@ export async function generateAPIWorkspaces({
     outputDir: string | undefined;
     noReplay: boolean;
     retryRateLimited: boolean;
+    requireEnvVars: boolean;
 }): Promise<void> {
     let token: FernToken | undefined = undefined;
 
@@ -153,7 +155,8 @@ export async function generateAPIWorkspaces({
                     fernignorePath,
                     dynamicIrOnly,
                     noReplay,
-                    retryRateLimited
+                    retryRateLimited,
+                    requireEnvVars
                 });
             });
         })

--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -3,13 +3,13 @@
 - version: 4.39.0
   changelogEntry:
     - summary: |
-        Add `--require-env-vars` flag to `fern generate`. When set to `false`,
-        undefined environment variables referenced in `generators.yml` are
-        substituted with empty strings instead of causing an error. This is
-        useful for local development when registry credentials are not needed.
+        Add `--require-env-vars` flag to `fern generate`. Use `--no-require-env-vars`
+        to substitute empty strings for undefined environment variables instead of
+        causing an error. Defined environment variables are still resolved normally.
+        This is useful for local development when registry credentials are not needed.
 
         ```bash
-        fern generate --group csharp-sdk --require-env-vars false
+        fern generate --group csharp-sdk --no-require-env-vars
         ```
       type: feat
   createdAt: "2026-03-20"

--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -1,5 +1,20 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 
+- version: 4.39.0
+  changelogEntry:
+    - summary: |
+        Add `--require-env-vars` flag to `fern generate`. When set to `false`,
+        undefined environment variables referenced in `generators.yml` are
+        substituted with empty strings instead of causing an error. This is
+        useful for local development when registry credentials are not needed.
+
+        ```bash
+        fern generate --group csharp-sdk --require-env-vars false
+        ```
+      type: feat
+  createdAt: "2026-03-20"
+  irVersion: 65
+
 - version: 4.38.0
   changelogEntry:
     - summary: |

--- a/packages/cli/generation/local-generation/local-workspace-runner/src/runLocalGenerationForWorkspace.ts
+++ b/packages/cli/generation/local-generation/local-workspace-runner/src/runLocalGenerationForWorkspace.ts
@@ -91,12 +91,18 @@ export async function runLocalGenerationForWorkspace({
     const results = await Promise.all(
         generatorGroup.generators.map(async (generatorInvocation) => {
             return context.runInteractiveTask({ name: generatorInvocation.name }, async (interactiveTaskContext) => {
-                const shouldSubstituteAsEmpty = absolutePathToPreview != null || !(requireEnvVars ?? true);
+                const isPreview = absolutePathToPreview != null;
                 const substituteEnvVars = <T>(stringOrObject: T) =>
                     replaceEnvVariables(
                         stringOrObject,
-                        { onError: (e) => interactiveTaskContext.failAndThrow(e) },
-                        { substituteAsEmpty: shouldSubstituteAsEmpty }
+                        {
+                            onError: (e) => {
+                                if (!isPreview && (requireEnvVars ?? true)) {
+                                    interactiveTaskContext.failAndThrow(e);
+                                }
+                            }
+                        },
+                        { substituteAsEmpty: isPreview }
                     );
 
                 generatorInvocation = substituteEnvVars(generatorInvocation);

--- a/packages/cli/generation/local-generation/local-workspace-runner/src/runLocalGenerationForWorkspace.ts
+++ b/packages/cli/generation/local-generation/local-workspace-runner/src/runLocalGenerationForWorkspace.ts
@@ -46,7 +46,8 @@ export async function runLocalGenerationForWorkspace({
     ai,
     replay,
     noReplay,
-    validateWorkspace
+    validateWorkspace,
+    requireEnvVars
 }: {
     token: FernToken | undefined;
     projectConfig: fernConfigJson.ProjectConfig;
@@ -62,6 +63,7 @@ export async function runLocalGenerationForWorkspace({
     replay?: generatorsYml.ReplayConfigSchema | undefined;
     noReplay?: boolean;
     validateWorkspace?: boolean;
+    requireEnvVars?: boolean;
 }): Promise<void> {
     // Fail fast: check all generators for version conflicts BEFORE starting any IR generation.
     // This avoids wasted work when one generator would fail the version check.
@@ -89,8 +91,13 @@ export async function runLocalGenerationForWorkspace({
     const results = await Promise.all(
         generatorGroup.generators.map(async (generatorInvocation) => {
             return context.runInteractiveTask({ name: generatorInvocation.name }, async (interactiveTaskContext) => {
+                const shouldSubstituteAsEmpty = absolutePathToPreview != null || !(requireEnvVars ?? true);
                 const substituteEnvVars = <T>(stringOrObject: T) =>
-                    replaceEnvVariables(stringOrObject, { onError: (e) => interactiveTaskContext.failAndThrow(e) });
+                    replaceEnvVariables(
+                        stringOrObject,
+                        { onError: (e) => interactiveTaskContext.failAndThrow(e) },
+                        { substituteAsEmpty: shouldSubstituteAsEmpty }
+                    );
 
                 generatorInvocation = substituteEnvVars(generatorInvocation);
 

--- a/packages/cli/generation/remote-generation/remote-workspace-runner/src/runRemoteGenerationForAPIWorkspace.ts
+++ b/packages/cli/generation/remote-generation/remote-workspace-runner/src/runRemoteGenerationForAPIWorkspace.ts
@@ -34,7 +34,8 @@ export async function runRemoteGenerationForAPIWorkspace({
     fernignorePath,
     dynamicIrOnly,
     validateWorkspace,
-    retryRateLimited
+    retryRateLimited,
+    requireEnvVars
 }: {
     projectConfig: fernConfigJson.ProjectConfig;
     organization: string;
@@ -51,6 +52,7 @@ export async function runRemoteGenerationForAPIWorkspace({
     dynamicIrOnly: boolean;
     validateWorkspace?: boolean;
     retryRateLimited: boolean;
+    requireEnvVars: boolean;
 }): Promise<RemoteGenerationForAPIWorkspaceResponse | null> {
     if (generatorGroup.generators.length === 0) {
         context.logger.warn("No generators specified.");
@@ -127,7 +129,8 @@ export async function runRemoteGenerationForAPIWorkspace({
                     absolutePathToPreview,
                     fernignorePath: effectiveFernignorePath,
                     dynamicIrOnly,
-                    retryRateLimited
+                    retryRateLimited,
+                    requireEnvVars
                 });
                 if (remoteTaskHandlerResponse != null && remoteTaskHandlerResponse.createdSnippets) {
                     snippetsProducedBy.push(generatorInvocation);

--- a/packages/cli/generation/remote-generation/remote-workspace-runner/src/runRemoteGenerationForGenerator.ts
+++ b/packages/cli/generation/remote-generation/remote-workspace-runner/src/runRemoteGenerationForGenerator.ts
@@ -40,7 +40,8 @@ export async function runRemoteGenerationForGenerator({
     readme,
     fernignorePath,
     dynamicIrOnly,
-    retryRateLimited
+    retryRateLimited,
+    requireEnvVars
 }: {
     projectConfig: fernConfigJson.ProjectConfig;
     organization: string;
@@ -58,6 +59,7 @@ export async function runRemoteGenerationForGenerator({
     fernignorePath: string | undefined;
     dynamicIrOnly: boolean;
     retryRateLimited: boolean;
+    requireEnvVars: boolean;
 }): Promise<RemoteTaskHandler.Response | undefined> {
     const fdr = createFdrService({ token: token.value });
 
@@ -68,12 +70,13 @@ export async function runRemoteGenerationForGenerator({
 
     /** Sugar to substitute templated env vars in a standard way */
     const isPreview = absolutePathToPreview != null;
+    const shouldSubstituteAsEmpty = isPreview || !requireEnvVars;
 
     const substituteEnvVars = <T>(stringOrObject: T) =>
         replaceEnvVariables(
             stringOrObject,
             { onError: (e) => interactiveTaskContext.failAndThrow(e) },
-            { substituteAsEmpty: isPreview }
+            { substituteAsEmpty: shouldSubstituteAsEmpty }
         );
 
     const generatorInvocationWithEnvVarSubstitutions = substituteEnvVars(generatorInvocation);

--- a/packages/cli/generation/remote-generation/remote-workspace-runner/src/runRemoteGenerationForGenerator.ts
+++ b/packages/cli/generation/remote-generation/remote-workspace-runner/src/runRemoteGenerationForGenerator.ts
@@ -70,13 +70,18 @@ export async function runRemoteGenerationForGenerator({
 
     /** Sugar to substitute templated env vars in a standard way */
     const isPreview = absolutePathToPreview != null;
-    const shouldSubstituteAsEmpty = isPreview || !requireEnvVars;
 
     const substituteEnvVars = <T>(stringOrObject: T) =>
         replaceEnvVariables(
             stringOrObject,
-            { onError: (e) => interactiveTaskContext.failAndThrow(e) },
-            { substituteAsEmpty: shouldSubstituteAsEmpty }
+            {
+                onError: (e) => {
+                    if (!isPreview && requireEnvVars) {
+                        interactiveTaskContext.failAndThrow(e);
+                    }
+                }
+            },
+            { substituteAsEmpty: isPreview }
         );
 
     const generatorInvocationWithEnvVarSubstitutions = substituteEnvVars(generatorInvocation);


### PR DESCRIPTION
## Description

Adds a `--require-env-vars` flag (default: `true`) to `fern generate`. Use `--no-require-env-vars` to substitute empty strings for undefined environment variables instead of throwing an error. Defined environment variables are still resolved normally.

**Motivation:** Running `fern generate --group csharp-sdk` locally fails with `Environment variable NUGET_API_KEY is not defined` even when you only want to test generation, not publish. The current workaround is `NUGET_API_KEY="" fern generate ...`. This flag eliminates that friction.

```bash
fern generate --group csharp-sdk --no-require-env-vars
```

## Changes Made

- Added `--require-env-vars` boolean CLI option in `cli.ts` (both `--api` and default code paths)
- Plumbed `requireEnvVars` through the full call chain:
  - `generateAPIWorkspaces` → `generateWorkspace` → `runLocalGenerationForWorkspace` / `runRemoteGenerationForAPIWorkspace` → `runRemoteGenerationForGenerator`
- In both local and remote runners, when `requireEnvVars` is `false`, the `onError` handler becomes a no-op so undefined env vars silently resolve to empty strings (via the existing `?? ""` fallback in `replaceEnvVars.ts:61`), while defined env vars are still used normally. Preview mode continues to use `substituteAsEmpty: true` (blanks everything), preserving existing behavior.
- Added `requireEnvVars: true` to `LegacyRemoteGenerationRunner.ts` in cli-v2 (safe default; cli-v2 doesn't expose the flag yet)
- Added `versions.yml` entry (4.39.0, feat)

## Review Checklist

- [x] In `runLocalGenerationForWorkspace.ts`, `requireEnvVars` is typed as optional (`boolean?`, defaults to `true` via `?? true`) since this function is called from other code paths that don't pass the flag. The remote runner types it as required. This asymmetry is intentional.
- [x] Both `generateAPIWorkspaces` call sites in `cli.ts` (line ~821 for `--api` and line ~879 for default) pass `requireEnvVars` through.
- [x] The flag does **not** apply to docs generation (`generateDocsWorkspace`), only SDK generation. This is intentional.
- [ ] **Verify `onError` no-op path**: When `requireEnvVars=false` and an env var is undefined, `onError` is a no-op, and `replaceEnvVars.ts:61` returns `envVarValue ?? ""` → empty string. Confirm this is correct by reviewing `replaceEnvVars.ts:53-61`.
- [ ] **Verify defined env vars are preserved**: When `requireEnvVars=false` and `substituteAsEmpty=false`, defined env vars go through the normal `process.env[envVarName]` lookup and are returned as-is.

## Testing

- [x] `pnpm run check` (biome lint/format) passes
- [ ] No new unit tests — the core `replaceEnvVariables` function already has thorough test coverage. This PR changes the `onError` and `substituteAsEmpty` arguments passed to it, not the function itself.

Link to Devin session: https://app.devin.ai/sessions/4c79fa8c1a6848e38c74bdf9035cd31b
Requested by: @Swimburger
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/13856" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
