### PR TITLE
feat(rust): generate convenience constructors for union variants with optional fields

### DIFF
--- a/generators/rust/model/src/__test__/snapshots/undiscriminated-union-types/types_response.rs
+++ b/generators/rust/model/src/__test__/snapshots/undiscriminated-union-types/types_response.rs
@@ -32,4 +32,8 @@ impl Response {
     pub fn error(error: String, code: i64) -> Self {
         Self::Error { error, code, details: None }
     }
+
+    pub fn error_with_details(error: String, code: i64, details: Vec<String>) -> Self {
+        Self::Error { error, code, details: Some(details) }
+    }
 }

--- a/generators/rust/model/src/__test__/snapshots/undiscriminated-union-types/types_search_result.rs
+++ b/generators/rust/model/src/__test__/snapshots/undiscriminated-union-types/types_search_result.rs
@@ -53,4 +53,8 @@ impl SearchResult {
     pub fn category(id: String, name: String, description: String) -> Self {
         Self::Category { id, name, description, parent_id: None }
     }
+
+    pub fn category_with_parent_id(id: String, name: String, description: String, parent_id: String) -> Self {
+        Self::Category { id, name, description, parent_id: Some(parent_id) }
+    }
 }

--- a/generators/rust/model/src/__test__/snapshots/union-types/types_animal.rs
+++ b/generators/rust/model/src/__test__/snapshots/union-types/types_animal.rs
@@ -49,4 +49,8 @@ impl Animal {
     pub fn bird(name: String, can_fly: bool) -> Self {
         Self::Bird { name, can_fly, wing_span: None }
     }
+
+    pub fn bird_with_wing_span(name: String, can_fly: bool, wing_span: f64) -> Self {
+        Self::Bird { name, can_fly, wing_span: Some(wing_span) }
+    }
 }

--- a/generators/rust/model/src/union/UnionGenerator.ts
+++ b/generators/rust/model/src/union/UnionGenerator.ts
@@ -453,11 +453,28 @@ export class UnionGenerator {
             // Generate constructor methods for all variants
             // Since #[non_exhaustive] prevents direct construction from outside the crate,
             // these constructors provide the way to create variant instances.
+            let needsNewline = false;
             this.unionTypeDeclaration.types.forEach((unionType, index) => {
                 if (index > 0) {
                     writer.newLine();
                 }
                 this.generateVariantConstructor(writer, unionType);
+                needsNewline = true;
+            });
+
+            // Generate convenience constructors for inlined variants with optional fields.
+            // For each optional field in an inlined variant, generate a `{variant}_with_{field}`
+            // constructor that takes the field as a required parameter (unwrapped from Option)
+            // alongside any required fields, defaulting all other optional fields to None.
+            this.unionTypeDeclaration.types.forEach((unionType) => {
+                const convenienceConstructors = this.getConvenienceConstructorsForVariant(unionType);
+                convenienceConstructors.forEach((gen) => {
+                    if (needsNewline) {
+                        writer.newLine();
+                    }
+                    gen(writer);
+                    needsNewline = true;
+                });
             });
 
             // Generate getter methods for base properties
@@ -610,6 +627,103 @@ export class UnionGenerator {
                 });
             }
         });
+    }
+
+    /**
+     * For inlined union variants with optional fields, generates convenience constructors
+     * like `{variant}_with_{field}` that accept the optional field as a required parameter
+     * (unwrapped from Option<T> to T), alongside any required fields. All other optional
+     * fields default to None.
+     *
+     * For example, for an Assistant variant with optional fields `content`, `name`,
+     * `reasoning_content`, and `tool_calls`, this generates:
+     *   - `assistant_with_content(content: Content) -> Self`
+     *   - `assistant_with_tool_calls(tool_calls: Vec<ToolCall>) -> Self`
+     *   - etc.
+     */
+    private getConvenienceConstructorsForVariant(
+        unionType: FernIr.SingleUnionType
+    ): ((writer: rust.Writer) => void)[] {
+        const constructors: ((writer: rust.Writer) => void)[] = [];
+        const rawVariantName = unionType.discriminantValue.name.pascalCase.unsafeName;
+        const variantName = this.context.escapeRustReservedType(rawVariantName);
+        const constructorBaseName = unionType.discriminantValue.name.snakeCase.unsafeName;
+        const typeId = Object.entries(this.context.ir.types).find(([_, type]) => type === this.typeDeclaration)?.[0];
+
+        unionType.shape._visit({
+            noProperties: () => {},
+            singleProperty: () => {},
+            samePropertiesAsObject: (declaredTypeName) => {
+                const canInline = this.context.inlinedUnionVariantTypeIds.has(declaredTypeName.typeId);
+                if (!canInline) {
+                    return;
+                }
+
+                const referencedType = this.context.ir.types[declaredTypeName.typeId];
+                if (referencedType?.shape.type !== "object") {
+                    return;
+                }
+
+                const properties = referencedType.shape.properties;
+                const optionalProperties = properties.filter((p) => isOptionalType(p.valueType));
+
+                // Only generate convenience constructors if there are optional fields
+                if (optionalProperties.length === 0) {
+                    return;
+                }
+
+                for (const optionalProperty of optionalProperties) {
+                    const optFieldName = this.context.escapeRustKeyword(optionalProperty.name.name.snakeCase.unsafeName);
+                    // Use the raw (unescaped) field name in the method name since r# prefixes
+                    // are not valid in function names
+                    const optFieldNameRaw = optionalProperty.name.name.snakeCase.unsafeName;
+                    const methodName = `${constructorBaseName}_with_${optFieldNameRaw}`;
+
+                    constructors.push((writer: rust.Writer) => {
+                        // Build required params + the one optional field (unwrapped)
+                        const params: string[] = [];
+                        const fieldAssignments: string[] = [];
+
+                        properties.forEach((property) => {
+                            const fieldName = this.context.escapeRustKeyword(property.name.name.snakeCase.unsafeName);
+                            const isRecursive = typeId ? isFieldRecursive(typeId, property.valueType, this.context.ir) : false;
+                            const isOptional = isOptionalType(property.valueType);
+
+                            if (property === optionalProperty) {
+                                // This is the target optional field: unwrap it from Option<T> to T
+                                const innerType = generateRustTypeForTypeReference(
+                                    getInnerTypeFromOptional(property.valueType),
+                                    this.context,
+                                    isRecursive
+                                );
+                                params.push(`${fieldName}: ${innerType.toString()}`);
+                                fieldAssignments.push(`${fieldName}: Some(${fieldName})`);
+                            } else if (isOptional) {
+                                // Other optional fields default to None
+                                fieldAssignments.push(`${fieldName}: None`);
+                            } else {
+                                // Required fields are passed as parameters
+                                const fieldType = generateRustTypeForTypeReference(property.valueType, this.context, isRecursive);
+                                params.push(`${fieldName}: ${fieldType.toString()}`);
+                                fieldAssignments.push(fieldName);
+                            }
+                        });
+
+                        const baseParams = this.getBasePropertyParams();
+                        const allParams = [...params, ...baseParams];
+                        const baseFields = this.getBasePropertyFieldAssignments();
+                        const allFields = [...fieldAssignments, ...baseFields];
+
+                        writer.writeBlock(`pub fn ${methodName}(${allParams.join(", ")}) -> Self`, () => {
+                            writer.writeLine(`Self::${variantName} { ${allFields.join(", ")} }`);
+                        });
+                    });
+                }
+            },
+            _other: () => {}
+        });
+
+        return constructors;
     }
 
     private getBasePropertyParams(): string[] {

--- a/generators/rust/model/versions.yml
+++ b/generators/rust/model/versions.yml
@@ -1,5 +1,5 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
-- version: 0.2.2
+- version: 0.3.0
   changelogEntry:
     - summary: |
         Generate convenience constructors for discriminated union variants with optional fields.

--- a/generators/rust/model/versions.yml
+++ b/generators/rust/model/versions.yml
@@ -1,4 +1,17 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 0.2.2
+  changelogEntry:
+    - summary: |
+        Generate convenience constructors for discriminated union variants with optional fields.
+        For each optional field in an inlined variant, a `{variant}_with_{field}` constructor is
+        generated that accepts the field as a required parameter (unwrapped from `Option<T>`) while
+        defaulting all other optional fields to `None`. For example, an `Assistant` variant with
+        optional `tool_calls` now gets an `assistant_with_tool_calls(tool_calls: Vec<ToolCall>)`
+        constructor.
+      type: feat
+  createdAt: "2026-03-22"
+  irVersion: 65
+
 - version: 0.2.1
   changelogEntry:
     - summary: |

--- a/generators/rust/sdk/versions.yml
+++ b/generators/rust/sdk/versions.yml
@@ -1,5 +1,18 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 
+- version: 0.25.2
+  changelogEntry:
+    - summary: |
+        Generate convenience constructors for discriminated union variants with optional fields.
+        For each optional field in an inlined variant, a `{variant}_with_{field}` constructor is
+        generated that accepts the field as a required parameter (unwrapped from `Option<T>`) while
+        defaulting all other optional fields to `None`. For example, an `Assistant` variant with
+        optional `tool_calls` now gets an `assistant_with_tool_calls(tool_calls: Vec<ToolCall>)`
+        constructor.
+      type: feat
+  createdAt: "2026-03-22"
+  irVersion: 65
+
 - version: 0.25.1
   changelogEntry:
     - summary: |

--- a/generators/rust/sdk/versions.yml
+++ b/generators/rust/sdk/versions.yml
@@ -1,6 +1,6 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 
-- version: 0.25.2
+- version: 0.26.0
   changelogEntry:
     - summary: |
         Generate convenience constructors for discriminated union variants with optional fields.

--- a/seed/rust-model/nullable-optional/src/nullable_optional_notification_method.rs
+++ b/seed/rust-model/nullable-optional/src/nullable_optional_notification_method.rs
@@ -56,4 +56,16 @@ impl NotificationMethod {
     pub fn push(device_token: String, title: String, body: String) -> Self {
         Self::Push { device_token, title, body, badge: None }
     }
+
+    pub fn email_with_html_content(email_address: String, subject: String, html_content: String) -> Self {
+        Self::Email { email_address, subject, html_content: Some(html_content) }
+    }
+
+    pub fn sms_with_short_code(phone_number: String, message: String, short_code: String) -> Self {
+        Self::Sms { phone_number, message, short_code: Some(short_code) }
+    }
+
+    pub fn push_with_badge(device_token: String, title: String, body: String, badge: i64) -> Self {
+        Self::Push { device_token, title, body, badge: Some(badge) }
+    }
 }

--- a/seed/rust-model/nullable-optional/src/nullable_optional_search_result.rs
+++ b/seed/rust-model/nullable-optional/src/nullable_optional_search_result.rs
@@ -45,4 +45,12 @@ impl SearchResult {
     pub fn document(id: String, title: String, content: String) -> Self {
         Self::Document { id, title, content, author: None, tags: None }
     }
+
+    pub fn document_with_author(id: String, title: String, content: String, author: String) -> Self {
+        Self::Document { id, title, content, author: Some(author), tags: None }
+    }
+
+    pub fn document_with_tags(id: String, title: String, content: String, tags: Vec<String>) -> Self {
+        Self::Document { id, title, content, author: None, tags: Some(tags) }
+    }
 }

--- a/seed/rust-model/server-sent-event-examples/src/completions_stream_event.rs
+++ b/seed/rust-model/server-sent-event-examples/src/completions_stream_event.rs
@@ -28,4 +28,8 @@ impl StreamEvent {
     pub fn error(error: String) -> Self {
         Self::Error { error, code: None }
     }
+
+    pub fn error_with_code(error: String, code: i64) -> Self {
+        Self::Error { error, code: Some(code) }
+    }
 }

--- a/seed/rust-model/trace/src/commons_debug_variable_value.rs
+++ b/seed/rust-model/trace/src/commons_debug_variable_value.rs
@@ -152,4 +152,8 @@ impl DebugVariableValue {
     pub fn generic_value(stringified_value: String) -> Self {
         Self::GenericValue { stringified_type: None, stringified_value }
     }
+
+    pub fn generic_value_with_stringified_type(stringified_type: String, stringified_value: String) -> Self {
+        Self::GenericValue { stringified_type: Some(stringified_type), stringified_value }
+    }
 }

--- a/seed/rust-model/trace/src/commons_variable_type.rs
+++ b/seed/rust-model/trace/src/commons_variable_type.rs
@@ -95,4 +95,8 @@ impl VariableType {
     pub fn doubly_linked_list_type() -> Self {
         Self::DoublyLinkedListType {}
     }
+
+    pub fn list_type_with_is_fixed_length(value_type: Box<VariableType>, is_fixed_length: bool) -> Self {
+        Self::ListType { value_type, is_fixed_length: Some(is_fixed_length) }
+    }
 }

--- a/seed/rust-model/trace/src/submission_code_execution_update.rs
+++ b/seed/rust-model/trace/src/submission_code_execution_update.rs
@@ -166,4 +166,16 @@ impl CodeExecutionUpdate {
     pub fn finished(submission_id: SubmissionId) -> Self {
         Self::Finished { submission_id }
     }
+
+    pub fn recording_with_test_case_id(submission_id: SubmissionId, test_case_id: String, line_number: i64, lightweight_stack_info: LightweightStackframeInformation) -> Self {
+        Self::Recording { submission_id, test_case_id: Some(test_case_id), line_number, lightweight_stack_info, traced_file: None }
+    }
+
+    pub fn recording_with_traced_file(submission_id: SubmissionId, line_number: i64, lightweight_stack_info: LightweightStackframeInformation, traced_file: TracedFile) -> Self {
+        Self::Recording { submission_id, test_case_id: None, line_number, lightweight_stack_info, traced_file: Some(traced_file) }
+    }
+
+    pub fn recorded_with_test_case_id(submission_id: SubmissionId, trace_responses_size: i64, test_case_id: String) -> Self {
+        Self::Recorded { submission_id, trace_responses_size, test_case_id: Some(test_case_id) }
+    }
 }

--- a/seed/rust-model/trace/src/submission_submission_request.rs
+++ b/seed/rust-model/trace/src/submission_submission_request.rs
@@ -83,4 +83,20 @@ impl SubmissionRequest {
     pub fn stop(submission_id: SubmissionId) -> Self {
         Self::Stop { submission_id }
     }
+
+    pub fn initialize_problem_request_with_problem_version(problem_id: ProblemId, problem_version: i64) -> Self {
+        Self::InitializeProblemRequest { problem_id, problem_version: Some(problem_version) }
+    }
+
+    pub fn submit_v_2_with_problem_version(submission_id: SubmissionId, language: Language, submission_files: Vec<SubmissionFileInfo>, problem_id: ProblemId, problem_version: i64) -> Self {
+        Self::SubmitV2 { submission_id, language, submission_files, problem_id, problem_version: Some(problem_version), user_id: None }
+    }
+
+    pub fn submit_v_2_with_user_id(submission_id: SubmissionId, language: Language, submission_files: Vec<SubmissionFileInfo>, problem_id: ProblemId, user_id: String) -> Self {
+        Self::SubmitV2 { submission_id, language, submission_files, problem_id, problem_version: None, user_id: Some(user_id) }
+    }
+
+    pub fn workspace_submit_with_user_id(submission_id: SubmissionId, language: Language, submission_files: Vec<SubmissionFileInfo>, user_id: String) -> Self {
+        Self::WorkspaceSubmit { submission_id, language, submission_files, user_id: Some(user_id) }
+    }
 }

--- a/seed/rust-model/trace/src/submission_test_case_grade.rs
+++ b/seed/rust-model/trace/src/submission_test_case_grade.rs
@@ -33,4 +33,12 @@ impl TestCaseGrade {
     pub fn non_hidden(passed: bool, stdout: String) -> Self {
         Self::NonHidden { passed, actual_result: None, exception: None, stdout }
     }
+
+    pub fn non_hidden_with_actual_result(passed: bool, actual_result: VariableValue, stdout: String) -> Self {
+        Self::NonHidden { passed, actual_result: Some(actual_result), exception: None, stdout }
+    }
+
+    pub fn non_hidden_with_exception(passed: bool, exception: ExceptionV2, stdout: String) -> Self {
+        Self::NonHidden { passed, actual_result: None, exception: Some(exception), stdout }
+    }
 }

--- a/seed/rust-model/unions/src/types_union_with_duplicative_discriminants.rs
+++ b/seed/rust-model/unions/src/types_union_with_duplicative_discriminants.rs
@@ -30,4 +30,12 @@ impl UnionWithDuplicativeDiscriminants {
     pub fn second_item_type(title: String) -> Self {
         Self::SecondItemType { r#type: None, title }
     }
+
+    pub fn first_item_type_with_type(r#type: String, name: String) -> Self {
+        Self::FirstItemType { r#type: Some(r#type), name }
+    }
+
+    pub fn second_item_type_with_type(r#type: String, title: String) -> Self {
+        Self::SecondItemType { r#type: Some(r#type), title }
+    }
 }

--- a/seed/rust-sdk/nullable-optional/src/api/types/nullable_optional_notification_method.rs
+++ b/seed/rust-sdk/nullable-optional/src/api/types/nullable_optional_notification_method.rs
@@ -69,4 +69,33 @@ impl NotificationMethod {
             badge: None,
         }
     }
+
+    pub fn email_with_html_content(
+        email_address: String,
+        subject: String,
+        html_content: String,
+    ) -> Self {
+        Self::Email {
+            email_address,
+            subject,
+            html_content: Some(html_content),
+        }
+    }
+
+    pub fn sms_with_short_code(phone_number: String, message: String, short_code: String) -> Self {
+        Self::Sms {
+            phone_number,
+            message,
+            short_code: Some(short_code),
+        }
+    }
+
+    pub fn push_with_badge(device_token: String, title: String, body: String, badge: i64) -> Self {
+        Self::Push {
+            device_token,
+            title,
+            body,
+            badge: Some(badge),
+        }
+    }
 }

--- a/seed/rust-sdk/nullable-optional/src/api/types/nullable_optional_search_result.rs
+++ b/seed/rust-sdk/nullable-optional/src/api/types/nullable_optional_search_result.rs
@@ -51,4 +51,34 @@ impl SearchResult {
             tags: None,
         }
     }
+
+    pub fn document_with_author(
+        id: String,
+        title: String,
+        content: String,
+        author: String,
+    ) -> Self {
+        Self::Document {
+            id,
+            title,
+            content,
+            author: Some(author),
+            tags: None,
+        }
+    }
+
+    pub fn document_with_tags(
+        id: String,
+        title: String,
+        content: String,
+        tags: Vec<String>,
+    ) -> Self {
+        Self::Document {
+            id,
+            title,
+            content,
+            author: None,
+            tags: Some(tags),
+        }
+    }
 }

--- a/seed/rust-sdk/server-sent-event-examples/with-wire-tests/src/api/types/completions_stream_event.rs
+++ b/seed/rust-sdk/server-sent-event-examples/with-wire-tests/src/api/types/completions_stream_event.rs
@@ -28,4 +28,11 @@ impl StreamEvent {
     pub fn error(error: String) -> Self {
         Self::Error { error, code: None }
     }
+
+    pub fn error_with_code(error: String, code: i64) -> Self {
+        Self::Error {
+            error,
+            code: Some(code),
+        }
+    }
 }

--- a/seed/rust-sdk/trace/src/api/types/commons_debug_variable_value.rs
+++ b/seed/rust-sdk/trace/src/api/types/commons_debug_variable_value.rs
@@ -149,4 +149,14 @@ impl DebugVariableValue {
             stringified_value,
         }
     }
+
+    pub fn generic_value_with_stringified_type(
+        stringified_type: String,
+        stringified_value: String,
+    ) -> Self {
+        Self::GenericValue {
+            stringified_type: Some(stringified_type),
+            stringified_value,
+        }
+    }
 }

--- a/seed/rust-sdk/trace/src/api/types/commons_variable_type.rs
+++ b/seed/rust-sdk/trace/src/api/types/commons_variable_type.rs
@@ -101,4 +101,14 @@ impl VariableType {
     pub fn doubly_linked_list_type() -> Self {
         Self::DoublyLinkedListType {}
     }
+
+    pub fn list_type_with_is_fixed_length(
+        value_type: Box<VariableType>,
+        is_fixed_length: bool,
+    ) -> Self {
+        Self::ListType {
+            value_type,
+            is_fixed_length: Some(is_fixed_length),
+        }
+    }
 }

--- a/seed/rust-sdk/trace/src/api/types/submission_code_execution_update.rs
+++ b/seed/rust-sdk/trace/src/api/types/submission_code_execution_update.rs
@@ -204,4 +204,46 @@ impl CodeExecutionUpdate {
     pub fn finished(submission_id: SubmissionId) -> Self {
         Self::Finished { submission_id }
     }
+
+    pub fn recording_with_test_case_id(
+        submission_id: SubmissionId,
+        test_case_id: String,
+        line_number: i64,
+        lightweight_stack_info: LightweightStackframeInformation,
+    ) -> Self {
+        Self::Recording {
+            submission_id,
+            test_case_id: Some(test_case_id),
+            line_number,
+            lightweight_stack_info,
+            traced_file: None,
+        }
+    }
+
+    pub fn recording_with_traced_file(
+        submission_id: SubmissionId,
+        line_number: i64,
+        lightweight_stack_info: LightweightStackframeInformation,
+        traced_file: TracedFile,
+    ) -> Self {
+        Self::Recording {
+            submission_id,
+            test_case_id: None,
+            line_number,
+            lightweight_stack_info,
+            traced_file: Some(traced_file),
+        }
+    }
+
+    pub fn recorded_with_test_case_id(
+        submission_id: SubmissionId,
+        trace_responses_size: i64,
+        test_case_id: String,
+    ) -> Self {
+        Self::Recorded {
+            submission_id,
+            trace_responses_size,
+            test_case_id: Some(test_case_id),
+        }
+    }
 }

--- a/seed/rust-sdk/trace/src/api/types/submission_submission_request.rs
+++ b/seed/rust-sdk/trace/src/api/types/submission_submission_request.rs
@@ -107,4 +107,62 @@ impl SubmissionRequest {
     pub fn stop(submission_id: SubmissionId) -> Self {
         Self::Stop { submission_id }
     }
+
+    pub fn initialize_problem_request_with_problem_version(
+        problem_id: ProblemId,
+        problem_version: i64,
+    ) -> Self {
+        Self::InitializeProblemRequest {
+            problem_id,
+            problem_version: Some(problem_version),
+        }
+    }
+
+    pub fn submit_v_2_with_problem_version(
+        submission_id: SubmissionId,
+        language: Language,
+        submission_files: Vec<SubmissionFileInfo>,
+        problem_id: ProblemId,
+        problem_version: i64,
+    ) -> Self {
+        Self::SubmitV2 {
+            submission_id,
+            language,
+            submission_files,
+            problem_id,
+            problem_version: Some(problem_version),
+            user_id: None,
+        }
+    }
+
+    pub fn submit_v_2_with_user_id(
+        submission_id: SubmissionId,
+        language: Language,
+        submission_files: Vec<SubmissionFileInfo>,
+        problem_id: ProblemId,
+        user_id: String,
+    ) -> Self {
+        Self::SubmitV2 {
+            submission_id,
+            language,
+            submission_files,
+            problem_id,
+            problem_version: None,
+            user_id: Some(user_id),
+        }
+    }
+
+    pub fn workspace_submit_with_user_id(
+        submission_id: SubmissionId,
+        language: Language,
+        submission_files: Vec<SubmissionFileInfo>,
+        user_id: String,
+    ) -> Self {
+        Self::WorkspaceSubmit {
+            submission_id,
+            language,
+            submission_files,
+            user_id: Some(user_id),
+        }
+    }
 }

--- a/seed/rust-sdk/trace/src/api/types/submission_test_case_grade.rs
+++ b/seed/rust-sdk/trace/src/api/types/submission_test_case_grade.rs
@@ -38,4 +38,26 @@ impl TestCaseGrade {
             stdout,
         }
     }
+
+    pub fn non_hidden_with_actual_result(
+        passed: bool,
+        actual_result: VariableValue,
+        stdout: String,
+    ) -> Self {
+        Self::NonHidden {
+            passed,
+            actual_result: Some(actual_result),
+            exception: None,
+            stdout,
+        }
+    }
+
+    pub fn non_hidden_with_exception(passed: bool, exception: ExceptionV2, stdout: String) -> Self {
+        Self::NonHidden {
+            passed,
+            actual_result: None,
+            exception: Some(exception),
+            stdout,
+        }
+    }
 }

--- a/seed/rust-sdk/unions/src/api/types/types_union_with_duplicative_discriminants.rs
+++ b/seed/rust-sdk/unions/src/api/types/types_union_with_duplicative_discriminants.rs
@@ -33,4 +33,18 @@ impl UnionWithDuplicativeDiscriminants {
             title,
         }
     }
+
+    pub fn first_item_type_with_type(r#type: String, name: String) -> Self {
+        Self::FirstItemType {
+            r#type: Some(r#type),
+            name,
+        }
+    }
+
+    pub fn second_item_type_with_type(r#type: String, title: String) -> Self {
+        Self::SecondItemType {
+            r#type: Some(r#type),
+            title,
+        }
+    }
 }


### PR DESCRIPTION
## Description

Refs https://github.com/fern-demo/xai-rust-internal/pull/20

The Rust generator produces `#[non_exhaustive]` enum variants for discriminated unions, which prevents direct construction outside the crate. While basic constructors are generated (taking required fields and defaulting optionals to `None`), there was no way to construct a variant with a specific optional field set without manually wrapping it in `Some(...)`.

This caused a compile error in the xai-rust-internal SDK where `Message::assistant_with_tool_calls(...)` was expected but didn't exist.

## Changes Made

- Added `getConvenienceConstructorsForVariant` in `UnionGenerator.ts` that generates `{variant}_with_{field}` constructors for each optional field in inlined union variants
- Each convenience constructor accepts the target optional field as a required parameter (unwrapped from `Option<T>` to `T`), alongside all required fields, defaulting all other optional fields to `None`
- Handles `r#` escaped Rust keywords correctly: raw identifiers are used in parameter names and field assignments but not in method names (e.g., method is `first_item_type_with_type` while parameter is `r#type`)
- Only generates for `samePropertiesAsObject` variants that are inlined (not shared types)
- Updated `versions.yml` for both rust-model (0.3.0) and rust-sdk (0.26.0)
- Updated seed snapshots for affected fixtures: unions, nullable-optional, server-sent-event-examples, trace
- Updated vitest file snapshots for union-types and undiscriminated-union-types
- [ ] Updated README.md generator (not applicable)

## Human Review Checklist

1. **`typeId` lookup** (~line 654): Uses reference equality (`type === this.typeDeclaration`) via `Object.entries(...).find(...)` to resolve the current type's ID for recursion checks. Verify this is reliable or if there's a better way to get the type ID.
2. **One constructor per optional field**: Each convenience constructor only sets *one* optional field. Combinations (e.g., setting two optional fields at once) still require the base constructor + manual `Some()`. This is a deliberate design choice — verify this is acceptable for the xai use case.
3. **Long parameter lists**: Variants with many required fields produce constructors with long signatures (e.g., `submit_v_2_with_user_id` takes 5 params). Consider whether this is acceptable ergonomics.

## Testing

- [x] Seed tests run for rust-model and rust-sdk across all affected fixtures (unions, nullable-optional, server-sent-event-examples, trace, exhaustive)
- [x] All seed tests pass
- [x] Vitest unit test snapshots updated and passing
- [x] Lint checks pass (`pnpm run check`)
- [x] CI green (all 57 checks pass)

Link to Devin session: https://app.devin.ai/sessions/a134a8fbf8f74691a298036dfaaa2586
Requested by: @iamnamananand996