### PR TITLE
chore: update posthog-node SDK to v5.28.6

### DIFF
--- a/packages/cli/cli-v2/package.json
+++ b/packages/cli/cli-v2/package.json
@@ -96,7 +96,7 @@
     "json-stream-stringify": "catalog:",
     "jsonwebtoken": "catalog:",
     "ora": "catalog:",
-    "posthog-node": "^5.14.0",
+    "posthog-node": "^5.28.6",
     "semver": "^7.6.2",
     "tsup": "catalog:",
     "typescript": "catalog:",

--- a/packages/cli/posthog-manager/package.json
+++ b/packages/cli/posthog-manager/package.json
@@ -36,7 +36,7 @@
     "@fern-api/core": "workspace:*",
     "@fern-api/fs-utils": "workspace:*",
     "@fern-api/task-context": "workspace:*",
-    "posthog-node": "^5.26.2",
+    "posthog-node": "^5.28.6",
     "uuid": "catalog:"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5255,8 +5255,8 @@ importers:
         specifier: 'catalog:'
         version: 7.0.1
       posthog-node:
-        specifier: ^5.14.0
-        version: 5.24.7
+        specifier: ^5.28.6
+        version: 5.28.6(rxjs@7.8.2)
       semver:
         specifier: ^7.6.2
         version: 7.7.4
@@ -6908,8 +6908,8 @@ importers:
         specifier: workspace:*
         version: link:../task-context
       posthog-node:
-        specifier: ^5.26.2
-        version: 5.26.2
+        specifier: ^5.28.6
+        version: 5.28.6(rxjs@7.8.2)
       uuid:
         specifier: 'catalog:'
         version: 9.0.1
@@ -10495,11 +10495,8 @@ packages:
     resolution: {integrity: sha512-h104Kh26rR8tm+a3Qkc5S4VLYint3FE48as7+/5oCEcKR2idC/pF1G6AhIXKI+eHPJa/3J9i5z0Al47IeGHPkA==}
     engines: {node: '>=12'}
 
-  '@posthog/core@1.17.0':
-    resolution: {integrity: sha512-8pDNL+/u9ojzXloA5wILVDXBCV5daJ7w2ipCALQlEEZmL752cCKhRpbyiHn3tjKXh3Hy6aOboJneYa1JdlVHrQ==}
-
-  '@posthog/core@1.23.2':
-    resolution: {integrity: sha512-zTDdda9NuSHrnwSOfFMxX/pyXiycF4jtU1kTr8DL61dHhV+7LF6XF1ndRZZTuaGGbfbb/GJYkEsjEX9SXfNZeQ==}
+  '@posthog/core@1.24.1':
+    resolution: {integrity: sha512-e8AciAnc6MRFws89ux8lJKFAaI03yEon0ASDoUO7yS91FVqbUGXYekObUUR3LHplcg+pmyiJBI0jolY0SFbGRA==}
 
   '@prisma/instrumentation@7.4.2':
     resolution: {integrity: sha512-r9JfchJF1Ae6yAxcaLu/V1TGqBhAuSDe3mRNOssBfx1rMzfZ4fdNvrgUBwyb/TNTGXFxlH9AZix5P257x07nrg==}
@@ -13939,13 +13936,14 @@ packages:
     resolution: {integrity: sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==}
     engines: {node: '>=0.10.0'}
 
-  posthog-node@5.24.7:
-    resolution: {integrity: sha512-IJ0Zj+v+eg/JQMZ75n0Hcp4NzuQzWcZjqFjcUQs6RhW2l5FiQIq09sKJMleXX33hYxD6sfjFsDTqugJlgeAohg==}
+  posthog-node@5.28.6:
+    resolution: {integrity: sha512-f3k45gplzVxbhIMj3x6jZP6iH1wacBurKrZxD1VwW+7f8L2DtjJbkiQw0oKwubgtCZcKNroPa8y6t/nDITgOMw==}
     engines: {node: ^20.20.0 || >=22.22.0}
-
-  posthog-node@5.26.2:
-    resolution: {integrity: sha512-fAivzhkhwsZiq6b3YdMYQ5av4Zo5ggV5BC9Uwr5id5N6y0o4OCOTYlKg3O+O+I6SvbbZNYIUZIjgQMWz2yIMkw==}
-    engines: {node: ^20.20.0 || >=22.22.0}
+    peerDependencies:
+      rxjs: ^7.0.0
+    peerDependenciesMeta:
+      rxjs:
+        optional: true
 
   prelude-ls@1.2.1:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
@@ -17576,11 +17574,7 @@ snapshots:
       '@pnpm/network.ca-file': 1.0.2
       config-chain: 1.1.13
 
-  '@posthog/core@1.17.0':
-    dependencies:
-      cross-spawn: 7.0.5
-
-  '@posthog/core@1.23.2':
+  '@posthog/core@1.24.1':
     dependencies:
       cross-spawn: 7.0.5
 
@@ -21507,13 +21501,11 @@ snapshots:
     dependencies:
       xtend: 4.0.2
 
-  posthog-node@5.24.7:
+  posthog-node@5.28.6(rxjs@7.8.2):
     dependencies:
-      '@posthog/core': 1.17.0
-
-  posthog-node@5.26.2:
-    dependencies:
-      '@posthog/core': 1.23.2
+      '@posthog/core': 1.24.1
+    optionalDependencies:
+      rxjs: 7.8.2
 
   prelude-ls@1.2.1: {}
 


### PR DESCRIPTION
## Description

Update `posthog-node` SDK to the latest version (v5.28.6) across both CLI packages that depend on it.

## Changes Made

- Updated `posthog-node` from `^5.14.0` to `^5.28.6` in `packages/cli/cli-v2`
- Updated `posthog-node` from `^5.26.2` to `^5.28.6` in `packages/cli/posthog-manager`
- Lockfile updated — both packages now resolve to a single `posthog-node@5.28.6` and a single `@posthog/core@1.24.1` (previously had two versions each)

## Review Notes

- `posthog-node@5.28.6` introduces an **optional** peer dependency on `rxjs@^7.0.0`. The lockfile resolves this with `rxjs@7.8.2` which was already present in the dependency tree. No additional packages were installed.
- The `cli-v2` package had the oldest pinned version (`^5.14.0` → resolved to `5.24.7`), so that's the largest version jump. Worth confirming no breaking changes in the PostHog Node SDK between those versions.

## Testing

- [x] `pnpm install` succeeds
- [x] Pre-commit hooks pass (filename validation)
- [ ] CI validation pending

Link to Devin session: https://app.devin.ai/sessions/2cf722b2acd242beb2f07695fc4fb399
Requested by: @dannysheridan