### PR TITLE
chore(swift): remove unused AS node alias in swift/sdk Dockerfile

### DIFF
--- a/generators/swift/sdk/Dockerfile
+++ b/generators/swift/sdk/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:22.12-alpine3.20 AS node
+FROM node:22.12-alpine3.20
 
 RUN apk --no-cache add bash curl git zip
 RUN git config --global user.email "115122769+fern-api[bot]@users.noreply.github.com" && \


### PR DESCRIPTION
## Description

Removes the unused `AS node` stage alias from the `FROM` line in the Swift SDK generator Dockerfile.

## Changes Made

- Removed `AS node` from `FROM node:22.12-alpine3.20 AS node` — this is a single-stage Dockerfile with no `COPY --from=node` or other multi-stage references, so the alias has no effect.

## Testing

- [ ] Dockerfile-only cosmetic change; relies on CI seed tests to validate the built image
- [ ] No functional behavior change — the image contents are identical with or without the alias

## Human Review Checklist

- [ ] Confirm there is no `COPY --from=node` or other stage reference in this Dockerfile (there isn't — it's a single-stage build)

Link to Devin session: https://app.devin.ai/sessions/371cc6bdbad447bb9161b29b0ab8ec28
Requested by: @Swimburger
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/13897" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
