### PR TITLE
chore(internal): standardize git user identity to fern-api bot across Dockerfiles

### DIFF
--- a/generators/csharp/model/Dockerfile
+++ b/generators/csharp/model/Dockerfile
@@ -8,8 +8,8 @@ ENV DOTNET_CLI_TELEMETRY_OPTOUT=1
 ENV DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1
 
 RUN apk --no-cache add bash curl git zip && \
-    git config --global user.name "fern" && \
-    git config --global user.email "hey@buildwithfern.com"
+    git config --global user.email "115122769+fern-api[bot]@users.noreply.github.com" && \
+    git config --global user.name "fern-api"
 
 # Copy over node contents to be able to run the compiled CLI
 COPY --from=node /usr/local/bin/node /usr/local/bin/

--- a/generators/go/model/Dockerfile
+++ b/generators/go/model/Dockerfile
@@ -4,7 +4,8 @@ FROM golang:1.23.8-alpine3.20
 ENV YARN_CACHE_FOLDER=/.yarn
 
 RUN apk --no-cache add bash curl git zip nodejs npm
-RUN git config --global user.name "fern" && git config --global user.email "hey@buildwithfern.com"
+RUN git config --global user.email "115122769+fern-api[bot]@users.noreply.github.com" && \
+    git config --global user.name "fern-api"
 
 COPY generators/go-v2/model/dist /dist
 

--- a/generators/go/sdk/Dockerfile
+++ b/generators/go/sdk/Dockerfile
@@ -2,7 +2,8 @@
 FROM node:22.12-alpine3.20 AS node
 
 RUN apk --no-cache add git zip
-RUN git config --global user.name "fern" && git config --global user.email "hey@buildwithfern.com"
+RUN git config --global user.email "115122769+fern-api[bot]@users.noreply.github.com" && \
+    git config --global user.name "fern-api"
 
 COPY generators/go-v2/sdk/dist/ /dist/
 
@@ -12,7 +13,8 @@ FROM golang:1.23.8-alpine3.20
 WORKDIR /workspace
 
 RUN apk add --no-cache ca-certificates git nodejs
-RUN git config --global user.name "fern" && git config --global user.email "hey@buildwithfern.com"
+RUN git config --global user.email "115122769+fern-api[bot]@users.noreply.github.com" && \
+    git config --global user.name "fern-api"
 
 COPY generators/go/go.mod generators/go/go.sum /workspace/
 RUN go mod download

--- a/generators/php/model/Dockerfile
+++ b/generators/php/model/Dockerfile
@@ -4,7 +4,8 @@ FROM composer:2.7.9
 ENV YARN_CACHE_FOLDER=/.yarn
 
 RUN apk --no-cache add bash curl git zip
-RUN git config --global user.name "fern" && git config --global user.email "hey@buildwithfern.com"
+RUN git config --global user.email "115122769+fern-api[bot]@users.noreply.github.com" && \
+    git config --global user.name "fern-api"
 
 # Copy over node contents to be able to run the compiled CLI
 COPY --from=node /usr/local/bin/node /usr/local/bin/

--- a/generators/php/sdk/Dockerfile
+++ b/generators/php/sdk/Dockerfile
@@ -4,7 +4,8 @@ FROM composer:2.7.9
 ENV YARN_CACHE_FOLDER=/.yarn
 
 RUN apk --no-cache add bash curl git zip
-RUN git config --global user.name "fern" && git config --global user.email "hey@buildwithfern.com"
+RUN git config --global user.email "115122769+fern-api[bot]@users.noreply.github.com" && \
+    git config --global user.name "fern-api"
 
 # Copy over node contents to be able to run the compiled CLI
 COPY --from=node /usr/local/bin/node /usr/local/bin/

--- a/generators/ruby-v2/model/Dockerfile
+++ b/generators/ruby-v2/model/Dockerfile
@@ -11,7 +11,8 @@ RUN apk --no-cache add \
     
 RUN gem install rubocop rubocop-minitest
 
-RUN git config --global user.name "fern" && git config --global user.email "hey@buildwithfern.com"
+RUN git config --global user.email "115122769+fern-api[bot]@users.noreply.github.com" && \
+    git config --global user.name "fern-api"
 
 COPY generators/ruby-v2/sdk/features.yml /assets/features.yml
 COPY generators/ruby-v2/sdk/dist /dist

--- a/generators/ruby-v2/sdk/Dockerfile
+++ b/generators/ruby-v2/sdk/Dockerfile
@@ -11,7 +11,8 @@ RUN apk --no-cache add \
     
 RUN gem install rubocop rubocop-minitest
 
-RUN git config --global user.name "fern" && git config --global user.email "hey@buildwithfern.com"
+RUN git config --global user.email "115122769+fern-api[bot]@users.noreply.github.com" && \
+    git config --global user.name "fern-api"
 
 COPY generators/ruby-v2/sdk/features.yml /assets/features.yml
 COPY generators/ruby-v2/sdk/dist /dist

--- a/generators/typescript/express/cli/Dockerfile
+++ b/generators/typescript/express/cli/Dockerfile
@@ -1,7 +1,8 @@
 FROM node:24.14-slim
 
 RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates git zip && rm -rf /var/lib/apt/lists/*
-RUN git config --global user.name "fern" && git config --global user.email "hey@buildwithfern.com"
+RUN git config --global user.email "115122769+fern-api[bot]@users.noreply.github.com" && \
+    git config --global user.name "fern-api"
 
 ENV PNPM_STORE_PATH=/.pnpm-cache
 ENV YARN_CACHE_FOLDER=/.yarn-cache

--- a/generators/typescript/sdk/cli/Dockerfile
+++ b/generators/typescript/sdk/cli/Dockerfile
@@ -1,7 +1,8 @@
 FROM node:24.14-slim
 
 RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates git zip && rm -rf /var/lib/apt/lists/*
-RUN git config --global user.name "fern" && git config --global user.email "hey@buildwithfern.com"
+RUN git config --global user.email "115122769+fern-api[bot]@users.noreply.github.com" && \
+    git config --global user.name "fern-api"
 
 ENV PNPM_STORE_PATH=/.pnpm-cache
 ENV YARN_CACHE_FOLDER=/.yarn-cache


### PR DESCRIPTION
## Description

Standardizes the git user identity configured in generator Dockerfiles. Several Dockerfiles used the older `fern` / `hey@buildwithfern.com` identity while newer generators (java/sdk, python/sdk, csharp/sdk, rust/sdk, swift/sdk) already use the `fern-api[bot]` identity. This PR aligns the remaining 9 Dockerfiles to the bot identity.

## Changes Made

- Updated git identity from `fern` / `hey@buildwithfern.com` → `fern-api` / `115122769+fern-api[bot]@users.noreply.github.com` in:
  - `generators/typescript/sdk/cli/Dockerfile`
  - `generators/typescript/express/cli/Dockerfile`
  - `generators/go/sdk/Dockerfile` (both build stages)
  - `generators/go/model/Dockerfile`
  - `generators/php/sdk/Dockerfile`
  - `generators/php/model/Dockerfile`
  - `generators/ruby-v2/sdk/Dockerfile`
  - `generators/ruby-v2/model/Dockerfile`
  - `generators/csharp/model/Dockerfile`
- Fixed missing trailing newline in `generators/go/model/Dockerfile`

## Human Review Checklist

- [ ] **Commit attribution change**: These generators use git to commit generated code into customer repositories. Confirm that `fern-api[bot]` is the desired author identity for commits made by _all_ generators, not just the SDK generators that already used it.
- [ ] Verify no workflows or automation depend on matching the old `fern` / `hey@buildwithfern.com` identity.

## Testing

- [ ] No unit tests applicable — Dockerfile-only config changes
- [ ] Verified by inspection that the target identity matches the one already used by java/sdk, python/sdk, csharp/sdk, rust/sdk, and swift/sdk Dockerfiles

Link to Devin session: https://app.devin.ai/sessions/371cc6bdbad447bb9161b29b0ab8ec28
Requested by: @Swimburger
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/13875" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
