### PR TITLE
chore(internal): pin npm@latest to npm@11.12.0 in java/sdk and python/sdk Dockerfiles

### DIFF
--- a/generators/java/sdk/Dockerfile
+++ b/generators/java/sdk/Dockerfile
@@ -78,7 +78,7 @@ RUN ln -s ../lib/node_modules/npm/bin/npm-cli.js /usr/local/bin/npm \
     && ln -s ../lib/node_modules/npm/bin/npx-cli.js /usr/local/bin/npx
 
 # Update npm and glob to fix CVE-2025-64756 (glob vulnerability requires 11.1.0+)
-RUN npm install -g npm@latest && npm install -g glob@11.1.0
+RUN npm install -g npm@11.12.0 && npm install -g glob@11.1.0
 
 # Patch npm's bundled glob to 11.1.0 (npm bundles its own copy at node_modules/npm/node_modules/glob)
 RUN cd /usr/local/lib/node_modules/npm/node_modules && \

--- a/generators/python/sdk/Dockerfile
+++ b/generators/python/sdk/Dockerfile
@@ -12,7 +12,7 @@ RUN . "$NVM_DIR/nvm.sh" && nvm alias default v${NODE_VERSION}
 ENV PATH="/root/.nvm/versions/node/v${NODE_VERSION}/bin/:${PATH}"
 RUN node --version
 RUN npm --version
-RUN npm install -g npm@latest
+RUN npm install -g npm@11.12.0
 
 # Install ruff.
 RUN pip install ruff


### PR DESCRIPTION
## Description

Pins `npm@latest` to `npm@11.12.0` in two generator Dockerfiles to ensure reproducible builds. The floating `@latest` tag means every Docker build can install a different npm version, which can cause non-reproducible behavior or unexpected breakages.

## Changes Made

- `generators/java/sdk/Dockerfile`: `npm@latest` → `npm@11.12.0`
- `generators/python/sdk/Dockerfile`: `npm@latest` → `npm@11.12.0`

## Human Review Checklist

- [ ] **Tradeoff: reproducibility vs. auto-patching** — The java/sdk Dockerfile uses `npm@latest` in a security-patching context (the comment references CVE-2025-64756). Pinning means future builds will no longer automatically pick up npm security fixes. Confirm this tradeoff is acceptable, or whether a different approach (e.g., Dependabot/Renovate bumps) is preferred.
- [ ] Verify `11.12.0` is compatible with the Node versions used in both images (Node 24.13.0 in java/sdk, Node 20.19.4 via nvm in python/sdk)

## Testing

- No functional testing — Dockerfile-only version pin change
- Verified `11.12.0` is the current latest npm release at time of PR creation

Link to Devin session: https://app.devin.ai/sessions/371cc6bdbad447bb9161b29b0ab8ec28
Requested by: @Swimburger
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/13877" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
