### PR TITLE
fix(java): strip markdown heading markers from custom license names in build.gradle

### DIFF
--- a/generators/java/generator-utils/src/main/java/com/fern/java/output/GeneratedBuildGradle.java
+++ b/generators/java/generator-utils/src/main/java/com/fern/java/output/GeneratedBuildGradle.java
@@ -215,7 +215,11 @@ public abstract class GeneratedBuildGradle extends GeneratedFile {
                         .findFirst()
                         .orElse("Custom License");
 
-                firstLine = firstLine.trim().replaceAll("[.:;]+$", "").replaceAll("\\s+", " ");
+                firstLine = firstLine
+                        .trim()
+                        .replaceAll("^#+\\s*", "")
+                        .replaceAll("[.:;]+$", "")
+                        .replaceAll("\\s+", " ");
 
                 firstLine = firstLine.replace("'", "\\'");
 

--- a/generators/java/sdk/versions.yml
+++ b/generators/java/sdk/versions.yml
@@ -1,4 +1,15 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 4.0.4
+  changelogEntry:
+    - summary: |
+        Fix custom license names in generated `build.gradle` including markdown
+        heading markers (e.g. `# Anduril ...` instead of `Anduril ...`). The
+        generator now strips leading `#` symbols from the first line of LICENSE
+        files before using it as the license name.
+      type: fix
+  createdAt: "2026-03-23"
+  irVersion: 65
+
 - version: 4.0.3
   changelogEntry:
     - summary: |


### PR DESCRIPTION
## Description
Linear ticket: Closes FER-9147

When a LICENSE file starts with a markdown heading (e.g. `# Anduril Industries, Inc. Proprietary License`), the `#` marker was leaking into the generated `build.gradle` license name. This adds a regex to strip leading `#` symbols before using the first line as the license name.

## Changes Made
- Added `.replaceAll("^#+\\s*", "")` to `extractLicenseFromFile()` in `GeneratedBuildGradle.java` to strip markdown heading markers from the first line of LICENSE files
- Updated `versions.yml` with v4.0.4 changelog entry

## Testing
- [ ] Unit tests added/updated
- [x] Spotless formatting verified locally

## Review Checklist
- [ ] Verify regex `^#+\s*` doesn't over-strip in edge cases (e.g. first line is only `#` or `## `, which would result in an empty license name)
- [ ] Confirm no unit tests needed, or request they be added — the previous attempt (PR #13855) included tests but was closed due to incorrect behavior changes

Link to Devin session: https://app.devin.ai/sessions/cf6cc57e695e4647b5af61caf66eb702
Requested by: @jsklan
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/13925" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
