### PR TITLE
chore(rust): include all optional fields as params in convenience constructors

### DIFF
--- a/generators/rust/model/src/union/UnionGenerator.ts
+++ b/generators/rust/model/src/union/UnionGenerator.ts
@@ -632,13 +632,14 @@ export class UnionGenerator {
     /**
      * For inlined union variants with optional fields, generates convenience constructors
      * like `{variant}_with_{field}` that accept the optional field as a required parameter
-     * (unwrapped from Option<T> to T), alongside any required fields. All other optional
-     * fields default to None.
+     * (unwrapped from Option<T> to T), alongside any required fields AND all other optional
+     * fields as Option<T> parameters. This gives callers maximum flexibility while making
+     * the promoted field required.
      *
      * For example, for an Assistant variant with optional fields `content`, `name`,
      * `reasoning_content`, and `tool_calls`, this generates:
-     *   - `assistant_with_content(content: Content) -> Self`
-     *   - `assistant_with_tool_calls(tool_calls: Vec<ToolCall>) -> Self`
+     *   - `assistant_with_content(content: Content, name: Option<String>, ...) -> Self`
+     *   - `assistant_with_tool_calls(content: Option<Content>, ..., tool_calls: Vec<ToolCall>) -> Self`
      *   - etc.
      */
     private getConvenienceConstructorsForVariant(
@@ -680,7 +681,8 @@ export class UnionGenerator {
                     const methodName = `${constructorBaseName}_with_${optFieldNameRaw}`;
 
                     constructors.push((writer: rust.Writer) => {
-                        // Build required params + the one optional field (unwrapped)
+                        // Build params: required fields + promoted optional field (unwrapped) +
+                        // other optional fields as Option<T>
                         const params: string[] = [];
                         const fieldAssignments: string[] = [];
 
@@ -706,8 +708,10 @@ export class UnionGenerator {
                                 params.push(`${fieldName}: ${innerType.toString()}`);
                                 fieldAssignments.push(`${fieldName}: Some(${fieldName})`);
                             } else if (isOptional) {
-                                // Other optional fields default to None
-                                fieldAssignments.push(`${fieldName}: None`);
+                                // Other optional fields are passed as Option<T> parameters
+                                const fieldType = generateRustTypeForTypeReference(property.valueType, this.context, isRecursive);
+                                params.push(`${fieldName}: ${fieldType.toString()}`);
+                                fieldAssignments.push(fieldName);
                             } else {
                                 // Required fields are passed as parameters
                                 const fieldType = generateRustTypeForTypeReference(property.valueType, this.context, isRecursive);

--- a/generators/rust/model/src/union/UnionGenerator.ts
+++ b/generators/rust/model/src/union/UnionGenerator.ts
@@ -690,9 +690,16 @@ export class UnionGenerator {
                             const isOptional = isOptionalType(property.valueType);
 
                             if (property === optionalProperty) {
-                                // This is the target optional field: unwrap it from Option<T> to T
+                                // This is the target optional field: unwrap it from Option<T> to T.
+                                // We must strip ALL optional/nullable layers because the IR may have
+                                // nested wrappers (e.g. optional<nullable<string>> from OpenAPI) that
+                                // the AST deduplicates into a single Option<T> at the field level.
+                                let bareTypeRef = property.valueType;
+                                while (isOptionalType(bareTypeRef)) {
+                                    bareTypeRef = getInnerTypeFromOptional(bareTypeRef);
+                                }
                                 const innerType = generateRustTypeForTypeReference(
-                                    getInnerTypeFromOptional(property.valueType),
+                                    bareTypeRef,
                                     this.context,
                                     isRecursive
                                 );

--- a/generators/rust/model/versions.yml
+++ b/generators/rust/model/versions.yml
@@ -1,4 +1,16 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 0.3.1
+  changelogEntry:
+    - summary: |
+        Fix convenience constructors for union variants whose optional fields have nested
+        optional/nullable IR wrappers (e.g. `optional<nullable<string>>` from OpenAPI).
+        Previously only one layer was unwrapped, leaving the parameter as `Option<T>` instead
+        of `T`, which caused `E0308 mismatched types` compilation errors. Now all
+        optional/nullable layers are stripped to produce the correct bare type.
+      type: fix
+  createdAt: "2026-03-22"
+  irVersion: 65
+
 - version: 0.3.0
   changelogEntry:
     - summary: |

--- a/generators/rust/model/versions.yml
+++ b/generators/rust/model/versions.yml
@@ -8,7 +8,7 @@
         as `Option<T>` parameters, giving callers full control over all fields. For example,
         `assistant_with_tool_calls` now accepts `(content: Option<Content>, ..., tool_calls: Vec<ToolCall>)`
         instead of just `(tool_calls: Vec<ToolCall>)`.
-      type: feat
+      type: chore
   createdAt: "2026-03-22"
   irVersion: 65
 

--- a/generators/rust/model/versions.yml
+++ b/generators/rust/model/versions.yml
@@ -1,4 +1,17 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 0.3.2
+  changelogEntry:
+    - summary: |
+        Include all optional fields as `Option<T>` parameters in convenience constructors.
+        Previously, `{variant}_with_{field}` constructors only accepted the promoted field and
+        defaulted all other optional fields to `None`. Now they accept all other optional fields
+        as `Option<T>` parameters, giving callers full control over all fields. For example,
+        `assistant_with_tool_calls` now accepts `(content: Option<Content>, ..., tool_calls: Vec<ToolCall>)`
+        instead of just `(tool_calls: Vec<ToolCall>)`.
+      type: feat
+  createdAt: "2026-03-22"
+  irVersion: 65
+
 - version: 0.3.1
   changelogEntry:
     - summary: |

--- a/generators/rust/sdk/versions.yml
+++ b/generators/rust/sdk/versions.yml
@@ -1,5 +1,17 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 
+- version: 0.26.1
+  changelogEntry:
+    - summary: |
+        Fix convenience constructors for union variants whose optional fields have nested
+        optional/nullable IR wrappers (e.g. `optional<nullable<string>>` from OpenAPI).
+        Previously only one layer was unwrapped, leaving the parameter as `Option<T>` instead
+        of `T`, which caused `E0308 mismatched types` compilation errors. Now all
+        optional/nullable layers are stripped to produce the correct bare type.
+      type: fix
+  createdAt: "2026-03-22"
+  irVersion: 65
+
 - version: 0.26.0
   changelogEntry:
     - summary: |

--- a/generators/rust/sdk/versions.yml
+++ b/generators/rust/sdk/versions.yml
@@ -9,7 +9,7 @@
         as `Option<T>` parameters, giving callers full control over all fields. For example,
         `assistant_with_tool_calls` now accepts `(content: Option<Content>, ..., tool_calls: Vec<ToolCall>)`
         instead of just `(tool_calls: Vec<ToolCall>)`.
-      type: feat
+      type: chore
   createdAt: "2026-03-22"
   irVersion: 65
 

--- a/generators/rust/sdk/versions.yml
+++ b/generators/rust/sdk/versions.yml
@@ -1,5 +1,18 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 
+- version: 0.26.2
+  changelogEntry:
+    - summary: |
+        Include all optional fields as `Option<T>` parameters in convenience constructors.
+        Previously, `{variant}_with_{field}` constructors only accepted the promoted field and
+        defaulted all other optional fields to `None`. Now they accept all other optional fields
+        as `Option<T>` parameters, giving callers full control over all fields. For example,
+        `assistant_with_tool_calls` now accepts `(content: Option<Content>, ..., tool_calls: Vec<ToolCall>)`
+        instead of just `(tool_calls: Vec<ToolCall>)`.
+      type: feat
+  createdAt: "2026-03-22"
+  irVersion: 65
+
 - version: 0.26.1
   changelogEntry:
     - summary: |

--- a/seed/rust-model/nullable-optional/src/nullable_optional_search_result.rs
+++ b/seed/rust-model/nullable-optional/src/nullable_optional_search_result.rs
@@ -46,11 +46,11 @@ impl SearchResult {
         Self::Document { id, title, content, author: None, tags: None }
     }
 
-    pub fn document_with_author(id: String, title: String, content: String, author: String) -> Self {
-        Self::Document { id, title, content, author: Some(author), tags: None }
+    pub fn document_with_author(id: String, title: String, content: String, author: String, tags: Option<Vec<String>>) -> Self {
+        Self::Document { id, title, content, author: Some(author), tags }
     }
 
-    pub fn document_with_tags(id: String, title: String, content: String, tags: Vec<String>) -> Self {
-        Self::Document { id, title, content, author: None, tags: Some(tags) }
+    pub fn document_with_tags(id: String, title: String, content: String, author: Option<String>, tags: Vec<String>) -> Self {
+        Self::Document { id, title, content, author, tags: Some(tags) }
     }
 }

--- a/seed/rust-model/trace/src/submission_code_execution_update.rs
+++ b/seed/rust-model/trace/src/submission_code_execution_update.rs
@@ -167,12 +167,12 @@ impl CodeExecutionUpdate {
         Self::Finished { submission_id }
     }
 
-    pub fn recording_with_test_case_id(submission_id: SubmissionId, test_case_id: String, line_number: i64, lightweight_stack_info: LightweightStackframeInformation) -> Self {
-        Self::Recording { submission_id, test_case_id: Some(test_case_id), line_number, lightweight_stack_info, traced_file: None }
+    pub fn recording_with_test_case_id(submission_id: SubmissionId, test_case_id: String, line_number: i64, lightweight_stack_info: LightweightStackframeInformation, traced_file: Option<TracedFile>) -> Self {
+        Self::Recording { submission_id, test_case_id: Some(test_case_id), line_number, lightweight_stack_info, traced_file }
     }
 
-    pub fn recording_with_traced_file(submission_id: SubmissionId, line_number: i64, lightweight_stack_info: LightweightStackframeInformation, traced_file: TracedFile) -> Self {
-        Self::Recording { submission_id, test_case_id: None, line_number, lightweight_stack_info, traced_file: Some(traced_file) }
+    pub fn recording_with_traced_file(submission_id: SubmissionId, test_case_id: Option<String>, line_number: i64, lightweight_stack_info: LightweightStackframeInformation, traced_file: TracedFile) -> Self {
+        Self::Recording { submission_id, test_case_id, line_number, lightweight_stack_info, traced_file: Some(traced_file) }
     }
 
     pub fn recorded_with_test_case_id(submission_id: SubmissionId, trace_responses_size: i64, test_case_id: String) -> Self {

--- a/seed/rust-model/trace/src/submission_submission_request.rs
+++ b/seed/rust-model/trace/src/submission_submission_request.rs
@@ -88,12 +88,12 @@ impl SubmissionRequest {
         Self::InitializeProblemRequest { problem_id, problem_version: Some(problem_version) }
     }
 
-    pub fn submit_v_2_with_problem_version(submission_id: SubmissionId, language: Language, submission_files: Vec<SubmissionFileInfo>, problem_id: ProblemId, problem_version: i64) -> Self {
-        Self::SubmitV2 { submission_id, language, submission_files, problem_id, problem_version: Some(problem_version), user_id: None }
+    pub fn submit_v_2_with_problem_version(submission_id: SubmissionId, language: Language, submission_files: Vec<SubmissionFileInfo>, problem_id: ProblemId, problem_version: i64, user_id: Option<String>) -> Self {
+        Self::SubmitV2 { submission_id, language, submission_files, problem_id, problem_version: Some(problem_version), user_id }
     }
 
-    pub fn submit_v_2_with_user_id(submission_id: SubmissionId, language: Language, submission_files: Vec<SubmissionFileInfo>, problem_id: ProblemId, user_id: String) -> Self {
-        Self::SubmitV2 { submission_id, language, submission_files, problem_id, problem_version: None, user_id: Some(user_id) }
+    pub fn submit_v_2_with_user_id(submission_id: SubmissionId, language: Language, submission_files: Vec<SubmissionFileInfo>, problem_id: ProblemId, problem_version: Option<i64>, user_id: String) -> Self {
+        Self::SubmitV2 { submission_id, language, submission_files, problem_id, problem_version, user_id: Some(user_id) }
     }
 
     pub fn workspace_submit_with_user_id(submission_id: SubmissionId, language: Language, submission_files: Vec<SubmissionFileInfo>, user_id: String) -> Self {

--- a/seed/rust-model/trace/src/submission_test_case_grade.rs
+++ b/seed/rust-model/trace/src/submission_test_case_grade.rs
@@ -34,11 +34,11 @@ impl TestCaseGrade {
         Self::NonHidden { passed, actual_result: None, exception: None, stdout }
     }
 
-    pub fn non_hidden_with_actual_result(passed: bool, actual_result: VariableValue, stdout: String) -> Self {
-        Self::NonHidden { passed, actual_result: Some(actual_result), exception: None, stdout }
+    pub fn non_hidden_with_actual_result(passed: bool, actual_result: VariableValue, exception: Option<ExceptionV2>, stdout: String) -> Self {
+        Self::NonHidden { passed, actual_result: Some(actual_result), exception, stdout }
     }
 
-    pub fn non_hidden_with_exception(passed: bool, exception: ExceptionV2, stdout: String) -> Self {
-        Self::NonHidden { passed, actual_result: None, exception: Some(exception), stdout }
+    pub fn non_hidden_with_exception(passed: bool, actual_result: Option<VariableValue>, exception: ExceptionV2, stdout: String) -> Self {
+        Self::NonHidden { passed, actual_result, exception: Some(exception), stdout }
     }
 }

--- a/seed/rust-sdk/trace/src/api/types/submission_code_execution_update.rs
+++ b/seed/rust-sdk/trace/src/api/types/submission_code_execution_update.rs
@@ -210,25 +210,27 @@ impl CodeExecutionUpdate {
         test_case_id: String,
         line_number: i64,
         lightweight_stack_info: LightweightStackframeInformation,
+        traced_file: Option<TracedFile>,
     ) -> Self {
         Self::Recording {
             submission_id,
             test_case_id: Some(test_case_id),
             line_number,
             lightweight_stack_info,
-            traced_file: None,
+            traced_file,
         }
     }
 
     pub fn recording_with_traced_file(
         submission_id: SubmissionId,
+        test_case_id: Option<String>,
         line_number: i64,
         lightweight_stack_info: LightweightStackframeInformation,
         traced_file: TracedFile,
     ) -> Self {
         Self::Recording {
             submission_id,
-            test_case_id: None,
+            test_case_id,
             line_number,
             lightweight_stack_info,
             traced_file: Some(traced_file),

--- a/seed/rust-sdk/trace/src/api/types/submission_submission_request.rs
+++ b/seed/rust-sdk/trace/src/api/types/submission_submission_request.rs
@@ -124,6 +124,7 @@ impl SubmissionRequest {
         submission_files: Vec<SubmissionFileInfo>,
         problem_id: ProblemId,
         problem_version: i64,
+        user_id: Option<String>,
     ) -> Self {
         Self::SubmitV2 {
             submission_id,
@@ -131,7 +132,7 @@ impl SubmissionRequest {
             submission_files,
             problem_id,
             problem_version: Some(problem_version),
-            user_id: None,
+            user_id,
         }
     }
 
@@ -140,6 +141,7 @@ impl SubmissionRequest {
         language: Language,
         submission_files: Vec<SubmissionFileInfo>,
         problem_id: ProblemId,
+        problem_version: Option<i64>,
         user_id: String,
     ) -> Self {
         Self::SubmitV2 {
@@ -147,7 +149,7 @@ impl SubmissionRequest {
             language,
             submission_files,
             problem_id,
-            problem_version: None,
+            problem_version,
             user_id: Some(user_id),
         }
     }

--- a/seed/rust-sdk/trace/src/api/types/submission_test_case_grade.rs
+++ b/seed/rust-sdk/trace/src/api/types/submission_test_case_grade.rs
@@ -42,20 +42,26 @@ impl TestCaseGrade {
     pub fn non_hidden_with_actual_result(
         passed: bool,
         actual_result: VariableValue,
+        exception: Option<ExceptionV2>,
         stdout: String,
     ) -> Self {
         Self::NonHidden {
             passed,
             actual_result: Some(actual_result),
-            exception: None,
+            exception,
             stdout,
         }
     }
 
-    pub fn non_hidden_with_exception(passed: bool, exception: ExceptionV2, stdout: String) -> Self {
+    pub fn non_hidden_with_exception(
+        passed: bool,
+        actual_result: Option<VariableValue>,
+        exception: ExceptionV2,
+        stdout: String,
+    ) -> Self {
         Self::NonHidden {
             passed,
-            actual_result: None,
+            actual_result,
             exception: Some(exception),
             stdout,
         }


### PR DESCRIPTION
## Description

Refs https://github.com/fern-demo/xai-rust-internal/pull/22

Changes convenience constructors (`{variant}_with_{field}`) to accept all other optional fields as `Option<T>` parameters, instead of silently defaulting them to `None`. This gives callers full control over every field when using a convenience constructor.

## Changes Made

- **`UnionGenerator.ts`**: For non-promoted optional fields in convenience constructors, generate an `Option<T>` parameter and pass it through directly, instead of hardcoding `None`.
- **Seed snapshots**: Updated `rust-model` and `rust-sdk` trace, nullable-optional fixtures to reflect new signatures.
- **`versions.yml`**: Bumped to `rust-model@0.3.2` / `rust-sdk@0.26.2` (changelog type: `chore`).

### Before
```rust
pub fn assistant_with_tool_calls(tool_calls: Vec<ToolCall>) -> Self {
    Self::Assistant { content: None, name: None, reasoning_content: None, tool_calls: Some(tool_calls) }
}
```

### After
```rust
pub fn assistant_with_tool_calls(
    content: Option<Content>,
    name: Option<String>,
    reasoning_content: Option<String>,
    tool_calls: Vec<ToolCall>,
) -> Self {
    Self::Assistant { content, name, reasoning_content, tool_calls: Some(tool_calls) }
}
```

## Testing

- [x] 16/16 vitest unit tests pass
- [x] Seed tests regenerated and pass for affected fixtures (trace, nullable-optional, unions, circular-references, server-sent-event-examples, file-upload)
- [x] `pnpm run check` (biome lint) passes
- [ ] No Rust compilation test — seed fixtures lack `Cargo.toml`. Real-world validation is via xai-rust-internal after regeneration.

## ⚠️ Review Checklist
- **This is a breaking change to generated constructor signatures.** Any downstream SDK code calling the old single-argument convenience constructors will get compile errors (additional arguments now required). The changelog is typed as `chore` — verify this is intentional given the breaking nature of the change.
- Verify that `generateRustTypeForTypeReference(property.valueType, ...)` correctly produces `Option<T>` (not `Option<Option<T>>`) for fields with nested `optional<nullable<T>>` wrappers. The promoted field path strips all layers via a `while` loop, but the non-promoted path here passes `property.valueType` directly — confirm `Type.option()` deduplication handles this correctly.
- Consider whether variants with many optional fields produce unwieldy parameter lists that diminish the ergonomic value of convenience constructors.

Link to Devin session: https://app.devin.ai/sessions/a134a8fbf8f74691a298036dfaaa2586
Requested by: @iamnamananand996