### PR TITLE
chore(python): remove HTTPX_LOG_LEVEL=trace from python/sdk Dockerfile

### DIFF
--- a/generators/python/sdk/Dockerfile
+++ b/generators/python/sdk/Dockerfile
@@ -21,7 +21,6 @@ RUN ruff --version
 # Set Python environment
 ENV PYTHONPATH=${PYTHONPATH}:${PWD}
 ENV _TYPER_STANDARD_TRACEBACK=1
-ENV HTTPX_LOG_LEVEL=trace
 
 # Keep in sync with the poetry-core version in pyproject.toml
 RUN pip3 install poetry==1.8.5


### PR DESCRIPTION
## Description

Removes the `HTTPX_LOG_LEVEL=trace` environment variable from the Python v1 SDK generator Dockerfile. This appears to be leftover debug configuration — trace-level logging causes httpx to emit verbose request/response logs for every HTTP call made during generation, which is unnecessary in production builds and adds noise to container output.

## Changes Made

- Removed `ENV HTTPX_LOG_LEVEL=trace` from `generators/python/sdk/Dockerfile`

## Human Review Checklist

- [ ] Confirm `HTTPX_LOG_LEVEL=trace` was not intentionally set for production use (e.g., required by a downstream log-collection pipeline)

## Testing

- No testing required — single env var removal from Dockerfile

Link to Devin session: https://app.devin.ai/sessions/371cc6bdbad447bb9161b29b0ab8ec28
Requested by: @Swimburger
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/13876" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
