### PR TITLE
fix(seed): report generate/build/test timings in seed run command

### DIFF
--- a/packages/seed/src/commands/run/runWithCustomFixture.ts
+++ b/packages/seed/src/commands/run/runWithCustomFixture.ts
@@ -10,6 +10,7 @@ import { GeneratorWorkspace } from "../../loadGeneratorWorkspaces.js";
 import { Semaphore } from "../../Semaphore.js";
 import { convertGeneratorWorkspaceToFernWorkspace } from "../../utils/convertSeedWorkspaceToFernWorkspace.js";
 import { ContainerScriptRunner, LocalScriptRunner, ScriptRunner } from "../test/index.js";
+import { printTestCases } from "../test/printTestCases.js";
 import { TaskContextFactory } from "../test/TaskContextFactory.js";
 import { ContainerTestRunner, LocalTestRunner, TestRunner } from "../test/test-runner/index.js";
 
@@ -133,7 +134,7 @@ export async function runWithCustomFixture({
 
         await testRunner.build();
 
-        await testRunner.run({
+        const result = await testRunner.run({
             fixture: "custom",
             configuration: runFixtureConfig,
             inspect,
@@ -144,6 +145,8 @@ export async function runWithCustomFixture({
             absolutePathToFernConfig: projectConfig?.absolutePathToFernConfig,
             lenient: true
         });
+
+        printTestCases([result]);
 
         taskContext.logger.info(`Wrote files to ${absolutePathToOutput}`);
 


### PR DESCRIPTION
## Description

`pnpm seed run` now prints the same generate/build/test timing table that `pnpm seed test` already displays.

## Changes Made

- Captured the return value of `testRunner.run()` in `runWithCustomFixture.ts` (was previously discarded)
- Called the existing `printTestCases()` utility to print a table with Generation Time, Build Time, and Test Time

## Testing

- [ ] Manual testing completed
- Verified no new type errors introduced via LSP diagnostics on the changed file

Link to Devin session: https://app.devin.ai/sessions/a33f0de005c4473b87c8f5e855a1f227
Requested by: @Swimburger
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/13889" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
