### PR TITLE
chore(seed): update AdoptOpenJDK to Eclipse Temurin in seed Dockerfile.java

### DIFF
--- a/docker/seed/Dockerfile.java
+++ b/docker/seed/Dockerfile.java
@@ -13,10 +13,10 @@ RUN set -eux; \
     ARCH="$(uname -m)"; \
     case "${ARCH}" in \
        aarch64|arm64) \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u292-b10/OpenJDK8U-jdk_aarch64_linux_hotspot_8u292b10.tar.gz'; \
+         BINARY_URL='https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u482-b08/OpenJDK8U-jdk_aarch64_linux_hotspot_8u482b08.tar.gz'; \
          ;; \
        amd64|x86_64) \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u292-b10/OpenJDK8U-jdk_x64_linux_hotspot_8u292b10.tar.gz'; \
+         BINARY_URL='https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u482-b08/OpenJDK8U-jdk_x64_linux_hotspot_8u482b08.tar.gz'; \
          ;; \
        *) \
          echo "Unsupported arch: ${ARCH}"; \
@@ -35,10 +35,10 @@ RUN set -eux; \
     ARCH="$(uname -m)"; \
     case "${ARCH}" in \
        aarch64|arm64) \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.9.1%2B1/OpenJDK11U-jdk_aarch64_linux_hotspot_11.0.9.1_1.tar.gz'; \
+         BINARY_URL='https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.30%2B7/OpenJDK11U-jdk_aarch64_linux_hotspot_11.0.30_7.tar.gz'; \
          ;; \
        amd64|x86_64) \
-         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.9.1%2B1/OpenJDK11U-jdk_x64_linux_hotspot_11.0.9.1_1.tar.gz'; \
+         BINARY_URL='https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.30%2B7/OpenJDK11U-jdk_x64_linux_hotspot_11.0.30_7.tar.gz'; \
          ;; \
        *) \
          echo "Unsupported arch: ${ARCH}"; \

--- a/packages/seed/src/__test__/affected.test.ts
+++ b/packages/seed/src/__test__/affected.test.ts
@@ -344,6 +344,74 @@ describe("detectAffected", () => {
         });
     });
 
+    describe("docker/seed/ Dockerfile detection", () => {
+        it("detects Dockerfile.java change affects Java generators", () => {
+            const result = detectAffected(["docker/seed/Dockerfile.java"], ALL_GENERATORS);
+
+            expect(result.allGeneratorsAffected).toBe(false);
+            expect(result.affectedGenerators).toContain("java-sdk");
+            expect(result.affectedGenerators).toContain("java-model");
+            expect(result.affectedGenerators).toContain("java-spring");
+            expect(result.generatorsWithAllFixtures).toContain("java-sdk");
+            expect(result.generatorsWithAllFixtures).toContain("java-model");
+            expect(result.generatorsWithAllFixtures).toContain("java-spring");
+            expect(result.affectedGenerators).not.toContain("ts-sdk");
+            expect(result.affectedGenerators).not.toContain("python-sdk");
+        });
+
+        it("detects Dockerfile.ts change affects TypeScript generators", () => {
+            const result = detectAffected(["docker/seed/Dockerfile.ts"], ALL_GENERATORS);
+
+            expect(result.affectedGenerators).toContain("ts-sdk");
+            expect(result.affectedGenerators).toContain("ts-express");
+            expect(result.affectedGenerators).not.toContain("java-sdk");
+        });
+
+        it("detects Dockerfile.python change affects Python generators", () => {
+            const result = detectAffected(["docker/seed/Dockerfile.python"], ALL_GENERATORS);
+
+            expect(result.affectedGenerators).toContain("python-sdk");
+            expect(result.affectedGenerators).toContain("pydantic");
+            expect(result.affectedGenerators).toContain("fastapi");
+        });
+
+        it("detects Dockerfile.go change affects Go generators", () => {
+            const result = detectAffected(["docker/seed/Dockerfile.go"], ALL_GENERATORS);
+
+            expect(result.affectedGenerators).toContain("go-sdk");
+            expect(result.affectedGenerators).toContain("go-model");
+        });
+
+        it("detects Dockerfile.csharp change affects C# generators", () => {
+            const result = detectAffected(["docker/seed/Dockerfile.csharp"], ALL_GENERATORS);
+
+            expect(result.affectedGenerators).toContain("csharp-sdk");
+            expect(result.affectedGenerators).toContain("csharp-model");
+        });
+
+        it("detects Dockerfile.php change affects PHP generators", () => {
+            const result = detectAffected(["docker/seed/Dockerfile.php"], ALL_GENERATORS);
+
+            expect(result.affectedGenerators).toContain("php-sdk");
+            expect(result.affectedGenerators).toContain("php-model");
+        });
+
+        it("detects Dockerfile.dockerignore change runs everything", () => {
+            const result = detectAffected(["docker/seed/Dockerfile.dockerignore"], ALL_GENERATORS);
+
+            expect(result.allGeneratorsAffected).toBe(true);
+            expect(result.allFixturesAffected).toBe(true);
+        });
+
+        it("ignores unknown files in docker/seed/", () => {
+            const result = detectAffected(["docker/seed/README.md"], ALL_GENERATORS);
+
+            expect(result.allGeneratorsAffected).toBe(false);
+            expect(result.allFixturesAffected).toBe(false);
+            expect(result.affectedGenerators).toEqual([]);
+        });
+    });
+
     describe("combined generator + fixture changes (precise union)", () => {
         it("returns precise union: affected generators get all fixtures, others get changed fixtures", () => {
             const result = detectAffected(
@@ -714,6 +782,26 @@ describe("end-to-end scenario tests", () => {
         expect(names).toContain("fastapi");
         expect(names).not.toContain("ts-sdk");
         expect(names).not.toContain("java-sdk");
+    });
+
+    it("scenario: docker/seed/Dockerfile.java change runs Java generators with all fixtures", () => {
+        const changedFiles = ["docker/seed/Dockerfile.java"];
+        const affected = detectAffected(changedFiles, ALL_GENERATORS);
+
+        // Only Java generators should run
+        const generators = resolveAffectedGenerators(affected, ALL_GENERATORS);
+        const names = generators.map((g) => g.workspaceName);
+        expect(names).toContain("java-sdk");
+        expect(names).toContain("java-model");
+        expect(names).toContain("java-spring");
+        expect(names).not.toContain("ts-sdk");
+        expect(names).not.toContain("python-sdk");
+
+        // Each Java generator should run ALL fixtures
+        for (const gen of generators) {
+            const fixtures = resolveAffectedFixtures(affected, ALL_FIXTURES, gen.workspaceName);
+            expect(fixtures).toEqual(ALL_FIXTURES);
+        }
     });
 
     it("scenario: versions.yml changes are fully ignored for seed detection", () => {

--- a/packages/seed/src/commands/affected/getAffected.ts
+++ b/packages/seed/src/commands/affected/getAffected.ts
@@ -66,6 +66,20 @@ const GLOBAL_AFFECT_PATHS = [
 const TEST_DEFINITION_PATHS = ["test-definitions/fern/apis/", "test-definitions-openapi/fern/apis/"];
 
 /**
+ * Maps docker/seed/ Dockerfiles to the generator workspaces they affect.
+ * When a seed Dockerfile changes, the corresponding generators need to re-run
+ * all their fixtures to verify the updated Docker image works correctly.
+ */
+const DOCKER_SEED_GENERATOR_PATHS: Record<string, string[]> = {
+    "docker/seed/Dockerfile.java": ["java-sdk", "java-model", "java-spring"],
+    "docker/seed/Dockerfile.ts": ["ts-sdk", "ts-express"],
+    "docker/seed/Dockerfile.python": ["python-sdk", "pydantic", "pydantic-v2", "fastapi"],
+    "docker/seed/Dockerfile.go": ["go-sdk", "go-model"],
+    "docker/seed/Dockerfile.csharp": ["csharp-sdk", "csharp-model"],
+    "docker/seed/Dockerfile.php": ["php-sdk", "php-model"]
+};
+
+/**
  * Maps generator workspace names to their source code paths.
  * Used to detect which generators are affected by file changes.
  */
@@ -218,6 +232,40 @@ export function detectAffected(changedFiles: string[], allGenerators: GeneratorW
                 }
             }
         }
+    }
+
+    // === DOCKER SEED DOCKERFILE DETECTION ===
+    // When a docker/seed/ Dockerfile changes, the generators that use that Docker
+    // image need to re-run all their fixtures to verify the updated image works.
+    for (const file of changedFiles) {
+        if (file.startsWith("docker/seed/")) {
+            if (file === "docker/seed/Dockerfile.dockerignore") {
+                // The shared .dockerignore affects all seed Docker builds
+                allGeneratorsAffected = true;
+                allFixturesAffected = true;
+                summary.push(`Seed Docker ignore changed: ${file} — affects all seed builds`);
+                break;
+            }
+            const generators = DOCKER_SEED_GENERATOR_PATHS[file];
+            if (generators != null) {
+                for (const gen of generators) {
+                    affectedGeneratorSet.add(gen);
+                }
+                summary.push(`Seed Dockerfile changed: ${file} — affects ${generators.join(", ")}`);
+            }
+        }
+    }
+
+    // If global changes detected from dockerignore, return early
+    if (allGeneratorsAffected && allFixturesAffected) {
+        return {
+            allGeneratorsAffected: true,
+            allFixturesAffected: true,
+            affectedGenerators: [],
+            generatorsWithAllFixtures: [],
+            affectedFixtures: [],
+            summary
+        };
     }
 
     // === SEED.YML DETECTION (always via git diff) ===


### PR DESCRIPTION
## Description

Updates the Java seed test Dockerfile from deprecated AdoptOpenJDK binaries (from 2021) to current Eclipse Temurin releases. AdoptOpenJDK has been succeeded by the Eclipse Adoptium project; the old binary URLs may eventually become unavailable.

Also fixes a gap in the seed affected detection logic: changes to `docker/seed/` Dockerfiles now properly trigger seed tests for the corresponding generators.

## Changes Made

- **JDK 8**: `8u292-b10` → `8u482-b08` (both aarch64 and x64)
- **JDK 11**: `11.0.9.1+1` → `11.0.30+7` (both aarch64 and x64)
- Download source changed from `github.com/AdoptOpenJDK/*` → `github.com/adoptium/temurin*-binaries`
- Added `DOCKER_SEED_GENERATOR_PATHS` mapping in `getAffected.ts` so that changes to `docker/seed/Dockerfile.*` trigger the corresponding generator seed tests (e.g. `Dockerfile.java` → java-sdk, java-model, java-spring)
- `Dockerfile.dockerignore` changes are treated as global (triggers all generators/fixtures)
- Added unit tests for docker/seed/ affected detection (8 new test cases + 1 end-to-end scenario)

## Updates Since Last Revision

Per reviewer feedback, the seed affected detection logic was updated to include `docker/seed/` paths. Previously, changes to files like `Dockerfile.java` did not trigger any seed tests because `docker/seed/` was not in `GLOBAL_AFFECT_PATHS` or `GENERATOR_SOURCE_PATHS`. The new `DOCKER_SEED_GENERATOR_PATHS` mapping provides granular per-language detection rather than treating all docker/seed changes as global.

## Testing

- [ ] Manual testing completed — Dockerfile-only change; requires Docker image build to validate
- Download URLs were verified via the [Adoptium API](https://api.adoptium.net)
- Affected detection unit tests pass locally (62 tests, all green)

## Human Review Checklist

- [ ] Verify the four download URLs resolve correctly (the old AdoptOpenJDK org is archived and URLs may break in the future)
- [ ] Confirm the large JDK version jumps (especially 11.0.9 → 11.0.30) don't cause seed test regressions — the Java seed tests compile and run generated code against these JDKs
- [ ] Verify `DOCKER_SEED_GENERATOR_PATHS` covers all `docker/seed/Dockerfile.*` files and maps to the correct generator workspaces — this mapping must be kept in sync manually if new seed Dockerfiles are added
- [ ] Note: the `packages/seed/` change will itself trigger all seed tests via `GLOBAL_AFFECT_PATHS`, which provides broad validation of this PR

Link to Devin session: https://app.devin.ai/sessions/371cc6bdbad447bb9161b29b0ab8ec28
Requested by: @Swimburger
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/13885" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
