### PR TITLE
fix(go): populate sub-package ErrorCodes from endpoint error references

### DIFF
--- a/generators/go-v2/sdk/src/internal/InternalFilesGenerator.ts
+++ b/generators/go-v2/sdk/src/internal/InternalFilesGenerator.ts
@@ -79,17 +79,40 @@ export class InternalFilesGenerator {
         return Array.from(namespaces.values());
     }
 
+    /**
+     * Groups error declarations by the namespace (service) that references them,
+     * not by where they are declared. This ensures that sub-packages whose endpoints
+     * reference errors declared elsewhere (e.g. at the root level) still get a
+     * populated ErrorCodes map.
+     */
     private groupErrorsByNamespace(): Map<string, FernIr.ErrorDeclaration[]> {
         const errorsByNamespace = new Map<string, FernIr.ErrorDeclaration[]>();
+        // Track seen status codes per namespace to avoid duplicates when multiple
+        // services in the same namespace reference the same error.
+        const seenStatusCodesByNamespace = new Map<string, Set<number>>();
 
-        for (const errorDeclaration of Object.values(this.context.ir.errors ?? {})) {
-            const location = this.context.getLocationForErrorId(errorDeclaration.name.errorId);
-            const importPath = location.importPath;
+        for (const service of Object.values(this.context.ir.services)) {
+            const serviceLocation = this.context.getPackageLocation(service.name.fernFilepath);
+            const serviceImportPath = serviceLocation.importPath;
 
-            if (!errorsByNamespace.has(importPath)) {
-                errorsByNamespace.set(importPath, []);
+            let seenStatusCodes = seenStatusCodesByNamespace.get(serviceImportPath);
+            if (seenStatusCodes == null) {
+                seenStatusCodes = new Set<number>();
+                seenStatusCodesByNamespace.set(serviceImportPath, seenStatusCodes);
             }
-            errorsByNamespace.get(importPath)?.push(errorDeclaration);
+
+            for (const endpoint of service.endpoints) {
+                for (const responseError of endpoint.errors) {
+                    const errorDeclaration = this.context.ir.errors[responseError.error.errorId];
+                    if (errorDeclaration != null && !seenStatusCodes.has(errorDeclaration.statusCode)) {
+                        seenStatusCodes.add(errorDeclaration.statusCode);
+                        if (!errorsByNamespace.has(serviceImportPath)) {
+                            errorsByNamespace.set(serviceImportPath, []);
+                        }
+                        errorsByNamespace.get(serviceImportPath)?.push(errorDeclaration);
+                    }
+                }
+            }
         }
 
         return errorsByNamespace;

--- a/generators/go/sdk/versions.yml
+++ b/generators/go/sdk/versions.yml
@@ -1,4 +1,18 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 1.31.4
+  changelogEntry:
+    - summary: |
+        Fix sub-package ErrorCodes maps being empty when errors are declared in a
+        different namespace than the endpoints that reference them. The generator now
+        groups errors by the service namespace that uses them (via endpoint error
+        references) instead of by where they are declared. This ensures that
+        sub-packages like `audio/` correctly get populated ErrorCodes with typed
+        errors (e.g. BadRequestError, UnauthorizedError) instead of an empty map
+        that would cause API errors to be returned as generic `*core.APIError`.
+      type: fix
+  createdAt: "2026-03-26"
+  irVersion: 61
+
 - version: 1.31.3
   changelogEntry:
     - summary: |

--- a/seed/go-sdk/examples/always-send-required-properties/error_codes.go
+++ b/seed/go-sdk/examples/always-send-required-properties/error_codes.go
@@ -3,14 +3,7 @@
 package examples
 
 import (
-	core "github.com/examples/fern/core"
 	internal "github.com/examples/fern/internal"
 )
 
-var ErrorCodes internal.ErrorCodes = internal.ErrorCodes{
-	404: func(apiError *core.APIError) error {
-		return &NotFoundError{
-			APIError: apiError,
-		}
-	},
-}
+var ErrorCodes internal.ErrorCodes = internal.ErrorCodes{}

--- a/seed/go-sdk/examples/always-send-required-properties/file/error_codes.go
+++ b/seed/go-sdk/examples/always-send-required-properties/file/error_codes.go
@@ -3,7 +3,15 @@
 package file
 
 import (
+	fern "github.com/examples/fern"
+	core "github.com/examples/fern/core"
 	internal "github.com/examples/fern/internal"
 )
 
-var ErrorCodes internal.ErrorCodes = internal.ErrorCodes{}
+var ErrorCodes internal.ErrorCodes = internal.ErrorCodes{
+	404: func(apiError *core.APIError) error {
+		return &fern.NotFoundError{
+			APIError: apiError,
+		}
+	},
+}

--- a/seed/go-sdk/examples/client-name-with-custom-constructor-name/error_codes.go
+++ b/seed/go-sdk/examples/client-name-with-custom-constructor-name/error_codes.go
@@ -3,14 +3,7 @@
 package examples
 
 import (
-	core "github.com/examples/fern/core"
 	internal "github.com/examples/fern/internal"
 )
 
-var ErrorCodes internal.ErrorCodes = internal.ErrorCodes{
-	404: func(apiError *core.APIError) error {
-		return &NotFoundError{
-			APIError: apiError,
-		}
-	},
-}
+var ErrorCodes internal.ErrorCodes = internal.ErrorCodes{}

--- a/seed/go-sdk/examples/client-name-with-custom-constructor-name/file/error_codes.go
+++ b/seed/go-sdk/examples/client-name-with-custom-constructor-name/file/error_codes.go
@@ -3,7 +3,15 @@
 package file
 
 import (
+	fern "github.com/examples/fern"
+	core "github.com/examples/fern/core"
 	internal "github.com/examples/fern/internal"
 )
 
-var ErrorCodes internal.ErrorCodes = internal.ErrorCodes{}
+var ErrorCodes internal.ErrorCodes = internal.ErrorCodes{
+	404: func(apiError *core.APIError) error {
+		return &fern.NotFoundError{
+			APIError: apiError,
+		}
+	},
+}

--- a/seed/go-sdk/examples/client-name/error_codes.go
+++ b/seed/go-sdk/examples/client-name/error_codes.go
@@ -3,14 +3,7 @@
 package examples
 
 import (
-	core "github.com/examples/fern/core"
 	internal "github.com/examples/fern/internal"
 )
 
-var ErrorCodes internal.ErrorCodes = internal.ErrorCodes{
-	404: func(apiError *core.APIError) error {
-		return &NotFoundError{
-			APIError: apiError,
-		}
-	},
-}
+var ErrorCodes internal.ErrorCodes = internal.ErrorCodes{}

--- a/seed/go-sdk/examples/client-name/file/error_codes.go
+++ b/seed/go-sdk/examples/client-name/file/error_codes.go
@@ -3,7 +3,15 @@
 package file
 
 import (
+	fern "github.com/examples/fern"
+	core "github.com/examples/fern/core"
 	internal "github.com/examples/fern/internal"
 )
 
-var ErrorCodes internal.ErrorCodes = internal.ErrorCodes{}
+var ErrorCodes internal.ErrorCodes = internal.ErrorCodes{
+	404: func(apiError *core.APIError) error {
+		return &fern.NotFoundError{
+			APIError: apiError,
+		}
+	},
+}

--- a/seed/go-sdk/examples/export-all-requests-at-root/error_codes.go
+++ b/seed/go-sdk/examples/export-all-requests-at-root/error_codes.go
@@ -3,14 +3,7 @@
 package examples
 
 import (
-	core "github.com/examples/fern/core"
 	internal "github.com/examples/fern/internal"
 )
 
-var ErrorCodes internal.ErrorCodes = internal.ErrorCodes{
-	404: func(apiError *core.APIError) error {
-		return &NotFoundError{
-			APIError: apiError,
-		}
-	},
-}
+var ErrorCodes internal.ErrorCodes = internal.ErrorCodes{}

--- a/seed/go-sdk/examples/export-all-requests-at-root/file/error_codes.go
+++ b/seed/go-sdk/examples/export-all-requests-at-root/file/error_codes.go
@@ -3,7 +3,15 @@
 package file
 
 import (
+	fern "github.com/examples/fern"
+	core "github.com/examples/fern/core"
 	internal "github.com/examples/fern/internal"
 )
 
-var ErrorCodes internal.ErrorCodes = internal.ErrorCodes{}
+var ErrorCodes internal.ErrorCodes = internal.ErrorCodes{
+	404: func(apiError *core.APIError) error {
+		return &fern.NotFoundError{
+			APIError: apiError,
+		}
+	},
+}

--- a/seed/go-sdk/examples/exported-client-name/error_codes.go
+++ b/seed/go-sdk/examples/exported-client-name/error_codes.go
@@ -3,14 +3,7 @@
 package examples
 
 import (
-	core "github.com/examples/fern/core"
 	internal "github.com/examples/fern/internal"
 )
 
-var ErrorCodes internal.ErrorCodes = internal.ErrorCodes{
-	404: func(apiError *core.APIError) error {
-		return &NotFoundError{
-			APIError: apiError,
-		}
-	},
-}
+var ErrorCodes internal.ErrorCodes = internal.ErrorCodes{}

--- a/seed/go-sdk/examples/exported-client-name/file/error_codes.go
+++ b/seed/go-sdk/examples/exported-client-name/file/error_codes.go
@@ -3,7 +3,15 @@
 package file
 
 import (
+	fern "github.com/examples/fern"
+	core "github.com/examples/fern/core"
 	internal "github.com/examples/fern/internal"
 )
 
-var ErrorCodes internal.ErrorCodes = internal.ErrorCodes{}
+var ErrorCodes internal.ErrorCodes = internal.ErrorCodes{
+	404: func(apiError *core.APIError) error {
+		return &fern.NotFoundError{
+			APIError: apiError,
+		}
+	},
+}

--- a/seed/go-sdk/examples/getters-pass-by-value/error_codes.go
+++ b/seed/go-sdk/examples/getters-pass-by-value/error_codes.go
@@ -3,14 +3,7 @@
 package examples
 
 import (
-	core "github.com/examples/fern/core"
 	internal "github.com/examples/fern/internal"
 )
 
-var ErrorCodes internal.ErrorCodes = internal.ErrorCodes{
-	404: func(apiError *core.APIError) error {
-		return &NotFoundError{
-			APIError: apiError,
-		}
-	},
-}
+var ErrorCodes internal.ErrorCodes = internal.ErrorCodes{}

--- a/seed/go-sdk/examples/getters-pass-by-value/file/error_codes.go
+++ b/seed/go-sdk/examples/getters-pass-by-value/file/error_codes.go
@@ -3,7 +3,15 @@
 package file
 
 import (
+	fern "github.com/examples/fern"
+	core "github.com/examples/fern/core"
 	internal "github.com/examples/fern/internal"
 )
 
-var ErrorCodes internal.ErrorCodes = internal.ErrorCodes{}
+var ErrorCodes internal.ErrorCodes = internal.ErrorCodes{
+	404: func(apiError *core.APIError) error {
+		return &fern.NotFoundError{
+			APIError: apiError,
+		}
+	},
+}

--- a/seed/go-sdk/examples/no-custom-config/error_codes.go
+++ b/seed/go-sdk/examples/no-custom-config/error_codes.go
@@ -3,14 +3,7 @@
 package examples
 
 import (
-	core "github.com/examples/fern/core"
 	internal "github.com/examples/fern/internal"
 )
 
-var ErrorCodes internal.ErrorCodes = internal.ErrorCodes{
-	404: func(apiError *core.APIError) error {
-		return &NotFoundError{
-			APIError: apiError,
-		}
-	},
-}
+var ErrorCodes internal.ErrorCodes = internal.ErrorCodes{}

--- a/seed/go-sdk/examples/no-custom-config/file/error_codes.go
+++ b/seed/go-sdk/examples/no-custom-config/file/error_codes.go
@@ -3,7 +3,15 @@
 package file
 
 import (
+	fern "github.com/examples/fern"
+	core "github.com/examples/fern/core"
 	internal "github.com/examples/fern/internal"
 )
 
-var ErrorCodes internal.ErrorCodes = internal.ErrorCodes{}
+var ErrorCodes internal.ErrorCodes = internal.ErrorCodes{
+	404: func(apiError *core.APIError) error {
+		return &fern.NotFoundError{
+			APIError: apiError,
+		}
+	},
+}

--- a/seed/go-sdk/examples/package-path/pleaseinhere/error_codes.go
+++ b/seed/go-sdk/examples/package-path/pleaseinhere/error_codes.go
@@ -3,14 +3,7 @@
 package examples
 
 import (
-	core "github.com/examples/fern/pleaseinhere/core"
 	internal "github.com/examples/fern/pleaseinhere/internal"
 )
 
-var ErrorCodes internal.ErrorCodes = internal.ErrorCodes{
-	404: func(apiError *core.APIError) error {
-		return &NotFoundError{
-			APIError: apiError,
-		}
-	},
-}
+var ErrorCodes internal.ErrorCodes = internal.ErrorCodes{}

--- a/seed/go-sdk/examples/package-path/pleaseinhere/file/error_codes.go
+++ b/seed/go-sdk/examples/package-path/pleaseinhere/file/error_codes.go
@@ -3,7 +3,15 @@
 package file
 
 import (
+	pleaseinhere "github.com/examples/fern/pleaseinhere"
+	core "github.com/examples/fern/pleaseinhere/core"
 	internal "github.com/examples/fern/pleaseinhere/internal"
 )
 
-var ErrorCodes internal.ErrorCodes = internal.ErrorCodes{}
+var ErrorCodes internal.ErrorCodes = internal.ErrorCodes{
+	404: func(apiError *core.APIError) error {
+		return &pleaseinhere.NotFoundError{
+			APIError: apiError,
+		}
+	},
+}

--- a/seed/go-sdk/examples/readme-config/error_codes.go
+++ b/seed/go-sdk/examples/readme-config/error_codes.go
@@ -3,14 +3,7 @@
 package examples
 
 import (
-	core "github.com/examples/fern/core"
 	internal "github.com/examples/fern/internal"
 )
 
-var ErrorCodes internal.ErrorCodes = internal.ErrorCodes{
-	404: func(apiError *core.APIError) error {
-		return &NotFoundError{
-			APIError: apiError,
-		}
-	},
-}
+var ErrorCodes internal.ErrorCodes = internal.ErrorCodes{}

--- a/seed/go-sdk/examples/readme-config/file/error_codes.go
+++ b/seed/go-sdk/examples/readme-config/file/error_codes.go
@@ -3,7 +3,15 @@
 package file
 
 import (
+	fern "github.com/examples/fern"
+	core "github.com/examples/fern/core"
 	internal "github.com/examples/fern/internal"
 )
 
-var ErrorCodes internal.ErrorCodes = internal.ErrorCodes{}
+var ErrorCodes internal.ErrorCodes = internal.ErrorCodes{
+	404: func(apiError *core.APIError) error {
+		return &fern.NotFoundError{
+			APIError: apiError,
+		}
+	},
+}

--- a/seed/go-sdk/examples/v0/error_codes.go
+++ b/seed/go-sdk/examples/v0/error_codes.go
@@ -3,14 +3,7 @@
 package examples
 
 import (
-	core "github.com/examples/fern/core"
 	internal "github.com/examples/fern/internal"
 )
 
-var ErrorCodes internal.ErrorCodes = internal.ErrorCodes{
-	404: func(apiError *core.APIError) error {
-		return &NotFoundError{
-			APIError: apiError,
-		}
-	},
-}
+var ErrorCodes internal.ErrorCodes = internal.ErrorCodes{}

--- a/seed/go-sdk/examples/v0/file/error_codes.go
+++ b/seed/go-sdk/examples/v0/file/error_codes.go
@@ -3,7 +3,15 @@
 package file
 
 import (
+	fern "github.com/examples/fern"
+	core "github.com/examples/fern/core"
 	internal "github.com/examples/fern/internal"
 )
 
-var ErrorCodes internal.ErrorCodes = internal.ErrorCodes{}
+var ErrorCodes internal.ErrorCodes = internal.ErrorCodes{
+	404: func(apiError *core.APIError) error {
+		return &fern.NotFoundError{
+			APIError: apiError,
+		}
+	},
+}


### PR DESCRIPTION
## Description

Refs https://github.com/cohere-ai/cohere-go/pull/149

Fixes a bug where the Go SDK generator produced empty `ErrorCodes{}` maps for sub-packages whose endpoints reference errors declared in a different namespace (e.g. root-level shared errors). This caused API errors from those endpoints to be returned as generic `*core.APIError` instead of typed errors.

## Root Cause

`InternalFilesGenerator.groupErrorsByNamespace()` grouped error declarations by where they are **declared** (their `fernFilepath`), not by which endpoints **reference** them. When a sub-package endpoint (e.g. `audio/transcriptions`) references errors declared at the root level, the sub-package's `ErrorCodes` map was empty because no errors were *declared* in the `audio` namespace.

## Changes Made

- Rewrote `groupErrorsByNamespace()` in `InternalFilesGenerator.ts` to iterate over services → endpoints → error references, collecting errors into the namespace where they are **used**
- Added per-namespace status code deduplication to handle multiple services/endpoints in the same namespace referencing the same error
- Updated `versions.yml` with v1.31.4 changelog entry
- Updated seed snapshots for the `examples` fixture (20 files) — errors correctly moved from root `error_codes.go` to `file/error_codes.go` where they are actually referenced

## Testing

- [x] Ran seed tests for `exhaustive`, `examples`, `inferred-auth-implicit`, `inferred-auth-implicit-api-key`, `inferred-auth-implicit-reference`, `oauth-client-credentials-nested-root`, `oauth-client-credentials-mandatory-auth`, `cross-package-type-names`, `mixed-file-directory`, `audiences` — all pass
- [x] Lint (`biome check`) passes clean

## Key review points

1. **Behavioral change**: Errors now appear in the namespace that *uses* them, not where they're *declared*. This is the correct semantic, but means existing generated SDKs will see `ErrorCodes` entries shift between packages. Since `raw_client.go` references `ErrorCodes` from the same package as the endpoint, this should be transparent.
2. **Errors declared but never referenced by any endpoint** will no longer appear in any `ErrorCodes` map. This is intentional — unused errors shouldn't be in error code maps.
3. **Status code deduplication**: If two different error types share the same status code within a namespace, only the first encountered is kept. This matches the existing `buildErrorDecoder` per-endpoint behavior.
4. **Not all seed fixtures were re-run** — only a representative set. CI will validate the full suite.

Link to Devin session: https://app.devin.ai/sessions/004e6c3099d4415c9e02119e86401de1
Requested by: @tstanmay13
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/14114" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
