### PR TITLE
chore(typescript): update oxfmt, oxlint, and oxlint-tsgolint to latest versions

### DIFF
--- a/docker/seed/Dockerfile.ts
+++ b/docker/seed/Dockerfile.ts
@@ -12,10 +12,10 @@ RUN corepack prepare yarn@1.22.22
 
 RUN pnpm add -g typescript@~5.7.2 \
   prettier@3.7.4 \
-  oxfmt@0.35.0 \
+  oxfmt@0.42.0 \
   @biomejs/biome@2.4.3 \
-  oxlint@1.50.0 \
-  oxlint-tsgolint@0.14.2 \
+  oxlint@1.57.0 \
+  oxlint-tsgolint@0.17.4 \
   @types/node@^18.19.70 \
   webpack@^5.97.1 \
   msw@2.11.2 \

--- a/generators/typescript/express/cli/Dockerfile
+++ b/generators/typescript/express/cli/Dockerfile
@@ -13,10 +13,10 @@ RUN npm install -g pnpm@10.33.0 --force && \
     npm install -g yarn@1.22.22 --force
 RUN pnpm add -g \
   prettier@3.8.1 \
-  oxfmt@0.35.0 \
+  oxfmt@0.42.0 \
   @biomejs/biome@2.4.9 \
-  oxlint@1.50.0 \
-  oxlint-tsgolint@0.14.2
+  oxlint@1.57.0 \
+  oxlint-tsgolint@0.17.4
 
 WORKDIR /tmp/cache-warm
 
@@ -32,9 +32,9 @@ RUN echo '{ \
     "express": "4.18.2", \
     "@biomejs/biome": "2.4.9", \
     "prettier": "3.8.1", \
-    "oxfmt": "0.35.0", \
-    "oxlint": "1.50.0", \
-    "oxlint-tsgolint": "0.14.2", \
+    "oxfmt": "0.42.0", \
+    "oxlint": "1.57.0", \
+    "oxlint-tsgolint": "0.17.4", \
     "typescript": "~5.9.3", \
     "url-join": "4.0.1" \
   } \

--- a/generators/typescript/express/versions.yml
+++ b/generators/typescript/express/versions.yml
@@ -1,4 +1,12 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 0.19.12
+  changelogEntry:
+    - summary: |
+        Update oxfmt from 0.35.0 to 0.42.0, oxlint from 1.50.0 to 1.57.0, and oxlint-tsgolint from 0.14.2 to 0.17.4.
+      type: chore
+  irVersion: 65
+  createdAt: "2026-03-26"
+
 - changelogEntry:
     - summary: |
         Upgrade generated project dependencies to latest stable versions:

--- a/generators/typescript/sdk/cli/Dockerfile
+++ b/generators/typescript/sdk/cli/Dockerfile
@@ -13,10 +13,10 @@ RUN npm install -g pnpm@10.33.0 --force
 RUN npm install -g yarn@1.22.22 --force
 RUN pnpm add -g typescript@~5.9.3 \
   prettier@3.8.1 \
-  oxfmt@0.35.0 \
+  oxfmt@0.42.0 \
   @biomejs/biome@2.4.9 \
-  oxlint@1.50.0 \
-  oxlint-tsgolint@0.14.2 \
+  oxlint@1.57.0 \
+  oxlint-tsgolint@0.17.4 \
   @types/node@^18.19.70 \
   ts-loader@^9.5.4 \
   webpack@^5.105.4 \

--- a/generators/typescript/sdk/versions.yml
+++ b/generators/typescript/sdk/versions.yml
@@ -1,4 +1,12 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 3.59.10
+  changelogEntry:
+    - summary: |
+        Update oxfmt from 0.35.0 to 0.42.0, oxlint from 1.50.0 to 1.57.0, and oxlint-tsgolint from 0.14.2 to 0.17.4.
+      type: chore
+  createdAt: "2026-03-26"
+  irVersion: 65
+
 - version: 3.59.9
   changelogEntry:
     - summary: |

--- a/generators/typescript/utils/commons/src/typescript-project/TypescriptProject.ts
+++ b/generators/typescript/utils/commons/src/typescript-project/TypescriptProject.ts
@@ -51,9 +51,9 @@ type COMMON_SCRIPTS = (typeof COMMON_SCRIPTS)[keyof typeof COMMON_SCRIPTS];
 const TOOL_VERSIONS = {
     BIOME: "2.4.9",
     PRETTIER: "3.8.1",
-    OXFMT: "0.35.0",
-    OXLINT: "1.50.0",
-    OXLINT_TSGOLINT: "0.14.2"
+    OXFMT: "0.42.0",
+    OXLINT: "1.57.0",
+    OXLINT_TSGOLINT: "0.17.4"
 } as const;
 
 export abstract class TypescriptProject {

--- a/seed/ts-sdk/simple-api/use-oxc/package.json
+++ b/seed/ts-sdk/simple-api/use-oxc/package.json
@@ -67,9 +67,9 @@
     "devDependencies": {
         "@types/node": "^18.19.70",
         "msw": "2.11.2",
-        "oxfmt": "0.35.0",
-        "oxlint": "1.50.0",
-        "oxlint-tsgolint": "0.14.2",
+        "oxfmt": "0.42.0",
+        "oxlint": "1.57.0",
+        "oxlint-tsgolint": "0.17.4",
         "ts-loader": "^9.5.4",
         "typescript": "~5.9.3",
         "vitest": "^4.1.1",

--- a/seed/ts-sdk/simple-api/use-oxfmt/package.json
+++ b/seed/ts-sdk/simple-api/use-oxfmt/package.json
@@ -68,7 +68,7 @@
         "@biomejs/biome": "2.4.9",
         "@types/node": "^18.19.70",
         "msw": "2.11.2",
-        "oxfmt": "0.35.0",
+        "oxfmt": "0.42.0",
         "ts-loader": "^9.5.4",
         "typescript": "~5.9.3",
         "vitest": "^4.1.1",

--- a/seed/ts-sdk/simple-api/use-oxlint/package.json
+++ b/seed/ts-sdk/simple-api/use-oxlint/package.json
@@ -64,8 +64,8 @@
         "@types/node": "^18.19.70",
         "typescript": "~5.9.3",
         "@biomejs/biome": "2.4.9",
-        "oxlint": "1.50.0",
-        "oxlint-tsgolint": "0.14.2"
+        "oxlint": "1.57.0",
+        "oxlint-tsgolint": "0.17.4"
     },
     "browser": {
         "fs": false,


### PR DESCRIPTION
## Description

Update oxc tooling packages to their latest stable versions in the TypeScript SDK and Express generators.

## Changes Made

- **oxfmt**: 0.35.0 → 0.42.0
- **oxlint**: 1.50.0 → 1.57.0
- **oxlint-tsgolint**: 0.14.2 → 0.17.4

Updated in:
- `TOOL_VERSIONS` constant in `TypescriptProject.ts` (source of truth for generated SDK `package.json`)
- Seed Dockerfile (`docker/seed/Dockerfile.ts`)
- SDK generator Dockerfile (`generators/typescript/sdk/cli/Dockerfile`)
- Express generator Dockerfile (`generators/typescript/express/cli/Dockerfile`), including the cache-warm `package.json`
- `versions.yml` for both SDK (→ 3.59.10) and Express (→ 0.19.12)
- Regenerated seed outputs for `use-oxc`, `use-oxfmt`, and `use-oxlint` fixtures

## Testing

- [x] Ran `pnpm seed test --generator ts-sdk --fixture simple-api --skip-scripts` — all 19/19 test cases passed
- [x] Verified all version references are consistent across Dockerfiles, `TOOL_VERSIONS`, and generated `package.json` files

## Reviewer Checklist
- [ ] Confirm 0.42.0 / 1.57.0 / 0.17.4 are the desired target versions
- [ ] Verify no oxc version references were missed (grep confirmed only `buf@1.50.0` and historical changelog entries remain)

Link to Devin session: https://app.devin.ai/sessions/49b02733867e4ac9921d7ae5b667f792
Requested by: @Swimburger
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/14122" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
