### PR TITLE
fix(rust): add versions.yml entry for Sec-WebSocket-Protocol header fix

### DIFF
--- a/generators/rust/sdk/versions.yml
+++ b/generators/rust/sdk/versions.yml
@@ -1,5 +1,16 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 
+- version: 0.26.3
+  changelogEntry:
+    - summary: |
+        Skip the `Sec-WebSocket-Protocol` header in WebSocket connections. This header is
+        reserved for RFC 6455 subprotocol negotiation and is handled internally by tungstenite.
+        Previously, including it as a regular HTTP header caused tungstenite to fail the
+        handshake when the server didn't echo it back.
+      type: fix
+  createdAt: "2026-03-22"
+  irVersion: 65
+
 - version: 0.26.2
   changelogEntry:
     - summary: |


### PR DESCRIPTION
## Description

Adds the missing `versions.yml` entry for the Rust SDK generator change merged in #13915, which skips the `Sec-WebSocket-Protocol` header in WebSocket connections.

## Changes Made

- Added version `0.26.3` entry to `generators/rust/sdk/versions.yml` with a `fix` changelog entry describing the `Sec-WebSocket-Protocol` header skip behavior

## Testing

- [ ] Unit tests added/updated — N/A (changelog-only change)
- [x] Manual testing completed — verified YAML structure matches existing entries

## Human Review Checklist

- [ ] Verify `0.26.3` is the correct next version (previous latest is `0.26.2`)
- [ ] Verify `irVersion: 65` is correct (consistent with recent entries)
- [ ] Confirm changelog summary accurately reflects the fix in #13915

Link to Devin session: https://app.devin.ai/sessions/59d0f271ae844953a6c6fcfc45cdc082
Requested by: @iamnamananand996