### PR TITLE
chore(rust): add missing versions.yml entry for rust SDK generator

### DIFF
--- a/generators/rust/model/versions.yml
+++ b/generators/rust/model/versions.yml
@@ -1,18 +1,4 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
-- version: 0.3.0
-  changelogEntry:
-    - summary: |
-        Improve discriminated union design with inlined variants and constructors. When an inner
-        type is only referenced by a single union variant, its fields are now inlined directly into
-        the enum variant instead of using a wrapper struct with `#[serde(flatten)]`. All enum
-        variants now include `#[non_exhaustive]` for forward compatibility, and constructor methods
-        are generated for every variant (required since `#[non_exhaustive]` prevents direct
-        construction outside the crate). Empty variants use struct syntax (`Variant {}`) instead
-        of unit syntax.
-      type: feat
-  createdAt: "2026-03-21"
-  irVersion: 65
-
 - version: 0.2.0
   changelogEntry:
     - summary: |

--- a/generators/rust/model/versions.yml
+++ b/generators/rust/model/versions.yml
@@ -1,4 +1,18 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 0.3.0
+  changelogEntry:
+    - summary: |
+        Improve discriminated union design with inlined variants and constructors. When an inner
+        type is only referenced by a single union variant, its fields are now inlined directly into
+        the enum variant instead of using a wrapper struct with `#[serde(flatten)]`. All enum
+        variants now include `#[non_exhaustive]` for forward compatibility, and constructor methods
+        are generated for every variant (required since `#[non_exhaustive]` prevents direct
+        construction outside the crate). Empty variants use struct syntax (`Variant {}`) instead
+        of unit syntax.
+      type: feat
+  createdAt: "2026-03-21"
+  irVersion: 65
+
 - version: 0.2.0
   changelogEntry:
     - summary: |

--- a/generators/rust/sdk/versions.yml
+++ b/generators/rust/sdk/versions.yml
@@ -1,5 +1,19 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 
+- version: 0.24.0
+  changelogEntry:
+    - summary: |
+        Improve discriminated union design with inlined variants and constructors. When an inner
+        type is only referenced by a single union variant, its fields are now inlined directly into
+        the enum variant instead of using a wrapper struct with `#[serde(flatten)]`. All enum
+        variants now include `#[non_exhaustive]` for forward compatibility, and constructor methods
+        are generated for every variant (required since `#[non_exhaustive]` prevents direct
+        construction outside the crate). Empty variants use struct syntax (`Variant {}`) instead
+        of unit syntax.
+      type: feat
+  createdAt: "2026-03-21"
+  irVersion: 65
+
 - version: 0.23.0
   changelogEntry:
     - summary: |


### PR DESCRIPTION
## Description

Refs #13849

PR #13849 (discriminated union inlining) modified the Rust SDK generator but did not add a corresponding `versions.yml` entry. This PR adds the missing `0.24.0` entry to `generators/rust/sdk/versions.yml`.

## Changes Made

- Added `0.24.0` entry to `generators/rust/sdk/versions.yml` documenting the discriminated union inlining feature from #13849
- [ ] Updated README.md generator (not applicable)

## Human Review Checklist

- [ ] Version bump `0.23.0` → `0.24.0` is appropriate (feat = minor bump)
- [ ] `irVersion: 65` matches the existing entries for this IR version
- [ ] Changelog summary accurately captures the discriminated union changes from #13849

## Testing

- [x] Lint passes (`pnpm run check`)
- [ ] No unit tests needed (YAML-only changelog entry)

Link to Devin session: https://app.devin.ai/sessions/69959c7e80bc4f019379de6ddee11114
Requested by: @iamnamananand996