### PR TITLE
fix(seed): add multi-arch support for Go download in seed Dockerfile.go

### DIFF
--- a/docker/seed/Dockerfile.go
+++ b/docker/seed/Dockerfile.go
@@ -11,13 +11,18 @@ FROM docker:28.4.0-dind-alpine3.22
 # Copy pre-pulled wiremock image
 COPY --from=wiremock-pull /wiremock.tar /wiremock.tar
 
-# Install Go
+# Install Go (multi-arch: supports both amd64 and arm64)
 ENV GO_VERSION=1.23.8
-RUN apk add --no-cache wget tar \
-    && wget -q https://go.dev/dl/go${GO_VERSION}.linux-amd64.tar.gz \
-    && tar -C /usr/local -xzf go${GO_VERSION}.linux-amd64.tar.gz \
-    && rm go${GO_VERSION}.linux-amd64.tar.gz \
-    && apk del wget tar
+RUN set -eux; \
+    ARCH="$(uname -m)"; \
+    case "${ARCH}" in \
+        aarch64|arm64) GOARCH="arm64" ;; \
+        x86_64|amd64) GOARCH="amd64" ;; \
+        *) echo "Unsupported arch: ${ARCH}"; exit 1 ;; \
+    esac; \
+    wget -q "https://go.dev/dl/go${GO_VERSION}.linux-${GOARCH}.tar.gz" \
+    && tar -C /usr/local -xzf "go${GO_VERSION}.linux-${GOARCH}.tar.gz" \
+    && rm "go${GO_VERSION}.linux-${GOARCH}.tar.gz"
 
 ENV PATH="/usr/local/go/bin:${PATH}" \
     GOPATH="/go" \


### PR DESCRIPTION
## Description

The Go seed Dockerfile hardcoded `linux-amd64` in the Go binary download URL, meaning it would install the wrong architecture binary on ARM machines (e.g., Apple Silicon, ARM CI runners).

## Changes Made

- Replaced the hardcoded `linux-amd64` URL with architecture detection using `uname -m`, matching the pattern already used in `docker/seed/Dockerfile.java`
- Removed the unnecessary `apk add --no-cache wget tar` / `apk del wget tar` — both `wget` and `tar` are already available in the `docker:28.4.0-dind-alpine3.22` base image via busybox
- Added `set -eux` for strict error handling during the install step

## Review Checklist

- [ ] Verify the `wget`/`tar` availability in the `docker:dind-alpine` base image is acceptable (the golangci-lint install on line 30 also depends on `wget` from the base image)
- [ ] Confirm architecture mapping: `aarch64|arm64 → arm64`, `x86_64|amd64 → amd64`
- [ ] Not tested with an actual ARM Docker build — correctness is inferred from the Go download URL naming convention and the same pattern used in `Dockerfile.java`

Link to Devin session: https://app.devin.ai/sessions/371cc6bdbad447bb9161b29b0ab8ec28
Requested by: @Swimburger
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/13890" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
