### PR TITLE
fix(go): sort generated imports following goimports conventions

### DIFF
--- a/generators/go-v2/ast/src/ast/core/GoFile.ts
+++ b/generators/go-v2/ast/src/ast/core/GoFile.ts
@@ -44,12 +44,42 @@ ${this.buffer}`
     }
 
     private stringifyImports(): string {
-        const result = Object.entries(this.imports)
-            .filter(([importPath, _]) => importPath !== this.importPath) // Skip the target import path
-            .sort(([pathA], [pathB]) => (pathA < pathB ? -1 : pathA > pathB ? 1 : 0))
-            .map(([importPath, alias]) => `    ${alias} "${importPath}"`)
-            .join("\n");
+        const entries = Object.entries(this.imports).filter(
+            ([importPath, _]) => importPath !== this.importPath // Skip the target import path
+        );
 
-        return result ? `import (\n${result}\n)` : "";
+        if (entries.length === 0) {
+            return "";
+        }
+
+        // Separate stdlib imports from third-party imports.
+        // Stdlib import paths do not contain a dot in the first path segment (e.g., "fmt", "net/http").
+        const stdlibImports: [string, string][] = [];
+        const thirdPartyImports: [string, string][] = [];
+        for (const entry of entries) {
+            const firstSegment = entry[0].split("/")[0] ?? "";
+            if (firstSegment.includes(".")) {
+                thirdPartyImports.push(entry);
+            } else {
+                stdlibImports.push(entry);
+            }
+        }
+
+        const sortEntries = (a: [string, string], b: [string, string]): number =>
+            a[0] < b[0] ? -1 : a[0] > b[0] ? 1 : 0;
+        stdlibImports.sort(sortEntries);
+        thirdPartyImports.sort(sortEntries);
+
+        const formatEntry = ([importPath, alias]: [string, string]): string => `    ${alias} "${importPath}"`;
+
+        const groups: string[] = [];
+        if (stdlibImports.length > 0) {
+            groups.push(stdlibImports.map(formatEntry).join("\n"));
+        }
+        if (thirdPartyImports.length > 0) {
+            groups.push(thirdPartyImports.map(formatEntry).join("\n"));
+        }
+
+        return `import (\n${groups.join("\n\n")}\n)`;
     }
 }

--- a/generators/go-v2/dynamic-snippets/src/__test__/__snapshots__/DynamicSnippetsGenerator.test.ts.snap
+++ b/generators/go-v2/dynamic-snippets/src/__test__/__snapshots__/DynamicSnippetsGenerator.test.ts.snap
@@ -5,6 +5,7 @@ exports[`snippets (default) > examples > 'GET /metadata (allow-multiple)' 1`] = 
 
 import (
 	context "context"
+
 	acme "github.com/acme/acme-go"
 	client "github.com/acme/acme-go/client"
 	option "github.com/acme/acme-go/option"
@@ -43,6 +44,7 @@ exports[`snippets (default) > examples > 'GET /metadata (simple)' 1`] = `
 
 import (
 	context "context"
+
 	acme "github.com/acme/acme-go"
 	client "github.com/acme/acme-go/client"
 	option "github.com/acme/acme-go/option"
@@ -78,6 +80,7 @@ exports[`snippets (default) > examples > 'POST /big-entity (simple)' 1`] = `
 
 import (
 	context "context"
+
 	acme "github.com/acme/acme-go"
 	client "github.com/acme/acme-go/client"
 	commons "github.com/acme/acme-go/commons"
@@ -162,6 +165,7 @@ exports[`snippets (default) > examples > 'POST /movie (simple)' 1`] = `
 
 import (
 	context "context"
+
 	acme "github.com/acme/acme-go"
 	client "github.com/acme/acme-go/client"
 	option "github.com/acme/acme-go/option"
@@ -209,6 +213,7 @@ exports[`snippets (default) > exhaustive > 'GET /object/get-and-return-with-opti
 
 import (
 	context "context"
+
 	acme "github.com/acme/acme-go"
 	client "github.com/acme/acme-go/client"
 	option "github.com/acme/acme-go/option"
@@ -312,6 +317,7 @@ exports[`snippets (default) > exhaustive > 'POST /container/list-of-objects (sim
 
 import (
 	context "context"
+
 	client "github.com/acme/acme-go/client"
 	option "github.com/acme/acme-go/option"
 	types "github.com/acme/acme-go/types"
@@ -347,6 +353,7 @@ exports[`snippets (default) > exhaustive > 'POST /container/list-of-primitives (
 
 import (
 	context "context"
+
 	client "github.com/acme/acme-go/client"
 	option "github.com/acme/acme-go/option"
 )
@@ -428,10 +435,11 @@ exports[`snippets (default) > file-upload > 'POST /' 1`] = `
 
 import (
 	context "context"
-	acme "github.com/acme/acme-go"
-	client "github.com/acme/acme-go/client"
 	io "io"
 	strings "strings"
+
+	acme "github.com/acme/acme-go"
+	client "github.com/acme/acme-go/client"
 )
 
 func do() {
@@ -465,9 +473,10 @@ exports[`snippets (default) > file-upload > 'POST /just-file' 1`] = `
 
 import (
 	context "context"
+	strings "strings"
+
 	acme "github.com/acme/acme-go"
 	client "github.com/acme/acme-go/client"
-	strings "strings"
 )
 
 func do() {
@@ -490,9 +499,10 @@ exports[`snippets (default) > file-upload > 'POST /just-file-with-query-params' 
 
 import (
 	context "context"
+	strings "strings"
+
 	acme "github.com/acme/acme-go"
 	client "github.com/acme/acme-go/client"
-	strings "strings"
 )
 
 func do() {
@@ -519,6 +529,7 @@ exports[`snippets (default) > imdb > 'GET /movies/{movieId} (simple)' 1`] = `
 
 import (
 	context "context"
+
 	client "github.com/acme/acme-go/client"
 	option "github.com/acme/acme-go/option"
 )
@@ -542,6 +553,7 @@ exports[`snippets (default) > imdb > 'POST /movies/create-movie (simple)' 1`] = 
 
 import (
 	context "context"
+
 	acme "github.com/acme/acme-go"
 	client "github.com/acme/acme-go/client"
 	option "github.com/acme/acme-go/option"
@@ -590,6 +602,7 @@ exports[`snippets (default) > multi-url-environment > 'Production environment' 1
 
 import (
 	context "context"
+
 	acme "github.com/acme/acme-go"
 	client "github.com/acme/acme-go/client"
 	option "github.com/acme/acme-go/option"
@@ -620,6 +633,7 @@ exports[`snippets (default) > multi-url-environment > 'Staging environment' 1`] 
 
 import (
 	context "context"
+
 	acme "github.com/acme/acme-go"
 	client "github.com/acme/acme-go/client"
 	option "github.com/acme/acme-go/option"
@@ -660,6 +674,7 @@ exports[`snippets (default) > nullable > 'Body properties' 1`] = `
 
 import (
 	context "context"
+
 	acme "github.com/acme/acme-go"
 	client "github.com/acme/acme-go/client"
 	option "github.com/acme/acme-go/option"
@@ -710,6 +725,7 @@ exports[`snippets (default) > nullable > 'Query parameters' 1`] = `
 
 import (
 	context "context"
+
 	acme "github.com/acme/acme-go"
 	client "github.com/acme/acme-go/client"
 	option "github.com/acme/acme-go/option"
@@ -745,6 +761,7 @@ exports[`snippets (default) > read-write-only > 'Body properties' 1`] = `
 
 import (
 	context "context"
+
 	acme "github.com/acme/acme-go"
 	client "github.com/acme/acme-go/client"
 	option "github.com/acme/acme-go/option"
@@ -777,6 +794,7 @@ exports[`snippets (default) > read-write-only > 'Readonly value in request' 1`] 
 
 import (
 	context "context"
+
 	acme "github.com/acme/acme-go"
 	client "github.com/acme/acme-go/client"
 	option "github.com/acme/acme-go/option"
@@ -810,6 +828,7 @@ exports[`snippets (default) > required-headers > 'GET /plants (simple)' 1`] = `
 
 import (
 	context "context"
+
 	client "github.com/acme/acme-go/client"
 	option "github.com/acme/acme-go/option"
 )
@@ -835,6 +854,7 @@ exports[`snippets (default) > required-headers > 'POST /plants (simple)' 1`] = `
 
 import (
 	context "context"
+
 	acme "github.com/acme/acme-go"
 	client "github.com/acme/acme-go/client"
 	option "github.com/acme/acme-go/option"
@@ -866,6 +886,7 @@ exports[`snippets (default) > single-url-environment-default > 'Production envir
 
 import (
 	context "context"
+
 	acme "github.com/acme/acme-go"
 	client "github.com/acme/acme-go/client"
 	option "github.com/acme/acme-go/option"
@@ -892,6 +913,7 @@ exports[`snippets (default) > single-url-environment-default > 'Staging environm
 
 import (
 	context "context"
+
 	acme "github.com/acme/acme-go"
 	client "github.com/acme/acme-go/client"
 	option "github.com/acme/acme-go/option"
@@ -918,6 +940,7 @@ exports[`snippets (default) > single-url-environment-default > 'custom baseURL' 
 
 import (
 	context "context"
+
 	client "github.com/acme/acme-go/client"
 	option "github.com/acme/acme-go/option"
 )
@@ -963,6 +986,7 @@ exports[`snippets (exportAllRequestsAtRoot) > examples > 'GET /metadata (allow-m
 
 import (
 	context "context"
+
 	acme "github.com/acme/acme-go"
 	client "github.com/acme/acme-go/client"
 	option "github.com/acme/acme-go/option"
@@ -1001,6 +1025,7 @@ exports[`snippets (exportAllRequestsAtRoot) > examples > 'GET /metadata (simple)
 
 import (
 	context "context"
+
 	acme "github.com/acme/acme-go"
 	client "github.com/acme/acme-go/client"
 	option "github.com/acme/acme-go/option"
@@ -1036,6 +1061,7 @@ exports[`snippets (exportAllRequestsAtRoot) > examples > 'POST /big-entity (simp
 
 import (
 	context "context"
+
 	acme "github.com/acme/acme-go"
 	client "github.com/acme/acme-go/client"
 	commons "github.com/acme/acme-go/commons"
@@ -1120,6 +1146,7 @@ exports[`snippets (exportAllRequestsAtRoot) > examples > 'POST /movie (simple)' 
 
 import (
 	context "context"
+
 	acme "github.com/acme/acme-go"
 	client "github.com/acme/acme-go/client"
 	option "github.com/acme/acme-go/option"
@@ -1167,6 +1194,7 @@ exports[`snippets (exportAllRequestsAtRoot) > exhaustive > 'GET /object/get-and-
 
 import (
 	context "context"
+
 	acme "github.com/acme/acme-go"
 	client "github.com/acme/acme-go/client"
 	option "github.com/acme/acme-go/option"
@@ -1270,6 +1298,7 @@ exports[`snippets (exportAllRequestsAtRoot) > exhaustive > 'POST /container/list
 
 import (
 	context "context"
+
 	client "github.com/acme/acme-go/client"
 	option "github.com/acme/acme-go/option"
 	types "github.com/acme/acme-go/types"
@@ -1305,6 +1334,7 @@ exports[`snippets (exportAllRequestsAtRoot) > exhaustive > 'POST /container/list
 
 import (
 	context "context"
+
 	client "github.com/acme/acme-go/client"
 	option "github.com/acme/acme-go/option"
 )
@@ -1386,10 +1416,11 @@ exports[`snippets (exportAllRequestsAtRoot) > file-upload > 'POST /' 1`] = `
 
 import (
 	context "context"
-	acme "github.com/acme/acme-go"
-	client "github.com/acme/acme-go/client"
 	io "io"
 	strings "strings"
+
+	acme "github.com/acme/acme-go"
+	client "github.com/acme/acme-go/client"
 )
 
 func do() {
@@ -1423,9 +1454,10 @@ exports[`snippets (exportAllRequestsAtRoot) > file-upload > 'POST /just-file' 1`
 
 import (
 	context "context"
+	strings "strings"
+
 	acme "github.com/acme/acme-go"
 	client "github.com/acme/acme-go/client"
-	strings "strings"
 )
 
 func do() {
@@ -1448,9 +1480,10 @@ exports[`snippets (exportAllRequestsAtRoot) > file-upload > 'POST /just-file-wit
 
 import (
 	context "context"
+	strings "strings"
+
 	acme "github.com/acme/acme-go"
 	client "github.com/acme/acme-go/client"
-	strings "strings"
 )
 
 func do() {
@@ -1477,6 +1510,7 @@ exports[`snippets (exportAllRequestsAtRoot) > imdb > 'GET /movies/{movieId} (sim
 
 import (
 	context "context"
+
 	client "github.com/acme/acme-go/client"
 	option "github.com/acme/acme-go/option"
 )
@@ -1500,6 +1534,7 @@ exports[`snippets (exportAllRequestsAtRoot) > imdb > 'POST /movies/create-movie 
 
 import (
 	context "context"
+
 	acme "github.com/acme/acme-go"
 	client "github.com/acme/acme-go/client"
 	option "github.com/acme/acme-go/option"
@@ -1548,6 +1583,7 @@ exports[`snippets (exportAllRequestsAtRoot) > multi-url-environment > 'Productio
 
 import (
 	context "context"
+
 	acme "github.com/acme/acme-go"
 	client "github.com/acme/acme-go/client"
 	option "github.com/acme/acme-go/option"
@@ -1578,6 +1614,7 @@ exports[`snippets (exportAllRequestsAtRoot) > multi-url-environment > 'Staging e
 
 import (
 	context "context"
+
 	acme "github.com/acme/acme-go"
 	client "github.com/acme/acme-go/client"
 	option "github.com/acme/acme-go/option"
@@ -1618,6 +1655,7 @@ exports[`snippets (exportAllRequestsAtRoot) > nullable > 'Body properties' 1`] =
 
 import (
 	context "context"
+
 	acme "github.com/acme/acme-go"
 	client "github.com/acme/acme-go/client"
 	option "github.com/acme/acme-go/option"
@@ -1668,6 +1706,7 @@ exports[`snippets (exportAllRequestsAtRoot) > nullable > 'Query parameters' 1`] 
 
 import (
 	context "context"
+
 	acme "github.com/acme/acme-go"
 	client "github.com/acme/acme-go/client"
 	option "github.com/acme/acme-go/option"
@@ -1703,6 +1742,7 @@ exports[`snippets (exportAllRequestsAtRoot) > read-write-only > 'Body properties
 
 import (
 	context "context"
+
 	acme "github.com/acme/acme-go"
 	client "github.com/acme/acme-go/client"
 	option "github.com/acme/acme-go/option"
@@ -1735,6 +1775,7 @@ exports[`snippets (exportAllRequestsAtRoot) > read-write-only > 'Readonly value 
 
 import (
 	context "context"
+
 	acme "github.com/acme/acme-go"
 	client "github.com/acme/acme-go/client"
 	option "github.com/acme/acme-go/option"
@@ -1768,6 +1809,7 @@ exports[`snippets (exportAllRequestsAtRoot) > required-headers > 'GET /plants (s
 
 import (
 	context "context"
+
 	client "github.com/acme/acme-go/client"
 	option "github.com/acme/acme-go/option"
 )
@@ -1793,6 +1835,7 @@ exports[`snippets (exportAllRequestsAtRoot) > required-headers > 'POST /plants (
 
 import (
 	context "context"
+
 	acme "github.com/acme/acme-go"
 	client "github.com/acme/acme-go/client"
 	option "github.com/acme/acme-go/option"
@@ -1824,6 +1867,7 @@ exports[`snippets (exportAllRequestsAtRoot) > single-url-environment-default > '
 
 import (
 	context "context"
+
 	acme "github.com/acme/acme-go"
 	client "github.com/acme/acme-go/client"
 	option "github.com/acme/acme-go/option"
@@ -1850,6 +1894,7 @@ exports[`snippets (exportAllRequestsAtRoot) > single-url-environment-default > '
 
 import (
 	context "context"
+
 	acme "github.com/acme/acme-go"
 	client "github.com/acme/acme-go/client"
 	option "github.com/acme/acme-go/option"
@@ -1876,6 +1921,7 @@ exports[`snippets (exportAllRequestsAtRoot) > single-url-environment-default > '
 
 import (
 	context "context"
+
 	client "github.com/acme/acme-go/client"
 	option "github.com/acme/acme-go/option"
 )
@@ -1921,6 +1967,7 @@ exports[`snippets (exportedClientName) > examples > 'GET /metadata (allow-multip
 
 import (
 	context "context"
+
 	acme "github.com/acme/acme-go"
 	client "github.com/acme/acme-go/client"
 	option "github.com/acme/acme-go/option"
@@ -1959,6 +2006,7 @@ exports[`snippets (exportedClientName) > examples > 'GET /metadata (simple)' 1`]
 
 import (
 	context "context"
+
 	acme "github.com/acme/acme-go"
 	client "github.com/acme/acme-go/client"
 	option "github.com/acme/acme-go/option"
@@ -1994,6 +2042,7 @@ exports[`snippets (exportedClientName) > examples > 'POST /big-entity (simple)' 
 
 import (
 	context "context"
+
 	acme "github.com/acme/acme-go"
 	client "github.com/acme/acme-go/client"
 	commons "github.com/acme/acme-go/commons"
@@ -2078,6 +2127,7 @@ exports[`snippets (exportedClientName) > examples > 'POST /movie (simple)' 1`] =
 
 import (
 	context "context"
+
 	acme "github.com/acme/acme-go"
 	client "github.com/acme/acme-go/client"
 	option "github.com/acme/acme-go/option"
@@ -2125,6 +2175,7 @@ exports[`snippets (exportedClientName) > exhaustive > 'GET /object/get-and-retur
 
 import (
 	context "context"
+
 	acme "github.com/acme/acme-go"
 	client "github.com/acme/acme-go/client"
 	option "github.com/acme/acme-go/option"
@@ -2228,6 +2279,7 @@ exports[`snippets (exportedClientName) > exhaustive > 'POST /container/list-of-o
 
 import (
 	context "context"
+
 	client "github.com/acme/acme-go/client"
 	option "github.com/acme/acme-go/option"
 	types "github.com/acme/acme-go/types"
@@ -2263,6 +2315,7 @@ exports[`snippets (exportedClientName) > exhaustive > 'POST /container/list-of-p
 
 import (
 	context "context"
+
 	client "github.com/acme/acme-go/client"
 	option "github.com/acme/acme-go/option"
 )
@@ -2344,10 +2397,11 @@ exports[`snippets (exportedClientName) > file-upload > 'POST /' 1`] = `
 
 import (
 	context "context"
-	acme "github.com/acme/acme-go"
-	client "github.com/acme/acme-go/client"
 	io "io"
 	strings "strings"
+
+	acme "github.com/acme/acme-go"
+	client "github.com/acme/acme-go/client"
 )
 
 func do() {
@@ -2381,9 +2435,10 @@ exports[`snippets (exportedClientName) > file-upload > 'POST /just-file' 1`] = `
 
 import (
 	context "context"
+	strings "strings"
+
 	acme "github.com/acme/acme-go"
 	client "github.com/acme/acme-go/client"
-	strings "strings"
 )
 
 func do() {
@@ -2406,9 +2461,10 @@ exports[`snippets (exportedClientName) > file-upload > 'POST /just-file-with-que
 
 import (
 	context "context"
+	strings "strings"
+
 	acme "github.com/acme/acme-go"
 	client "github.com/acme/acme-go/client"
-	strings "strings"
 )
 
 func do() {
@@ -2435,6 +2491,7 @@ exports[`snippets (exportedClientName) > imdb > 'GET /movies/{movieId} (simple)'
 
 import (
 	context "context"
+
 	client "github.com/acme/acme-go/client"
 	option "github.com/acme/acme-go/option"
 )
@@ -2458,6 +2515,7 @@ exports[`snippets (exportedClientName) > imdb > 'POST /movies/create-movie (simp
 
 import (
 	context "context"
+
 	acme "github.com/acme/acme-go"
 	client "github.com/acme/acme-go/client"
 	option "github.com/acme/acme-go/option"
@@ -2506,6 +2564,7 @@ exports[`snippets (exportedClientName) > multi-url-environment > 'Production env
 
 import (
 	context "context"
+
 	acme "github.com/acme/acme-go"
 	client "github.com/acme/acme-go/client"
 	option "github.com/acme/acme-go/option"
@@ -2536,6 +2595,7 @@ exports[`snippets (exportedClientName) > multi-url-environment > 'Staging enviro
 
 import (
 	context "context"
+
 	acme "github.com/acme/acme-go"
 	client "github.com/acme/acme-go/client"
 	option "github.com/acme/acme-go/option"
@@ -2576,6 +2636,7 @@ exports[`snippets (exportedClientName) > nullable > 'Body properties' 1`] = `
 
 import (
 	context "context"
+
 	acme "github.com/acme/acme-go"
 	client "github.com/acme/acme-go/client"
 	option "github.com/acme/acme-go/option"
@@ -2626,6 +2687,7 @@ exports[`snippets (exportedClientName) > nullable > 'Query parameters' 1`] = `
 
 import (
 	context "context"
+
 	acme "github.com/acme/acme-go"
 	client "github.com/acme/acme-go/client"
 	option "github.com/acme/acme-go/option"
@@ -2661,6 +2723,7 @@ exports[`snippets (exportedClientName) > read-write-only > 'Body properties' 1`]
 
 import (
 	context "context"
+
 	acme "github.com/acme/acme-go"
 	client "github.com/acme/acme-go/client"
 	option "github.com/acme/acme-go/option"
@@ -2693,6 +2756,7 @@ exports[`snippets (exportedClientName) > read-write-only > 'Readonly value in re
 
 import (
 	context "context"
+
 	acme "github.com/acme/acme-go"
 	client "github.com/acme/acme-go/client"
 	option "github.com/acme/acme-go/option"
@@ -2726,6 +2790,7 @@ exports[`snippets (exportedClientName) > required-headers > 'GET /plants (simple
 
 import (
 	context "context"
+
 	client "github.com/acme/acme-go/client"
 	option "github.com/acme/acme-go/option"
 )
@@ -2751,6 +2816,7 @@ exports[`snippets (exportedClientName) > required-headers > 'POST /plants (simpl
 
 import (
 	context "context"
+
 	acme "github.com/acme/acme-go"
 	client "github.com/acme/acme-go/client"
 	option "github.com/acme/acme-go/option"
@@ -2782,6 +2848,7 @@ exports[`snippets (exportedClientName) > single-url-environment-default > 'Produ
 
 import (
 	context "context"
+
 	acme "github.com/acme/acme-go"
 	client "github.com/acme/acme-go/client"
 	option "github.com/acme/acme-go/option"
@@ -2808,6 +2875,7 @@ exports[`snippets (exportedClientName) > single-url-environment-default > 'Stagi
 
 import (
 	context "context"
+
 	acme "github.com/acme/acme-go"
 	client "github.com/acme/acme-go/client"
 	option "github.com/acme/acme-go/option"
@@ -2834,6 +2902,7 @@ exports[`snippets (exportedClientName) > single-url-environment-default > 'custo
 
 import (
 	context "context"
+
 	client "github.com/acme/acme-go/client"
 	option "github.com/acme/acme-go/option"
 )

--- a/generators/go/sdk/versions.yml
+++ b/generators/go/sdk/versions.yml
@@ -1,4 +1,14 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 1.31.1
+  changelogEntry:
+    - summary: |
+        Sort generated Go imports following goimports conventions. Standard library
+        imports are now grouped separately from third-party imports with a blank line
+        separator between them, matching the canonical Go import style.
+      type: fix
+  createdAt: "2026-03-24"
+  irVersion: 61
+
 - version: 1.31.0
   changelogEntry:
     - summary: |


### PR DESCRIPTION
## Description

Refs https://github.com/fern-api/fern-platform/pull/8900

Generated Go snippets were not sorting imports correctly — stdlib and third-party imports were interleaved in a single flat alphabetical sort. This updates the Go AST's `stringifyImports()` to follow `goimports` conventions: stdlib imports first, blank line separator, then third-party imports, each group sorted alphabetically.

## Changes Made

- Modified `generators/go-v2/ast/src/ast/core/GoFile.ts` — `stringifyImports()` now partitions imports into stdlib vs third-party groups (stdlib = first path segment has no dot, e.g. `context`, `io`; third-party = first segment contains a dot, e.g. `github.com/...`), sorts each group, and joins them with a blank line separator.
- Updated 69 dynamic snippet test snapshots to reflect the new import grouping.
- Bumped `generators/go/sdk/versions.yml` → `1.31.1`.

## Important review points

1. **Stdlib detection heuristic**: Uses `firstSegment.includes(".")` to distinguish third-party imports. This matches the standard `goimports` convention. Worth confirming this covers all edge cases the generator may encounter.
2. **Broader impact**: `GoFile.ts` is shared by both the SDK generator and dynamic snippets generator. Seed test snapshots for the full SDK generator may also need updating (would be caught by CI seed tests).

## Testing

- [x] Unit tests updated (`@fern-api/go-ast` — 21 tests pass, `@fern-api/go-dynamic-snippets` — 96 tests pass with 69 snapshots updated)
- [x] Lint passes (`biome check`)

Link to Devin session: https://app.devin.ai/sessions/f811190cf39348fa8efaea975eaf9254
Requested by: @davidkonigsberg