### PR TITLE
fix(ts-sdk): use deserialized casing for SSE streaming wire test expectations

### DIFF
--- a/generators/typescript/sdk/generator/src/test-generator/TestGenerator.ts
+++ b/generators/typescript/sdk/generator/src/test-generator/TestGenerator.ts
@@ -1518,8 +1518,8 @@ describe("${serviceName}", () => {
             return undefined;
         }
 
-        // Determine the SSE protocol discriminant field, if any
-        let discriminantField: string | undefined;
+        // Determine the SSE protocol discriminant field name (using deserialized casing), if any
+        let discriminantName: string | undefined;
         const ssePayload =
             endpoint.response?.body?.type === "streaming" && endpoint.response.body.value.type === "sse"
                 ? endpoint.response.body.value.payload
@@ -1530,17 +1530,19 @@ describe("${serviceName}", () => {
                 typeDeclaration.shape.type === "union" &&
                 typeDeclaration.shape.discriminatorContext === FernIr.UnionDiscriminatorContext.Protocol
             ) {
-                discriminantField = typeDeclaration.shape.discriminant.wireValue;
+                discriminantName = this.getName({ name: typeDeclaration.shape.discriminant.name, context });
             }
         }
 
-        const createRawJsonExample = this.createRawJsonExample.bind(this);
         const eventCodes = sseEvents.map((event) => {
-            if (discriminantField != null) {
-                const merged = { [discriminantField]: event.event, ...((event.data.jsonExample ?? {}) as object) };
-                return code`${literalOf(merged)}`;
+            const exampleExpr = context.type.getGeneratedExample(event.data).build(context, {
+                isForSnippet: true,
+                isForResponse: true
+            });
+            if (discriminantName != null) {
+                return code`{ ${discriminantName}: ${literalOf(event.event)}, ...${getTextOfTsNode(exampleExpr)} }`;
             }
-            return createRawJsonExample({ example: event.data, isForRequest: false, isForResponse: true });
+            return code`${getTextOfTsNode(exampleExpr)}`;
         });
         return code`${arrayOf(...eventCodes)}`;
     }

--- a/generators/typescript/sdk/versions.yml
+++ b/generators/typescript/sdk/versions.yml
@@ -1,4 +1,17 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 3.59.7
+  changelogEntry:
+    - summary: |
+        Fix wire test generation for SSE streaming endpoints to use deserialized
+        (camelCase) property names in test expectations instead of raw wire format
+        (snake_case). Previously, the generated test assertions compared SDK output
+        against wire-format keys (e.g. `call_id`), but the SDK deserializes these
+        to camelCase (e.g. `callId`) when the serde layer is enabled. This caused
+        wire test failures for SSE endpoints with multi-word property names.
+      type: fix
+  createdAt: "2026-03-25"
+  irVersion: 65
+
 - version: 3.59.6
   changelogEntry:
     - summary: |

--- a/seed/ts-sdk/server-sent-event-examples/tests/wire/completions.test.ts
+++ b/seed/ts-sdk/server-sent-event-examples/tests/wire/completions.test.ts
@@ -29,8 +29,14 @@ describe("CompletionsClient", () => {
             events.push(event);
         }
         expect(events).toEqual([
-            { delta: "foo", tokens: 1 },
-            { delta: "bar", tokens: 2 },
+            {
+                delta: "foo",
+                tokens: 1,
+            },
+            {
+                delta: "bar",
+                tokens: 2,
+            },
         ]);
     });
 
@@ -80,8 +86,14 @@ describe("CompletionsClient", () => {
             events.push(event);
         }
         expect(events).toEqual([
-            { event: "completion", content: "hello" },
-            { event: "error", error: "something went wrong" },
+            {
+                event: "completion",
+                content: "hello",
+            },
+            {
+                event: "error",
+                error: "something went wrong",
+            },
         ]);
     });
 
@@ -131,8 +143,20 @@ describe("CompletionsClient", () => {
             events.push(event);
         }
         expect(events).toEqual([
-            { event: "completion", content: "hello" },
-            { event: "error", error: "something went wrong" },
+            {
+                event: "completion",
+                ...{
+                    event: "completion",
+                    content: "hello",
+                },
+            },
+            {
+                event: "error",
+                ...{
+                    event: "error",
+                    error: "something went wrong",
+                },
+            },
         ]);
     });
 

--- a/seed/ts-sdk/server-sent-events/tests/wire/completions.test.ts
+++ b/seed/ts-sdk/server-sent-events/tests/wire/completions.test.ts
@@ -28,8 +28,14 @@ describe("CompletionsClient", () => {
             events.push(event);
         }
         expect(events).toEqual([
-            { delta: "hello", tokens: 1 },
-            { delta: " world", tokens: 2 },
+            {
+                delta: "hello",
+                tokens: 1,
+            },
+            {
+                delta: " world",
+                tokens: 2,
+            },
         ]);
     });
 
@@ -55,6 +61,11 @@ describe("CompletionsClient", () => {
         for await (const event of response) {
             events.push(event);
         }
-        expect(events).toEqual([{ delta: "delta", tokens: 1 }]);
+        expect(events).toEqual([
+            {
+                delta: "delta",
+                tokens: 1,
+            },
+        ]);
     });
 });


### PR DESCRIPTION
## Description
Refs [FER-9192](https://linear.app/buildwithfern/issue/FER-9192/cohere-typescript-wire-test-failure-streaming-sse-events-not)

Wire tests for SSE streaming endpoints were generating test expectations using raw wire-format keys (e.g. `call_id`) instead of deserialized camelCase keys (e.g. `callId`). This caused test failures for any SSE endpoint with multi-word property names when the serde layer is enabled.

## Changes Made
- **`TestGenerator.ts` — `getSseExpectedEvents`**: Replaced `createRawJsonExample` / `literalOf(merged)` with `context.type.getGeneratedExample(event.data).build(context, ...)`, which is the same deserialization-aware approach used by `getExpectedResponse` for non-streaming endpoints.
- For **protocol-discriminated unions**: the discriminant field name now uses `this.getName(...)` (camelCase-aware) instead of `discriminant.wireValue`.
- Updated seed snapshots for `server-sent-events` and `server-sent-event-examples` fixtures.
- Added `versions.yml` entry (v3.59.7).

## Things for reviewer to verify
- [ ] The protocol-discriminated union path generates `{ event: "completion", ...{ event: "completion", content: "hello" } }` — the explicit discriminant before the spread is redundant when `getGeneratedExample` already includes it. Functionally correct (spread wins), but worth confirming this pattern is acceptable.
- [ ] Existing seed fixtures only have single-word property names where wire format = camelCase, so the snapshots don't directly demonstrate the snake→camel fix. The fix is correct by construction (same `getGeneratedExample` path as non-streaming), but a new fixture with snake_case SSE properties could be added separately for regression coverage.

## Testing
- [x] Seed tests pass for `server-sent-events` and `server-sent-event-examples` fixtures
- [x] `pnpm run check` (biome lint) passes

Link to Devin session: https://app.devin.ai/sessions/c6e5448570a04ff2839f962c2074e2c2
Requested by: @jsklan