### PR TITLE
chore(ci): bump generator-cli to trigger publish with OIDC auth

### DIFF
--- a/packages/generator-cli/versions.yml
+++ b/packages/generator-cli/versions.yml
@@ -1,4 +1,10 @@
 # yaml-language-server: $schema=../../versions-yml.schema.json
+- changelogEntry:
+    - summary: |
+        Update generator-cli to use the new publish command in seed which includes provenance information in the published package. This allows us to track exactly which version of the generator was used to publish each version of the CLI, improving traceability and debugging.
+      type: chore
+  createdAt: "2026-03-25"
+  version: 0.6.14
 
 - changelogEntry:
     - summary: |

--- a/packages/generator-cli/versions.yml
+++ b/packages/generator-cli/versions.yml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=../../versions-yml.schema.json
 - changelogEntry:
     - summary: |
-        Update generator-cli to use the new publish command in seed which includes provenance information in the published package. This allows us to track exactly which version of the generator was used to publish each version of the CLI, improving traceability and debugging.
+        Update generator-cli to trigger new publish after changing to oidc auth for publish action.
       type: chore
   createdAt: "2026-03-25"
   version: 0.6.14


### PR DESCRIPTION
## Description
Bumps generator-cli to 0.6.14 to trigger a new publish after switching the publish action to OIDC authentication.

## Changes Made
- **generator-cli versioning**: Added version 0.6.14 changelog entry to trigger republish with OIDC auth

## Testing
- [x] Version file format validated