### PR TITLE
feat(cli): add retry logic and improved timeouts for library docs generation

### DIFF
--- a/packages/cli/cli/src/commands/docs-md-generate/generateLibraryDocs.ts
+++ b/packages/cli/cli/src/commands/docs-md-generate/generateLibraryDocs.ts
@@ -103,7 +103,21 @@ function isGitLibraryInput(
 }
 
 const POLL_INTERVAL_MS = 3000;
-const POLL_TIMEOUT_MS = 3 * 60 * 1000; // 3 minutes
+const POLL_TIMEOUT_MS = 8 * 60 * 1000; // 8 minutes
+
+/** Error codes from the backend that indicate a transient Lambda failure worth retrying. */
+const RETRYABLE_ERROR_CODES = new Set([
+    "LAMBDA_FUNCTION_ERROR",
+    "LAMBDA_NO_RESPONSE",
+    "LAMBDA_NO_IR",
+    "GENERATION_FAILED"
+]);
+
+/** Maximum number of times to retry the full generate→poll cycle on transient failures. */
+const MAX_JOB_RETRIES = 2;
+
+/** Delay before retrying a failed job (ms). */
+const JOB_RETRY_DELAY_MS = 5000;
 
 /**
  * Generate library documentation from source code.
@@ -230,7 +244,7 @@ async function generateSingleLibrary({
 
         interactiveTaskContext.logger.debug(`Starting generation for library '${name}' from ${gitInput.git}`);
 
-        const jobId = await startGeneration(client, interactiveTaskContext, {
+        const ir = await startAndPollWithRetry(client, interactiveTaskContext, {
             orgId,
             githubUrl: gitInput.git,
             language,
@@ -238,10 +252,6 @@ async function generateSingleLibrary({
             name,
             doxyfileContent
         });
-
-        await pollForCompletion(client, jobId, name, interactiveTaskContext);
-
-        const ir = await downloadIr(client, jobId, name, language, interactiveTaskContext);
 
         if (config.lang === "cpp") {
             const cppIr = ir as CppLibraryDocsIr;
@@ -273,17 +283,63 @@ async function generateSingleLibrary({
     });
 }
 
+interface GenerationOpts {
+    orgId: string;
+    githubUrl: string;
+    language: "PYTHON" | "CPP";
+    packagePath?: string;
+    name: string;
+    doxyfileContent?: string;
+}
+
+/**
+ * Run the full start → poll → download cycle, retrying automatically on
+ * transient Lambda failures (cold-start timeouts, infrastructure errors).
+ */
+async function startAndPollWithRetry(
+    client: LibraryDocsClient,
+    context: InteractiveTaskContext,
+    opts: GenerationOpts
+): Promise<unknown> {
+    let lastError: string | undefined;
+
+    for (let attempt = 0; attempt <= MAX_JOB_RETRIES; attempt++) {
+        if (attempt > 0) {
+            context.logger.info(
+                chalk.yellow(
+                    `Retrying generation for library '${opts.name}' (attempt ${attempt + 1}/${MAX_JOB_RETRIES + 1})...`
+                )
+            );
+            await new Promise((r) => setTimeout(r, JOB_RETRY_DELAY_MS));
+        }
+
+        const jobId = await startGeneration(client, context, opts);
+        const pollResult = await pollForCompletion(client, jobId, opts.name, context);
+
+        if (pollResult.ok) {
+            return downloadIr(client, jobId, opts.name, opts.language, context);
+        }
+
+        // Check whether the failure is retryable
+        lastError = pollResult.errorMessage;
+        if (!pollResult.retryable) {
+            return context.failAndThrow(lastError);
+        }
+
+        context.logger.warn(
+            chalk.yellow(`Generation attempt failed for '${opts.name}': ${lastError}`)
+        );
+    }
+
+    return context.failAndThrow(
+        `Generation failed for library '${opts.name}' after ${MAX_JOB_RETRIES + 1} attempts. Last error: ${lastError ?? "Unknown error"}`
+    );
+}
+
 async function startGeneration(
     client: LibraryDocsClient,
     context: InteractiveTaskContext,
-    opts: {
-        orgId: string;
-        githubUrl: string;
-        language: "PYTHON" | "CPP";
-        packagePath?: string;
-        name: string;
-        doxyfileContent?: string;
-    }
+    opts: GenerationOpts
 ): Promise<string> {
     try {
         const result = await client.startLibraryDocsGeneration({
@@ -307,13 +363,18 @@ async function startGeneration(
     }
 }
 
+type PollResult =
+    | { ok: true }
+    | { ok: false; retryable: boolean; errorMessage: string };
+
 async function pollForCompletion(
     client: LibraryDocsClient,
     jobId: string,
     libraryName: string,
     context: InteractiveTaskContext
-): Promise<void> {
+): Promise<PollResult> {
     const deadline = Date.now() + POLL_TIMEOUT_MS;
+    let pendingSince: number | undefined;
 
     while (Date.now() < deadline) {
         await new Promise((r) => setTimeout(r, POLL_INTERVAL_MS));
@@ -328,27 +389,51 @@ async function pollForCompletion(
         }
 
         switch (status.status) {
-            case "PENDING":
-                context.logger.debug(`Status: PENDING`);
+            case "PENDING": {
+                if (pendingSince == null) {
+                    pendingSince = Date.now();
+                }
+                const waitedMs = Date.now() - pendingSince;
+                if (waitedMs > 30_000 && waitedMs < 33_000 + POLL_INTERVAL_MS) {
+                    context.logger.info(
+                        chalk.dim("Parser is starting up — this may take a moment on first run...")
+                    );
+                }
+                context.logger.debug("Status: PENDING");
                 break;
+            }
             case "PARSING": {
+                pendingSince = undefined;
                 context.logger.debug(`Status: PARSING${status.progress ? ` — ${status.progress}` : ""}`);
                 break;
             }
             case "COMPLETED":
-                return;
-            case "FAILED":
-                return context.failAndThrow(
-                    `Generation failed for library '${libraryName}': ${status.error?.message ?? "Unknown error"} (${status.error?.code ?? "UNKNOWN"})`
-                );
+                return { ok: true };
+            case "FAILED": {
+                const errorCode = status.error?.code ?? "UNKNOWN";
+                const errorMessage =
+                    `Generation failed for library '${libraryName}': ` +
+                    `${status.error?.message ?? "Unknown error"} (${errorCode})`;
+                return {
+                    ok: false,
+                    retryable: RETRYABLE_ERROR_CODES.has(errorCode),
+                    errorMessage
+                };
+            }
             default:
-                return context.failAndThrow(
-                    `Unexpected generation status for library '${libraryName}': ${status.status}`
-                );
+                return {
+                    ok: false,
+                    retryable: false,
+                    errorMessage: `Unexpected generation status for library '${libraryName}': ${status.status}`
+                };
         }
     }
 
-    return context.failAndThrow(`Generation timed out for library '${libraryName}' after ${POLL_TIMEOUT_MS / 1000}s`);
+    return {
+        ok: false,
+        retryable: true,
+        errorMessage: `Generation timed out for library '${libraryName}' after ${POLL_TIMEOUT_MS / 1000}s`
+    };
 }
 
 async function downloadIr(

--- a/packages/cli/cli/src/commands/docs-md-generate/generateLibraryDocs.ts
+++ b/packages/cli/cli/src/commands/docs-md-generate/generateLibraryDocs.ts
@@ -326,9 +326,7 @@ async function startAndPollWithRetry(
             return context.failAndThrow(lastError);
         }
 
-        context.logger.warn(
-            chalk.yellow(`Generation attempt failed for '${opts.name}': ${lastError}`)
-        );
+        context.logger.warn(chalk.yellow(`Generation attempt failed for '${opts.name}': ${lastError}`));
     }
 
     return context.failAndThrow(
@@ -363,9 +361,7 @@ async function startGeneration(
     }
 }
 
-type PollResult =
-    | { ok: true }
-    | { ok: false; retryable: boolean; errorMessage: string };
+type PollResult = { ok: true } | { ok: false; retryable: boolean; errorMessage: string };
 
 async function pollForCompletion(
     client: LibraryDocsClient,
@@ -395,9 +391,7 @@ async function pollForCompletion(
                 }
                 const waitedMs = Date.now() - pendingSince;
                 if (waitedMs > 30_000 && waitedMs < 33_000 + POLL_INTERVAL_MS) {
-                    context.logger.info(
-                        chalk.dim("Parser is starting up — this may take a moment on first run...")
-                    );
+                    context.logger.info(chalk.dim("Parser is starting up — this may take a moment on first run..."));
                 }
                 context.logger.debug("Status: PENDING");
                 break;


### PR DESCRIPTION
## Description

Addresses intermittent failures in `fern docs generate-library-docs` caused by Lambda cold starts (Docker image Lambdas in VPC can take 10-30s+ to initialize). The CLI previously had a tight 3-minute poll timeout and no retry logic, so transient infrastructure failures would immediately surface as user-facing errors.

## Changes Made

- Increased poll timeout from 3 minutes → 8 minutes to accommodate Lambda cold starts and large repo parsing
- Added automatic retry of the full start→poll→download cycle (up to 2 retries / 3 total attempts) on transient Lambda failures
- Retryable error codes: `LAMBDA_FUNCTION_ERROR`, `LAMBDA_NO_RESPONSE`, `LAMBDA_NO_IR`, `GENERATION_FAILED`; timeouts are also retried
- Non-retryable errors (`PARSE_FAILED`, `INVALID_URL`, etc.) still fail immediately
- Added user-facing "Parser is starting up" message when PENDING state exceeds 30 seconds
- Refactored `pollForCompletion` to return a `PollResult` discriminated union instead of throwing, enabling the retry orchestrator to inspect error codes
- Extracted `GenerationOpts` interface and `startAndPollWithRetry` orchestrator function

## Testing

- [x] Existing unit tests pass (8/8 in `generateLibraryDocs.test.ts`)
- [x] Biome check passes (`pnpm run check`)
- [x] All required CI checks pass
- [ ] No new unit tests for the retry path — worth adding coverage for retry/non-retry distinction

## Key areas for review

1. **`startGeneration` still throws via `failAndThrow`** — start-phase HTTP failures (e.g., 401, 500 from FDR) are NOT retried, only poll-phase failures are. This is likely correct (auth errors shouldn't retry) but worth confirming.
2. **Worst-case wait time**: 8 min timeout × 3 attempts = ~24 min maximum. Is this acceptable UX?
3. **Cold start message timing window**: uses `waitedMs > 30_000 && waitedMs < 33_000 + POLL_INTERVAL_MS` to fire once — this depends on poll interval alignment and could theoretically miss or double-fire in edge cases.
4. **`startAndPollWithRetry` returns `Promise<unknown>`** because `downloadIr` returns different shapes for Python vs C++. The caller immediately casts, so this is functionally fine but not fully type-safe.

Link to Devin session: https://app.devin.ai/sessions/c2fedfbefdfb40029b21b07b9dede6e8
Requested by: @paarthfern