### PR TITLE
feat(cli): support configurable container registry for `fern generate --local`

### DIFF
--- a/fern/apis/generators-yml/definition/generators.yml
+++ b/fern/apis/generators-yml/definition/generators.yml
@@ -43,6 +43,12 @@ types:
           Configuration for SDK customization replay.
           Automatically preserves user customizations across SDK regenerations.
       ai: optional<ai.AIServicesSchema>
+      container-registry:
+        type: optional<string>
+        docs: |
+          The container registry URL to pull generator images from during local generation.
+          When set, `fern generate --local` will pull images from this registry instead of Docker Hub.
+          Example: `ghcr.io/myorg` or `123456789.dkr.ecr.us-east-1.amazonaws.com`
       autorelease:
         type: optional<boolean>
         docs: |

--- a/packages/cli/cli-v2/src/api/adapter/LegacyFernWorkspaceAdapter.ts
+++ b/packages/cli/cli-v2/src/api/adapter/LegacyFernWorkspaceAdapter.ts
@@ -147,6 +147,7 @@ export class LegacyFernWorkspaceAdapter {
             whitelabel: undefined,
             ai: undefined,
             replay: undefined,
+            containerRegistry: undefined,
             rawConfiguration: {}
         };
     }

--- a/packages/cli/cli-v2/src/sdk/generator/LegacyLocalGenerationRunner.ts
+++ b/packages/cli/cli-v2/src/sdk/generator/LegacyLocalGenerationRunner.ts
@@ -182,7 +182,8 @@ export class LegacyLocalGenerationRunner {
             absolutePathToPreview: undefined,
             inspect: false,
             ai: undefined,
-            skipFernignore: args.skipFernignore
+            skipFernignore: args.skipFernignore,
+            containerRegistry: fernWorkspace.generatorsConfiguration?.containerRegistry
         });
 
         if (taskContext.getResult() === TaskResult.Failure) {

--- a/packages/cli/cli/src/commands/generate/generateAPIWorkspace.ts
+++ b/packages/cli/cli/src/commands/generate/generateAPIWorkspace.ts
@@ -154,7 +154,8 @@ export async function generateWorkspace({
                     noReplay,
                     validateWorkspace: true,
                     requireEnvVars,
-                    skipFernignore
+                    skipFernignore,
+                    containerRegistry: workspace.generatorsConfiguration?.containerRegistry
                 });
             } else if (token != null) {
                 await runRemoteGenerationForAPIWorkspace({

--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -1,4 +1,19 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 4.44.0
+  changelogEntry:
+    - summary: |
+        Add `container-registry` option to `generators.yml` for configuring a custom
+        container registry for `fern generate --local`. When set, Docker images are
+        pulled from the specified registry instead of Docker Hub. This is useful for
+        organizations that mirror generator images to internal registries.
+
+        ```yaml
+        container-registry: ghcr.io/myorg
+        ```
+      type: feat
+  createdAt: "2026-03-25"
+  irVersion: 65
+
 - version: 4.43.3
   changelogEntry:
     - summary: |

--- a/packages/cli/configuration-loader/src/generators-yml/convertGeneratorsConfiguration.ts
+++ b/packages/cli/configuration-loader/src/generators-yml/convertGeneratorsConfiguration.ts
@@ -98,7 +98,8 @@ export async function convertGeneratorsConfiguration({
                   }
                 : undefined,
         ai: rawGeneratorsConfiguration.ai,
-        replay: rawGeneratorsConfiguration.replay
+        replay: rawGeneratorsConfiguration.replay,
+        containerRegistry: rawGeneratorsConfiguration["container-registry"] ?? undefined
     };
 }
 

--- a/packages/cli/configuration/src/generators-yml/GeneratorsConfiguration.ts
+++ b/packages/cli/configuration/src/generators-yml/GeneratorsConfiguration.ts
@@ -28,6 +28,7 @@ export interface GeneratorsConfiguration {
     whitelabel: FernFiddle.WhitelabelConfig | undefined;
     ai: generatorsYml.AiServicesSchema | undefined;
     replay: generatorsYml.ReplayConfigSchema | undefined;
+    containerRegistry: string | undefined;
 
     rawConfiguration: GeneratorsConfigurationSchema;
     absolutePathToConfiguration: AbsoluteFilePath;

--- a/packages/cli/configuration/src/generators-yml/schemas/api/resources/generators/types/GeneratorsConfigurationSchema.ts
+++ b/packages/cli/configuration/src/generators-yml/schemas/api/resources/generators/types/GeneratorsConfigurationSchema.ts
@@ -28,6 +28,12 @@ export interface GeneratorsConfigurationSchema {
     replay?: GeneratorsYml.ReplayConfigSchema;
     ai?: GeneratorsYml.AiServicesSchema;
     /**
+     * The container registry URL to pull generator images from during local generation.
+     * When set, `fern generate --local` will pull images from this registry instead of Docker Hub.
+     * Example: `ghcr.io/myorg` or `123456789.dkr.ecr.us-east-1.amazonaws.com`
+     */
+    "container-registry"?: string;
+    /**
      * If true, automatically release SDKs when changes are detected.
      * Can be overridden at the individual generator level.
      */

--- a/packages/cli/configuration/src/generators-yml/schemas/serialization/resources/generators/types/GeneratorsConfigurationSchema.ts
+++ b/packages/cli/configuration/src/generators-yml/schemas/serialization/resources/generators/types/GeneratorsConfigurationSchema.ts
@@ -32,6 +32,7 @@ export const GeneratorsConfigurationSchema: core.serialization.ObjectSchema<
     reviewers: ReviewersSchema.optional(),
     replay: ReplayConfigSchema.optional(),
     ai: AiServicesSchema.optional(),
+    "container-registry": core.serialization.string().optional(),
     autorelease: core.serialization.boolean().optional(),
     openapi: GeneratorsOpenApiSchema.optional(),
     "openapi-overrides": core.serialization.string().optional(),
@@ -53,6 +54,7 @@ export declare namespace GeneratorsConfigurationSchema {
         reviewers?: ReviewersSchema.Raw | null;
         replay?: ReplayConfigSchema.Raw | null;
         ai?: AiServicesSchema.Raw | null;
+        "container-registry"?: string | null;
         autorelease?: boolean | null;
         openapi?: GeneratorsOpenApiSchema.Raw | null;
         "openapi-overrides"?: string | null;

--- a/packages/cli/generation/local-generation/local-workspace-runner/src/runGenerator.ts
+++ b/packages/cli/generation/local-generation/local-workspace-runner/src/runGenerator.ts
@@ -79,7 +79,8 @@ export async function writeFilesToDiskAndRunGenerator({
     ai,
     autoVersioningCache,
     absolutePathToSpecRepo,
-    skipFernignore
+    skipFernignore,
+    containerRegistry
 }: {
     organization: string;
     absolutePathToFernConfig: AbsoluteFilePath | undefined;
@@ -108,6 +109,7 @@ export async function writeFilesToDiskAndRunGenerator({
     autoVersioningCache?: AutoVersioningCache;
     absolutePathToSpecRepo: AbsoluteFilePath | undefined;
     skipFernignore?: boolean;
+    containerRegistry?: string;
 }): Promise<{
     ir: IntermediateRepresentation;
     generatorConfig: FernGeneratorExec.GeneratorConfig;
@@ -167,7 +169,9 @@ export async function writeFilesToDiskAndRunGenerator({
     const environment =
         executionEnvironment ??
         new ContainerExecutionEnvironment({
-            containerImage: `${generatorInvocation.name}:${generatorInvocation.version}`,
+            containerImage: containerRegistry
+                ? `${containerRegistry}/${generatorInvocation.name}:${generatorInvocation.version}`
+                : `${generatorInvocation.name}:${generatorInvocation.version}`,
             keepContainer: keepDocker
         });
 

--- a/packages/cli/generation/local-generation/local-workspace-runner/src/runLocalGenerationForWorkspace.ts
+++ b/packages/cli/generation/local-generation/local-workspace-runner/src/runLocalGenerationForWorkspace.ts
@@ -48,7 +48,8 @@ export async function runLocalGenerationForWorkspace({
     noReplay,
     validateWorkspace,
     requireEnvVars,
-    skipFernignore
+    skipFernignore,
+    containerRegistry
 }: {
     token: FernToken | undefined;
     projectConfig: fernConfigJson.ProjectConfig;
@@ -66,6 +67,7 @@ export async function runLocalGenerationForWorkspace({
     validateWorkspace?: boolean;
     requireEnvVars?: boolean;
     skipFernignore?: boolean;
+    containerRegistry?: string;
 }): Promise<void> {
     // Fail fast: check all generators for version conflicts BEFORE starting any IR generation.
     // This avoids wasted work when one generator would fail the version check.
@@ -346,7 +348,8 @@ export async function runLocalGenerationForWorkspace({
                     ai,
                     autoVersioningCache,
                     absolutePathToSpecRepo: dirname(workspace.absoluteFilePath),
-                    skipFernignore
+                    skipFernignore,
+                    containerRegistry
                 });
 
                 interactiveTaskContext.logger.info(chalk.green("Wrote files to " + absolutePathToLocalOutput));

--- a/packages/cli/yaml/generators-validator/src/ast/visitGeneratorsYamlAst.ts
+++ b/packages/cli/yaml/generators-validator/src/ast/visitGeneratorsYamlAst.ts
@@ -25,6 +25,7 @@ export async function visitGeneratorsYamlAst(
         "async-api": noop,
         "api-settings": noop,
         ai: noop,
+        "container-registry": noop,
         autorelease: noop,
         replay: noop,
         groups: async (groups) => {


### PR DESCRIPTION
## Description

Linear ticket: Closes [FER-9061](https://linear.app/buildwithfern/issue/FER-9061/support-configurable-container-registry-for-fern-generate-local)

Adds a top-level `container-registry` option to `generators.yml` so that `fern generate --local` can pull generator Docker images from a custom registry instead of Docker Hub. This unblocks organizations that mirror images to internal registries (e.g. ECR, GHCR).

```yaml
# generators.yml
container-registry: ghcr.io/myorg
```

When set, the image reference becomes `<container-registry>/<generator-name>:<version>` instead of `<generator-name>:<version>`.

## Changes Made

- Added `container-registry` optional string field to the Fern definition (`generators.yml` schema) and updated the auto-generated API + serialization types
- Added `containerRegistry` to the `GeneratorsConfiguration` interface and wired it through `convertGeneratorsConfiguration`
- Threaded `containerRegistry` through `runLocalGenerationForWorkspace` → `writeFilesToDiskAndRunGenerator` → `ContainerExecutionEnvironment` image name construction
- Updated both callers: `generateAPIWorkspace.ts` (CLI v1) and `LegacyLocalGenerationRunner.ts` (CLI v2)
- Added CLI `versions.yml` entry for v4.44.0

## Human Review Checklist

- [ ] **Image name construction**: Verify that `generatorInvocation.name` does not already include a registry prefix (e.g. `dockerhub.io/fernapi/...`). If it can, prepending `containerRegistry` would produce a malformed image reference. See `runGenerator.ts` lines 171-173.
- [ ] **No input validation**: The registry string is passed through as-is with no trimming, trailing-slash normalization, or empty-string guard. Decide if that's acceptable.
- [ ] **Scope**: The setting is top-level in `generators.yml`, not per-generator or per-group. Confirm this matches the desired UX.

## Testing

- [x] `pnpm run check` (biome lint) passes
- [ ] No unit tests added — this is a config-threading change; manual testing with a custom registry would be ideal
- [ ] Not tested end-to-end with an actual custom container registry

Link to Devin session: https://app.devin.ai/sessions/cabcf31c984140be9c882facdb9fd8dc
Requested by: @jsklan