### PR TITLE
fix(seed): cap container pool size at actual test case count

### DIFF
--- a/packages/seed/src/cli.ts
+++ b/packages/seed/src/cli.ts
@@ -305,6 +305,32 @@ function addTestCommand(cli: Argv) {
                     }
                 }
 
+                // Compute the actual test case count from fixturesForGenerator using the
+                // same expansion logic that testWorkspaceFixtures.ts uses, so we don't
+                // spin up more containers than there are test cases.
+                let testCaseCount = 0;
+                for (const fixture of fixturesForGenerator) {
+                    let fixtureName = fixture;
+                    let fixtureOutputFolder: string | undefined;
+                    if (fixture.includes(":")) {
+                        const [name, folder] = fixture.split(":", 2);
+                        fixtureName = name!;
+                        fixtureOutputFolder = folder;
+                    }
+                    const config = generator.workspaceConfig.fixtures?.[fixtureName];
+                    if (config != null) {
+                        if (fixtureOutputFolder != null) {
+                            // Only count the matching output folder
+                            testCaseCount += config.filter((c) => c.outputFolder === fixtureOutputFolder).length || 1;
+                        } else {
+                            testCaseCount += config.length;
+                        }
+                    } else {
+                        testCaseCount += 1;
+                    }
+                }
+                const effectiveParallelism = Math.min(argv.parallel, testCaseCount);
+
                 if (argv.local) {
                     if (generator.workspaceConfig.test.local == null) {
                         throw new Error(
@@ -339,7 +365,7 @@ function addTestCommand(cli: Argv) {
                         taskContextFactory.create("docker-script-runner"),
                         argv["log-level"],
                         argv.containerRuntime as "docker" | "podman" | undefined,
-                        argv.parallel
+                        effectiveParallelism
                     );
                     testRunner = new ContainerTestRunner({
                         generator,
@@ -350,7 +376,7 @@ function addTestCommand(cli: Argv) {
                         scriptRunner,
                         inspect: argv.inspect,
                         runner: argv.containerRuntime as "docker" | "podman" | undefined,
-                        parallelism: argv.parallel,
+                        parallelism: effectiveParallelism,
                         workspaceCache: new WorkspaceCache(),
                         logLevel: argv["log-level"]
                     });

--- a/packages/seed/src/cli.ts
+++ b/packages/seed/src/cli.ts
@@ -311,7 +311,7 @@ function addTestCommand(cli: Argv) {
                 let testCaseCount = 0;
                 for (const fixture of fixturesForGenerator) {
                     let fixtureName = fixture;
-                    let fixtureOutputFolder: string | undefined;
+                    let fixtureOutputFolder: string | undefined = argv.outputFolder;
                     if (fixture.includes(":")) {
                         const [name, folder] = fixture.split(":", 2);
                         fixtureName = name!;


### PR DESCRIPTION
## Description

Caps the container pool size for seed tests at the actual number of test cases rather than always using the raw `--parallel` value. This avoids spinning up more containers than needed (e.g., `--parallel 16` with only 3 test cases would previously start 16 containers).

## Changes Made

- Computes `testCaseCount` from `fixturesForGenerator` using the same fixture→test-case expansion logic as `testWorkspaceFixtures.ts` (handling `name:outputFolder` format, multi-config fixtures, and single-config fixtures)
- Initializes `fixtureOutputFolder` from `argv.outputFolder` so that `--outputFolder` filtering is also respected in the count
- Derives `effectiveParallelism = Math.min(argv.parallel, testCaseCount)` and passes it to both `ContainerScriptRunner` (pool size) and `ContainerTestRunner` (parallelism)
- The global `Semaphore(argv.parallel)` is intentionally left unchanged — it controls cross-generator concurrency and should retain the full `--parallel` value

## Reviewer Checklist

- [ ] Verify the counting logic in `cli.ts` matches the expansion in [`testWorkspaceFixtures.ts` lines 32-74](packages/seed/src/commands/test/testWorkspaceFixtures.ts) — the counting is intentionally duplicated rather than extracted into a shared helper, so ensure both stay in sync
- [ ] The `|| 1` fallback on the output folder filter handles the case where no config instance matches the requested output folder — note this may slightly overcount vs. the actual runner (which would produce 0 test cases for that fixture), but errs on the safe side
- [ ] Language prefix filtering (`LANGUAGE_SPECIFIC_FIXTURE_PREFIXES`) is **not** included in this count; the count may be slightly higher than actual test cases but never lower
- [ ] Confirm `effectiveParallelism = 0` is safe when `fixturesForGenerator` is empty (both runners use it as a loop bound / pool size, so 0 means no containers started)

## Testing

- [ ] Lint passes via `pnpm run check`
- [ ] No unit tests added — this is a CLI-level optimization with no new testable branches

Link to Devin session: https://app.devin.ai/sessions/702e1719e5a743529fc34d0a553f5bbb
Requested by: @jsklan
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/13935" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
