### PR TITLE
feat(cli): scope docs preview list to caller's organizations

### DIFF
--- a/packages/cli/cli/src/commands/docs-preview/listDocsPreview.ts
+++ b/packages/cli/cli/src/commands/docs-preview/listDocsPreview.ts
@@ -54,17 +54,11 @@ export async function listDocsPreview({
             }
         }
 
-        // Preview URLs match the pattern: {org}-preview-{hash}.docs.buildwithfern.com
-        // The hash can be alphanumeric or a UUID with hyphens (e.g., 9b2b47f0-c44b-4338-b579-46872f33404a)
-        const previewUrlPattern = /-preview-[a-f0-9-]+\.docs\.buildwithfern\.com$/;
-
-        const previewDeployments: PreviewDeployment[] = listResponse.body.urls
-            .filter((item) => previewUrlPattern.test(item.domain))
-            .map((item) => ({
-                url: item.basePath != null ? `${item.domain}${item.basePath}` : item.domain,
-                organizationId: item.organizationId,
-                updatedAt: item.updatedAt
-            }));
+        const previewDeployments: PreviewDeployment[] = listResponse.body.urls.map((item) => ({
+            url: item.basePath != null ? `${item.domain}${item.basePath}` : item.domain,
+            organizationId: item.organizationId,
+            updatedAt: item.updatedAt
+        }));
 
         if (previewDeployments.length === 0) {
             context.logger.info("No preview deployments found.");

--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -1,4 +1,14 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 4.44.0
+  changelogEntry:
+    - summary: |
+        The `fern docs preview list` command now works for all authenticated
+        users, not just Fern employees. Results are scoped to the caller's
+        organization(s) so each user only sees their own preview deployments.
+      type: feat
+  createdAt: "2026-03-24"
+  irVersion: 65
+
 - version: 4.43.2
   changelogEntry:
     - summary: |


### PR DESCRIPTION
## Description

Refs companion PR: https://github.com/fern-api/fern-platform/pull/8932

Removes the client-side preview URL regex filter from `fern docs preview list`. The backend (FDR) companion PR scopes the `listAllDocsUrls` endpoint to the caller's organizations, so client-side filtering is no longer needed.

Previously, `fern docs preview list` only worked for Fern employees because the FDR endpoint required membership in the `"fern"` org. With the backend change, any authenticated user can list their own org's preview deployments.

## Changes Made
- Removed the `-preview-` regex pattern filter in `listDocsPreview.ts` — the API now returns only the caller's org-scoped results with `preview: true`
- Added `4.44.0` changelog entry

## Testing
- [ ] Unit tests added/updated
- [x] Lint passes (`biome check`)

## Human Review Checklist
- **Deployment ordering**: The FDR backend PR (#8932 in fern-platform) must be deployed before this CLI version is published, otherwise non-Fern users will still hit the old `orgId: "fern"` auth check
- **Client-side filter removal**: The removed regex was redundant — the DB query already filters by `isPreview: preview`. Confirm this is acceptable

Link to Devin session: https://app.devin.ai/sessions/ff9695570aa1454183e98156852383b6
Requested by: @fern-support