### PR TITLE
chore(ruby): pin rubocop to ~> 1.21 in ruby-v2/sdk and model Dockerfiles

### DIFF
--- a/generators/ruby-v2/model/Dockerfile
+++ b/generators/ruby-v2/model/Dockerfile
@@ -9,7 +9,7 @@ RUN apk --no-cache add \
     nodejs \
     npm
     
-RUN gem install rubocop -v '~> 1.21' rubocop-minitest
+RUN gem install 'rubocop:~> 1.21' rubocop-minitest
 
 RUN git config --global user.email "115122769+fern-api[bot]@users.noreply.github.com" && \
     git config --global user.name "fern-api"

--- a/generators/ruby-v2/model/Dockerfile
+++ b/generators/ruby-v2/model/Dockerfile
@@ -9,7 +9,7 @@ RUN apk --no-cache add \
     nodejs \
     npm
     
-RUN gem install rubocop rubocop-minitest
+RUN gem install rubocop -v '~> 1.21' rubocop-minitest
 
 RUN git config --global user.email "115122769+fern-api[bot]@users.noreply.github.com" && \
     git config --global user.name "fern-api"

--- a/generators/ruby-v2/sdk/Dockerfile
+++ b/generators/ruby-v2/sdk/Dockerfile
@@ -9,7 +9,7 @@ RUN apk --no-cache add \
     nodejs \
     npm
     
-RUN gem install rubocop -v '~> 1.21' rubocop-minitest
+RUN gem install 'rubocop:~> 1.21' rubocop-minitest
 
 RUN git config --global user.email "115122769+fern-api[bot]@users.noreply.github.com" && \
     git config --global user.name "fern-api"

--- a/generators/ruby-v2/sdk/Dockerfile
+++ b/generators/ruby-v2/sdk/Dockerfile
@@ -9,7 +9,7 @@ RUN apk --no-cache add \
     nodejs \
     npm
     
-RUN gem install rubocop rubocop-minitest
+RUN gem install rubocop -v '~> 1.21' rubocop-minitest
 
 RUN git config --global user.email "115122769+fern-api[bot]@users.noreply.github.com" && \
     git config --global user.name "fern-api"


### PR DESCRIPTION
## Description

Pins `rubocop` to `~> 1.21` in the ruby-v2 generator Dockerfiles, matching the version constraint specified in `RubyProject.ts` for generated projects. Previously, `gem install rubocop` fetched the latest version, which could silently introduce breaking lint rules or new cops that cause generated code to fail formatting checks.

## Changes Made

- Pinned `rubocop` to `~> 1.21` (>= 1.21, < 2.0) in both `generators/ruby-v2/sdk/Dockerfile` and `generators/ruby-v2/model/Dockerfile`
- Uses the RubyGems colon syntax (`gem install 'rubocop:~> 1.21' rubocop-minitest`) which supports version constraints with multiple gems in a single command
- `rubocop-minitest` remains unpinned (no version constraint found in the codebase for it)

### Updates since last revision

- Switched from `-v` flag syntax to colon syntax — `gem install rubocop -v '~> 1.21' rubocop-minitest` fails because `-v` cannot be used when installing multiple gems simultaneously. The colon syntax is supported in RubyGems 3.0+ (base image ships with 3.5.22).

## Testing

- [x] Verified `gem install 'rubocop:~> 1.21' rubocop-minitest` works in `ruby:3.3-alpine3.20` with `build-base` installed — installs rubocop 1.85.1 successfully
- [ ] Dockerfile-only change; relies on CI seed tests to validate the built images

## Human Review Checklist

- [ ] Note: the Graphite bot flagged the colon syntax as invalid — this is incorrect; the syntax is valid in RubyGems 3.0+ ([docs](https://guides.rubygems.org/command-reference/#gem-install)) and was verified locally
- [ ] Consider whether `rubocop-minitest` should also be pinned for full reproducibility
- [ ] Confirm `~> 1.21` matches the constraint in `RubyProject.ts`

Link to Devin session: https://app.devin.ai/sessions/371cc6bdbad447bb9161b29b0ab8ec28
Requested by: @Swimburger
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/13896" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
