### PR TITLE
fix(java): use client-class-name for exception type in README

### DIFF
--- a/generators/java-v2/sdk/src/SdkGeneratorContext.ts
+++ b/generators/java-v2/sdk/src/SdkGeneratorContext.ts
@@ -239,7 +239,10 @@ export class SdkGeneratorContext extends AbstractJavaGeneratorContext<SdkCustomC
     }
 
     public getApiExceptionClassName(): string {
-        return this.customConfig?.["base-api-exception-class-name"] ?? `${this.getBaseNamePrefix()}ApiException`;
+        return (
+            this.customConfig?.["base-api-exception-class-name"] ??
+            `${this.customConfig?.["client-class-name"] ?? this.getBaseNamePrefix()}ApiException`
+        );
     }
 
     public getHttpResponseClassName(): string {

--- a/generators/java/sdk/versions.yml
+++ b/generators/java/sdk/versions.yml
@@ -1,4 +1,15 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 4.0.5
+  changelogEntry:
+    - summary: |
+        Fix generated README exception handling snippet using `{org}ApiException`
+        instead of `{clientClassName}ApiException` when `client-class-name` is
+        specified in the Java custom config. The README now uses the same exception
+        type name that is actually generated in the SDK.
+      type: fix
+  createdAt: "2026-03-25"
+  irVersion: 65
+
 - version: 4.0.4
   changelogEntry:
     - summary: |

--- a/seed/java-sdk/exhaustive/custom-client-class-name/README.md
+++ b/seed/java-sdk/exhaustive/custom-client-class-name/README.md
@@ -90,11 +90,11 @@ Best client = Best
 When the API returns a non-success status code (4xx or 5xx response), an API exception will be thrown.
 
 ```java
-import com.seed.exhaustive.core.SeedExhaustiveApiException;
+import com.seed.exhaustive.core.BestApiException;
 
 try{
     client.endpoints().container().getAndReturnListOfPrimitives(...);
-} catch (SeedExhaustiveApiException e){
+} catch (BestApiException e){
     // Do something with the API exception...
 }
 ```


### PR DESCRIPTION
## Description

When `client-class-name` is specified in the Java generator custom config, the v1 generator creates an exception class named `{clientClassName}ApiException`. However, the v2 README generator was ignoring `client-class-name` and always using `{org}ApiException` (via `getBaseNamePrefix()`), causing the README's exception handling snippet to reference a class that doesn't exist in the SDK.

## Changes Made

- Updated `getApiExceptionClassName()` in `SdkGeneratorContext.ts` to check `client-class-name` before falling back to `getBaseNamePrefix()`, matching v1's logic in `ClientPoetClassNameFactory.getApiErrorClassName()`
- Added changelog entry (version 4.0.5)

**Priority chain is now:**
1. `base-api-exception-class-name` (explicit override) — unchanged
2. `client-class-name` + `"ApiException"` — **new**
3. `getBaseNamePrefix()` + `"ApiException"` (org-based default) — unchanged

## Human Review Checklist

- [ ] Verify the fallback priority matches v1's `ClientPoetClassNameFactory.getApiErrorClassName()` at `generators/java/sdk/src/main/java/com/fern/java/client/ClientPoetClassNameFactory.java:160-167`
- [ ] Consider whether similar `client-class-name` awareness is missing in other v2 naming methods (e.g., `getBaseExceptionClassName` equivalent if one exists)

## Testing

- [ ] Unit tests added/updated
- [x] Verified pre-existing compile errors are unrelated to this change
- [ ] Manual testing completed

Link to Devin session: https://app.devin.ai/sessions/3cb0ef910a644cf7b635abc52e59943b
Requested by: @jsklan
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/14045" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
