### PR TITLE
chore(seed): clean up Dockerfile.java — remove no-op source, add yum cleanup, merge layers

### DIFF
--- a/docker/seed/Dockerfile.java
+++ b/docker/seed/Dockerfile.java
@@ -1,13 +1,14 @@
 # Small ubuntu base image
 FROM redhat/ubi9:latest
 
-# Install sdkman
-RUN yum update -y
-RUN yum -y install git zip unzip
+# Install dependencies
+RUN yum update -y && \
+    yum -y install git zip unzip && \
+    yum clean all && \
+    rm -rf /var/cache/yum
 RUN git clone https://github.com/jenv/jenv.git ~/.jenv
 RUN echo 'export PATH="$HOME/.jenv/bin:$PATH"' >> ~/.bash_profile
 RUN echo 'eval "$(jenv init -)"' >> ~/.bash_profile
-RUN source ~/.bash_profile
 
 RUN set -eux; \
     ARCH="$(uname -m)"; \


### PR DESCRIPTION
## Description

Cleans up three minor issues in the Java seed Dockerfile.

## Changes Made

- **Removed no-op `RUN source ~/.bash_profile`** (line 10): Each `RUN` creates a new shell, so environment variables set by `source` are discarded after the layer completes. This line had no effect — subsequent lines that need jenv already source inline (e.g. `RUN source ~/.bash_profile && jenv add ...`).
- **Added yum cache cleanup**: `yum clean all && rm -rf /var/cache/yum` removes cached packages and metadata, reducing image size.
- **Merged two separate yum layers** (`yum update` + `yum install`) into a single `RUN` to reduce the number of image layers and avoid caching stale package metadata.
- Fixed inaccurate comment ("Install sdkman" → "Install dependencies" — this installs jenv, not sdkman).

## Testing

- [ ] Dockerfile-only change; relies on CI seed tests to validate the built image
- [ ] No functional behavior changes — only layer optimization and dead code removal

## Human Review Checklist

- [ ] Verify that removing `RUN source ~/.bash_profile` is safe — confirm all subsequent jenv commands source it inline in the same `RUN` (lines 32, 54–57 in the full file)

Link to Devin session: https://app.devin.ai/sessions/371cc6bdbad447bb9161b29b0ab8ec28
Requested by: @Swimburger
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/13895" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
