### PR TITLE
fix(csharp, go, java, php, python, ruby, rust, swift, typescript): thread `endpointId` through dynamic snippet generator

### DIFF
--- a/generators/csharp/sdk/versions.yml
+++ b/generators/csharp/sdk/versions.yml
@@ -1,4 +1,13 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 2.54.4
+  changelogEntry:
+    - summary: |
+        Thread endpoint ID through dynamic snippet generator to differentiate
+        generated snippets by endpoint.
+      type: fix
+  createdAt: "2026-03-25"
+  irVersion: 65
+
 - version: 2.54.3
   changelogEntry:
     - summary: |

--- a/generators/go/sdk/versions.yml
+++ b/generators/go/sdk/versions.yml
@@ -1,4 +1,13 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 1.31.2
+  changelogEntry:
+    - summary: |
+        Thread endpoint ID through dynamic snippet generator to differentiate
+        generated snippets by endpoint.
+      type: fix
+  createdAt: "2026-03-25"
+  irVersion: 61
+
 - version: 1.31.1
   changelogEntry:
     - summary: |

--- a/generators/java/sdk/versions.yml
+++ b/generators/java/sdk/versions.yml
@@ -1,4 +1,13 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 4.0.7
+  changelogEntry:
+    - summary: |
+        Thread endpoint ID through dynamic snippet generator to differentiate
+        generated snippets by endpoint.
+      type: fix
+  createdAt: "2026-03-25"
+  irVersion: 65
+
 - version: 4.0.6
   changelogEntry:
     - summary: |

--- a/generators/php/dynamic-snippets/src/DynamicSnippetsGenerator.ts
+++ b/generators/php/dynamic-snippets/src/DynamicSnippetsGenerator.ts
@@ -23,9 +23,10 @@ export class DynamicSnippetsGenerator extends AbstractDynamicSnippetsGenerator<
     }
 
     public async generate(
-        request: FernIr.dynamic.EndpointSnippetRequest
+        request: FernIr.dynamic.EndpointSnippetRequest,
+        options: Options = {}
     ): Promise<FernIr.dynamic.EndpointSnippetResponse> {
-        return super.generate(request);
+        return super.generate(request, options);
     }
 
     public generateSync(request: FernIr.dynamic.EndpointSnippetRequest): FernIr.dynamic.EndpointSnippetResponse {

--- a/generators/php/sdk/versions.yml
+++ b/generators/php/sdk/versions.yml
@@ -1,4 +1,13 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 2.2.4
+  changelogEntry:
+    - summary: |
+        Thread endpoint ID through dynamic snippet generator to differentiate
+        generated snippets by endpoint.
+      type: fix
+  createdAt: "2026-03-25"
+  irVersion: 62
+
 - version: 2.2.3
   changelogEntry:
     - summary: |

--- a/generators/python/sdk/versions.yml
+++ b/generators/python/sdk/versions.yml
@@ -1,5 +1,14 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 # For unreleased changes, use unreleased.yml
+- version: 5.0.7
+  changelogEntry:
+    - summary: |
+        Thread endpoint ID through dynamic snippet generator to differentiate
+        generated snippets by endpoint.
+      type: fix
+  createdAt: "2026-03-25"
+  irVersion: 65
+
 - version: 5.0.6
   changelogEntry:
     - summary: |

--- a/generators/ruby-v2/dynamic-snippets/src/DynamicSnippetsGenerator.ts
+++ b/generators/ruby-v2/dynamic-snippets/src/DynamicSnippetsGenerator.ts
@@ -2,7 +2,8 @@ import {
     AbstractAstNode,
     AbstractDynamicSnippetsGenerator,
     AbstractFormatter,
-    FernGeneratorExec
+    FernGeneratorExec,
+    Options
 } from "@fern-api/browser-compatible-base-generator";
 import { FernIr } from "@fern-api/dynamic-ir-sdk";
 import { DynamicSnippetsGeneratorContext } from "./context/DynamicSnippetsGeneratorContext.js";
@@ -28,9 +29,10 @@ export class DynamicSnippetsGenerator extends AbstractDynamicSnippetsGenerator<
     }
 
     public async generate(
-        request: FernIr.dynamic.EndpointSnippetRequest
+        request: FernIr.dynamic.EndpointSnippetRequest,
+        options: Options = {}
     ): Promise<FernIr.dynamic.EndpointSnippetResponse> {
-        return super.generate(request);
+        return super.generate(request, options);
     }
 
     public generateSync(request: FernIr.dynamic.EndpointSnippetRequest): FernIr.dynamic.EndpointSnippetResponse {

--- a/generators/ruby-v2/sdk/versions.yml
+++ b/generators/ruby-v2/sdk/versions.yml
@@ -1,5 +1,14 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 
+- version: 1.1.3
+  changelogEntry:
+    - summary: |
+        Thread endpoint ID through dynamic snippet generator to differentiate
+        generated snippets by endpoint.
+      type: fix
+  createdAt: "2026-03-25"
+  irVersion: 61
+
 - version: 1.1.2
   changelogEntry:
     - summary: |

--- a/generators/rust/sdk/versions.yml
+++ b/generators/rust/sdk/versions.yml
@@ -1,5 +1,14 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 
+- version: 0.26.7
+  changelogEntry:
+    - summary: |
+        Thread endpoint ID through dynamic snippet generator to differentiate
+        generated snippets by endpoint.
+      type: fix
+  createdAt: "2026-03-25"
+  irVersion: 65
+
 - version: 0.26.6
   changelogEntry:
     - summary: |

--- a/generators/swift/sdk/versions.yml
+++ b/generators/swift/sdk/versions.yml
@@ -1,5 +1,14 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 
+- version: 0.28.3
+  changelogEntry:
+    - summary: |
+        Thread endpoint ID through dynamic snippet generator to differentiate
+        generated snippets by endpoint.
+      type: fix
+  createdAt: "2026-03-25"
+  irVersion: 61
+
 - version: 0.28.2
   changelogEntry:
     - summary: |

--- a/generators/typescript-v2/dynamic-snippets/src/DynamicSnippetsGenerator.ts
+++ b/generators/typescript-v2/dynamic-snippets/src/DynamicSnippetsGenerator.ts
@@ -1,7 +1,8 @@
 import {
     AbstractAstNode,
     AbstractDynamicSnippetsGenerator,
-    FernGeneratorExec
+    FernGeneratorExec,
+    Options
 } from "@fern-api/browser-compatible-base-generator";
 import { FernIr } from "@fern-api/dynamic-ir-sdk";
 import { DynamicSnippetsGeneratorContext } from "./context/DynamicSnippetsGeneratorContext.js";
@@ -22,9 +23,10 @@ export class DynamicSnippetsGenerator extends AbstractDynamicSnippetsGenerator<
     }
 
     public async generate(
-        request: FernIr.dynamic.EndpointSnippetRequest
+        request: FernIr.dynamic.EndpointSnippetRequest,
+        options: Options = {}
     ): Promise<FernIr.dynamic.EndpointSnippetResponse> {
-        return super.generate(request);
+        return super.generate(request, options);
     }
 
     public generateSync(request: FernIr.dynamic.EndpointSnippetRequest): FernIr.dynamic.EndpointSnippetResponse {

--- a/generators/typescript/sdk/versions.yml
+++ b/generators/typescript/sdk/versions.yml
@@ -1,4 +1,13 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 3.59.6
+  changelogEntry:
+    - summary: |
+        Thread endpoint ID through dynamic snippet generator to differentiate
+        generated snippets by endpoint.
+      type: fix
+  createdAt: "2026-03-25"
+  irVersion: 65
+
 - version: 3.59.5
   changelogEntry:
     - summary: |

--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -1,4 +1,13 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 4.43.4
+  changelogEntry:
+    - summary: |
+        Thread endpoint ID through dynamic snippet generators to differentiate
+        generated snippets by endpoint.
+      type: fix
+  createdAt: "2026-03-25"
+  irVersion: 65
+
 - version: 4.43.3
   changelogEntry:
     - summary: |

--- a/packages/cli/generation/local-generation/local-workspace-runner/src/dynamic-snippets/DynamicSnippetsTestGenerator.ts
+++ b/packages/cli/generation/local-generation/local-workspace-runner/src/dynamic-snippets/DynamicSnippetsTestGenerator.ts
@@ -5,7 +5,7 @@ import { TaskContext } from "@fern-api/task-context";
 import { FernGeneratorExec } from "@fern-fern/generator-exec-sdk";
 
 import { DynamicSnippetsCsharpTestGenerator } from "./csharp/DynamicSnippetsCsharpTestGenerator.js";
-import { DynamicSnippetsTestSuite } from "./DynamicSnippetsTestSuite.js";
+import { DynamicSnippetsTestRequest, DynamicSnippetsTestSuite } from "./DynamicSnippetsTestSuite.js";
 import { DynamicSnippetsGoTestGenerator } from "./go/DynamicSnippetsGoTestGenerator.js";
 import { DynamicSnippetsJavaTestGenerator } from "./java/DynamicSnippetsJavaTestGenerator.js";
 import { DynamicSnippetsPhpTestGenerator } from "./php/DynamicSnippetsPhpTestGenerator.js";
@@ -21,10 +21,7 @@ interface DynamicSnippetsGenerator {
         ir: dynamic.DynamicIntermediateRepresentation,
         config: FernGeneratorExec.GeneratorConfig
     ): {
-        generateTests(params: {
-            outputDir: AbsoluteFilePath;
-            requests: dynamic.EndpointSnippetRequest[];
-        }): Promise<void>;
+        generateTests(params: { outputDir: AbsoluteFilePath; requests: DynamicSnippetsTestRequest[] }): Promise<void>;
     };
 }
 

--- a/packages/cli/generation/local-generation/local-workspace-runner/src/dynamic-snippets/DynamicSnippetsTestSuite.ts
+++ b/packages/cli/generation/local-generation/local-workspace-runner/src/dynamic-snippets/DynamicSnippetsTestSuite.ts
@@ -2,8 +2,13 @@ import { dynamic as DynamicSnippets } from "@fern-api/ir-sdk";
 
 import { FernGeneratorExec } from "@fern-fern/generator-exec-sdk";
 
+export interface DynamicSnippetsTestRequest {
+    endpointId: string;
+    request: DynamicSnippets.EndpointSnippetRequest;
+}
+
 export interface DynamicSnippetsTestSuite {
     ir: DynamicSnippets.DynamicIntermediateRepresentation;
     config: FernGeneratorExec.GeneratorConfig;
-    requests: DynamicSnippets.EndpointSnippetRequest[];
+    requests: DynamicSnippetsTestRequest[];
 }

--- a/packages/cli/generation/local-generation/local-workspace-runner/src/dynamic-snippets/csharp/DynamicSnippetsCsharpTestGenerator.ts
+++ b/packages/cli/generation/local-generation/local-workspace-runner/src/dynamic-snippets/csharp/DynamicSnippetsCsharpTestGenerator.ts
@@ -7,6 +7,7 @@ import { FernGeneratorExec } from "@fern-fern/generator-exec-sdk";
 import { mkdir, writeFile } from "fs/promises";
 import path from "path";
 
+import { DynamicSnippetsTestRequest } from "../DynamicSnippetsTestSuite.js";
 import { convertDynamicEndpointSnippetRequest } from "../utils/convertEndpointSnippetRequest.js";
 import { convertIr } from "../utils/convertIr.js";
 
@@ -56,14 +57,14 @@ export class DynamicSnippetsCsharpTestGenerator {
         requests
     }: {
         outputDir: AbsoluteFilePath;
-        requests: dynamic.EndpointSnippetRequest[];
+        requests: DynamicSnippetsTestRequest[];
     }): Promise<void> {
         this.context.logger.debug("Generating dynamic snippet tests...");
 
         // generate the names for everything up front.
-        this.dynamicSnippetsGenerator.context.precalculate(requests);
+        this.dynamicSnippetsGenerator.context.precalculate(requests.map((r) => r.request));
         const absolutePathToOutputDir = await this.initializeProject(outputDir);
-        for (const [idx, request] of requests.entries()) {
+        for (const [idx, { endpointId, request }] of requests.entries()) {
             try {
                 const convertedRequest = convertDynamicEndpointSnippetRequest(request);
                 if (convertedRequest == null) {
@@ -73,7 +74,8 @@ export class DynamicSnippetsCsharpTestGenerator {
                     config: {
                         fullStyleClassName: `Example${idx}`
                     } as Config,
-                    style: Style.Full
+                    style: Style.Full,
+                    endpointId
                 });
                 const dynamicSnippetFilePath = this.getTestFilePath({ absolutePathToOutputDir, idx });
                 await mkdir(path.dirname(dynamicSnippetFilePath), { recursive: true });

--- a/packages/cli/generation/local-generation/local-workspace-runner/src/dynamic-snippets/generateDynamicSnippetsTestSuite.ts
+++ b/packages/cli/generation/local-generation/local-workspace-runner/src/dynamic-snippets/generateDynamicSnippetsTestSuite.ts
@@ -17,10 +17,13 @@ export async function generateDynamicSnippetsTestSuite({
     return {
         ir: ir.dynamic,
         config,
-        requests: Object.values(ir.dynamic.endpoints).flatMap((endpoint) =>
+        requests: Object.entries(ir.dynamic.endpoints).flatMap(([endpointId, endpoint]) =>
             (endpoint.examples ?? []).map((example) => ({
-                ...example,
-                baseUrl: "https://api.fern.com"
+                endpointId,
+                request: {
+                    ...example,
+                    baseUrl: "https://api.fern.com"
+                }
             }))
         )
     };

--- a/packages/cli/generation/local-generation/local-workspace-runner/src/dynamic-snippets/go/DynamicSnippetsGoTestGenerator.ts
+++ b/packages/cli/generation/local-generation/local-workspace-runner/src/dynamic-snippets/go/DynamicSnippetsGoTestGenerator.ts
@@ -6,6 +6,7 @@ import { FernGeneratorExec } from "@fern-fern/generator-exec-sdk";
 import { mkdir, writeFile } from "fs/promises";
 import path from "path";
 
+import { DynamicSnippetsTestRequest } from "../DynamicSnippetsTestSuite.js";
 import { convertDynamicEndpointSnippetRequest } from "../utils/convertEndpointSnippetRequest.js";
 import { convertIr } from "../utils/convertIr.js";
 
@@ -41,16 +42,18 @@ export class DynamicSnippetsGoTestGenerator {
         requests
     }: {
         outputDir: AbsoluteFilePath;
-        requests: dynamic.EndpointSnippetRequest[];
+        requests: DynamicSnippetsTestRequest[];
     }): Promise<void> {
         this.context.logger.debug("Generating dynamic snippet tests...");
-        for (const [idx, request] of requests.entries()) {
+        for (const [idx, { endpointId, request }] of requests.entries()) {
             try {
                 const convertedRequest = convertDynamicEndpointSnippetRequest(request);
                 if (convertedRequest == null) {
                     continue;
                 }
-                const response = await this.dynamicSnippetsGenerator.generate(convertedRequest);
+                const response = await this.dynamicSnippetsGenerator.generate(convertedRequest, {
+                    endpointId
+                });
                 const dynamicSnippetFilePath = this.getTestFilePath({ outputDir, idx });
                 await mkdir(path.dirname(dynamicSnippetFilePath), { recursive: true });
                 await writeFile(dynamicSnippetFilePath, response.snippet);

--- a/packages/cli/generation/local-generation/local-workspace-runner/src/dynamic-snippets/java/DynamicSnippetsJavaTestGenerator.ts
+++ b/packages/cli/generation/local-generation/local-workspace-runner/src/dynamic-snippets/java/DynamicSnippetsJavaTestGenerator.ts
@@ -8,6 +8,7 @@ import { FernGeneratorExec } from "@fern-fern/generator-exec-sdk";
 import { cp, mkdir, writeFile } from "fs/promises";
 import path from "path";
 
+import { DynamicSnippetsTestRequest } from "../DynamicSnippetsTestSuite.js";
 import { convertDynamicEndpointSnippetRequest } from "../utils/convertEndpointSnippetRequest.js";
 import { convertIr } from "../utils/convertIr.js";
 
@@ -43,11 +44,11 @@ export class DynamicSnippetsJavaTestGenerator {
         requests
     }: {
         outputDir: AbsoluteFilePath;
-        requests: dynamic.EndpointSnippetRequest[];
+        requests: DynamicSnippetsTestRequest[];
     }): Promise<void> {
         this.context.logger.debug("Generating dynamic snippet tests...");
         const absolutePathToOutputDir = await this.initializeProject(outputDir);
-        for (const [idx, request] of requests.entries()) {
+        for (const [idx, { endpointId, request }] of requests.entries()) {
             try {
                 const convertedRequest = convertDynamicEndpointSnippetRequest(request);
                 if (convertedRequest == null) {
@@ -58,7 +59,8 @@ export class DynamicSnippetsJavaTestGenerator {
                         fullStyleClassName: `Example${idx}`,
                         fullStylePackageName: "com.snippets"
                     } as Config,
-                    style: Style.Full
+                    style: Style.Full,
+                    endpointId
                 });
                 const dynamicSnippetFilePath = this.getTestFilePath({ absolutePathToOutputDir, idx });
                 await mkdir(path.dirname(dynamicSnippetFilePath), { recursive: true });

--- a/packages/cli/generation/local-generation/local-workspace-runner/src/dynamic-snippets/php/DynamicSnippetsPhpTestGenerator.ts
+++ b/packages/cli/generation/local-generation/local-workspace-runner/src/dynamic-snippets/php/DynamicSnippetsPhpTestGenerator.ts
@@ -6,6 +6,7 @@ import { FernGeneratorExec } from "@fern-fern/generator-exec-sdk";
 import { mkdir, writeFile } from "fs/promises";
 import path from "path";
 
+import { DynamicSnippetsTestRequest } from "../DynamicSnippetsTestSuite.js";
 import { convertDynamicEndpointSnippetRequest } from "../utils/convertEndpointSnippetRequest.js";
 import { convertIr } from "../utils/convertIr.js";
 
@@ -41,16 +42,18 @@ export class DynamicSnippetsPhpTestGenerator {
         requests
     }: {
         outputDir: AbsoluteFilePath;
-        requests: dynamic.EndpointSnippetRequest[];
+        requests: DynamicSnippetsTestRequest[];
     }): Promise<void> {
         this.context.logger.debug("Generating dynamic snippet tests...");
-        for (const [idx, request] of requests.entries()) {
+        for (const [idx, { endpointId, request }] of requests.entries()) {
             try {
                 const convertedRequest = convertDynamicEndpointSnippetRequest(request);
                 if (convertedRequest == null) {
                     continue;
                 }
-                const response = await this.dynamicSnippetsGenerator.generate(convertedRequest);
+                const response = await this.dynamicSnippetsGenerator.generate(convertedRequest, {
+                    endpointId
+                });
                 const dynamicSnippetFilePath = this.getTestFilePath({ outputDir, idx });
                 await mkdir(path.dirname(dynamicSnippetFilePath), { recursive: true });
                 await writeFile(dynamicSnippetFilePath, response.snippet);

--- a/packages/cli/generation/local-generation/local-workspace-runner/src/dynamic-snippets/python/DynamicSnippetsPythonTestGenerator.ts
+++ b/packages/cli/generation/local-generation/local-workspace-runner/src/dynamic-snippets/python/DynamicSnippetsPythonTestGenerator.ts
@@ -6,6 +6,7 @@ import { FernGeneratorExec } from "@fern-fern/generator-exec-sdk";
 import { mkdir, writeFile } from "fs/promises";
 import path from "path";
 
+import { DynamicSnippetsTestRequest } from "../DynamicSnippetsTestSuite.js";
 import { convertDynamicEndpointSnippetRequest } from "../utils/convertEndpointSnippetRequest.js";
 import { convertIr } from "../utils/convertIr.js";
 
@@ -41,16 +42,18 @@ export class DynamicSnippetsPythonTestGenerator {
         requests
     }: {
         outputDir: AbsoluteFilePath;
-        requests: dynamic.EndpointSnippetRequest[];
+        requests: DynamicSnippetsTestRequest[];
     }): Promise<void> {
         this.context.logger.debug("Generating dynamic snippet tests...");
-        for (const [idx, request] of requests.entries()) {
+        for (const [idx, { endpointId, request }] of requests.entries()) {
             try {
                 const convertedRequest = convertDynamicEndpointSnippetRequest(request);
                 if (convertedRequest == null) {
                     continue;
                 }
-                const response = await this.dynamicSnippetsGenerator.generate(convertedRequest);
+                const response = await this.dynamicSnippetsGenerator.generate(convertedRequest, {
+                    endpointId
+                });
                 const dynamicSnippetFilePath = this.getTestFilePath({ outputDir, idx });
                 await mkdir(path.dirname(dynamicSnippetFilePath), { recursive: true });
                 await writeFile(dynamicSnippetFilePath, response.snippet);

--- a/packages/cli/generation/local-generation/local-workspace-runner/src/dynamic-snippets/ruby/DynamicSnippetsRubyTestGenerator.ts
+++ b/packages/cli/generation/local-generation/local-workspace-runner/src/dynamic-snippets/ruby/DynamicSnippetsRubyTestGenerator.ts
@@ -6,6 +6,7 @@ import { FernGeneratorExec } from "@fern-fern/generator-exec-sdk";
 import { mkdir, writeFile } from "fs/promises";
 import path from "path";
 
+import { DynamicSnippetsTestRequest } from "../DynamicSnippetsTestSuite.js";
 import { convertDynamicEndpointSnippetRequest } from "../utils/convertEndpointSnippetRequest.js";
 import { convertIr } from "../utils/convertIr.js";
 
@@ -41,16 +42,18 @@ export class DynamicSnippetsRubyTestGenerator {
         requests
     }: {
         outputDir: AbsoluteFilePath;
-        requests: dynamic.EndpointSnippetRequest[];
+        requests: DynamicSnippetsTestRequest[];
     }): Promise<void> {
         this.context.logger.debug("Generating dynamic snippet tests...");
-        for (const [idx, request] of requests.entries()) {
+        for (const [idx, { endpointId, request }] of requests.entries()) {
             try {
                 const convertedRequest = convertDynamicEndpointSnippetRequest(request);
                 if (convertedRequest == null) {
                     continue;
                 }
-                const response = await this.dynamicSnippetsGenerator.generate(convertedRequest);
+                const response = await this.dynamicSnippetsGenerator.generate(convertedRequest, {
+                    endpointId
+                });
                 const dynamicSnippetFilePath = this.getTestFilePath({ outputDir, idx });
                 await mkdir(path.dirname(dynamicSnippetFilePath), { recursive: true });
                 await writeFile(dynamicSnippetFilePath, response.snippet);

--- a/packages/cli/generation/local-generation/local-workspace-runner/src/dynamic-snippets/rust/DynamicSnippetsRustTestGenerator.ts
+++ b/packages/cli/generation/local-generation/local-workspace-runner/src/dynamic-snippets/rust/DynamicSnippetsRustTestGenerator.ts
@@ -7,6 +7,7 @@ import { DynamicSnippetsGenerator } from "@fern-api/rust-dynamic-snippets";
 import { TaskContext } from "@fern-api/task-context";
 import { FernGeneratorExec } from "@fern-fern/generator-exec-sdk";
 
+import { DynamicSnippetsTestRequest } from "../DynamicSnippetsTestSuite.js";
 import { convertDynamicEndpointSnippetRequest } from "../utils/convertEndpointSnippetRequest.js";
 import { convertIr } from "../utils/convertIr.js";
 
@@ -42,11 +43,11 @@ export class DynamicSnippetsRustTestGenerator {
         requests
     }: {
         outputDir: AbsoluteFilePath;
-        requests: dynamic.EndpointSnippetRequest[];
+        requests: DynamicSnippetsTestRequest[];
     }): Promise<void> {
         this.context.logger.debug("Generating dynamic snippet tests...");
         const absolutePathToOutputDir = await this.initializeProject(outputDir);
-        for (const [idx, request] of requests.entries()) {
+        for (const [idx, { endpointId, request }] of requests.entries()) {
             try {
                 const convertedRequest = convertDynamicEndpointSnippetRequest(request);
                 if (convertedRequest == null) {
@@ -54,7 +55,8 @@ export class DynamicSnippetsRustTestGenerator {
                 }
                 const response = await this.dynamicSnippetsGenerator.generate(convertedRequest, {
                     config: {},
-                    style: Style.Full
+                    style: Style.Full,
+                    endpointId
                 });
                 const dynamicSnippetFilePath = this.getTestFilePath({
                     absolutePathToOutputDir,

--- a/packages/cli/generation/local-generation/local-workspace-runner/src/dynamic-snippets/swift/DynamicSnippetsSwiftTestGenerator.ts
+++ b/packages/cli/generation/local-generation/local-workspace-runner/src/dynamic-snippets/swift/DynamicSnippetsSwiftTestGenerator.ts
@@ -7,6 +7,7 @@ import { DynamicSnippetsGenerator } from "@fern-api/swift-dynamic-snippets";
 import { TaskContext } from "@fern-api/task-context";
 import { FernGeneratorExec } from "@fern-fern/generator-exec-sdk";
 
+import { DynamicSnippetsTestRequest } from "../DynamicSnippetsTestSuite.js";
 import { convertDynamicEndpointSnippetRequest } from "../utils/convertEndpointSnippetRequest.js";
 import { convertIr } from "../utils/convertIr.js";
 
@@ -42,11 +43,11 @@ export class DynamicSnippetsSwiftTestGenerator {
         requests
     }: {
         outputDir: AbsoluteFilePath;
-        requests: dynamic.EndpointSnippetRequest[];
+        requests: DynamicSnippetsTestRequest[];
     }): Promise<void> {
         this.context.logger.debug("Generating dynamic snippet tests...");
         const absolutePathToOutputDir = await this.initializeProject(outputDir);
-        for (const [idx, request] of requests.entries()) {
+        for (const [idx, { endpointId, request }] of requests.entries()) {
             try {
                 const convertedRequest = convertDynamicEndpointSnippetRequest(request);
                 if (convertedRequest == null) {
@@ -54,7 +55,8 @@ export class DynamicSnippetsSwiftTestGenerator {
                 }
                 const response = await this.dynamicSnippetsGenerator.generate(convertedRequest, {
                     config: {},
-                    style: Style.Full
+                    style: Style.Full,
+                    endpointId
                 });
                 const dynamicSnippetFilePath = this.getTestFilePath({
                     absolutePathToOutputDir,

--- a/packages/cli/generation/local-generation/local-workspace-runner/src/dynamic-snippets/typescript/DynamicSnippetsTypeScriptTestGenerator.ts
+++ b/packages/cli/generation/local-generation/local-workspace-runner/src/dynamic-snippets/typescript/DynamicSnippetsTypeScriptTestGenerator.ts
@@ -6,6 +6,7 @@ import { FernGeneratorExec } from "@fern-fern/generator-exec-sdk";
 import { mkdir, writeFile } from "fs/promises";
 import path from "path";
 
+import { DynamicSnippetsTestRequest } from "../DynamicSnippetsTestSuite.js";
 import { convertDynamicEndpointSnippetRequest } from "../utils/convertEndpointSnippetRequest.js";
 import { convertIr } from "../utils/convertIr.js";
 
@@ -41,16 +42,18 @@ export class DynamicSnippetsTypeScriptTestGenerator {
         requests
     }: {
         outputDir: AbsoluteFilePath;
-        requests: dynamic.EndpointSnippetRequest[];
+        requests: DynamicSnippetsTestRequest[];
     }): Promise<void> {
         this.context.logger.debug("Generating dynamic snippet tests...");
-        for (const [idx, request] of requests.entries()) {
+        for (const [idx, { endpointId, request }] of requests.entries()) {
             try {
                 const convertedRequest = convertDynamicEndpointSnippetRequest(request);
                 if (convertedRequest == null) {
                     continue;
                 }
-                const response = await this.dynamicSnippetsGenerator.generate(convertedRequest);
+                const response = await this.dynamicSnippetsGenerator.generate(convertedRequest, {
+                    endpointId
+                });
                 const dynamicSnippetFilePath = this.getTestFilePath({ outputDir, idx });
                 await mkdir(path.dirname(dynamicSnippetFilePath), { recursive: true });
                 await writeFile(dynamicSnippetFilePath, response.snippet);


### PR DESCRIPTION
## Description
Finishes up the work done in https://github.com/fern-api/fern/pull/11941 to thread `endpointId` through every language's dynamic snippet generator. When an endpoint doesn't have `endpointId` in each dynamic snippet generator, the endpoint is matched via method+path, which is not necessarily deterministic and will lead to problems for certain APIs (Deepgram, i.e., which has a `transcribeUrl` and `transcribeFile` on the same endpoint).

## Changes Made
Every language's dynamic snippet generator.

## Testing
Seed, and Deepgram.
- [X] Unit tests added/updated
- [X] Manual testing completed
