### PR TITLE
chore(seed): pin ubi9 to 9.7 and add ENTRYPOINT in Dockerfile.java

### DIFF
--- a/docker/seed/Dockerfile.java
+++ b/docker/seed/Dockerfile.java
@@ -1,5 +1,5 @@
-# Small ubuntu base image
-FROM redhat/ubi9:latest
+# Small RHEL base image
+FROM redhat/ubi9:9.7
 
 # Install dependencies
 RUN yum update -y && \
@@ -56,3 +56,5 @@ RUN source ~/.bash_profile && jenv add /opt/java/openjdk11
 RUN source ~/.bash_profile && jenv global 11
 RUN source ~/.bash_profile && jenv enable-plugin export
 RUN source ~/.bash_profile && jenv enable-plugin gradle
+
+ENTRYPOINT ["tail", "-f", "/dev/null"]


### PR DESCRIPTION
## Description

Improves the Java seed Dockerfile for reproducibility and consistency with all other seed Dockerfiles.

## Changes Made

- **Pin base image**: `redhat/ubi9:latest` → `redhat/ubi9:9.7` for reproducible builds (verified this is the current `:latest` version)
- **Add ENTRYPOINT**: `["tail", "-f", "/dev/null"]` to keep the container running — consistent with `Dockerfile.ts`, `Dockerfile.csharp`, and the DinD seed Dockerfiles (`Dockerfile.go`, `Dockerfile.python`, `Dockerfile.php`). `Dockerfile.java` was the only seed Dockerfile without an ENTRYPOINT.
- **Fix comment**: "Small ubuntu base image" → "Small RHEL base image" (UBI9 is Red Hat, not Ubuntu)

## Review Checklist

- [ ] Verify the seed framework uses `docker exec` (not `docker run <cmd>`) for Java seed containers — adding this ENTRYPOINT means `docker run seed-java <cmd>` would no longer work as a direct command execution
- [ ] Confirm `ubi9:9.7` is acceptable as the pinned version (current `:latest` as of 2026-03-22)

## Testing

- Verified `redhat/ubi9:latest` resolves to RHEL 9.7 via `docker run --rm redhat/ubi9:latest cat /etc/redhat-release`
- Confirmed all other seed Dockerfiles have an ENTRYPOINT (`tail -f /dev/null` or `/entrypoint.sh`)

Link to Devin session: https://app.devin.ai/sessions/371cc6bdbad447bb9161b29b0ab8ec28
Requested by: @Swimburger
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/13901" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
