### PR TITLE
chore(rust): add Default implementation for client initialization

### DIFF
--- a/generators/rust/base/src/asIs/client.rs
+++ b/generators/rust/base/src/asIs/client.rs
@@ -23,6 +23,14 @@ pub struct ApiClientBuilder {
     config: ClientConfig,
 }
 
+impl Default for ApiClientBuilder {
+    fn default() -> Self {
+        Self {
+            config: ClientConfig::default(),
+        }
+    }
+}
+
 impl ApiClientBuilder {
     /// Create a new builder with the specified base URL
     pub fn new(base_url: impl Into<String>) -> Self {

--- a/generators/rust/sdk/src/__test__/snapshots/api-client-builder-api-key.rs
+++ b/generators/rust/sdk/src/__test__/snapshots/api-client-builder-api-key.rs
@@ -23,6 +23,14 @@ pub struct ApiClientBuilder {
     config: ClientConfig,
 }
 
+impl Default for ApiClientBuilder {
+    fn default() -> Self {
+        Self {
+            config: ClientConfig::default(),
+        }
+    }
+}
+
 impl ApiClientBuilder {
     /// Create a new builder with the specified base URL
     pub fn new(base_url: impl Into<String>) -> Self {

--- a/generators/rust/sdk/src/readme/ReadmeSnippetBuilder.ts
+++ b/generators/rust/sdk/src/readme/ReadmeSnippetBuilder.ts
@@ -643,24 +643,19 @@ export class ReadmeSnippetBuilder extends AbstractReadmeSnippetBuilder {
         writer.newLine();
         writer.newLine();
 
-        // Create client config and root client (same pattern as pagination snippets)
+        // Create client using ClientConfig with token auth (matching the standard SDK pattern)
         const rootClientName = this.context.getClientName();
-        const configStatement = Statement.let({
-            name: "config",
-            value: this.getClientConfigStruct("error")
-        });
-        configStatement.write(writer);
+        writer.write(`let client = ${rootClientName}::new(ClientConfig {`);
         writer.newLine();
-        const clientBuild = Expression.methodCall({
-            target: Expression.raw(`${rootClientName}::new(config)`),
-            method: "expect",
-            args: [Expression.stringLiteral("Failed to build client")]
-        });
-        const clientStatement = Statement.let({
-            name: "client",
-            value: clientBuild
-        });
-        clientStatement.write(writer);
+        writer.indent();
+        writer.write(`token: Some("your-api-key".to_string()),`);
+        writer.newLine();
+        writer.write(`..Default::default()`);
+        writer.dedent();
+        writer.newLine();
+        writer.write(`})`);
+        writer.newLine();
+        writer.write(`.expect("Failed to create client");`);
         writer.newLine();
         writer.newLine();
 

--- a/generators/rust/sdk/versions.yml
+++ b/generators/rust/sdk/versions.yml
@@ -1,5 +1,14 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 
+- version: 0.26.4
+  changelogEntry:
+    - summary: |
+        Add `Default` implementation for `ApiClientBuilder` and update README snippet generation
+        to use a simpler struct-based client initialization pattern with `ClientConfig { token: ..., ..Default::default() }`.
+      type: feat
+  createdAt: "2026-03-23"
+  irVersion: 65
+
 - version: 0.26.3
   changelogEntry:
     - summary: |

--- a/generators/rust/sdk/versions.yml
+++ b/generators/rust/sdk/versions.yml
@@ -5,7 +5,7 @@
     - summary: |
         Add `Default` implementation for `ApiClientBuilder` and update README snippet generation
         to use a simpler struct-based client initialization pattern with `ClientConfig { token: ..., ..Default::default() }`.
-      type: feat
+      type: chore
   createdAt: "2026-03-23"
   irVersion: 65
 


### PR DESCRIPTION
## Description

Adds a `Default` implementation for `ApiClientBuilder` in the Rust SDK and updates the README snippet generation to use a simpler struct-based client initialization pattern leveraging `..Default::default()`.

## Changes Made

- Added `impl Default for ApiClientBuilder` in `generators/rust/base/src/asIs/client.rs`, delegating to `ClientConfig::default()`
- Updated `ReadmeSnippetBuilder.ts` to generate client initialization snippets using the `ClientConfig { token: ..., ..Default::default() }` pattern instead of the previous programmatic `Statement.let` / `Expression.methodCall` approach
- Added `versions.yml` entry for Rust SDK v0.26.4 (`type: chore`)
- Updated test snapshot `api-client-builder-api-key.rs` to match the new `Default` impl

## Human Review Checklist
- [ ] Confirm that hardcoding `token: Some("your-api-key".to_string())` in the README snippet is appropriate for all auth configurations. The previous code used `this.getClientConfigStruct("error")` which may have handled different auth patterns (OAuth, API key header, basic auth) dynamically.
- [ ] Check that the generated README snippet formatting (indentation, newlines) renders correctly — the switch from AST-based generation to raw `writer.write()` calls is less guarded against formatting regressions
- [ ] Verify that `ClientConfig` already derives or implements `Default`
- [ ] Verify the version bump to 0.26.4 is correct (no version conflicts with other in-flight PRs)

## Testing
- [x] Unit tests updated (snapshot `api-client-builder-api-key.rs` updated to include `Default` impl)
- [x] All 27 tests in `@fern-api/rust-sdk` pass locally
- [ ] Seed snapshot verification for Rust SDK README output

Link to Devin session: https://app.devin.ai/sessions/7bd8cd34108044229cfd8c91098b686c
Requested by: @iamnamananand996