### PR TITLE
chore(internal): add exhaustive checks rule to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -214,6 +214,27 @@ Multi-stage process: API Schema → IR Updates → Generator Updates → Release
 
 **When working with external data (API responses, JSON parsing), validate and narrow with type guards—never assert the shape blindly.**
 
+#### Exhaustive Checks
+
+**Always handle all cases when switching on discriminated unions.** Every `switch` statement on a discriminated union's type field must include a `case` for every variant. The `default` case must call `assertNever` from `@fern-api/core-utils` to ensure compile-time exhaustiveness—if a new variant is added to the union, any unhandled switch will fail to compile.
+
+```typescript
+import { assertNever } from "@fern-api/core-utils";
+
+switch (shape.type) {
+    case "circle":
+        return handleCircle(shape);
+    case "square":
+        return handleSquare(shape);
+    default:
+        assertNever(shape);
+}
+```
+
+**Never leave a `default` case that silently ignores unknown variants.** The whole point of `assertNever` is to turn missed cases into compile-time errors rather than silent runtime bugs. If you find yourself wanting to skip a variant, handle it explicitly (even if the handler is a no-op with a comment explaining why).
+
+**This applies to all discriminated union patterns in the codebase**, including IR types, generator configuration unions, OpenAPI schema variants, and any other tagged union. Use `assertNeverNoThrow` from `@fern-api/core-utils` only when you intentionally want to ignore unexpected variants without throwing (e.g., forward-compatible parsing), and add a comment explaining why.
+
 Here are additional TypeScript rules beyond type safety:
 
 #### Async/Await & Promises


### PR DESCRIPTION
## Description

Adds guidance to the root `CLAUDE.md` requiring exhaustive checks on discriminated union switch statements using the `assertNever` utility.

## Changes Made

- Added new **Exhaustive Checks** subsection under TypeScript Rules > Typing in the root `CLAUDE.md`
- Documents the requirement that every `switch` on a discriminated union must handle all cases, with `default` calling `assertNever` from `@fern-api/core-utils`
- Includes a code example demonstrating the pattern
- Notes when `assertNeverNoThrow` is acceptable (forward-compatible parsing) and that it requires a comment explaining why

## Review Checklist

- [ ] Wording accurately reflects the team's expectations for exhaustive checks
- [ ] Placement within the TypeScript Rules section is appropriate (currently between Typing rules and Async/Await rules)
- [ ] Guidance around `assertNeverNoThrow` as an escape hatch is acceptable

## Testing

- No code changes — documentation only
- Verified `pnpm run check` (Biome lint) passes

Link to Devin session: https://app.devin.ai/sessions/bf4b508a8cd1456e8d598463a3675a73
Requested by: @Swimburger
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/13869" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
