### PR TITLE
chore(internal): add missing properties to generators-yml definition and regenerate JSON schemas

### DIFF
--- a/fern/apis/generators-yml/definition/generators.yml
+++ b/fern/apis/generators-yml/definition/generators.yml
@@ -409,6 +409,32 @@ types:
           If false, throw hard errors when schema collisions are detected.
           Defaults to false.
         default: false
+      infer-forward-compatible:
+        type: optional<boolean>
+        docs: |
+          If true, infer forward-compatible enums from oneOf [enum, string] or anyOf [enum, string] patterns. Defaults to false.
+        default: false
+      infer-default-environment:
+        type: optional<boolean>
+        docs: Whether to automatically infer the default environment from the first server. Defaults to true. When false, SDK users must explicitly provide a base URL.
+        default: true
+      coerce-consts-to:
+        type: optional<CoerceConstsTo>
+        docs: |
+          Controls how `const` values in OpenAPI specs are represented.
+          - `literals`: Convert const values directly to literals with defaults.
+          - `enums`: Convert const values to single-element enums; blocks transitive coercion via `coerce-enums-to-literals`.
+          - `enums-coerceable-to-literals`: Convert const values to single-element enums, but allow `coerce-enums-to-literals` to coerce them transitively.
+          Defaults to `enums-coerceable-to-literals`.
+        default: enums-coerceable-to-literals
+
+  CoerceConstsTo:
+    docs: Controls how const values in OpenAPI specs are represented.
+    enum:
+      - literals
+      - enums
+      - name: enumsCoerceableToLiterals
+        value: enums-coerceable-to-literals
 
   OpenAPISettingsSchema:
     extends:

--- a/generators-yml.schema.json
+++ b/generators-yml.schema.json
@@ -1761,6 +1761,14 @@
         }
       ]
     },
+    "generators.CoerceConstsTo": {
+      "type": "string",
+      "enum": [
+        "literals",
+        "enums",
+        "enums-coerceable-to-literals"
+      ]
+    },
     "generators.FormParameterEncoding": {
       "type": "string",
       "enum": [
@@ -1974,6 +1982,36 @@
           "oneOf": [
             {
               "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "infer-forward-compatible": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "infer-default-environment": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "coerce-consts-to": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/generators.CoerceConstsTo"
             },
             {
               "type": "null"
@@ -2322,6 +2360,36 @@
           "oneOf": [
             {
               "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "infer-forward-compatible": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "infer-default-environment": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "coerce-consts-to": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/generators.CoerceConstsTo"
             },
             {
               "type": "null"
@@ -2800,6 +2868,36 @@
           "oneOf": [
             {
               "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "infer-forward-compatible": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "infer-default-environment": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "coerce-consts-to": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/generators.CoerceConstsTo"
             },
             {
               "type": "null"

--- a/packages/cli/configuration/src/generators-yml/schemas/api/resources/generators/types/ApiDefinitionSettingsSchema.ts
+++ b/packages/cli/configuration/src/generators-yml/schemas/api/resources/generators/types/ApiDefinitionSettingsSchema.ts
@@ -47,8 +47,6 @@ export interface ApiDefinitionSettingsSchema {
      * - Add protocol if still collision (e.g., "prod: wss://api.com/foo" -> "foo_wss", only for non-HTTPS protocols)
      */
     "group-environments-by-host"?: boolean;
-    /** Whether to automatically infer the default environment from the first server. Defaults to true. When false, SDK users must explicitly provide a base URL. */
-    "infer-default-environment"?: boolean;
     /**
      * If `always`, remove discriminant properties from schemas when generating types, unless the schema is also used outside of a discriminated union.
      * If `never`, keep discriminant properties in schemas when generating types.

--- a/packages/cli/configuration/src/generators-yml/schemas/api/resources/generators/types/BaseApiSettingsSchema.ts
+++ b/packages/cli/configuration/src/generators-yml/schemas/api/resources/generators/types/BaseApiSettingsSchema.ts
@@ -32,8 +32,6 @@ export interface BaseApiSettingsSchema {
      * - Add protocol if still collision (e.g., "prod: wss://api.com/foo" -> "foo_wss", only for non-HTTPS protocols)
      */
     "group-environments-by-host"?: boolean;
-    /** Whether to automatically infer the default environment from the first server. Defaults to true. When false, SDK users must explicitly provide a base URL. */
-    "infer-default-environment"?: boolean;
     /**
      * If `always`, remove discriminant properties from schemas when generating types, unless the schema is also used outside of a discriminated union.
      * If `never`, keep discriminant properties in schemas when generating types.
@@ -53,8 +51,10 @@ export interface BaseApiSettingsSchema {
      * Defaults to false.
      */
     "resolve-schema-collisions"?: boolean;
-    /** If true, infer forward-compatible enums from `oneOf: [enum, string]` or `anyOf: [enum, string]` patterns. Defaults to false. */
+    /** If true, infer forward-compatible enums from oneOf [enum, string] or anyOf [enum, string] patterns. Defaults to false. */
     "infer-forward-compatible"?: boolean;
+    /** Whether to automatically infer the default environment from the first server. Defaults to true. When false, SDK users must explicitly provide a base URL. */
+    "infer-default-environment"?: boolean;
     /**
      * Controls how `const` values in OpenAPI specs are represented.
      * - `literals`: Convert const values directly to literals with defaults.

--- a/packages/cli/configuration/src/generators-yml/schemas/serialization/resources/generators/types/ApiDefinitionSettingsSchema.ts
+++ b/packages/cli/configuration/src/generators-yml/schemas/serialization/resources/generators/types/ApiDefinitionSettingsSchema.ts
@@ -22,7 +22,6 @@ export const ApiDefinitionSettingsSchema: core.serialization.ObjectSchema<
     "wrap-references-to-nullable-in-optional": core.serialization.boolean().optional(),
     "coerce-optional-schemas-to-nullable": core.serialization.boolean().optional(),
     "group-environments-by-host": core.serialization.boolean().optional(),
-    "infer-default-environment": core.serialization.boolean().optional(),
     "remove-discriminants-from-schemas": RemoveDiscriminantsFromSchemas.optional(),
     "path-parameter-order": PathParameterOrder.optional(),
 });
@@ -39,7 +38,6 @@ export declare namespace ApiDefinitionSettingsSchema {
         "wrap-references-to-nullable-in-optional"?: boolean | null;
         "coerce-optional-schemas-to-nullable"?: boolean | null;
         "group-environments-by-host"?: boolean | null;
-        "infer-default-environment"?: boolean | null;
         "remove-discriminants-from-schemas"?: RemoveDiscriminantsFromSchemas.Raw | null;
         "path-parameter-order"?: PathParameterOrder.Raw | null;
     }

--- a/packages/cli/configuration/src/generators-yml/schemas/serialization/resources/generators/types/BaseApiSettingsSchema.ts
+++ b/packages/cli/configuration/src/generators-yml/schemas/serialization/resources/generators/types/BaseApiSettingsSchema.ts
@@ -19,11 +19,11 @@ export const BaseApiSettingsSchema: core.serialization.ObjectSchema<
     "wrap-references-to-nullable-in-optional": core.serialization.boolean().optional(),
     "coerce-optional-schemas-to-nullable": core.serialization.boolean().optional(),
     "group-environments-by-host": core.serialization.boolean().optional(),
-    "infer-default-environment": core.serialization.boolean().optional(),
     "remove-discriminants-from-schemas": RemoveDiscriminantsFromSchemas.optional(),
     "path-parameter-order": PathParameterOrder.optional(),
     "resolve-schema-collisions": core.serialization.boolean().optional(),
     "infer-forward-compatible": core.serialization.boolean().optional(),
+    "infer-default-environment": core.serialization.boolean().optional(),
     "coerce-consts-to": CoerceConstsTo.optional(),
 });
 
@@ -37,11 +37,11 @@ export declare namespace BaseApiSettingsSchema {
         "wrap-references-to-nullable-in-optional"?: boolean | null;
         "coerce-optional-schemas-to-nullable"?: boolean | null;
         "group-environments-by-host"?: boolean | null;
-        "infer-default-environment"?: boolean | null;
         "remove-discriminants-from-schemas"?: RemoveDiscriminantsFromSchemas.Raw | null;
         "path-parameter-order"?: PathParameterOrder.Raw | null;
         "resolve-schema-collisions"?: boolean | null;
         "infer-forward-compatible"?: boolean | null;
+        "infer-default-environment"?: boolean | null;
         "coerce-consts-to"?: CoerceConstsTo.Raw | null;
     }
 }

--- a/packages/cli/configuration/src/generators-yml/schemas/serialization/resources/generators/types/CoerceConstsTo.ts
+++ b/packages/cli/configuration/src/generators-yml/schemas/serialization/resources/generators/types/CoerceConstsTo.ts
@@ -4,10 +4,8 @@ import type * as GeneratorsYml from "../../../../api/index.js";
 import * as core from "../../../../core/index.js";
 import type * as serializers from "../../../index.js";
 
-export const CoerceConstsTo: core.serialization.Schema<
-    serializers.CoerceConstsTo.Raw,
-    GeneratorsYml.CoerceConstsTo
-> = core.serialization.enum_(["literals", "enums", "enums-coerceable-to-literals"]);
+export const CoerceConstsTo: core.serialization.Schema<serializers.CoerceConstsTo.Raw, GeneratorsYml.CoerceConstsTo> =
+    core.serialization.enum_(["literals", "enums", "enums-coerceable-to-literals"]);
 
 export declare namespace CoerceConstsTo {
     export type Raw = "literals" | "enums" | "enums-coerceable-to-literals";


### PR DESCRIPTION
## Description

The `generators-yml.schema.json` was missing several properties that already existed in the generated TypeScript SDK types, causing YAML schema validation errors (e.g., `Property coerce-consts-to is not allowed`).

## Changes Made

- Added `coerce-consts-to`, `infer-forward-compatible`, and `infer-default-environment` to `BaseAPISettingsSchema` in the Fern definition (`fern/apis/generators-yml/definition/generators.yml`)
- Added the `CoerceConstsTo` enum type (`literals`, `enums`, `enums-coerceable-to-literals`)
- Regenerated TypeScript SDK types via `fern generate --api generators-yml --local`
- Regenerated `generators-yml.schema.json` via `pnpm generators-yml:jsonschema`

### Side effects of regeneration
- `infer-default-environment` was removed from the deprecated `ApiDefinitionSettingsSchema` (v1 settings) since it now lives in `BaseAPISettingsSchema` which both OpenAPI and AsyncAPI settings extend
- Minor formatting changes in `CoerceConstsTo.ts` serialization file (auto-generated)

## Human Review Checklist
- [ ] Verify that removing `infer-default-environment` from `ApiDefinitionSettingsSchema` (deprecated v1) doesn't break existing users who reference it through that path — it should be fine since `BaseApiSettingsSchema` (which it extends) still has it
- [ ] Confirm the `CoerceConstsTo` enum values match what the CLI/importers actually support

## Testing
- [x] `pnpm run check` (biome lint) passes
- [x] Verified `coerce-consts-to` appears in regenerated `generators-yml.schema.json`

Link to Devin session: https://app.devin.ai/sessions/f468a449f570496495c36e5d1ea23305
Requested by: @Swimburger
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/13859" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
