### PR TITLE
feat(cli): use Fern GitHub App token for replay init

### DIFF
--- a/packages/cli/cli/src/cli.ts
+++ b/packages/cli/cli/src/cli.ts
@@ -2,6 +2,7 @@
 import type { ReadStream, WriteStream } from "node:tty";
 import { fromBinary, toBinary } from "@bufbuild/protobuf";
 import { CodeGeneratorRequestSchema, CodeGeneratorResponseSchema } from "@bufbuild/protobuf/wkt";
+import type { FernToken } from "@fern-api/auth";
 import { runCliV2 } from "@fern-api/cli-v2";
 import {
     correctIncorrectDockerOrg,
@@ -80,7 +81,7 @@ import { writeDocsDefinitionForProject } from "./commands/write-docs-definition/
 import { writeTranslationForProject } from "./commands/write-translation/writeTranslationForProject.js";
 import { FERN_CWD_ENV_VAR } from "./cwd.js";
 import { rerunFernCliAtVersion } from "./rerunFernCliAtVersion.js";
-import { fetchInstallationToken, resolveGroupGithubConfig } from "./resolveGroupGithubConfig.js";
+import { resolveGroupGithubConfig } from "./resolveGroupGithubConfig.js";
 import { RUNTIME } from "./runtime.js";
 
 void runCli();
@@ -2297,28 +2298,25 @@ function addReplayInitCommand(cli: Argv<GlobalCliOptions>, cliContext: CliContex
 
             // If --group is provided, load config from generators.yml
             if (argv.group != null) {
-                const resolved = await resolveGroupGithubConfig(cliContext, argv.group, argv.api);
+                // Get Fern token as fallback when GITHUB_TOKEN is not set
+                let fernToken: FernToken | undefined;
+                if (token == null && process.env.GITHUB_TOKEN == null) {
+                    try {
+                        fernToken = await cliContext.runTask((context) => {
+                            return askToLogin(context);
+                        });
+                    } catch {
+                        cliContext.logger.debug("Could not obtain Fern token for GitHub App fallback.");
+                    }
+                }
+
+                const resolved = await resolveGroupGithubConfig(cliContext, argv.group, argv.api, fernToken);
                 // Use group config as defaults, allow --github/--token to override
                 githubRepo = githubRepo ?? resolved.githubRepo;
                 token = token ?? resolved.token;
             }
 
-            // Always try to get Fern App installation token for write operations (push + PR).
-            // The user's GITHUB_TOKEN may not have write access to the target repo,
-            // but the Fern GitHub App installation token will.
-            let writeToken: string | undefined;
-            if (githubRepo != null) {
-                try {
-                    const fernToken = await cliContext.runTask((context) => askToLogin(context));
-                    writeToken = await fetchInstallationToken(cliContext, githubRepo, fernToken);
-                } catch {
-                    cliContext.logger.debug("Could not obtain Fern App installation token for write operations.");
-                }
-            }
-
-            // Need at least one token (for clone) and writeToken or token (for push)
-            const readToken = token ?? writeToken;
-            if (githubRepo == null || readToken == null) {
+            if (githubRepo == null || token == null) {
                 const hint =
                     githubRepo != null
                         ? "Repository found but no token. Ensure the Fern GitHub App (https://github.com/apps/fern-api) is installed on the repository, or pass --token / set GITHUB_TOKEN."
@@ -2334,8 +2332,7 @@ function addReplayInitCommand(cli: Argv<GlobalCliOptions>, cliContext: CliContex
             try {
                 const result = await replayInit({
                     githubRepo,
-                    token: readToken,
-                    writeToken,
+                    token,
                     dryRun: argv.dryRun,
                     maxCommitsToScan: argv.maxCommits,
                     force: argv.force

--- a/packages/cli/cli/src/cli.ts
+++ b/packages/cli/cli/src/cli.ts
@@ -2,6 +2,7 @@
 import type { ReadStream, WriteStream } from "node:tty";
 import { fromBinary, toBinary } from "@bufbuild/protobuf";
 import { CodeGeneratorRequestSchema, CodeGeneratorResponseSchema } from "@bufbuild/protobuf/wkt";
+import type { FernToken } from "@fern-api/auth";
 import { runCliV2 } from "@fern-api/cli-v2";
 import {
     correctIncorrectDockerOrg,
@@ -2297,7 +2298,19 @@ function addReplayInitCommand(cli: Argv<GlobalCliOptions>, cliContext: CliContex
 
             // If --group is provided, load config from generators.yml
             if (argv.group != null) {
-                const resolved = await resolveGroupGithubConfig(cliContext, argv.group, argv.api);
+                // Get Fern token as fallback when GITHUB_TOKEN is not set
+                let fernToken: FernToken | undefined;
+                if (token == null && process.env.GITHUB_TOKEN == null) {
+                    try {
+                        fernToken = await cliContext.runTask((context) => {
+                            return askToLogin(context);
+                        });
+                    } catch {
+                        cliContext.logger.debug("Could not obtain Fern token for GitHub App fallback.");
+                    }
+                }
+
+                const resolved = await resolveGroupGithubConfig(cliContext, argv.group, argv.api, fernToken);
                 // Use group config as defaults, allow --github/--token to override
                 githubRepo = githubRepo ?? resolved.githubRepo;
                 token = token ?? resolved.token;
@@ -2306,7 +2319,7 @@ function addReplayInitCommand(cli: Argv<GlobalCliOptions>, cliContext: CliContex
             if (githubRepo == null || token == null) {
                 const hint =
                     githubRepo != null
-                        ? "Repository found but no token. Pass --token or set GITHUB_TOKEN environment variable."
+                        ? "Repository found but no token. Ensure the Fern GitHub App (https://github.com/apps/fern-api) is installed on the repository, or pass --token / set GITHUB_TOKEN."
                         : "Either use --group to read from generators.yml, or provide --github and --token directly.";
                 return cliContext.failAndThrow(`Missing required github config. ${hint}`);
             }

--- a/packages/cli/cli/src/cli.ts
+++ b/packages/cli/cli/src/cli.ts
@@ -2,7 +2,6 @@
 import type { ReadStream, WriteStream } from "node:tty";
 import { fromBinary, toBinary } from "@bufbuild/protobuf";
 import { CodeGeneratorRequestSchema, CodeGeneratorResponseSchema } from "@bufbuild/protobuf/wkt";
-import type { FernToken } from "@fern-api/auth";
 import { runCliV2 } from "@fern-api/cli-v2";
 import {
     correctIncorrectDockerOrg,
@@ -81,7 +80,7 @@ import { writeDocsDefinitionForProject } from "./commands/write-docs-definition/
 import { writeTranslationForProject } from "./commands/write-translation/writeTranslationForProject.js";
 import { FERN_CWD_ENV_VAR } from "./cwd.js";
 import { rerunFernCliAtVersion } from "./rerunFernCliAtVersion.js";
-import { resolveGroupGithubConfig } from "./resolveGroupGithubConfig.js";
+import { fetchInstallationToken, resolveGroupGithubConfig } from "./resolveGroupGithubConfig.js";
 import { RUNTIME } from "./runtime.js";
 
 void runCli();
@@ -2298,25 +2297,28 @@ function addReplayInitCommand(cli: Argv<GlobalCliOptions>, cliContext: CliContex
 
             // If --group is provided, load config from generators.yml
             if (argv.group != null) {
-                // Get Fern token as fallback when GITHUB_TOKEN is not set
-                let fernToken: FernToken | undefined;
-                if (token == null && process.env.GITHUB_TOKEN == null) {
-                    try {
-                        fernToken = await cliContext.runTask((context) => {
-                            return askToLogin(context);
-                        });
-                    } catch {
-                        cliContext.logger.debug("Could not obtain Fern token for GitHub App fallback.");
-                    }
-                }
-
-                const resolved = await resolveGroupGithubConfig(cliContext, argv.group, argv.api, fernToken);
+                const resolved = await resolveGroupGithubConfig(cliContext, argv.group, argv.api);
                 // Use group config as defaults, allow --github/--token to override
                 githubRepo = githubRepo ?? resolved.githubRepo;
                 token = token ?? resolved.token;
             }
 
-            if (githubRepo == null || token == null) {
+            // Always try to get Fern App installation token for write operations (push + PR).
+            // The user's GITHUB_TOKEN may not have write access to the target repo,
+            // but the Fern GitHub App installation token will.
+            let writeToken: string | undefined;
+            if (githubRepo != null) {
+                try {
+                    const fernToken = await cliContext.runTask((context) => askToLogin(context));
+                    writeToken = await fetchInstallationToken(cliContext, githubRepo, fernToken);
+                } catch {
+                    cliContext.logger.debug("Could not obtain Fern App installation token for write operations.");
+                }
+            }
+
+            // Need at least one token (for clone) and writeToken or token (for push)
+            const readToken = token ?? writeToken;
+            if (githubRepo == null || readToken == null) {
                 const hint =
                     githubRepo != null
                         ? "Repository found but no token. Ensure the Fern GitHub App (https://github.com/apps/fern-api) is installed on the repository, or pass --token / set GITHUB_TOKEN."
@@ -2332,7 +2334,8 @@ function addReplayInitCommand(cli: Argv<GlobalCliOptions>, cliContext: CliContex
             try {
                 const result = await replayInit({
                     githubRepo,
-                    token,
+                    token: readToken,
+                    writeToken,
                     dryRun: argv.dryRun,
                     maxCommitsToScan: argv.maxCommits,
                     force: argv.force

--- a/packages/cli/cli/src/resolveGroupGithubConfig.ts
+++ b/packages/cli/cli/src/resolveGroupGithubConfig.ts
@@ -1,4 +1,6 @@
+import { FernToken } from "@fern-api/auth";
 import { isGithubSelfhosted } from "@fern-api/configuration-loader";
+import { getFiddleOrigin } from "@fern-api/core";
 import { replaceEnvVariables } from "@fern-api/core-utils";
 import { CliContext } from "./cli-context/CliContext.js";
 import { loadProjectAndRegisterWorkspacesWithContext } from "./cliCommons.js";
@@ -13,7 +15,8 @@ export interface ResolvedGithubConfig {
 export async function resolveGroupGithubConfig(
     cliContext: CliContext,
     groupName: string,
-    apiWorkspace: string | undefined
+    apiWorkspace: string | undefined,
+    fernToken?: FernToken
 ): Promise<ResolvedGithubConfig> {
     const project = await loadProjectAndRegisterWorkspacesWithContext(cliContext, {
         commandLineApiWorkspace: apiWorkspace,
@@ -64,12 +67,19 @@ export async function resolveGroupGithubConfig(
 
     if (generatorWithRepo?.raw?.github != null && "repository" in generatorWithRepo.raw.github) {
         const githubConfig = resolveEnv(generatorWithRepo.raw.github);
-        const token = process.env.GITHUB_TOKEN;
+        let token: string | undefined = process.env.GITHUB_TOKEN;
 
-        cliContext.logger.info(
-            `Using repository config from group "${groupName}" generator "${generatorWithRepo.name}"` +
-                (token != null ? ". Using GITHUB_TOKEN from environment." : ".")
-        );
+        if (token != null) {
+            cliContext.logger.info(
+                `Using repository config from group "${groupName}" generator "${generatorWithRepo.name}". Using GITHUB_TOKEN from environment.`
+            );
+        } else if (fernToken != null) {
+            token = await fetchInstallationToken(cliContext, githubConfig.repository, fernToken);
+        } else {
+            cliContext.logger.info(
+                `Using repository config from group "${groupName}" generator "${generatorWithRepo.name}".`
+            );
+        }
 
         return {
             githubRepo: githubConfig.repository,
@@ -80,4 +90,48 @@ export async function resolveGroupGithubConfig(
     }
 
     return cliContext.failAndThrow(`No generator in group "${groupName}" has a github configuration.`);
+}
+
+async function fetchInstallationToken(
+    cliContext: CliContext,
+    repository: string,
+    fernToken: FernToken
+): Promise<string | undefined> {
+    // Parse "owner/repo" from the repository string (may include github.com prefix)
+    const parts = repository
+        .replace(/^https?:\/\//, "")
+        .replace(/\.git$/, "")
+        .split("/");
+    const owner = parts.length >= 2 ? parts[parts.length - 2] : undefined;
+    const repo = parts.length >= 2 ? parts[parts.length - 1] : undefined;
+
+    if (owner == null || repo == null) {
+        cliContext.logger.debug(`Could not parse owner/repo from repository: ${repository}`);
+        return undefined;
+    }
+
+    try {
+        const fiddleOrigin = getFiddleOrigin();
+        const response = await fetch(`${fiddleOrigin}/api/remote-gen/github/installation-token`, {
+            method: "POST",
+            headers: {
+                "Content-Type": "application/json",
+                Authorization: `Bearer ${fernToken.value}`
+            },
+            body: JSON.stringify({ owner, repo })
+        });
+
+        if (!response.ok) {
+            const body = await response.text();
+            cliContext.logger.debug(`Failed to get installation token from Fiddle (${response.status}): ${body}`);
+            return undefined;
+        }
+
+        const data = (await response.json()) as { token: string };
+        cliContext.logger.info("Using Fern GitHub App installation token.");
+        return data.token;
+    } catch (error) {
+        cliContext.logger.debug(`Failed to fetch installation token from Fiddle: ${error}`);
+        return undefined;
+    }
 }

--- a/packages/cli/cli/src/resolveGroupGithubConfig.ts
+++ b/packages/cli/cli/src/resolveGroupGithubConfig.ts
@@ -15,7 +15,8 @@ export interface ResolvedGithubConfig {
 export async function resolveGroupGithubConfig(
     cliContext: CliContext,
     groupName: string,
-    apiWorkspace: string | undefined
+    apiWorkspace: string | undefined,
+    fernToken?: FernToken
 ): Promise<ResolvedGithubConfig> {
     const project = await loadProjectAndRegisterWorkspacesWithContext(cliContext, {
         commandLineApiWorkspace: apiWorkspace,
@@ -66,12 +67,19 @@ export async function resolveGroupGithubConfig(
 
     if (generatorWithRepo?.raw?.github != null && "repository" in generatorWithRepo.raw.github) {
         const githubConfig = resolveEnv(generatorWithRepo.raw.github);
-        const token: string | undefined = process.env.GITHUB_TOKEN;
+        let token: string | undefined = process.env.GITHUB_TOKEN;
 
-        cliContext.logger.info(
-            `Using repository config from group "${groupName}" generator "${generatorWithRepo.name}"` +
-                (token != null ? ". Using GITHUB_TOKEN from environment." : ".")
-        );
+        if (token != null) {
+            cliContext.logger.info(
+                `Using repository config from group "${groupName}" generator "${generatorWithRepo.name}". Using GITHUB_TOKEN from environment.`
+            );
+        } else if (fernToken != null) {
+            token = await fetchInstallationToken(cliContext, githubConfig.repository, fernToken);
+        } else {
+            cliContext.logger.info(
+                `Using repository config from group "${groupName}" generator "${generatorWithRepo.name}".`
+            );
+        }
 
         return {
             githubRepo: githubConfig.repository,
@@ -84,7 +92,7 @@ export async function resolveGroupGithubConfig(
     return cliContext.failAndThrow(`No generator in group "${groupName}" has a github configuration.`);
 }
 
-export async function fetchInstallationToken(
+async function fetchInstallationToken(
     cliContext: CliContext,
     repository: string,
     fernToken: FernToken

--- a/packages/cli/cli/src/resolveGroupGithubConfig.ts
+++ b/packages/cli/cli/src/resolveGroupGithubConfig.ts
@@ -15,8 +15,7 @@ export interface ResolvedGithubConfig {
 export async function resolveGroupGithubConfig(
     cliContext: CliContext,
     groupName: string,
-    apiWorkspace: string | undefined,
-    fernToken?: FernToken
+    apiWorkspace: string | undefined
 ): Promise<ResolvedGithubConfig> {
     const project = await loadProjectAndRegisterWorkspacesWithContext(cliContext, {
         commandLineApiWorkspace: apiWorkspace,
@@ -67,19 +66,12 @@ export async function resolveGroupGithubConfig(
 
     if (generatorWithRepo?.raw?.github != null && "repository" in generatorWithRepo.raw.github) {
         const githubConfig = resolveEnv(generatorWithRepo.raw.github);
-        let token: string | undefined = process.env.GITHUB_TOKEN;
+        const token: string | undefined = process.env.GITHUB_TOKEN;
 
-        if (token != null) {
-            cliContext.logger.info(
-                `Using repository config from group "${groupName}" generator "${generatorWithRepo.name}". Using GITHUB_TOKEN from environment.`
-            );
-        } else if (fernToken != null) {
-            token = await fetchInstallationToken(cliContext, githubConfig.repository, fernToken);
-        } else {
-            cliContext.logger.info(
-                `Using repository config from group "${groupName}" generator "${generatorWithRepo.name}".`
-            );
-        }
+        cliContext.logger.info(
+            `Using repository config from group "${groupName}" generator "${generatorWithRepo.name}"` +
+                (token != null ? ". Using GITHUB_TOKEN from environment." : ".")
+        );
 
         return {
             githubRepo: githubConfig.repository,
@@ -92,7 +84,7 @@ export async function resolveGroupGithubConfig(
     return cliContext.failAndThrow(`No generator in group "${groupName}" has a github configuration.`);
 }
 
-async function fetchInstallationToken(
+export async function fetchInstallationToken(
     cliContext: CliContext,
     repository: string,
     fernToken: FernToken

--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -1,4 +1,16 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 4.47.0
+  changelogEntry:
+    - summary: |
+        `fern replay init --group` now uses the Fern GitHub App installation token
+        for write operations (push and PR creation) when the user's personal token
+        lacks write access to the target repository. This enables replay init on
+        customer repos where the Fern App is installed without requiring a personal
+        access token with write permissions.
+      type: feat
+  createdAt: "2026-03-26"
+  irVersion: 65
+
 - version: 4.46.2
   changelogEntry:
     - summary: |

--- a/packages/generator-cli/src/replay/replay-init.ts
+++ b/packages/generator-cli/src/replay/replay-init.ts
@@ -9,10 +9,8 @@ import { ensureReplayFernignoreEntriesSync } from "./fernignore";
 export interface ReplayInitParams {
     /** GitHub repo URI (e.g., "fern-demo/fern-replay-testbed-java-sdk") */
     githubRepo: string;
-    /** GitHub token for clone (read access). Falls back to writeToken if not set. */
+    /** GitHub token with push + PR permissions */
     token: string;
-    /** Fern GitHub App installation token for push + PR (write access). Falls back to token if not set. */
-    writeToken?: string;
     /** Report what would happen but don't create PR */
     dryRun?: boolean;
     /** Max commits to scan for generation history */
@@ -111,19 +109,11 @@ export async function replayInit(params: ReplayInitParams): Promise<ReplayInitRe
         commitMessage
     ]);
 
-    // Use installation token for write operations if available
-    const effectiveWriteToken = params.writeToken ?? token;
-    if (params.writeToken != null) {
-        const parsed = parseRepository(githubRepo);
-        const writeUrl = `https://x-access-token:${params.writeToken}@${parsed.remote}/${parsed.owner}/${parsed.repo}.git`;
-        await git.exec(["remote", "set-url", "origin", writeUrl]);
-    }
-
     await repository.pushUpstream(branchName);
 
     // Create PR
     const parsed = parseRepository(githubRepo);
-    const octokit = new Octokit({ auth: effectiveWriteToken });
+    const octokit = new Octokit({ auth: token });
     const prTitle = params.prTitle ?? "[fern-replay] Initialize Replay for SDK customizations";
     const prBody = params.prBody ?? buildPrBody(bootstrapResult);
 

--- a/packages/generator-cli/src/replay/replay-init.ts
+++ b/packages/generator-cli/src/replay/replay-init.ts
@@ -9,8 +9,10 @@ import { ensureReplayFernignoreEntriesSync } from "./fernignore";
 export interface ReplayInitParams {
     /** GitHub repo URI (e.g., "fern-demo/fern-replay-testbed-java-sdk") */
     githubRepo: string;
-    /** GitHub token with push + PR permissions */
+    /** GitHub token for clone (read access). Falls back to writeToken if not set. */
     token: string;
+    /** Fern GitHub App installation token for push + PR (write access). Falls back to token if not set. */
+    writeToken?: string;
     /** Report what would happen but don't create PR */
     dryRun?: boolean;
     /** Max commits to scan for generation history */
@@ -109,11 +111,19 @@ export async function replayInit(params: ReplayInitParams): Promise<ReplayInitRe
         commitMessage
     ]);
 
+    // Use installation token for write operations if available
+    const effectiveWriteToken = params.writeToken ?? token;
+    if (params.writeToken != null) {
+        const parsed = parseRepository(githubRepo);
+        const writeUrl = `https://x-access-token:${params.writeToken}@${parsed.remote}/${parsed.owner}/${parsed.repo}.git`;
+        await git.exec(["remote", "set-url", "origin", writeUrl]);
+    }
+
     await repository.pushUpstream(branchName);
 
     // Create PR
     const parsed = parseRepository(githubRepo);
-    const octokit = new Octokit({ auth: token });
+    const octokit = new Octokit({ auth: effectiveWriteToken });
     const prTitle = params.prTitle ?? "[fern-replay] Initialize Replay for SDK customizations";
     const prBody = params.prBody ?? buildPrBody(bootstrapResult);
 


### PR DESCRIPTION
## Summary

- `fern replay init --group <name>` now automatically fetches a GitHub App installation token from Fiddle when `GITHUB_TOKEN` is not set, matching how `fern generate` works without requiring manual token setup
- Falls back gracefully: `--token` flag > `GITHUB_TOKEN` env > Fiddle installation token > actionable error message
- Updated error message to mention Fern GitHub App installation as a resolution path

**Requires**: Corresponding Fiddle backend endpoint (`POST /api/remote-gen/github/installation-token`) to be deployed first. Fiddle changes are in a separate PR.

## Test plan

- [ ] Deploy Fiddle endpoint first
- [ ] Run `fern replay init --group python` without `GITHUB_TOKEN` set, with `fern login` completed and Fern App installed on the repo — should succeed
- [ ] Run with `GITHUB_TOKEN` set — should use env var (no Fiddle call)
- [ ] Run with `--token` flag — should use flag directly
- [ ] Run without Fern App installed — should fail with actionable error message
- [ ] `pnpm compile` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)