### PR TITLE
perf(typescript): optimize fixImportsForEsm with merged regex, early exit, and string builder

### DIFF
--- a/generators/typescript/utils/commons/src/typescript-project/fixImportsForEsm.ts
+++ b/generators/typescript/utils/commons/src/typescript-project/fixImportsForEsm.ts
@@ -39,32 +39,29 @@ export async function fixImportsForEsm(pathToProject: AbsoluteFilePath): Promise
     // so we scan src/ directly. This avoids the complexity and fragility of parsing
     // tsconfig include/exclude (which can contain globs, JSONC comments, extends
     // chains, etc.) while matching the original ts-morph scoping behavior.
-    const fileExistenceCache = new Set<string>();
     const srcDir = join(pathToProject, RelativeFilePath.of("src"));
-    await collectFiles(srcDir, fileExistenceCache);
+    const fileExistenceCache = await collectFiles(srcDir);
 
     // Phase 2: Process each TypeScript file via string replacement
     const importModificationCache = new Map<string, ImportModificationType>();
 
-    const tsFiles = [...fileExistenceCache].filter((f) => {
-        const ext = path.extname(f);
-        return TS_EXTENSIONS.has(ext);
-    });
-
-    // Process in parallel batches for I/O throughput
-    const BATCH_SIZE = 100;
-    for (let i = 0; i < tsFiles.length; i += BATCH_SIZE) {
-        const batch = tsFiles.slice(i, i + BATCH_SIZE);
-        await Promise.all(
-            batch.map(async (filePath) => {
-                const content = await readFile(filePath, "utf-8");
-                const newContent = fixImportsInSource(content, filePath, fileExistenceCache, importModificationCache);
-                if (newContent !== content) {
-                    await writeFile(filePath, newContent);
-                }
-            })
-        );
+    const tsFiles: string[] = [];
+    for (const f of fileExistenceCache) {
+        if (TS_EXTENSIONS.has(path.extname(f))) {
+            tsFiles.push(f);
+        }
     }
+
+    // Process all files in parallel for maximum I/O throughput
+    await Promise.all(
+        tsFiles.map(async (filePath) => {
+            const content = await readFile(filePath, "utf-8");
+            const newContent = fixImportsInSource(content, filePath, fileExistenceCache, importModificationCache);
+            if (newContent !== content) {
+                await writeFile(filePath, newContent);
+            }
+        })
+    );
 }
 
 /**
@@ -83,78 +80,73 @@ function stripComments(source: string): string {
     return source.replace(pattern, (match) => " ".repeat(match.length));
 }
 
-// Regex for static imports/exports: from "./path" or from '../path'
-// Also handles side-effect imports: import "./path" or import './path'
-const STATIC_IMPORT_REGEX = /(?:from|import)\s+["'](\.\.?\/[^"']*?)["']/g;
+// Combined regex for both static and dynamic imports in a single pass.
+// Group 1: static import specifier (from "..." / import "...")
+// Group 2: dynamic import specifier (import("..."))
+// Using a single regex eliminates one full-text scan and the need to sort matches,
+// since exec() already yields matches in document order.
+const IMPORT_REGEX = /(?:from|import)\s+["'](\.\.?\/[^"']*?)["']|import\(\s*["'](\.\.?\/[^"']*?)["']\s*\)/g;
 
-// Regex for dynamic imports: import("./path") or import('./path')
-const DYNAMIC_IMPORT_REGEX = /import\(\s*["'](\.\.?\/[^"']*?)["']\s*\)/g;
-
-function fixImportsInSource(
+/**
+ * Fixes import specifiers in a single source file's content string.
+ * Exported so callers can apply this to in-memory content without disk I/O.
+ */
+export function fixImportsInSource(
     content: string,
     filePath: string,
     fileExistenceCache: Set<string>,
     importModificationCache: Map<string, ImportModificationType>
 ): string {
-    // Strip comments to find where real imports are, then apply
-    // replacements to the original content using the positions from the stripped version.
-    const stripped = stripComments(content);
+    // Fast path: skip files with no relative imports at all
+    if (!content.includes("./") && !content.includes("../")) {
+        return content;
+    }
 
-    let result = content;
-    // Track offset shifts from replacements so far
-    let offset = 0;
+    // Strip comments so regex doesn't match patterns inside comments.
+    // Skip the strip pass entirely if there are no comment markers.
+    const hasComments = content.includes("//") || content.includes("/*");
+    const stripped = hasComments ? stripComments(content) : content;
 
-    // Collect all matches from the stripped source (comments/strings removed)
-    const matches: Array<{ specifier: string; specifierStart: number; specifierEnd: number }> = [];
+    // Single-pass: collect matches and build result using a string builder
+    // to avoid O(n*m) copying from repeated slice+concat.
+    const parts: string[] = [];
+    let lastEnd = 0;
 
     let match: RegExpExecArray | null;
-
-    // Find static import/export matches
-    STATIC_IMPORT_REGEX.lastIndex = 0;
-    while ((match = STATIC_IMPORT_REGEX.exec(stripped)) !== null) {
-        const fullMatch = match[0];
-        const specifier = match[1];
-        if (specifier == null) {
+    IMPORT_REGEX.lastIndex = 0;
+    while ((match = IMPORT_REGEX.exec(stripped)) !== null) {
+        // Group 1 = static import specifier, Group 2 = dynamic import specifier
+        const specifier = match[1] ?? match[2];
+        if (specifier == null || specifier.endsWith(".js")) {
             continue;
         }
-        const quoteChar = fullMatch.charAt(fullMatch.indexOf(specifier) - 1);
-        const specifierStart = match.index + fullMatch.indexOf(quoteChar + specifier) + 1;
-        const specifierEnd = specifierStart + specifier.length;
-        matches.push({ specifier, specifierStart, specifierEnd });
-    }
 
-    // Find dynamic import matches
-    DYNAMIC_IMPORT_REGEX.lastIndex = 0;
-    while ((match = DYNAMIC_IMPORT_REGEX.exec(stripped)) !== null) {
-        const fullMatch = match[0];
-        const specifier = match[1];
-        if (specifier == null) {
-            continue;
-        }
-        const quoteChar = fullMatch.charAt(fullMatch.indexOf(specifier) - 1);
-        const specifierStart = match.index + fullMatch.indexOf(quoteChar + specifier) + 1;
-        const specifierEnd = specifierStart + specifier.length;
-        matches.push({ specifier, specifierStart, specifierEnd });
-    }
-
-    // Sort by position to apply replacements in order
-    matches.sort((a, b) => a.specifierStart - b.specifierStart);
-
-    for (const { specifier, specifierStart, specifierEnd } of matches) {
-        if (specifier.endsWith(".js")) {
-            continue;
-        }
         const modification = getCachedModification(specifier, filePath, fileExistenceCache, importModificationCache);
-        if (modification !== ImportModification.NONE) {
-            const newSpecifier = getModifiedSpecifier(specifier, modification);
-            const adjustedStart = specifierStart + offset;
-            const adjustedEnd = specifierEnd + offset;
-            result = result.slice(0, adjustedStart) + newSpecifier + result.slice(adjustedEnd);
-            offset += newSpecifier.length - specifier.length;
+        if (modification === ImportModification.NONE) {
+            continue;
         }
+
+        // Locate the specifier within the full match to get its absolute position
+        const fullMatch = match[0];
+        const quoteChar = fullMatch.charAt(fullMatch.indexOf(specifier) - 1);
+        const specifierStart = match.index + fullMatch.indexOf(quoteChar + specifier) + 1;
+        const specifierEnd = specifierStart + specifier.length;
+
+        // Append everything from the last replacement end to the start of this specifier,
+        // then append the modified specifier.
+        parts.push(content.slice(lastEnd, specifierStart));
+        parts.push(getModifiedSpecifier(specifier, modification));
+        lastEnd = specifierEnd;
     }
 
-    return result;
+    // If no replacements were made, return the original content (avoids allocation)
+    if (parts.length === 0) {
+        return content;
+    }
+
+    // Append the remainder of the file
+    parts.push(content.slice(lastEnd));
+    return parts.join("");
 }
 
 function getCachedModification(
@@ -225,16 +217,22 @@ function determineModification(
     return ImportModification.NONE;
 }
 
-// Recursively collect all source file paths, skipping node_modules and .git
-async function collectFiles(dir: string, files: Set<string>): Promise<void> {
+// Recursively collect all source file paths, parallelizing subdirectory traversal.
+async function collectFiles(dir: string): Promise<Set<string>> {
+    const files = new Set<string>();
+    await collectFilesRecursive(dir, files);
+    return files;
+}
+
+async function collectFilesRecursive(dir: string, files: Set<string>): Promise<void> {
     const entries = await readdir(dir, { withFileTypes: true });
+    const subdirs: Promise<void>[] = [];
     for (const entry of entries) {
         const fullPath = path.join(dir, entry.name);
         if (entry.isDirectory()) {
-            if (entry.name === "node_modules" || entry.name === ".git") {
-                continue;
+            if (entry.name !== "node_modules" && entry.name !== ".git") {
+                subdirs.push(collectFilesRecursive(fullPath, files));
             }
-            await collectFiles(fullPath, files);
         } else {
             const ext = path.extname(entry.name);
             if (ALL_EXTENSIONS.has(ext)) {
@@ -242,4 +240,5 @@ async function collectFiles(dir: string, files: Set<string>): Promise<void> {
             }
         }
     }
+    await Promise.all(subdirs);
 }


### PR DESCRIPTION
## Description

Refs FER-8691

Performance optimizations for `fixImportsForEsm` to reduce string processing overhead and improve I/O throughput.

## Changes Made

- **Merged regex**: Combined `STATIC_IMPORT_REGEX` and `DYNAMIC_IMPORT_REGEX` into a single `IMPORT_REGEX`, eliminating one full-text regex scan and the subsequent sort step (single `exec()` loop yields matches in document order)
- **Early exit**: Skip files with no relative imports (`./` or `../`) entirely — avoids comment stripping and regex matching for files that can't have any work to do
- **Conditional comment stripping**: Only run `stripComments()` when the file contains `//` or `/*`
- **String builder**: Replaced offset-tracking `slice+concat` pattern with `parts[]` array + `join("")` to avoid O(n×m) string copying for files with many imports
- **Removed batch processing**: Replaced `BATCH_SIZE = 100` chunked loop with a single `Promise.all` for maximum I/O parallelism
- **Parallel directory traversal**: Subdirectory `readdir` calls now fire concurrently via `Promise.all` instead of sequential `await`
- **Exported `fixImportsInSource`**: Made the per-file function public so callers can apply it to in-memory content without disk I/O (enables future Tier 1 optimization of processing files before writing to disk)

## Review Checklist

- [ ] **Unbounded parallelism**: Removing the `BATCH_SIZE = 100` cap means all files are processed concurrently. Could this cause fd exhaustion on very large projects? Node's libuv thread pool (default 4 threads for fs ops) naturally throttles, but worth considering.
- [ ] **Combined regex correctness**: Verify the `|` alternation doesn't change matching behavior — the `\s+` after `import` in the static branch should prevent matching `import(`, keeping the two alternatives disjoint.
- [ ] **Shared mutable Set in parallel traversal**: `collectFilesRecursive` has multiple concurrent async calls adding to the same `Set`. This is safe in single-threaded JS (no concurrent `Set.add` calls), but worth a glance.

## Testing

- [x] TypeScript compilation passes
- [x] Seed tests: 19/19 `ts-sdk:simple-api` configs pass with zero `.ts` file diffs

Link to Devin session: https://app.devin.ai/sessions/875263aabe0c4dcbbdacaabc7478ce1c
Requested by: @Swimburger
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/14123" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
