### PR TITLE
chore(cli): remove generatePaginatedClients Venus config dependency

### DIFF
--- a/packages/cli/generation/local-generation/local-workspace-runner/src/GenerationRunner.ts
+++ b/packages/cli/generation/local-generation/local-workspace-runner/src/GenerationRunner.ts
@@ -199,7 +199,6 @@ export class GenerationRunner {
             outputVersionOverride,
             writeUnitTests: true,
             generateOauthClients: true,
-            generatePaginatedClients: true,
             includeOptionalRequestPropertyExamples: true,
             inspect,
             executionEnvironment: this.executionEnvironment,

--- a/packages/cli/generation/local-generation/local-workspace-runner/src/getGeneratorConfig.ts
+++ b/packages/cli/generation/local-generation/local-workspace-runner/src/getGeneratorConfig.ts
@@ -90,7 +90,6 @@ export declare namespace getGeneratorConfig {
         absolutePathToFernConfig: AbsoluteFilePath | undefined;
         writeUnitTests: boolean;
         generateOauthClients: boolean;
-        generatePaginatedClients: boolean;
         whiteLabel?: boolean;
         paths: {
             snippetPath: AbsoluteFilePath | undefined;
@@ -185,7 +184,6 @@ export function getGeneratorConfig({
     absolutePathToFernConfig,
     writeUnitTests,
     generateOauthClients,
-    generatePaginatedClients,
     whiteLabel,
     paths
 }: getGeneratorConfig.Args): FernGeneratorExec.GeneratorConfig {
@@ -276,7 +274,7 @@ export function getGeneratorConfig({
         whitelabel: whiteLabel ?? false,
         writeUnitTests,
         generateOauthClients,
-        generatePaginatedClients,
+        generatePaginatedClients: true,
         license: licenseInfo
     };
 }

--- a/packages/cli/generation/local-generation/local-workspace-runner/src/runGenerator.ts
+++ b/packages/cli/generation/local-generation/local-workspace-runner/src/runGenerator.ts
@@ -69,7 +69,6 @@ export async function writeFilesToDiskAndRunGenerator({
     outputVersionOverride,
     writeUnitTests,
     generateOauthClients,
-    generatePaginatedClients,
     includeOptionalRequestPropertyExamples,
     inspect,
     executionEnvironment,
@@ -97,7 +96,6 @@ export async function writeFilesToDiskAndRunGenerator({
     outputVersionOverride: string | undefined;
     writeUnitTests: boolean;
     generateOauthClients: boolean;
-    generatePaginatedClients: boolean;
     includeOptionalRequestPropertyExamples: boolean;
     inspect: boolean;
     executionEnvironment?: ExecutionEnvironment;
@@ -208,7 +206,6 @@ export async function writeFilesToDiskAndRunGenerator({
         absolutePathToFernConfig,
         writeUnitTests,
         generateOauthClients,
-        generatePaginatedClients,
         whiteLabel,
         paths
     });

--- a/packages/cli/generation/local-generation/local-workspace-runner/src/runLocalGenerationForWorkspace.ts
+++ b/packages/cli/generation/local-generation/local-workspace-runner/src/runLocalGenerationForWorkspace.ts
@@ -336,7 +336,6 @@ export async function runLocalGenerationForWorkspace({
                     outputVersionOverride: version,
                     writeUnitTests: true,
                     generateOauthClients: organization.ok ? (organization?.body.oauthClientEnabled ?? false) : false,
-                    generatePaginatedClients: organization.ok ? (organization?.body.paginationEnabled ?? false) : false,
                     includeOptionalRequestPropertyExamples: false,
                     inspect,
                     executionEnvironment: undefined, // This should use the Docker fallback with proper image name


### PR DESCRIPTION
## Description

Removes the `generatePaginatedClients` Venus org-level feature flag dependency from the local generation pipeline. Pagination is now always enabled (`true`) instead of being gated by the organization's `paginationEnabled` setting fetched from Venus.

## Changes Made

- Hardcoded `generatePaginatedClients: true` in `getGeneratorConfig.ts` instead of accepting it as a parameter
- Removed `generatePaginatedClients` from function signatures in `writeFilesToDiskAndRunGenerator` and `getGeneratorConfig.Args`
- Removed Venus-dependent lookup (`organization?.body.paginationEnabled`) in `runLocalGenerationForWorkspace.ts`
- Removed the already-hardcoded `generatePaginatedClients: true` from `GenerationRunner.ts`

**Note:** The `generatePaginatedClients` field still exists in the `GeneratorConfig` IR SDK type and in generator code — generators continue to read it, but it is now always `true`.

## Review Checklist

- [ ] Confirm always enabling pagination is safe for all existing customers (previously orgs without `paginationEnabled` in Venus would get `false`)
- [ ] Consider whether `generateOauthClients` (still reads from Venus via `oauthClientEnabled`) should also be decoupled in a follow-up
- [ ] Generator-side tests that set `generatePaginatedClients: false` are still valid for testing generator behavior — no test changes needed

## Testing

- [x] `biome check` passes
- [ ] Relies on existing CI for broader validation

Link to Devin session: https://app.devin.ai/sessions/bdc35077215c4e1eab443ffab54a8760
Requested by: @Swimburger
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/13888" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
