### PR TITLE
chore(ci): pin node:lts-slim to node:22.12-slim for reproducible builds

### DIFF
--- a/docker/seed/Dockerfile.ts
+++ b/docker/seed/Dockerfile.ts
@@ -1,4 +1,4 @@
-FROM node:lts-slim
+FROM node:22.12-slim
 
 ENV PNPM_STORE_PATH=/.pnpm-cache
 ENV YARN_CACHE_FOLDER=/.yarn-cache

--- a/generators/python-v2/pydantic-model/Dockerfile
+++ b/generators/python-v2/pydantic-model/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:lts-slim
+FROM node:22.12-slim
 RUN apt-get update && apt-get install -y curl
 RUN curl -LsSf https://astral.sh/ruff/install.sh | sh
 ENV PATH="/root/.cargo/bin:${PATH}"

--- a/generators/python-v2/sdk/Dockerfile
+++ b/generators/python-v2/sdk/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:lts-slim
+FROM node:22.12-slim
 RUN apt-get update && apt-get install -y curl
 RUN curl -LsSf https://astral.sh/ruff/install.sh | sh
 ENV PATH="/root/.local/bin:${PATH}"


### PR DESCRIPTION
## Description

Replaces the floating `node:lts-slim` tag with a pinned `node:22.12-slim` across three Dockerfiles. The `lts-slim` tag is mutable — it currently resolves to Node 22 but will silently jump to Node 24 (or later) when the LTS designation moves, risking non-reproducible builds and surprise breakages.

## Changes Made

- `docker/seed/Dockerfile.ts` — seed test runner for TypeScript
- `generators/python-v2/sdk/Dockerfile` — Python v2 SDK generator
- `generators/python-v2/pydantic-model/Dockerfile` — Python v2 pydantic-model generator

All three: `FROM node:lts-slim` → `FROM node:22.12-slim`

Node 22 is the current LTS line and matches the `node:22.12-alpine3.20` base used by most other generator Dockerfiles in the repo.

## Review Checklist

- [ ] Confirm `node:22.12-slim` is compatible with `pnpm@10.20.0` and `yarn@1.22.22` installed in `Dockerfile.ts`
- [ ] **Note:** `generators/python-v2/pydantic-model/Dockerfile` still has a pre-existing bug: `ENV PATH="/root/.cargo/bin:${PATH}"` should be `/root/.local/bin` (ruff installs there, not in `.cargo`). That fix is tracked in a separate PR.

## Testing

- Verified `node:22.12-slim` resolves to Node v22.12.0 by pulling and running the image
- No functional testing — these are base image tag changes only

Link to Devin session: https://app.devin.ai/sessions/371cc6bdbad447bb9161b29b0ab8ec28
Requested by: @Swimburger
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/13873" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
