### PR TITLE
feat(cli): show all content on preview links regardless of audiences

### DIFF
--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -1,4 +1,16 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 4.44.0
+  changelogEntry:
+    - summary: |
+        Show all content on preview links regardless of audience settings.
+        When generating docs with `--preview`, both navigation-level audience
+        filtering (products/versions) and per-API-section audience filtering
+        (endpoints) are now bypassed so that preview links display the
+        complete documentation.
+      type: feat
+  createdAt: "2026-03-24"
+  irVersion: 65
+
 - version: 4.43.1
   changelogEntry:
     - summary: |

--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -1,16 +1,4 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
-- version: 4.44.0
-  changelogEntry:
-    - summary: |
-        Show all content on preview links regardless of audience settings.
-        When generating docs with `--preview`, both navigation-level audience
-        filtering (products/versions) and per-API-section audience filtering
-        (endpoints) are now bypassed so that preview links display the
-        complete documentation.
-      type: feat
-  createdAt: "2026-03-24"
-  irVersion: 65
-
 - version: 4.43.1
   changelogEntry:
     - summary: |

--- a/packages/cli/docs-resolver/src/DocsDefinitionResolver.ts
+++ b/packages/cli/docs-resolver/src/DocsDefinitionResolver.ts
@@ -117,8 +117,6 @@ export interface DocsDefinitionResolverArgs {
     uploadFiles?: UploadFilesFn;
     registerApi?: RegisterApiFn;
     targetAudiences?: string[];
-    /** When true, ignores per-API-section audience filters so all endpoints are included (e.g. for preview). */
-    showAllAudiences?: boolean;
 }
 
 export class DocsDefinitionResolver {
@@ -131,7 +129,6 @@ export class DocsDefinitionResolver {
     private uploadFiles: UploadFilesFn;
     private registerApi: RegisterApiFn;
     private targetAudiences?: string[];
-    private showAllAudiences: boolean;
 
     constructor({
         domain,
@@ -142,8 +139,7 @@ export class DocsDefinitionResolver {
         editThisPage,
         uploadFiles = defaultUploadFiles,
         registerApi = defaultRegisterApi,
-        targetAudiences,
-        showAllAudiences = false
+        targetAudiences
     }: DocsDefinitionResolverArgs) {
         this.domain = domain;
         this.docsWorkspace = docsWorkspace;
@@ -154,7 +150,6 @@ export class DocsDefinitionResolver {
         this.uploadFiles = uploadFiles;
         this.registerApi = registerApi;
         this.targetAudiences = targetAudiences;
-        this.showAllAudiences = showAllAudiences;
     }
 
     #idgen = NodeIdGenerator.init();
@@ -1346,7 +1341,7 @@ export class DocsDefinitionResolver {
                 openapiWorkspace = this.getOpenApiWorkspaceForApiSection(item);
                 ir = await openapiWorkspace.getIntermediateRepresentation({
                     context: this.taskContext,
-                    audiences: this.showAllAudiences ? { type: "all" } : item.audiences,
+                    audiences: item.audiences,
                     enableUniqueErrorsPerEndpoint: true,
                     generateV1Examples: false,
                     logWarnings: false
@@ -1400,7 +1395,7 @@ export class DocsDefinitionResolver {
             );
             ir = generateIntermediateRepresentation({
                 workspace,
-                audiences: this.showAllAudiences ? { type: "all" } : item.audiences,
+                audiences: item.audiences,
                 generationLanguage: undefined,
                 keywords: undefined,
                 smartCasing: false,

--- a/packages/cli/docs-resolver/src/DocsDefinitionResolver.ts
+++ b/packages/cli/docs-resolver/src/DocsDefinitionResolver.ts
@@ -117,6 +117,8 @@ export interface DocsDefinitionResolverArgs {
     uploadFiles?: UploadFilesFn;
     registerApi?: RegisterApiFn;
     targetAudiences?: string[];
+    /** When true, ignores per-API-section audience filters so all endpoints are included (e.g. for preview). */
+    showAllAudiences?: boolean;
 }
 
 export class DocsDefinitionResolver {
@@ -129,6 +131,7 @@ export class DocsDefinitionResolver {
     private uploadFiles: UploadFilesFn;
     private registerApi: RegisterApiFn;
     private targetAudiences?: string[];
+    private showAllAudiences: boolean;
 
     constructor({
         domain,
@@ -139,7 +142,8 @@ export class DocsDefinitionResolver {
         editThisPage,
         uploadFiles = defaultUploadFiles,
         registerApi = defaultRegisterApi,
-        targetAudiences
+        targetAudiences,
+        showAllAudiences = false
     }: DocsDefinitionResolverArgs) {
         this.domain = domain;
         this.docsWorkspace = docsWorkspace;
@@ -150,6 +154,7 @@ export class DocsDefinitionResolver {
         this.uploadFiles = uploadFiles;
         this.registerApi = registerApi;
         this.targetAudiences = targetAudiences;
+        this.showAllAudiences = showAllAudiences;
     }
 
     #idgen = NodeIdGenerator.init();
@@ -1341,7 +1346,7 @@ export class DocsDefinitionResolver {
                 openapiWorkspace = this.getOpenApiWorkspaceForApiSection(item);
                 ir = await openapiWorkspace.getIntermediateRepresentation({
                     context: this.taskContext,
-                    audiences: item.audiences,
+                    audiences: this.showAllAudiences ? { type: "all" } : item.audiences,
                     enableUniqueErrorsPerEndpoint: true,
                     generateV1Examples: false,
                     logWarnings: false
@@ -1395,7 +1400,7 @@ export class DocsDefinitionResolver {
             );
             ir = generateIntermediateRepresentation({
                 workspace,
-                audiences: item.audiences,
+                audiences: this.showAllAudiences ? { type: "all" } : item.audiences,
                 generationLanguage: undefined,
                 keywords: undefined,
                 smartCasing: false,

--- a/packages/cli/generation/remote-generation/remote-workspace-runner/src/publishDocs.ts
+++ b/packages/cli/generation/remote-generation/remote-workspace-runner/src/publishDocs.ts
@@ -503,8 +503,7 @@ export async function publishDocs({
                 }
             }
         },
-        targetAudiences,
-        showAllAudiences: preview
+        targetAudiences
     });
 
     context.logger.info("Resolving docs definition...");

--- a/packages/cli/generation/remote-generation/remote-workspace-runner/src/publishDocs.ts
+++ b/packages/cli/generation/remote-generation/remote-workspace-runner/src/publishDocs.ts
@@ -503,7 +503,8 @@ export async function publishDocs({
                 }
             }
         },
-        targetAudiences
+        targetAudiences,
+        showAllAudiences: preview
     });
 
     context.logger.info("Resolving docs definition...");

--- a/packages/cli/generation/remote-generation/remote-workspace-runner/src/runRemoteGenerationForDocsWorkspace.ts
+++ b/packages/cli/generation/remote-generation/remote-workspace-runner/src/runRemoteGenerationForDocsWorkspace.ts
@@ -127,13 +127,11 @@ export async function runRemoteGenerationForDocsWorkspace({
                 withAiExamples:
                     docsWorkspace.config.aiExamples?.enabled ?? docsWorkspace.config.experimental?.aiExamples ?? true,
                 excludeApis: docsWorkspace.config.experimental?.excludeApis ?? false,
-                targetAudiences: preview
-                    ? undefined
-                    : maybeInstance.audiences
-                      ? Array.isArray(maybeInstance.audiences)
-                          ? maybeInstance.audiences
-                          : [maybeInstance.audiences]
-                      : undefined,
+                targetAudiences: maybeInstance.audiences
+                    ? Array.isArray(maybeInstance.audiences)
+                        ? maybeInstance.audiences
+                        : [maybeInstance.audiences]
+                    : undefined,
                 docsUrl: maybeInstance.url,
                 cliVersion,
                 ciSource

--- a/packages/cli/generation/remote-generation/remote-workspace-runner/src/runRemoteGenerationForDocsWorkspace.ts
+++ b/packages/cli/generation/remote-generation/remote-workspace-runner/src/runRemoteGenerationForDocsWorkspace.ts
@@ -127,11 +127,13 @@ export async function runRemoteGenerationForDocsWorkspace({
                 withAiExamples:
                     docsWorkspace.config.aiExamples?.enabled ?? docsWorkspace.config.experimental?.aiExamples ?? true,
                 excludeApis: docsWorkspace.config.experimental?.excludeApis ?? false,
-                targetAudiences: maybeInstance.audiences
-                    ? Array.isArray(maybeInstance.audiences)
-                        ? maybeInstance.audiences
-                        : [maybeInstance.audiences]
-                    : undefined,
+                targetAudiences: preview
+                    ? undefined
+                    : maybeInstance.audiences
+                      ? Array.isArray(maybeInstance.audiences)
+                          ? maybeInstance.audiences
+                          : [maybeInstance.audiences]
+                      : undefined,
                 docsUrl: maybeInstance.url,
                 cliVersion,
                 ciSource


### PR DESCRIPTION
## Description

When generating docs with `--preview`, audience-filtered content was hidden from preview links, making it impossible to review the full documentation before publishing. This change bypasses both layers of audience filtering in preview mode so that preview links display all content.

## Changes Made

Two independent audience filtering layers are bypassed when `preview` is true:

1. **Navigation-level filtering** (`runRemoteGenerationForDocsWorkspace.ts`): Sets `targetAudiences: undefined` in preview mode, skipping instance-level product/version filtering.

2. **Per-API-section endpoint filtering** (`DocsDefinitionResolver.ts`): Adds a `showAllAudiences` flag that overrides `item.audiences` to `{ type: "all" }` during IR generation, ensuring all endpoints are included regardless of per-API audience config.

3. **Threading** (`publishDocs.ts`): Passes `showAllAudiences: preview` to the resolver constructor.

4. **Changelog**: Added `versions.yml` entry for CLI v4.44.0.

## Testing

- [ ] Unit tests added/updated
- [x] Lint passes (`pnpm lint:biome`)

## Review Checklist

- [ ] Verify there are no other usages of `item.audiences` in `DocsDefinitionResolver` that should also be overridden (two spots in `toApiSectionNode` are updated — v3 parser path at L1349 and fallback IR generation at L1403)
- [ ] Confirm production (non-preview) behavior is unchanged — all new logic is gated on `preview` / `showAllAudiences`
- [ ] Verify `fern docs dev` (local dev server) behavior is not affected — it already skips audiences via a separate code path

Link to Devin session: https://app.devin.ai/sessions/ec78aef7e4814918bbdcbe658bf64914
Requested by: @fern-support