### PR TITLE
chore(php): pin php-cs-fixer to v3.94.2 in php/sdk and php/model Dockerfiles

### DIFF
--- a/generators/php/model/Dockerfile
+++ b/generators/php/model/Dockerfile
@@ -13,8 +13,9 @@ COPY --from=node /usr/local/lib/node_modules /usr/local/lib/node_modules
 RUN ln -s ../lib/node_modules/npm/bin/npm-cli.js /usr/local/bin/npm \
     && ln -s ../lib/node_modules/npm/bin/npx-cli.js /usr/local/bin/npx
 
-RUN curl -L https://cs.symfony.com/download/php-cs-fixer-v3.phar -o /usr/local/bin/php-cs-fixer \
-    && chmod +x /usr/local/bin/php-cs-fixer
+RUN curl -fsSL https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/releases/download/v3.94.2/php-cs-fixer.phar -o /usr/local/bin/php-cs-fixer \
+    && chmod +x /usr/local/bin/php-cs-fixer \
+    && php-cs-fixer --version
 
 COPY generators/php/model/dist /dist
 

--- a/generators/php/sdk/Dockerfile
+++ b/generators/php/sdk/Dockerfile
@@ -13,8 +13,9 @@ COPY --from=node /usr/local/lib/node_modules /usr/local/lib/node_modules
 RUN ln -s ../lib/node_modules/npm/bin/npm-cli.js /usr/local/bin/npm \
     && ln -s ../lib/node_modules/npm/bin/npx-cli.js /usr/local/bin/npx
 
-RUN curl -L https://cs.symfony.com/download/php-cs-fixer-v3.phar -o /usr/local/bin/php-cs-fixer \
-    && chmod +x /usr/local/bin/php-cs-fixer
+RUN curl -fsSL https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/releases/download/v3.94.2/php-cs-fixer.phar -o /usr/local/bin/php-cs-fixer \
+    && chmod +x /usr/local/bin/php-cs-fixer \
+    && php-cs-fixer --version
 
 # Copy generator files (these change frequently, so keep them last)
 COPY generators/php/sdk/features.yml /assets/features.yml


### PR DESCRIPTION
## Description

Pins php-cs-fixer to a specific version (v3.94.2) in both PHP generator Dockerfiles for reproducible builds. Previously, the download URL (`cs.symfony.com/download/php-cs-fixer-v3.phar`) always fetched the latest release, meaning builds could silently pick up new versions with potentially breaking changes.

## Changes Made

- Replaced the floating `cs.symfony.com` download URL with a pinned GitHub release URL for v3.94.2 in both `generators/php/sdk/Dockerfile` and `generators/php/model/Dockerfile`
- Changed `curl -L` to `curl -fsSL` so the build fails fast on HTTP errors instead of silently writing an error page to the binary
- Added `php-cs-fixer --version` as a build-time sanity check (consistent with similar checks for ruff and rustfmt in other Dockerfiles)

## Testing

- [ ] Dockerfile-only change; relies on CI seed tests to validate the built images
- [ ] The `php-cs-fixer --version` check will catch incompatibility at build time

## Human Review Checklist

- [ ] Verify v3.94.2 is compatible with the PHP version shipped in `composer:2.7.9`
- [ ] Note: no SHA checksum verification is included — the GitHub release URL is pinned by tag, which is sufficient for reproducibility but not tamper-proofing

Link to Devin session: https://app.devin.ai/sessions/371cc6bdbad447bb9161b29b0ab8ec28
Requested by: @Swimburger
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/13894" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
