### PR TITLE
chore(python): add apt-get cleanup and best practices in python/sdk Dockerfile

### DIFF
--- a/generators/python/sdk/Dockerfile
+++ b/generators/python/sdk/Dockerfile
@@ -3,7 +3,7 @@ FROM python:3.13.7-slim AS python-base
 
 # Install node and npm.
 ENV NODE_VERSION=20.19.4
-RUN apt update && apt install -y curl git
+RUN apt-get update && apt-get install -y --no-install-recommends curl git && rm -rf /var/lib/apt/lists/*
 RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.0/install.sh | bash
 ENV NVM_DIR=/root/.nvm
 RUN . "$NVM_DIR/nvm.sh" && nvm install ${NODE_VERSION}


### PR DESCRIPTION
## Description

Applies standard Dockerfile best practices to the `apt` invocation in the Python v1 SDK generator image.

## Changes Made

- `apt` → `apt-get` (avoid the unstable CLI warning in non-interactive contexts)
- Added `--no-install-recommends` to skip unnecessary suggested packages
- Added `rm -rf /var/lib/apt/lists/*` to clean up the apt cache and reduce final image size

## Testing

- [ ] Visual inspection only — standard Dockerfile hygiene, no functional change

## Human Review Checklist

- [ ] Confirm `--no-install-recommends` doesn't drop anything `curl` or `git` need at runtime in this image (it shouldn't, but worth a sanity check if builds break)

Link to Devin session: https://app.devin.ai/sessions/371cc6bdbad447bb9161b29b0ab8ec28
Requested by: @Swimburger
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/13878" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
