### PR TITLE
chore(python): pin ruff to 0.15.7 in python/sdk Dockerfile

### DIFF
--- a/generators/python/sdk/Dockerfile
+++ b/generators/python/sdk/Dockerfile
@@ -15,7 +15,7 @@ RUN node --version
 RUN npm --version
 
 # Install ruff.
-RUN pip install ruff
+RUN pip install ruff==0.15.7
 RUN ruff --version
 
 # Set Python environment


### PR DESCRIPTION
## Description

Pins the `ruff` linter to version `0.15.7` in the python/sdk Dockerfile for reproducible builds. This was the only Dockerfile left with an unpinned `pip install ruff` — all other Dockerfiles that install ruff (python-v2/sdk, python-v2/pydantic-model) already pin to `0.15.7`.

## Changes Made

- Pinned `pip install ruff` → `pip install ruff==0.15.7` in `generators/python/sdk/Dockerfile`

## Testing

- [ ] Dockerfile-only change; relies on CI seed tests to validate the built image
- [ ] Version `0.15.7` is already validated by python-v2/sdk and python-v2/pydantic-model Dockerfiles

## Human Review Checklist

- [ ] Confirm `0.15.7` is the desired version to standardize on across all Python Dockerfiles

Link to Devin session: https://app.devin.ai/sessions/371cc6bdbad447bb9161b29b0ab8ec28
Requested by: @Swimburger
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/13892" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
