### PR TITLE
fix(typescript): fix ENOTEMPTY error in deleteGitIgnoredFiles during GitHub output mode

### DIFF
--- a/generators/typescript/sdk/versions.yml
+++ b/generators/typescript/sdk/versions.yml
@@ -1,4 +1,17 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 3.59.4
+  changelogEntry:
+    - summary: |
+        Fix `ENOTEMPTY` error during GitHub output mode when removing the temporary
+        `.git` directory in `deleteGitIgnoredFiles`. The `fs.rm` call now uses
+        `maxRetries: 3` to handle race conditions with git background processes
+        (e.g. auto-gc) that may still hold references to `.git/objects/pack`.
+        Also disables git auto-gc during the temporary `git init` to reduce the
+        likelihood of the race condition.
+      type: fix
+  createdAt: "2026-03-23"
+  irVersion: 65
+
 - version: 3.59.3
   changelogEntry:
     - summary: |

--- a/generators/typescript/utils/commons/src/typescript-project/PersistedTypescriptProject.ts
+++ b/generators/typescript/utils/commons/src/typescript-project/PersistedTypescriptProject.ts
@@ -485,7 +485,12 @@ export class PersistedTypescriptProject {
         ]);
         await git(["clean", "-fdx"]);
 
-        await rm(join(this.directory, RelativeFilePath.of(".git")), { recursive: true, force: true });
+        await rm(join(this.directory, RelativeFilePath.of(".git")), {
+            recursive: true,
+            force: true,
+            maxRetries: 3,
+            retryDelay: 100
+        });
     }
 
     public async writeArbitraryFiles(run: (pathToProject: AbsoluteFilePath) => Promise<void>): Promise<void> {

--- a/generators/typescript/utils/commons/src/typescript-project/PersistedTypescriptProject.ts
+++ b/generators/typescript/utils/commons/src/typescript-project/PersistedTypescriptProject.ts
@@ -466,7 +466,10 @@ export class PersistedTypescriptProject {
             cwd: this.directory,
             logger
         });
-        await git(["-c", "gc.auto=0", "init"]);
+        await git(["init"]);
+        // Disable auto-gc so that no background pack processes run during
+        // the subsequent add/commit/clean, which would race with the rm(.git) below.
+        await git(["config", "gc.auto", "0"]);
         await git(["add", "."]);
         await git([
             "-c",
@@ -482,11 +485,7 @@ export class PersistedTypescriptProject {
         ]);
         await git(["clean", "-fdx"]);
 
-        await rm(join(this.directory, RelativeFilePath.of(".git")), {
-            recursive: true,
-            maxRetries: 3,
-            retryDelay: 100
-        });
+        await rm(join(this.directory, RelativeFilePath.of(".git")), { recursive: true, force: true });
     }
 
     public async writeArbitraryFiles(run: (pathToProject: AbsoluteFilePath) => Promise<void>): Promise<void> {

--- a/generators/typescript/utils/commons/src/typescript-project/PersistedTypescriptProject.ts
+++ b/generators/typescript/utils/commons/src/typescript-project/PersistedTypescriptProject.ts
@@ -466,7 +466,7 @@ export class PersistedTypescriptProject {
             cwd: this.directory,
             logger
         });
-        await git(["init"]);
+        await git(["-c", "gc.auto=0", "init"]);
         await git(["add", "."]);
         await git([
             "-c",
@@ -482,7 +482,7 @@ export class PersistedTypescriptProject {
         ]);
         await git(["clean", "-fdx"]);
 
-        await rm(join(this.directory, RelativeFilePath.of(".git")), { recursive: true });
+        await rm(join(this.directory, RelativeFilePath.of(".git")), { recursive: true, maxRetries: 3, retryDelay: 100 });
     }
 
     public async writeArbitraryFiles(run: (pathToProject: AbsoluteFilePath) => Promise<void>): Promise<void> {

--- a/generators/typescript/utils/commons/src/typescript-project/PersistedTypescriptProject.ts
+++ b/generators/typescript/utils/commons/src/typescript-project/PersistedTypescriptProject.ts
@@ -482,7 +482,11 @@ export class PersistedTypescriptProject {
         ]);
         await git(["clean", "-fdx"]);
 
-        await rm(join(this.directory, RelativeFilePath.of(".git")), { recursive: true, maxRetries: 3, retryDelay: 100 });
+        await rm(join(this.directory, RelativeFilePath.of(".git")), {
+            recursive: true,
+            maxRetries: 3,
+            retryDelay: 100
+        });
     }
 
     public async writeArbitraryFiles(run: (pathToProject: AbsoluteFilePath) => Promise<void>): Promise<void> {


### PR DESCRIPTION
## Description

Refs: Reported by Candid Health — their TypeScript SDK publish began failing with:
```
ENOTEMPTY: directory not empty, rmdir '/tmp/tmp-1-Mo5p5Cq1hGar/.git/objects/pack'
```

The error occurs in the `deleteGitIgnoredFiles` method of `PersistedTypescriptProject`, which creates a temporary git repo to identify gitignored files, then removes the `.git` directory. A race condition between `fs.rm` and git background processes (e.g. auto-gc repacking objects) can cause `rmdir` to fail with `ENOTEMPTY`.

## Changes Made

Two-layer fix — prevention + defense-in-depth:

1. **Prevention:** Run `git config gc.auto 0` immediately after `git init` to disable auto-gc in the repo config. Unlike `-c gc.auto=0` (which only applies to a single command), this persists in `.git/config` and applies to all subsequent git operations (`add`, `commit`, `clean`), preventing background pack processes from spawning in the first place.
2. **Defense-in-depth:** Add `maxRetries: 3, retryDelay: 100, force: true` to the `fs.rm(.git)` call. `maxRetries` is a Node.js built-in option that retries on transient `ENOTEMPTY`/`EBUSY` errors during recursive deletion.
3. Bump TypeScript SDK generator version to `3.59.4` in `generators/typescript/sdk/versions.yml`.

## Testing

- [x] TypeScript type-check passes (`tsc --noEmit`)
- [x] Biome lint/format passes
- [x] All CI checks green (compile, test, test-ete, seed tests)
- [ ] Not unit-testable (race condition fix); validated by reading Node.js [`fs.rm` docs](https://nodejs.org/api/fs.html#fspromisesrmpath-options) confirming `maxRetries` handles `ENOTEMPTY`

## Human Review Checklist

- [ ] Verify `git config gc.auto 0` after `git init` persists in `.git/config` and applies to the subsequent `git add`, `git commit`, and `git clean` calls (it does — `git config` without `--global` writes to the local repo config)
- [ ] Confirm `maxRetries` and `retryDelay` are supported in the Node.js version used by the `fern-typescript-node-sdk` Docker image (available since Node 14.14+)
- [ ] Consider whether 3 retries with 100ms delay is sufficient, or if more aggressive retry parameters are warranted for CI environments under heavy I/O load

Link to Devin session: https://app.devin.ai/sessions/7b9aa28a398641eb822577ea30606aa5
Requested by: @jon-fern
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/13926" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
