### PR TITLE
fix(typescript): prevent unhandled WebSocket error crash on close during CONNECTING state

### DIFF
--- a/generators/typescript/sdk/versions.yml
+++ b/generators/typescript/sdk/versions.yml
@@ -1,4 +1,16 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 3.59.5
+  changelogEntry:
+    - summary: |
+        Fix unhandled WebSocket error crash when closing a connection in the CONNECTING state.
+        The `_disconnect()` and `_handleAbort()` methods removed all event listeners before
+        calling `close()`, but `close()` on a CONNECTING-state WebSocket emits an error event
+        asynchronously via `abortHandshake()`. A no-op error listener is now attached after
+        removing listeners to prevent this from crashing the Node.js process.
+      type: fix
+  createdAt: "2026-03-25"
+  irVersion: 65
+
 - version: 3.59.4
   changelogEntry:
     - summary: |

--- a/generators/typescript/utils/core-utilities/src/core/websocket/ws.ts
+++ b/generators/typescript/utils/core-utilities/src/core/websocket/ws.ts
@@ -416,6 +416,8 @@ export class ReconnectingWebSocket {
         this._clearTimeouts();
         if (this._ws) {
             this._removeListeners();
+            // Absorb async errors emitted by ws when closing during CONNECTING state
+            this._ws.addEventListener("error", () => {});
             try {
                 this._ws.close(1000, "aborted");
                 this._handleClose(new Events.CloseEvent(1000, "aborted", this));
@@ -436,6 +438,8 @@ export class ReconnectingWebSocket {
             return;
         }
         this._removeListeners();
+        // Absorb async errors emitted by ws when closing during CONNECTING state
+        this._ws.addEventListener("error", () => {});
         try {
             this._ws.close(code, reason);
             this._handleClose(new Events.CloseEvent(code, reason, this));

--- a/seed/ts-sdk/websocket-bearer-auth/websockets/src/core/websocket/ws.ts
+++ b/seed/ts-sdk/websocket-bearer-auth/websockets/src/core/websocket/ws.ts
@@ -418,6 +418,8 @@ export class ReconnectingWebSocket {
         this._clearTimeouts();
         if (this._ws) {
             this._removeListeners();
+            // Absorb async errors emitted by ws when closing during CONNECTING state
+            this._ws.addEventListener("error", () => {});
             try {
                 this._ws.close(1000, "aborted");
                 this._handleClose(new Events.CloseEvent(1000, "aborted", this));
@@ -438,6 +440,8 @@ export class ReconnectingWebSocket {
             return;
         }
         this._removeListeners();
+        // Absorb async errors emitted by ws when closing during CONNECTING state
+        this._ws.addEventListener("error", () => {});
         try {
             this._ws.close(code, reason);
             this._handleClose(new Events.CloseEvent(code, reason, this));

--- a/seed/ts-sdk/websocket-inferred-auth/websockets/src/core/websocket/ws.ts
+++ b/seed/ts-sdk/websocket-inferred-auth/websockets/src/core/websocket/ws.ts
@@ -418,6 +418,8 @@ export class ReconnectingWebSocket {
         this._clearTimeouts();
         if (this._ws) {
             this._removeListeners();
+            // Absorb async errors emitted by ws when closing during CONNECTING state
+            this._ws.addEventListener("error", () => {});
             try {
                 this._ws.close(1000, "aborted");
                 this._handleClose(new Events.CloseEvent(1000, "aborted", this));
@@ -438,6 +440,8 @@ export class ReconnectingWebSocket {
             return;
         }
         this._removeListeners();
+        // Absorb async errors emitted by ws when closing during CONNECTING state
+        this._ws.addEventListener("error", () => {});
         try {
             this._ws.close(code, reason);
             this._handleClose(new Events.CloseEvent(code, reason, this));

--- a/seed/ts-sdk/websocket/no-serde/src/core/websocket/ws.ts
+++ b/seed/ts-sdk/websocket/no-serde/src/core/websocket/ws.ts
@@ -418,6 +418,8 @@ export class ReconnectingWebSocket {
         this._clearTimeouts();
         if (this._ws) {
             this._removeListeners();
+            // Absorb async errors emitted by ws when closing during CONNECTING state
+            this._ws.addEventListener("error", () => {});
             try {
                 this._ws.close(1000, "aborted");
                 this._handleClose(new Events.CloseEvent(1000, "aborted", this));
@@ -438,6 +440,8 @@ export class ReconnectingWebSocket {
             return;
         }
         this._removeListeners();
+        // Absorb async errors emitted by ws when closing during CONNECTING state
+        this._ws.addEventListener("error", () => {});
         try {
             this._ws.close(code, reason);
             this._handleClose(new Events.CloseEvent(code, reason, this));

--- a/seed/ts-sdk/websocket/serde/src/core/websocket/ws.ts
+++ b/seed/ts-sdk/websocket/serde/src/core/websocket/ws.ts
@@ -418,6 +418,8 @@ export class ReconnectingWebSocket {
         this._clearTimeouts();
         if (this._ws) {
             this._removeListeners();
+            // Absorb async errors emitted by ws when closing during CONNECTING state
+            this._ws.addEventListener("error", () => {});
             try {
                 this._ws.close(1000, "aborted");
                 this._handleClose(new Events.CloseEvent(1000, "aborted", this));
@@ -438,6 +440,8 @@ export class ReconnectingWebSocket {
             return;
         }
         this._removeListeners();
+        // Absorb async errors emitted by ws when closing during CONNECTING state
+        this._ws.addEventListener("error", () => {});
         try {
             this._ws.close(code, reason);
             this._handleClose(new Events.CloseEvent(code, reason, this));


### PR DESCRIPTION
## Description

Fix a process-crashing bug in the generated TypeScript SDK's `ReconnectingWebSocket`. When `_disconnect()` or `_handleAbort()` called `close()` on a WebSocket still in the CONNECTING state, the `ws` library's `abortHandshake()` emitted an error event **asynchronously**. Since `_removeListeners()` had already removed all listeners, Node.js threw an unhandled error event that crashed the entire process — killing all active connections on the server, not just the one that timed out.

Reported by Phonic (SDK v0.30.37), manually patched in [Phonic-Co/phonic-node#166](https://github.com/Phonic-Co/phonic-node/pull/166).

## Changes Made

- Added a no-op error listener (`this._ws.addEventListener("error", () => {})`) after `_removeListeners()` but before `close()` in both `_disconnect()` and `_handleAbort()` methods in `generators/typescript/utils/core-utilities/src/core/websocket/ws.ts`
- Added version 3.53.5 entry to `generators/typescript/sdk/versions.yml`
- Regenerated all 4 websocket seed fixtures to reflect the fix

## Testing

- [x] `pnpm compile` — no TypeScript errors
- [x] `pnpm seed test --generator ts-sdk --fixture websocket --skip-scripts --local` — 3/3 passed
- [x] `pnpm seed test --generator ts-sdk --fixture websocket-bearer-auth --skip-scripts --local` — 1/1 passed
- [x] `pnpm seed test --generator ts-sdk --fixture websocket-inferred-auth --skip-scripts --local` — 1/1 passed
- [x] Verified `git diff` on all seed fixtures shows only the expected 2-line additions

🤖 Generated with [Claude Code](https://claude.com/claude-code)