### PR TITLE
chore(python): pin ruff version to 0.15.7 in python-v2 Dockerfiles

### DIFF
--- a/generators/python-v2/pydantic-model/Dockerfile
+++ b/generators/python-v2/pydantic-model/Dockerfile
@@ -1,6 +1,6 @@
 FROM node:lts-slim
 RUN apt-get update && apt-get install -y curl
-RUN curl -LsSf https://astral.sh/ruff/install.sh | sh
+RUN curl -LsSf https://astral.sh/ruff/0.15.7/install.sh | sh
 ENV PATH="/root/.cargo/bin:${PATH}"
 # RUN ruff --version
 COPY generators/python-v2/pydantic-model/dist /dist

--- a/generators/python-v2/sdk/Dockerfile
+++ b/generators/python-v2/sdk/Dockerfile
@@ -1,6 +1,6 @@
 FROM node:lts-slim
 RUN apt-get update && apt-get install -y curl
-RUN curl -LsSf https://astral.sh/ruff/install.sh | sh
+RUN curl -LsSf https://astral.sh/ruff/0.15.7/install.sh | sh
 ENV PATH="/root/.local/bin:${PATH}"
 # RUN ruff --version
 COPY generators/python-v2/sdk/dist /dist


### PR DESCRIPTION
## Description

Pins the ruff formatter version in the python-v2 generator Dockerfiles. Previously, `https://astral.sh/ruff/install.sh` was used without a version, meaning every Docker build could pull a different ruff release — risking non-reproducible builds and unexpected formatting changes in generated SDKs.

## Changes Made

- Pinned ruff install URL to version `0.15.7` in `generators/python-v2/sdk/Dockerfile`
- Pinned ruff install URL to version `0.15.7` in `generators/python-v2/pydantic-model/Dockerfile`

## Review Checklist

- [ ] Confirm `0.15.7` is an acceptable ruff version to lock to (this was the latest release at time of PR creation)
- [ ] **Note:** `pydantic-model/Dockerfile` still has a pre-existing PATH bug (`/root/.cargo/bin` should be `/root/.local/bin`) — that fix is tracked in a separate PR

## Testing

- Verified the versioned installer URL format (`astral.sh/ruff/0.15.7/install.sh`) works by running it in a `node:22.12-slim` container
- No unit tests applicable — Dockerfile-only change

Link to Devin session: https://app.devin.ai/sessions/371cc6bdbad447bb9161b29b0ab8ec28
Requested by: @Swimburger
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/13874" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
