### PR TITLE
chore(ci): allow update-test workflow to be triggered via PR comment

### DIFF
--- a/.github/workflows/update-test.yml
+++ b/.github/workflows/update-test.yml
@@ -2,10 +2,16 @@ name: Update Test
 
 on:
   workflow_dispatch:
+  issue_comment:
+    types: [created]
+
+permissions:
+  contents: write
+  pull-requests: read
 
 # Cancel previous workflows on previous push
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.issue.number || github.ref }}
   cancel-in-progress: true
 
 env:
@@ -18,13 +24,31 @@ env:
 
 jobs:
   update-test:
-    if: github.repository == 'fern-api/fern' && github.ref != 'refs/heads/main'
+    if: |
+      github.repository == 'fern-api/fern' && (
+        (github.event_name == 'workflow_dispatch' && github.ref != 'refs/heads/main') ||
+        (github.event_name == 'issue_comment' && github.event.issue.pull_request && startsWith(github.event.comment.body, '/update-test'))
+      )
     runs-on: Test
     timeout-minutes: 90
     steps:
+      - name: Get PR head ref
+        id: pr-ref
+        if: github.event_name == 'issue_comment'
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const { data: pr } = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.issue.number
+            });
+            core.setOutput('ref', pr.head.ref);
+
       - name: Checkout repo
         uses: actions/checkout@v6
         with:
+          ref: ${{ steps.pr-ref.outputs.ref || github.ref }}
           lfs: true
 
       - name: Install

--- a/.github/workflows/update-test.yml
+++ b/.github/workflows/update-test.yml
@@ -32,6 +32,17 @@ jobs:
     runs-on: Test
     timeout-minutes: 90
     steps:
+      - name: Check commenter permissions
+        if: github.event_name == 'issue_comment'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          PERMISSION=$(gh api "repos/${{ github.repository }}/collaborators/${{ github.actor }}/permission" --jq '.permission')
+          if [[ "$PERMISSION" != "admin" && "$PERMISSION" != "write" ]]; then
+            echo "::error::User ${{ github.actor }} does not have write access (has '$PERMISSION'). Only collaborators with write access can trigger /update-test."
+            exit 1
+          fi
+
       - name: Get PR head ref
         id: pr-ref
         if: github.event_name == 'issue_comment'

--- a/.github/workflows/update-test.yml
+++ b/.github/workflows/update-test.yml
@@ -27,7 +27,7 @@ jobs:
     if: |
       github.repository == 'fern-api/fern' && (
         (github.event_name == 'workflow_dispatch' && github.ref != 'refs/heads/main') ||
-        (github.event_name == 'issue_comment' && github.event.issue.pull_request && startsWith(github.event.comment.body, '(aside) /update-test'))
+        (github.event_name == 'issue_comment' && github.event.issue.pull_request && (startsWith(github.event.comment.body, '/update-test') || startsWith(github.event.comment.body, '(aside) /update-test')))
       )
     runs-on: Test
     timeout-minutes: 90

--- a/.github/workflows/update-test.yml
+++ b/.github/workflows/update-test.yml
@@ -27,7 +27,7 @@ jobs:
     if: |
       github.repository == 'fern-api/fern' && (
         (github.event_name == 'workflow_dispatch' && github.ref != 'refs/heads/main') ||
-        (github.event_name == 'issue_comment' && github.event.issue.pull_request && startsWith(github.event.comment.body, '/update-test'))
+        (github.event_name == 'issue_comment' && github.event.issue.pull_request && startsWith(github.event.comment.body, '(aside) /update-test'))
       )
     runs-on: Test
     timeout-minutes: 90


### PR DESCRIPTION
## Description

Adds the ability to trigger the `Update Test` workflow on a PR's branch by commenting on the PR, in addition to the existing `workflow_dispatch` trigger.

## Changes Made

- Added `issue_comment` trigger (on comment creation) to the workflow
- Added a "Check commenter permissions" step that verifies the commenter has `write` or `admin` access before proceeding (matches pattern from `infisical-testing.yml`)
- Added a "Get PR head ref" step that resolves the PR's head branch via the GitHub API when triggered by a comment
- Updated the checkout step to use the resolved PR branch ref (falls back to `github.ref` for `workflow_dispatch`)
- Updated the `if` condition to accept both `/update-test` and `(aside) /update-test` comment formats, and to verify the comment is on a PR
- Added explicit `permissions` block (`contents: write`, `pull-requests: read`)
- Updated concurrency group to use `github.event.issue.number` for comment-triggered runs

## Usage

Comment either of the following on any PR to run the full test update pipeline on that PR's branch:

- `/update-test`
- `(aside) /update-test` — use this format to prevent Devin from responding to the comment

Only collaborators with **write** or **admin** access can trigger the workflow. Snapshot changes will be committed and pushed back to the PR branch automatically.

## Testing

- [ ] Manual testing required — comment `/update-test` on a PR after merge to validate (the `issue_comment` trigger runs from the default branch's workflow file, so it only works after merge)

## Human Review Checklist

- **`issue_comment` runs on default branch**: GitHub Actions runs `issue_comment`-triggered workflows from the default branch's workflow file. This means the trigger will only work **after this PR is merged** and cannot be validated in CI on this PR.
- **Fallback expression**: When triggered via `workflow_dispatch`, the `pr-ref` step is skipped and `${{ steps.pr-ref.outputs.ref || github.ref }}` falls back to `github.ref`. Worth confirming this behaves as expected with skipped step outputs.
- **Permission check**: The commenter permission check uses `gh api` to verify `write`/`admin` access. This follows the same pattern as `infisical-testing.yml` but is worth verifying runs correctly on the self-hosted `Test` runner (i.e., that `gh` is available).

Link to Devin session: https://app.devin.ai/sessions/0ce39266714445ae89ef0a029ac3193e
Requested by: @jsklan
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/14046" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
