### PR TITLE
chore(python): add explicit ca-certificates in python/sdk Dockerfile

### DIFF
--- a/generators/python/sdk/Dockerfile
+++ b/generators/python/sdk/Dockerfile
@@ -10,7 +10,7 @@ COPY --from=node /usr/local/lib/node_modules /usr/local/lib/node_modules
 RUN ln -s /usr/local/lib/node_modules/npm/bin/npm-cli.js /usr/local/bin/npm && \
     ln -s /usr/local/lib/node_modules/npm/bin/npx-cli.js /usr/local/bin/npx
 
-RUN apt-get update && apt-get install -y --no-install-recommends curl git && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates curl git && rm -rf /var/lib/apt/lists/*
 RUN node --version
 RUN npm --version
 


### PR DESCRIPTION
## Description

Adds explicit `ca-certificates` to the `apt-get install` line in the python/sdk Dockerfile for consistency and safety.

## Changes Made

- Added `ca-certificates` to `apt-get install -y --no-install-recommends` on line 13 of `generators/python/sdk/Dockerfile`

## Context

The Dockerfile uses `--no-install-recommends` (which strips transitive dependencies), `curl` (which needs system CA certs for HTTPS), and `python:3.13.7-slim` as the base image. While `python:3.13.7-slim` currently ships with `ca-certificates` pre-installed, listing it explicitly is the correct practice — if the base image ever changes or drops the package, `curl` HTTPS operations (and `pip install` via system certs) would silently break.

This aligns with `typescript/sdk/cli/Dockerfile` and `typescript/express/cli/Dockerfile`, which already explicitly install `ca-certificates` alongside `--no-install-recommends`.

## Review Checklist

- [ ] Confirm `ca-certificates` is appropriate here (defensive measure — base image has it, but explicit is safer with `--no-install-recommends`)

## Testing

- [ ] Dockerfile-only change; relies on CI seed tests to validate the built image still works correctly

Link to Devin session: https://app.devin.ai/sessions/371cc6bdbad447bb9161b29b0ab8ec28
Requested by: @Swimburger
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/13899" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
