### PR TITLE
fix(ruby): fix ruby-v2/model Dockerfile to copy model files instead of SDK files

### DIFF
--- a/generators/ruby-v2/model/Dockerfile
+++ b/generators/ruby-v2/model/Dockerfile
@@ -14,7 +14,6 @@ RUN gem install 'rubocop:~> 1.21' rubocop-minitest
 RUN git config --global user.email "115122769+fern-api[bot]@users.noreply.github.com" && \
     git config --global user.name "fern-api"
 
-COPY generators/ruby-v2/sdk/features.yml /assets/features.yml
-COPY generators/ruby-v2/sdk/dist /dist
+COPY generators/ruby-v2/model/dist /dist
 
 ENTRYPOINT ["node", "--enable-source-maps", "/dist/cli.cjs"]

--- a/generators/ruby-v2/model/Dockerfile.dockerignore
+++ b/generators/ruby-v2/model/Dockerfile.dockerignore
@@ -1,3 +1,2 @@
 *
-!generators/ruby-v2/sdk/features.yml
-!generators/ruby-v2/sdk/dist
+!generators/ruby-v2/model/dist


### PR DESCRIPTION
## Description

Fixes a copy-paste bug where the ruby-v2/model Dockerfile and its `.dockerignore` both referenced `generators/ruby-v2/sdk/` paths instead of `generators/ruby-v2/model/`. This caused `docker build` to fail since the SDK's dist files aren't in the model's build context.

## Changes Made

- **Dockerfile**: Changed `COPY generators/ruby-v2/sdk/dist /dist` → `COPY generators/ruby-v2/model/dist /dist`
- **Dockerfile**: Removed `COPY generators/ruby-v2/sdk/features.yml /assets/features.yml` — model generators don't have a `features.yml` (consistent with all other model Dockerfiles: go/model, rust/model, csharp/model, swift/model, php/model)
- **Dockerfile.dockerignore**: Updated whitelist from `ruby-v2/sdk/` paths to `ruby-v2/model/dist`

## Review Checklist

- [ ] Confirm `generators/ruby-v2/model/dist` is the correct output path for the model build (`build.mjs` uses the standard `buildGenerator` helper)
- [ ] Confirm the model generator doesn't need a `features.yml` at `/assets/features.yml` at runtime

## Testing

- Verified the previous Dockerfile fails to build: `"/generators/ruby-v2/sdk/dist": not found`
- Confirmed no other model Dockerfile in the repo includes a `features.yml`
- Confirmed `generators/ruby-v2/model/` has its own `build.mjs` that produces `dist/`

Link to Devin session: https://app.devin.ai/sessions/371cc6bdbad447bb9161b29b0ab8ec28
Requested by: @Swimburger
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/13900" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
