### PR TITLE
fix(generator-cli): bundle workspace deps and filter them from dist package.json

### DIFF
--- a/packages/generator-cli/build.mjs
+++ b/packages/generator-cli/build.mjs
@@ -37,7 +37,7 @@ async function main() {
     await tsup.build({
         ...commonConfig,
         entry: ["src/api.ts"],
-        noExternal: ["@fern-api/github", "@fern-api/fs-utils"],
+        noExternal: ["@fern-api/github", "@fern-api/fs-utils", "@fern-api/core-utils"],
         external: ["@fern-api/replay", "@octokit/rest", "es-toolkit", "tmp-promise"],
         clean: false
     });
@@ -71,7 +71,11 @@ async function main() {
                     "generator-cli": "bin/cli"
                 },
                 files: ["**"],
-                dependencies: packageJson.dependencies,
+                dependencies: Object.fromEntries(
+                    Object.entries(packageJson.dependencies).filter(
+                        ([, v]) => !String(v).startsWith("workspace:")
+                    )
+                ),
                 license: packageJson.license
             },
             undefined,

--- a/packages/generator-cli/build.mjs
+++ b/packages/generator-cli/build.mjs
@@ -72,9 +72,7 @@ async function main() {
                 },
                 files: ["**"],
                 dependencies: Object.fromEntries(
-                    Object.entries(packageJson.dependencies).filter(
-                        ([, v]) => !String(v).startsWith("workspace:")
-                    )
+                    Object.entries(packageJson.dependencies).filter(([, v]) => !String(v).startsWith("workspace:"))
                 ),
                 license: packageJson.license
             },

--- a/packages/generator-cli/versions.yml
+++ b/packages/generator-cli/versions.yml
@@ -2,6 +2,14 @@
 
 - changelogEntry:
     - summary: |
+        Fix publish by bundling @fern-api/core-utils into the API build and
+        filtering workspace protocol dependencies from the dist package.json.
+      type: fix
+  createdAt: "2026-03-25"
+  version: 0.6.13
+
+- changelogEntry:
+    - summary: |
         Include version number in the Gradle installation snippet for Java SDKs
         in generated README.md files. Previously only the Maven snippet included
         the version.


### PR DESCRIPTION
## Description

Fixes the `generator-cli` publish workflow which was failing with:
```
ERR_PNPM_CANNOT_RESOLVE_WORKSPACE_PROTOCOL  Cannot resolve workspace protocol of dependency "@fern-api/core-utils" because this dependency is not installed.
```

This was triggered by the 0.6.12 release (merged in #14043). The root cause predates that PR — `@fern-api/core-utils` was added as a `workspace:*` dependency but was never added to the API build's `noExternal` list or excluded from the dist `package.json`.

## Changes Made

- **`build.mjs`**: Add `@fern-api/core-utils` to `noExternal` in the API tsup build so it gets bundled into the output rather than left as an external import
- **`build.mjs`**: Filter out all `workspace:` protocol dependencies from the generated dist `package.json`, preventing future publish failures if new workspace deps are added
- **`versions.yml`**: Bump to `0.6.13`

## Testing

- [x] Ran `pnpm turbo run dist:cli --filter=@fern-api/generator-cli` — build succeeds
- [x] Verified dist `package.json` no longer contains `workspace:*` references
- [x] Ran `pnpm publish --dry-run` from dist directory — no workspace resolution errors
- [x] Ran `pnpm turbo run test --filter=@fern-api/generator-cli` — 83 tests pass

## Review Checklist

- [ ] Verify `@fern-api/core-utils` is the only workspace dep in `dependencies` (not `devDependencies`) that was missing from `noExternal` — the others (`@fern-api/github`, `@fern-api/fs-utils`) were already there
- [ ] Confirm `catalog:` protocol deps (e.g. `@octokit/rest`, `es-toolkit`) still resolve correctly during `pnpm publish` (they should — pnpm handles these within workspace context)

Link to Devin session: https://app.devin.ai/sessions/d0644705d81c41bbb4034d4e2345b110
Requested by: @jsklan
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/14049" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
