### PR TITLE
chore(express): consolidate RUN layers in typescript/express Dockerfile

### DIFF
--- a/generators/typescript/express/cli/Dockerfile
+++ b/generators/typescript/express/cli/Dockerfile
@@ -8,13 +8,14 @@ ENV YARN_CACHE_FOLDER=/.yarn-cache
 ENV PNPM_HOME=/.pnpm
 ENV PATH=$PNPM_HOME:$PATH
 
-RUN npm install -g pnpm@10.20.0 --force
-RUN npm install -g yarn@1.22.22 --force
-RUN pnpm install -g prettier@3.7.4
-RUN pnpm install -g oxfmt@0.35.0
-RUN pnpm install -g @biomejs/biome@2.4.3
-RUN pnpm install -g oxlint@1.50.0
-RUN pnpm install -g oxlint-tsgolint@0.14.2
+RUN npm install -g pnpm@10.20.0 --force && \
+    npm install -g yarn@1.22.22 --force
+RUN pnpm add -g \
+  prettier@3.7.4 \
+  oxfmt@0.35.0 \
+  @biomejs/biome@2.4.3 \
+  oxlint@1.50.0 \
+  oxlint-tsgolint@0.14.2
 
 WORKDIR /tmp/cache-warm
 
@@ -40,8 +41,7 @@ RUN echo '{ \
 
 RUN yarn install --ignore-scripts
 
-RUN rm -rf node_modules
-RUN rm -rf yarn.lock
+RUN rm -rf node_modules yarn.lock
 
 RUN pnpm install
 


### PR DESCRIPTION
## Description

Reduces the number of Docker image layers in the TypeScript Express generator Dockerfile by combining related `RUN` instructions. Fewer layers means a smaller final image and slightly faster builds.

## Changes Made

- Combined two `npm install -g` calls (pnpm + yarn) into a single `RUN` layer
- Consolidated five separate `pnpm install -g` calls into one `pnpm add -g` with all packages listed together
- Merged two `rm -rf` calls into one

No package versions were changed. No functional behavior change.

## Testing

- [ ] Manual testing completed — Dockerfile-only change, verified by inspection

## Human Review Checklist

- [ ] Verify `pnpm add -g` behaves identically to `pnpm install -g` for global installs (the command name changed as part of the consolidation)
- [ ] Confirm that a single combined `npm install -g` layer with `&&` still correctly installs both pnpm and yarn (failure in either should fail the build, which is the desired behavior)

Link to Devin session: https://app.devin.ai/sessions/371cc6bdbad447bb9161b29b0ab8ec28
Requested by: @Swimburger
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/13882" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
