### PR TITLE
fix(java): resolve custom license file from Docker mount path and strip markdown formatting

### DIFF
--- a/generators/java/generator-utils/src/main/java/com/fern/java/output/GeneratedBuildGradle.java
+++ b/generators/java/generator-utils/src/main/java/com/fern/java/output/GeneratedBuildGradle.java
@@ -179,14 +179,22 @@ public abstract class GeneratedBuildGradle extends GeneratedFile {
 
     /**
      * Reads a license file and extracts the license name. For standard licenses (Apache, MIT, etc.), returns the SPDX
-     * identifier. For custom licenses, returns the first line of the file as the license name.
+     * identifier. For custom licenses, returns the first non-empty line of the file as the license name,
+     * with markdown formatting stripped.
      */
     private String extractLicenseFromFile(String filename) {
         try {
             Path licensePath = Paths.get(filename);
 
+            // When running inside Docker, the CLI mounts the license file at /tmp/<filename>
             if (!Files.exists(licensePath)) {
-                // Return a descriptive name if file not found
+                Path tmpPath = Paths.get("/tmp", licensePath.getFileName().toString());
+                if (Files.exists(tmpPath)) {
+                    licensePath = tmpPath;
+                }
+            }
+
+            if (!Files.exists(licensePath)) {
                 return "Custom License (" + licensePath.getFileName().toString() + ")";
             }
 
@@ -215,6 +223,12 @@ public abstract class GeneratedBuildGradle extends GeneratedFile {
                         .findFirst()
                         .orElse("Custom License");
 
+                // Strip markdown formatting (headers, bold, italic, etc.)
+                firstLine = firstLine.replaceAll("^#+\\s*", "");
+                firstLine = firstLine.replaceAll("\\*+", "");
+                firstLine = firstLine.replaceAll("_+", " ");
+                firstLine = firstLine.replaceAll("\\[([^\\]]+)\\]\\([^)]+\\)", "$1");
+
                 firstLine = firstLine.trim().replaceAll("[.:;]+$", "").replaceAll("\\s+", " ");
 
                 firstLine = firstLine.replace("'", "\\'");
@@ -222,7 +236,6 @@ public abstract class GeneratedBuildGradle extends GeneratedFile {
                 return firstLine;
             }
         } catch (IOException e) {
-            // Return a descriptive name instead of null
             return "Custom License (" + Paths.get(filename).getFileName().toString() + ")";
         }
     }

--- a/generators/java/generator-utils/src/main/java/com/fern/java/output/GeneratedBuildGradle.java
+++ b/generators/java/generator-utils/src/main/java/com/fern/java/output/GeneratedBuildGradle.java
@@ -226,7 +226,7 @@ public abstract class GeneratedBuildGradle extends GeneratedFile {
                 // Strip markdown formatting (headers, bold, italic, etc.)
                 firstLine = firstLine.replaceAll("^#+\\s*", "");
                 firstLine = firstLine.replaceAll("\\*+", "");
-                firstLine = firstLine.replaceAll("_+", " ");
+                firstLine = firstLine.replaceAll("_([^_]+)_", "$1");
                 firstLine = firstLine.replaceAll("\\[([^\\]]+)\\]\\([^)]+\\)", "$1");
 
                 firstLine = firstLine.trim().replaceAll("[.:;]+$", "").replaceAll("\\s+", " ");

--- a/generators/java/generator-utils/src/main/java/com/fern/java/output/GeneratedBuildGradle.java
+++ b/generators/java/generator-utils/src/main/java/com/fern/java/output/GeneratedBuildGradle.java
@@ -188,7 +188,7 @@ public abstract class GeneratedBuildGradle extends GeneratedFile {
 
             // When running inside Docker, the CLI mounts the license file at /tmp/<filename>
             if (!Files.exists(licensePath)) {
-                Path tmpPath = Paths.get("/tmp", licensePath.getFileName().toString());
+                Path tmpPath = Paths.get("/tmp/LICENSE");
                 if (Files.exists(tmpPath)) {
                     licensePath = tmpPath;
                 }

--- a/generators/java/generator-utils/src/main/java/com/fern/java/output/GeneratedBuildGradle.java
+++ b/generators/java/generator-utils/src/main/java/com/fern/java/output/GeneratedBuildGradle.java
@@ -179,8 +179,8 @@ public abstract class GeneratedBuildGradle extends GeneratedFile {
 
     /**
      * Reads a license file and extracts the license name. For standard licenses (Apache, MIT, etc.), returns the SPDX
-     * identifier. For custom licenses, returns the first non-empty line of the file as the license name,
-     * with markdown formatting stripped.
+     * identifier. For custom licenses, returns the first non-empty line of the file as the license name, with markdown
+     * formatting stripped.
      */
     private String extractLicenseFromFile(String filename) {
         try {

--- a/generators/java/generator-utils/src/main/java/com/fern/java/output/GeneratedBuildGradle.java
+++ b/generators/java/generator-utils/src/main/java/com/fern/java/output/GeneratedBuildGradle.java
@@ -225,7 +225,8 @@ public abstract class GeneratedBuildGradle extends GeneratedFile {
 
                 // Strip markdown formatting (headers, bold, italic, etc.)
                 firstLine = firstLine.replaceAll("^#+\\s*", "");
-                firstLine = firstLine.replaceAll("\\*+", "");
+                firstLine = firstLine.replaceAll("\\*\\*([^*]+)\\*\\*", "$1"); // bold
+                firstLine = firstLine.replaceAll("\\*([^*]+)\\*", "$1"); // italic
                 firstLine = firstLine.replaceAll("_([^_]+)_", "$1");
                 firstLine = firstLine.replaceAll("\\[([^\\]]+)\\]\\([^)]+\\)", "$1");
 

--- a/generators/java/sdk/versions.yml
+++ b/generators/java/sdk/versions.yml
@@ -1,4 +1,17 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 4.0.5
+  changelogEntry:
+    - summary: |
+        Fix custom license not being resolved in `build.gradle` when using
+        local generation (`--local`). The license file is mounted at `/tmp/LICENSE`
+        inside Docker, but the generator was looking for it at a relative path that
+        did not exist. The generator now checks `/tmp/<filename>` as a fallback.
+        Additionally, markdown formatting (headers, bold, etc.) is now stripped
+        from the first line of the license file when used as the license name.
+      type: fix
+  createdAt: "2026-03-25"
+  irVersion: 65
+
 - version: 4.0.4
   changelogEntry:
     - summary: |


### PR DESCRIPTION
## Description

Fixes custom license not being resolved in `build.gradle` when using local generation (`fern generate --local`). Instead of reading the first line of the referenced license file, the generator was outputting `Custom License (LICENSE)`.

## Root Cause

The CLI mounts the license file at `/tmp/LICENSE` inside the Docker container (`ContainerExecutionEnvironment.ts`), but only passes the basename (e.g., `"LICENSE"`) in the generator config via `path.basename(licenseConfig.value)`. The Java generator's `extractLicenseFromFile` tried to read `"LICENSE"` as a relative path, which doesn't exist in the container's working directory, so it fell through to the fallback string.

## Changes Made

- **`GeneratedBuildGradle.java`**: `extractLicenseFromFile` now checks `/tmp/<filename>` as a fallback when the given path doesn't exist — matching the CLI's Docker mount convention
- **`GeneratedBuildGradle.java`**: Added markdown formatting stripping (headers `#`, bold `**`, italic `_`, links `[text](url)`) from the first line of the license file before using it as the POM license name
- Updated `generators/java/sdk/versions.yml` with `4.0.5` changelog entry

## Testing

- [ ] Unit tests added/updated
- [x] Manual review of Docker mount path alignment (`ContainerExecutionEnvironment.ts:68` → `/tmp/LICENSE:ro`)

## Reviewer Checklist

- Verify the `/tmp` fallback path matches the CLI mount convention in `ContainerExecutionEnvironment.ts` and `ReusableContainerExecutionEnvironment.ts`
- Review markdown-stripping regexes: `_+` replaces all underscores with spaces (could be aggressive), `\\*+` strips all asterisks anywhere in the line (not just markdown delimiters). Are these acceptable for real-world license files?
- No unit tests cover the new fallback or stripping behavior

Link to Devin session: https://app.devin.ai/sessions/011cccb98c644e8e9d1dd36a65f2d92b
Requested by: @jsklan
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/14050" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
