### PR TITLE
fix(rust): unwrap all optional/nullable layers in convenience constructor params

### DIFF
--- a/generators/rust/model/src/union/UnionGenerator.ts
+++ b/generators/rust/model/src/union/UnionGenerator.ts
@@ -690,9 +690,16 @@ export class UnionGenerator {
                             const isOptional = isOptionalType(property.valueType);
 
                             if (property === optionalProperty) {
-                                // This is the target optional field: unwrap it from Option<T> to T
+                                // This is the target optional field: unwrap it from Option<T> to T.
+                                // We must strip ALL optional/nullable layers because the IR may have
+                                // nested wrappers (e.g. optional<nullable<string>> from OpenAPI) that
+                                // the AST deduplicates into a single Option<T> at the field level.
+                                let bareTypeRef = property.valueType;
+                                while (isOptionalType(bareTypeRef)) {
+                                    bareTypeRef = getInnerTypeFromOptional(bareTypeRef);
+                                }
                                 const innerType = generateRustTypeForTypeReference(
-                                    getInnerTypeFromOptional(property.valueType),
+                                    bareTypeRef,
                                     this.context,
                                     isRecursive
                                 );

--- a/generators/rust/model/versions.yml
+++ b/generators/rust/model/versions.yml
@@ -1,4 +1,16 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 0.3.1
+  changelogEntry:
+    - summary: |
+        Fix convenience constructors for union variants whose optional fields have nested
+        optional/nullable IR wrappers (e.g. `optional<nullable<string>>` from OpenAPI).
+        Previously only one layer was unwrapped, leaving the parameter as `Option<T>` instead
+        of `T`, which caused `E0308 mismatched types` compilation errors. Now all
+        optional/nullable layers are stripped to produce the correct bare type.
+      type: fix
+  createdAt: "2026-03-22"
+  irVersion: 65
+
 - version: 0.3.0
   changelogEntry:
     - summary: |

--- a/generators/rust/sdk/versions.yml
+++ b/generators/rust/sdk/versions.yml
@@ -1,5 +1,17 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 
+- version: 0.26.1
+  changelogEntry:
+    - summary: |
+        Fix convenience constructors for union variants whose optional fields have nested
+        optional/nullable IR wrappers (e.g. `optional<nullable<string>>` from OpenAPI).
+        Previously only one layer was unwrapped, leaving the parameter as `Option<T>` instead
+        of `T`, which caused `E0308 mismatched types` compilation errors. Now all
+        optional/nullable layers are stripped to produce the correct bare type.
+      type: fix
+  createdAt: "2026-03-22"
+  irVersion: 65
+
 - version: 0.26.0
   changelogEntry:
     - summary: |


### PR DESCRIPTION
## Description

Refs https://github.com/fern-demo/xai-rust-internal/pull/21

Fixes `E0308 mismatched types` compilation errors in generated Rust SDKs when union variant fields have nested optional/nullable IR wrappers (e.g. `optional<nullable<string>>` from OpenAPI specs where a field is both not-required AND nullable).

## Changes Made

- **`UnionGenerator.ts`**: Replace single `getInnerTypeFromOptional()` call with a `while` loop that strips **all** optional/nullable layers from the target field's type reference before generating the convenience constructor parameter type. This matches the `unwrapAllOptionals()` pattern already used in `builderUtils.ts`.
- **`rust/model/versions.yml`**: Bump to 0.3.1 with fix changelog entry.
- **`rust/sdk/versions.yml`**: Bump to 0.26.1 with fix changelog entry.

### Root cause

The AST's `Type.option()` deduplicates `Option<Option<T>>` → `Option<T>` at the field level, so `optional<nullable<string>>` becomes `Option<String>` in the enum field. But the convenience constructor only unwrapped one layer (`optional` → `nullable<string>`), generating `Option<String>` as the parameter type. Wrapping that in `Some()` produced `Option<Option<String>>`, causing the type mismatch.

## Testing

- [x] Seed tests pass for `rust-model` and `rust-sdk` on `unions` and `trace` fixtures
- [x] `pnpm run check` (biome lint) passes
- [ ] No new seed fixture added — existing fixtures don't have `optional<nullable<T>>` nesting, so no snapshot changes. The real-world validation is that xai-rust-internal will compile after regeneration.

## Review checklist
- [ ] Verify the `while (isOptionalType(...))` loop handles all nesting combinations correctly (e.g. `optional<nullable<optional<T>>>`)
- [ ] Consider whether a shared `unwrapAllOptionals` utility should be imported from `builderUtils.ts` instead of inlining the loop
- [ ] Consider whether a seed test fixture with `optional<nullable<T>>` fields should be added to prevent regression

Link to Devin session: https://app.devin.ai/sessions/a134a8fbf8f74691a298036dfaaa2586
Requested by: @iamnamananand996