### PR TITLE
chore(python): remove commented-out generator-cli install in python/sdk Dockerfile

### DIFF
--- a/generators/python/sdk/Dockerfile
+++ b/generators/python/sdk/Dockerfile
@@ -46,8 +46,6 @@ COPY ./generators/python/sdk/features.yml /assets/features.yml
 COPY ./generators/python/tests /assets/tests
 COPY ./generators/python/src ./src
 
-# RUN npm install -f -g @fern-api/generator-cli@0.5.3
-
 RUN git config --global user.email "115122769+fern-api[bot]@users.noreply.github.com" && \
     git config --global user.name "fern-api"
 


### PR DESCRIPTION
## Description

Removes a stale commented-out `npm install` line from the Python v1 SDK generator Dockerfile.

## Changes Made

- Removed `# RUN npm install -f -g @fern-api/generator-cli@0.5.3` from `generators/python/sdk/Dockerfile`

This line was commented out and served no purpose. The pinned version (`0.5.3`) is very old, suggesting this was leftover from an earlier architecture where the generator CLI was installed globally inside the container.

## Testing

- No testing required — dead code removal only

## Human Review Checklist

- [ ] Confirm `@fern-api/generator-cli` is no longer needed inside this container (the Python v1 generator now uses `python-v2` CLI copied to `/bin/python-v2` on line 39 instead)

Link to Devin session: https://app.devin.ai/sessions/371cc6bdbad447bb9161b29b0ab8ec28
Requested by: @Swimburger
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/13881" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
