### PR TITLE
chore(rust): align rust/model toolchain to 1.82.0 to match rust/sdk

### DIFF
--- a/generators/rust/model/Dockerfile
+++ b/generators/rust/model/Dockerfile
@@ -2,7 +2,7 @@ FROM node:22.12-alpine3.20
 
 # Install system dependencies and Rust toolchain
 RUN apk --no-cache add curl
-RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain 1.78.0 --profile minimal --component rustfmt
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain 1.82.0 --profile minimal --component rustfmt
 ENV PATH="/root/.cargo/bin:${PATH}"
 RUN rustfmt --version  # Verify rustfmt is available
 


### PR DESCRIPTION
## Description

Aligns the Rust toolchain version in `generators/rust/model/Dockerfile` to match `generators/rust/sdk/Dockerfile`. The model generator was pinned to Rust 1.78.0 while the SDK generator already uses 1.82.0.

## Changes Made

- Bumped `--default-toolchain` from `1.78.0` → `1.82.0` in `generators/rust/model/Dockerfile`

## Testing

- [ ] Manual testing completed — Dockerfile-only change; requires Docker build to fully validate

## Human Review Checklist

- [ ] Confirm the 1.78.0 pin on the model generator was not intentional (e.g. due to a rustfmt output difference between versions that affects generated code snapshots)
- [ ] Verify that `rustfmt` output is stable between 1.78.0 and 1.82.0 for the patterns used by the model generator — a formatting change could cause seed test snapshot diffs

Link to Devin session: https://app.devin.ai/sessions/371cc6bdbad447bb9161b29b0ab8ec28
Requested by: @Swimburger
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/13884" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
