### PR TITLE
fix(ci): use npm OIDC trusted publishing for generator-cli

### DIFF
--- a/.github/workflows/publish-generator-cli.yml
+++ b/.github/workflows/publish-generator-cli.yml
@@ -89,17 +89,10 @@ jobs:
           GITHUB_TOKEN: ${{ env.GITHUB_TOKEN }}
         run: pnpm turbo run test --filter=${{ env.PACKAGE_NAME }}
 
-      - name: Setup Node for npm publish
-        uses: actions/setup-node@v6
-        with:
-          node-version: 22
-          registry-url: https://registry.npmjs.org
-          scope: "@fern-api"
-
       - name: Publish generator-cli
         run: |
           cd packages/generator-cli/dist
-          pnpm publish --access public --tag latest --no-git-checks
+          npm publish --provenance --access public --tag latest
 
   publish-sdks:
     needs: check-version

--- a/.github/workflows/publish-generator-cli.yml
+++ b/.github/workflows/publish-generator-cli.yml
@@ -92,7 +92,7 @@ jobs:
       - name: Publish generator-cli
         run: |
           cd packages/generator-cli/dist
-          pnpm publish --provenance --access public --tag latest
+          pnpm publish --provenance --access public --tag latest --no-git-checks
 
   publish-sdks:
     needs: check-version

--- a/.github/workflows/publish-generator-cli.yml
+++ b/.github/workflows/publish-generator-cli.yml
@@ -92,7 +92,7 @@ jobs:
       - name: Publish generator-cli
         run: |
           cd packages/generator-cli/dist
-          npm publish --provenance --access public --tag latest
+          pnpm publish --provenance --access public --tag latest
 
   publish-sdks:
     needs: check-version

--- a/.github/workflows/publish-generator-cli.yml
+++ b/.github/workflows/publish-generator-cli.yml
@@ -89,6 +89,13 @@ jobs:
           GITHUB_TOKEN: ${{ env.GITHUB_TOKEN }}
         run: pnpm turbo run test --filter=${{ env.PACKAGE_NAME }}
 
+      - name: Setup Node for npm publish
+        uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          registry-url: https://registry.npmjs.org
+          scope: "@fern-api"
+
       - name: Publish generator-cli
         run: |
           cd packages/generator-cli/dist


### PR DESCRIPTION
## Description

Fixes the `publish-generator-cli` workflow which is failing with a 404 error because npm registry authentication is not configured for the publish step.

Failing run: https://github.com/fern-api/fern/actions/runs/23556710080/job/68585985790

```
npm error code E404
npm error 404 Not Found - PUT https://registry.npmjs.org/@fern-api%2fgenerator-cli
```

## Changes Made

- Switched from `pnpm publish` to `npm publish --provenance` to use npm's [OIDC trusted publishing](https://docs.npmjs.com/trusted-publishers/) — the same mechanism used by the Fern CLI publish workflow (`publish-cli.yml`)
- The `.github/actions/install` composite action already runs `actions/setup-node@v6` with `registry-url`, and the workflow already has `id-token: write` permission, so the only missing piece was using `npm publish --provenance` to trigger the OIDC token exchange

## ⚠️ Required npm-side configuration

**Before merging**, a trusted publisher must be configured for `@fern-api/generator-cli` on npmjs.com:

1. Go to https://www.npmjs.com/package/@fern-api/generator-cli → Settings → Trusted Publishers
2. Add GitHub Actions as a trusted publisher:
   - **Organization**: `fern-api`
   - **Repository**: `fern`
   - **Workflow filename**: `publish-generator-cli.yml`

Without this, the publish will still fail with a 404.

## Testing

- [ ] Cannot be tested locally — requires re-triggering the publish workflow after merge
- [ ] Verify trusted publisher is configured on npmjs.com before merging

Link to Devin session: https://app.devin.ai/sessions/6975c51a4a194883b2b5b3383a1f313c
Requested by: @jsklan
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/14052" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
