### PR TITLE
fix(swift): add missing COPY for dist files in swift/model/Dockerfile

### DIFF
--- a/generators/swift/model/Dockerfile
+++ b/generators/swift/model/Dockerfile
@@ -1,3 +1,5 @@
-FROM node:22.12-alpine3.20 AS node
+FROM node:22.12-alpine3.20
+
+COPY generators/swift/model/dist /dist
 
 ENTRYPOINT ["node", "--enable-source-maps", "/dist/cli.cjs"]


### PR DESCRIPTION
## Description

The `swift/model/Dockerfile` was missing a `COPY` instruction for the dist directory, meaning the built image would fail at runtime because `/dist/cli.cjs` does not exist in the container.

## Changes Made

- Added `COPY generators/swift/model/dist /dist` to copy the compiled CLI into the image
- Removed unused `AS node` alias from the `FROM` line (no multi-stage build needed)

The fix follows the same pattern used by other simple Node-based generator Dockerfiles (e.g., `openapi/Dockerfile`, `postman/Dockerfile`). The existing `.dockerignore` already whitelists `generators/swift/model/dist`, confirming this was the intended source path.

## Review Checklist

- [ ] Verify the `COPY` source path (`generators/swift/model/dist`) is correct for the repo-root build context used by the publish pipeline
- [ ] Note: `generators/swift/model/versions.yml` is currently empty (`[]`), so this generator may not yet be published — but the Dockerfile should still be correct for when it is

## Testing

- [ ] Not tested locally (no dist artifacts available without a full build). Verified correctness by comparing with other generator Dockerfiles and the existing `.dockerignore`.

Link to Devin session: https://app.devin.ai/sessions/371cc6bdbad447bb9161b29b0ab8ec28
Requested by: @Swimburger
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/13870" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
