### PR TITLE
fix(rust): skip Sec-WebSocket-Protocol header in WebSocket connections

### DIFF
--- a/generators/rust/sdk/src/generators/WebSocketChannelGenerator.ts
+++ b/generators/rust/sdk/src/generators/WebSocketChannelGenerator.ts
@@ -347,6 +347,16 @@ ${methods.join("\n\n")}
         return !hasExplicitAuth;
     }
 
+    /**
+     * Returns true if the header is `Sec-WebSocket-Protocol` (case-insensitive).
+     * This header is handled specially by tungstenite for RFC 6455 subprotocol
+     * negotiation and must NOT be inserted as a regular HTTP header, because
+     * tungstenite will fail the handshake if the server does not echo it back.
+     */
+    private isWebSocketProtocolHeader(header: FernIr.HttpHeader): boolean {
+        return header.name.wireValue.toLowerCase() === "sec-websocket-protocol";
+    }
+
     private buildConnectParams(channel: FernIr.WebSocketChannel): Array<{ name: string; type: string }> {
         const params: Array<{ name: string; type: string }> = [];
 
@@ -360,6 +370,11 @@ ${methods.join("\n\n")}
         }
 
         for (const header of channel.headers) {
+            // Skip Sec-WebSocket-Protocol — tungstenite handles subprotocol
+            // negotiation internally and fails if the server doesn't echo it.
+            if (this.isWebSocketProtocolHeader(header)) {
+                continue;
+            }
             params.push({ name: header.name.name.snakeCase.safeName, type: "&str" });
         }
 
@@ -399,6 +414,10 @@ ${methods.join("\n\n")}
         }
 
         for (const header of channel.headers) {
+            // Skip Sec-WebSocket-Protocol — see isWebSocketProtocolHeader().
+            if (this.isWebSocketProtocolHeader(header)) {
+                continue;
+            }
             const paramName = header.name.name.snakeCase.safeName;
             const wireValue = header.name.wireValue;
             headerLines.push(`        options.headers.insert("${wireValue}".to_string(), ${paramName}.to_string());`);


### PR DESCRIPTION
## Description

Fixes an issue where the Rust SDK generator would insert `Sec-WebSocket-Protocol` as a regular HTTP header in WebSocket connections, causing tungstenite to fail the handshake when the server doesn't echo it back. This header is reserved for RFC 6455 subprotocol negotiation and is handled internally by tungstenite.

## Changes Made

- Added `isWebSocketProtocolHeader()` helper that matches the header name case-insensitively
- Skip `Sec-WebSocket-Protocol` in `buildConnectParams` (so it's not exposed as a method parameter)
- Skip it in the header insertion logic (so it's not added to the outgoing request)

## Testing

- [ ] Unit tests added/updated
- [ ] Manual testing completed

## Review Checklist

- [ ] Are there other iteration sites over `channel.headers` in the generator that also need this filter?
- [ ] Is silently dropping the header the right behavior, or should a warning be emitted when the Fern spec defines this header on a WebSocket channel?
- [ ] Should this filtering be handled at a higher layer (e.g., IR processing) so other language generators also benefit?

Link to Devin session: https://app.devin.ai/sessions/59d0f271ae844953a6c6fcfc45cdc082
Requested by: @iamnamananand996