### PR TITLE
feat(cli): add missing-redirects rule to fern check

### DIFF
--- a/docs-yml.schema.json
+++ b/docs-yml.schema.json
@@ -4693,6 +4693,16 @@
               "type": "null"
             }
           ]
+        },
+        "missing-redirects": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/docs.CheckRuleSeverity"
+            },
+            {
+              "type": "null"
+            }
+          ]
         }
       },
       "additionalProperties": false

--- a/fern/apis/docs-yml/definition/docs.yml
+++ b/fern/apis/docs-yml/definition/docs.yml
@@ -177,6 +177,9 @@ types:
       valid-docs-endpoints:
         type: optional<CheckRuleSeverity>
         docs: Severity for docs endpoint URL validation. Default is warn.
+      missing-redirects:
+        type: optional<CheckRuleSeverity>
+        docs: Severity for detecting previously published URLs that disappeared without an explicit redirect. Default is warn.
 
   CheckConfig:
     docs: |

--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -1,5 +1,18 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 
+- version: 4.57.0
+  changelogEntry:
+    - summary: |
+        Add a `missing-redirects` docs validation rule to `fern check` that compares
+        the current docs navigation against the previously published markdown slug
+        table in FDR. The check warns when a published page is removed or moved
+        without a redirect in `docs.yml`, helping prevent broken historical docs URLs.
+        The rule also handles first-publish, unauthenticated, offline, and timeout
+        scenarios gracefully based on the configured check severity.
+      type: feat
+  createdAt: "2026-04-02"
+  irVersion: 65
+
 - version: 4.56.0
   changelogEntry:
     - summary: |

--- a/packages/cli/configuration/src/docs-yml/DocsYmlSchemas.ts
+++ b/packages/cli/configuration/src/docs-yml/DocsYmlSchemas.ts
@@ -574,7 +574,8 @@ export const CheckRulesConfig = z.object({
     "no-non-component-refs": CheckRuleSeverity.optional(),
     "valid-local-references": CheckRuleSeverity.optional(),
     "no-circular-redirects": CheckRuleSeverity.optional(),
-    "valid-docs-endpoints": CheckRuleSeverity.optional()
+    "valid-docs-endpoints": CheckRuleSeverity.optional(),
+    "missing-redirects": CheckRuleSeverity.optional()
 });
 
 export const CheckConfig = z.object({

--- a/packages/cli/configuration/src/docs-yml/schemas/sdk/api/resources/docs/types/CheckRulesConfig.ts
+++ b/packages/cli/configuration/src/docs-yml/schemas/sdk/api/resources/docs/types/CheckRulesConfig.ts
@@ -15,4 +15,6 @@ export interface CheckRulesConfig {
     noCircularRedirects?: FernDocsConfig.CheckRuleSeverity;
     /** Severity for docs endpoint URL validation. Default is warn. */
     validDocsEndpoints?: FernDocsConfig.CheckRuleSeverity;
+    /** Severity for detecting previously published URLs that disappeared without an explicit redirect. Default is warn. */
+    missingRedirects?: FernDocsConfig.CheckRuleSeverity;
 }

--- a/packages/cli/configuration/src/docs-yml/schemas/sdk/serialization/resources/docs/types/CheckRulesConfig.ts
+++ b/packages/cli/configuration/src/docs-yml/schemas/sdk/serialization/resources/docs/types/CheckRulesConfig.ts
@@ -15,6 +15,7 @@ export const CheckRulesConfig: core.serialization.ObjectSchema<
     validLocalReferences: core.serialization.property("valid-local-references", CheckRuleSeverity.optional()),
     noCircularRedirects: core.serialization.property("no-circular-redirects", CheckRuleSeverity.optional()),
     validDocsEndpoints: core.serialization.property("valid-docs-endpoints", CheckRuleSeverity.optional()),
+    missingRedirects: core.serialization.property("missing-redirects", CheckRuleSeverity.optional()),
 });
 
 export declare namespace CheckRulesConfig {
@@ -25,5 +26,6 @@ export declare namespace CheckRulesConfig {
         "valid-local-references"?: CheckRuleSeverity.Raw | null;
         "no-circular-redirects"?: CheckRuleSeverity.Raw | null;
         "valid-docs-endpoints"?: CheckRuleSeverity.Raw | null;
+        "missing-redirects"?: CheckRuleSeverity.Raw | null;
     }
 }

--- a/packages/cli/workspace/loader/src/docs-yml.schema.json
+++ b/packages/cli/workspace/loader/src/docs-yml.schema.json
@@ -4693,6 +4693,16 @@
               "type": "null"
             }
           ]
+        },
+        "missing-redirects": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/docs.CheckRuleSeverity"
+            },
+            {
+              "type": "null"
+            }
+          ]
         }
       },
       "additionalProperties": false

--- a/packages/cli/yaml/docs-validator/package.json
+++ b/packages/cli/yaml/docs-validator/package.json
@@ -33,6 +33,7 @@
   },
   "dependencies": {
     "@fern-api/api-workspace-commons": "workspace:*",
+    "@fern-api/auth": "workspace:*",
     "@fern-api/cli-source-resolver": "workspace:*",
     "@fern-api/configuration-loader": "workspace:*",
     "@fern-api/core-utils": "workspace:*",

--- a/packages/cli/yaml/docs-validator/src/getAllRules.ts
+++ b/packages/cli/yaml/docs-validator/src/getAllRules.ts
@@ -2,6 +2,7 @@ import { Rule } from "./Rule.js";
 import { AccentColorContrastRule } from "./rules/accent-color-contrast/index.js";
 import { AllRolesMustBeDeclaredRule } from "./rules/all-roles-must-be-declared/index.js";
 import { FilepathsExistRule } from "./rules/filepaths-exist/index.js";
+import { MissingRedirectsRule } from "./rules/missing-redirects/index.js";
 import { NoCircularRedirectsRule } from "./rules/no-circular-redirects/index.js";
 import { NoNonComponentRefsRule } from "./rules/no-non-component-refs/index.js";
 import { NoOpenApiV2InDocsRule } from "./rules/no-openapi-v2-in-docs/index.js";
@@ -27,6 +28,7 @@ const allRules = [
     ValidateProductFileRule,
     ValidInstanceUrlRule, // Validate instance URLs have valid subdomains
     NoCircularRedirectsRule, // Detect circular redirect chains
+    MissingRedirectsRule, // Check if any previously published URLs disappear without a redirect
     AccentColorContrastRule,
     ValidMarkdownLinks,
     ValidFileTypes,

--- a/packages/cli/yaml/docs-validator/src/rules/index.ts
+++ b/packages/cli/yaml/docs-validator/src/rules/index.ts
@@ -1,6 +1,7 @@
 export * from "./accent-color-contrast/index.js";
 export * from "./all-roles-must-be-declared/index.js";
 export * from "./filepaths-exist/index.js";
+export * from "./missing-redirects/index.js";
 export * from "./no-circular-redirects/index.js";
 export * from "./only-versioned-navigation/index.js";
 export * from "./tab-with-href/index.js";

--- a/packages/cli/yaml/docs-validator/src/rules/missing-redirects/__test__/missing-redirects.test.ts
+++ b/packages/cli/yaml/docs-validator/src/rules/missing-redirects/__test__/missing-redirects.test.ts
@@ -1,0 +1,171 @@
+import { checkMissingRedirects, findRemovedSlugs, type MarkdownEntry } from "../missing-redirects-logic.js";
+
+describe("findRemovedSlugs", () => {
+    it("returns empty when published and local are identical", () => {
+        const published: MarkdownEntry[] = [
+            { pageId: "docs/welcome.mdx", slug: "welcome" },
+            { pageId: "docs/guide.mdx", slug: "guide" }
+        ];
+        const local = new Map([
+            ["docs/welcome.mdx", "welcome"],
+            ["docs/guide.mdx", "guide"]
+        ]);
+        expect(findRemovedSlugs(published, local)).toEqual([]);
+    });
+
+    it("detects a removed page (pageId absent from local)", () => {
+        const published: MarkdownEntry[] = [
+            { pageId: "docs/welcome.mdx", slug: "welcome" },
+            { pageId: "docs/old-page.mdx", slug: "old-page" }
+        ];
+        const local = new Map([["docs/welcome.mdx", "welcome"]]);
+        const removed = findRemovedSlugs(published, local);
+        expect(removed).toEqual([{ pageId: "docs/old-page.mdx", oldSlug: "old-page", newSlug: undefined }]);
+    });
+
+    it("detects a moved page (same pageId, different slug)", () => {
+        const published: MarkdownEntry[] = [{ pageId: "docs/guide.mdx", slug: "getting-started" }];
+        const local = new Map([["docs/guide.mdx", "guides/quickstart"]]);
+        const removed = findRemovedSlugs(published, local);
+        expect(removed).toEqual([
+            { pageId: "docs/guide.mdx", oldSlug: "getting-started", newSlug: "guides/quickstart" }
+        ]);
+    });
+
+    it("detects multiple removals and moves together", () => {
+        const published: MarkdownEntry[] = [
+            { pageId: "docs/a.mdx", slug: "a" },
+            { pageId: "docs/b.mdx", slug: "b" },
+            { pageId: "docs/c.mdx", slug: "c" }
+        ];
+        const local = new Map([
+            ["docs/a.mdx", "a"],
+            ["docs/b.mdx", "new-b"]
+        ]);
+        const removed = findRemovedSlugs(published, local);
+        expect(removed).toHaveLength(2);
+        expect(removed).toContainEqual({ pageId: "docs/b.mdx", oldSlug: "b", newSlug: "new-b" });
+        expect(removed).toContainEqual({ pageId: "docs/c.mdx", oldSlug: "c", newSlug: undefined });
+    });
+
+    it("ignores new pages that only exist locally", () => {
+        const published: MarkdownEntry[] = [{ pageId: "docs/existing.mdx", slug: "existing" }];
+        const local = new Map([
+            ["docs/existing.mdx", "existing"],
+            ["docs/brand-new.mdx", "brand-new"]
+        ]);
+        expect(findRemovedSlugs(published, local)).toEqual([]);
+    });
+
+    it("returns empty for empty published entries (first publish)", () => {
+        const local = new Map([["docs/welcome.mdx", "welcome"]]);
+        expect(findRemovedSlugs([], local)).toEqual([]);
+    });
+});
+
+describe("checkMissingRedirects", () => {
+    it("returns a violation for a removed page without redirect", () => {
+        const violations = checkMissingRedirects(
+            [{ pageId: "docs/old.mdx", oldSlug: "old-page", newSlug: undefined }],
+            [],
+            undefined
+        );
+        expect(violations).toHaveLength(1);
+        expect(violations[0]?.severity).toBe("warning");
+        expect(violations[0]?.message).toContain("was removed");
+        expect(violations[0]?.message).toContain("/old-page");
+    });
+
+    it("returns a violation for a moved page without redirect", () => {
+        const violations = checkMissingRedirects(
+            [{ pageId: "docs/guide.mdx", oldSlug: "getting-started", newSlug: "guides/quickstart" }],
+            [],
+            undefined
+        );
+        expect(violations).toHaveLength(1);
+        expect(violations[0]?.severity).toBe("warning");
+        expect(violations[0]?.message).toContain("was moved");
+        expect(violations[0]?.message).toContain("/getting-started");
+        expect(violations[0]?.message).toContain("/guides/quickstart");
+    });
+
+    it("suppresses violation when an exact redirect covers the old slug", () => {
+        const violations = checkMissingRedirects(
+            [{ pageId: "docs/guide.mdx", oldSlug: "getting-started", newSlug: "guides/quickstart" }],
+            [{ source: "/getting-started", destination: "/guides/quickstart" }],
+            undefined
+        );
+        expect(violations).toEqual([]);
+    });
+
+    it("suppresses violation when a wildcard redirect covers the old slug", () => {
+        const violations = checkMissingRedirects(
+            [{ pageId: "docs/guide.mdx", oldSlug: "old/guide", newSlug: "new/guide" }],
+            [{ source: "/old/:path*", destination: "/new/:path*" }],
+            undefined
+        );
+        expect(violations).toEqual([]);
+    });
+
+    it("does not suppress when redirect source does not match", () => {
+        const violations = checkMissingRedirects(
+            [{ pageId: "docs/guide.mdx", oldSlug: "getting-started", newSlug: "guides/quickstart" }],
+            [{ source: "/unrelated", destination: "/somewhere" }],
+            undefined
+        );
+        expect(violations).toHaveLength(1);
+    });
+
+    it("handles basePath by prepending it to redirect sources", () => {
+        const violations = checkMissingRedirects(
+            [{ pageId: "docs/guide.mdx", oldSlug: "/docs/getting-started", newSlug: "/docs/quickstart" }],
+            [{ source: "/getting-started", destination: "/quickstart" }],
+            "/docs"
+        );
+        expect(violations).toEqual([]);
+    });
+
+    it("produces violations for multiple uncovered removals", () => {
+        const violations = checkMissingRedirects(
+            [
+                { pageId: "docs/a.mdx", oldSlug: "page-a", newSlug: undefined },
+                { pageId: "docs/b.mdx", oldSlug: "page-b", newSlug: "new-b" }
+            ],
+            [],
+            undefined
+        );
+        expect(violations).toHaveLength(2);
+        expect(violations[0]?.message).toContain("was removed");
+        expect(violations[1]?.message).toContain("was moved");
+    });
+
+    it("returns empty when all removed slugs are covered by redirects", () => {
+        const violations = checkMissingRedirects(
+            [
+                { pageId: "docs/a.mdx", oldSlug: "page-a", newSlug: undefined },
+                { pageId: "docs/b.mdx", oldSlug: "page-b", newSlug: "new-b" }
+            ],
+            [
+                { source: "/page-a", destination: "/somewhere" },
+                { source: "/page-b", destination: "/new-b" }
+            ],
+            undefined
+        );
+        expect(violations).toEqual([]);
+    });
+
+    it("returns empty for empty removed slugs", () => {
+        expect(checkMissingRedirects([], [], undefined)).toEqual([]);
+    });
+
+    it("violation message suggests the correct redirect for a moved page", () => {
+        const violations = checkMissingRedirects(
+            [{ pageId: "docs/guide.mdx", oldSlug: "old-path", newSlug: "new-path" }],
+            [],
+            undefined
+        );
+        expect(violations).toHaveLength(1);
+        expect(violations[0]?.message).toContain('source: "/old-path"');
+        expect(violations[0]?.message).toContain('destination: "/new-path"');
+    });
+});

--- a/packages/cli/yaml/docs-validator/src/rules/missing-redirects/buildPageIdToSlugMap.ts
+++ b/packages/cli/yaml/docs-validator/src/rules/missing-redirects/buildPageIdToSlugMap.ts
@@ -1,0 +1,47 @@
+/**
+ * TODO(kafkas): This file is an exact copy of the canonical implementation in fdr-sdk.
+ * Once this repo upgrades to the latest fdr-sdk version that contains this utility,
+ * replace the usage in missing-redirects.ts with:
+ *
+ *   import { FernNavigation } from "@fern-api/fdr-sdk";
+ *   const pageIdToSlug = FernNavigation.utils.buildPageIdToSlugMap(root);
+ *
+ * and delete this file.
+ */
+
+import { FernNavigation } from "@fern-api/fdr-sdk";
+
+/**
+ * Builds a map from pageId to slug from a navigation root node.
+ *
+ * This mirrors how FDR's slug table stores page → URL mappings and should be
+ * used by both the server (when populating the slug table on publish) and the
+ * CLI (when building the local "after" state for the missing-redirects check).
+ *
+ * Changelog entries are special-cased: they map to their parent changelog
+ * node's slug rather than their own individual entry slug, because individual
+ * changelog entries are rendered on the parent changelog page.
+ */
+export function buildPageIdToSlugMap(root: FernNavigation.NavigationNode): Map<string, string> {
+    const collector = FernNavigation.NodeCollector.collect(root);
+    const pageIdToSlug = new Map<string, string>();
+    for (const entry of collector.getSlugMapWithParents().values()) {
+        const { node, parents } = entry;
+        if (!FernNavigation.isPage(node)) {
+            continue;
+        }
+        const pageId = FernNavigation.getPageId(node);
+        if (pageId == null) {
+            continue;
+        }
+        let slug = node.canonicalSlug ?? node.slug;
+        if (node.type === "changelogEntry") {
+            const changelogParent = parents.findLast((p) => p.type === "changelog");
+            if (changelogParent != null && FernNavigation.hasMetadata(changelogParent)) {
+                slug = changelogParent.canonicalSlug ?? changelogParent.slug;
+            }
+        }
+        pageIdToSlug.set(pageId, slug);
+    }
+    return pageIdToSlug;
+}

--- a/packages/cli/yaml/docs-validator/src/rules/missing-redirects/index.ts
+++ b/packages/cli/yaml/docs-validator/src/rules/missing-redirects/index.ts
@@ -1,0 +1,1 @@
+export { MissingRedirectsRule } from "./missing-redirects.js";

--- a/packages/cli/yaml/docs-validator/src/rules/missing-redirects/missing-redirects-logic.ts
+++ b/packages/cli/yaml/docs-validator/src/rules/missing-redirects/missing-redirects-logic.ts
@@ -1,0 +1,113 @@
+import { match } from "path-to-regexp";
+
+export interface MarkdownEntry {
+    pageId: string;
+    slug: string;
+}
+
+export interface RemovedSlug {
+    pageId: string;
+    oldSlug: string;
+    newSlug: string | undefined;
+}
+
+export interface Redirect {
+    source: string;
+    destination: string;
+}
+
+export interface MissingRedirectViolation {
+    severity: "warning";
+    message: string;
+}
+
+function removeTrailingSlash(pathname: string): string {
+    return pathname.endsWith("/") ? pathname.slice(0, -1) : pathname;
+}
+
+function withBasepath(source: string, basePath: string | undefined): string {
+    if (basePath == null) {
+        return source;
+    }
+    return source.startsWith(basePath)
+        ? source
+        : `${removeTrailingSlash(basePath)}${source.startsWith("/") ? "" : "/"}${source}`;
+}
+
+function matchPath(pattern: string, path: string): boolean {
+    if (pattern === path) {
+        return true;
+    }
+    try {
+        return match(pattern)(path) !== false;
+    } catch {
+        return false;
+    }
+}
+
+function isSlugCoveredByRedirect(oldSlug: string, redirects: Redirect[], basePath: string | undefined): boolean {
+    const oldPath = oldSlug.startsWith("/") ? oldSlug : `/${oldSlug}`;
+    return redirects.some((redirect) => {
+        const source = removeTrailingSlash(withBasepath(redirect.source, basePath));
+        return matchPath(source, oldPath);
+    });
+}
+
+/**
+ * Compares published slug table entries against the local pageId->slug map
+ * and returns entries whose slug disappeared or changed.
+ */
+export function findRemovedSlugs(
+    publishedEntries: MarkdownEntry[],
+    localPageIdToSlug: Map<string, string>
+): RemovedSlug[] {
+    const removed: RemovedSlug[] = [];
+    for (const entry of publishedEntries) {
+        const newSlug = localPageIdToSlug.get(entry.pageId);
+        if (newSlug === undefined) {
+            removed.push({ pageId: entry.pageId, oldSlug: entry.slug, newSlug: undefined });
+        } else if (newSlug !== entry.slug) {
+            removed.push({ pageId: entry.pageId, oldSlug: entry.slug, newSlug });
+        }
+    }
+    return removed;
+}
+
+/**
+ * Produces rule violations for removed/moved slugs that are not covered
+ * by any configured redirect.
+ */
+export function checkMissingRedirects(
+    removedSlugs: RemovedSlug[],
+    redirects: Redirect[],
+    basePath: string | undefined
+): MissingRedirectViolation[] {
+    const violations: MissingRedirectViolation[] = [];
+    for (const removed of removedSlugs) {
+        if (isSlugCoveredByRedirect(removed.oldSlug, redirects, basePath)) {
+            continue;
+        }
+
+        const oldPath = removed.oldSlug.startsWith("/") ? removed.oldSlug : `/${removed.oldSlug}`;
+
+        if (removed.newSlug != null) {
+            const newPath = removed.newSlug.startsWith("/") ? removed.newSlug : `/${removed.newSlug}`;
+            violations.push({
+                severity: "warning",
+                message:
+                    `Page "${removed.pageId}" was moved from "${oldPath}" to "${newPath}". ` +
+                    `The old URL will return 404 without a redirect. ` +
+                    `Add to docs.yml: redirects: [{source: "${oldPath}", destination: "${newPath}"}]`
+            });
+        } else {
+            violations.push({
+                severity: "warning",
+                message:
+                    `Page "${removed.pageId}" was removed. ` +
+                    `The previously published URL "${oldPath}" will return 404 without a redirect. ` +
+                    `Consider adding a redirect in docs.yml to preserve existing links.`
+            });
+        }
+    }
+    return violations;
+}

--- a/packages/cli/yaml/docs-validator/src/rules/missing-redirects/missing-redirects.ts
+++ b/packages/cli/yaml/docs-validator/src/rules/missing-redirects/missing-redirects.ts
@@ -5,22 +5,12 @@ import { FernNavigation } from "@fern-api/fdr-sdk";
 import { createLogger } from "@fern-api/logger";
 import { createMockTaskContext } from "@fern-api/task-context";
 
-import { Rule, RuleViolation } from "../../Rule.js";
-import { matchPath } from "../valid-markdown-link/redirect-for-path.js";
-import { getInstanceUrls, removeTrailingSlash, toBaseUrl } from "../valid-markdown-link/url-utils.js";
+import { Rule } from "../../Rule.js";
+import { getInstanceUrls, toBaseUrl } from "../valid-markdown-link/url-utils.js";
+import { buildPageIdToSlugMap } from "./buildPageIdToSlugMap.js";
+import { checkMissingRedirects, findRemovedSlugs, type MarkdownEntry } from "./missing-redirects-logic.js";
 
 const NOOP_CONTEXT = createMockTaskContext({ logger: createLogger(noop) });
-
-interface MarkdownEntry {
-    pageId: string;
-    slug: string;
-}
-
-interface RemovedSlug {
-    pageId: string;
-    oldSlug: string;
-    newSlug: string | undefined;
-}
 
 type FetchResult =
     | { type: "success"; entries: MarkdownEntry[] }
@@ -49,7 +39,8 @@ async function fetchMarkdownEntries(
                 "Content-Type": "application/json",
                 Authorization: `Bearer ${authToken}`
             },
-            body: JSON.stringify({ domain, basepath: basepath ?? "" })
+            body: JSON.stringify({ domain, basepath: basepath ?? "" }),
+            signal: AbortSignal.timeout(30_000)
         });
         if (!response.ok) {
             return { error: `FDR returned ${response.status}` };
@@ -76,28 +67,6 @@ function getFdrOrigin(): string {
         process.env.DEFAULT_FDR_ORIGIN ??
         "https://registry.buildwithfern.com"
     );
-}
-
-function withBasepath(source: string, basePath: string | undefined): string {
-    if (basePath == null) {
-        return source;
-    }
-
-    return source.startsWith(basePath)
-        ? source
-        : `${removeTrailingSlash(basePath)}${source.startsWith("/") ? "" : "/"}${source}`;
-}
-
-function isSlugCoveredByRedirect(
-    oldSlug: string,
-    redirects: { source: string; destination: string }[],
-    basePath: string | undefined
-): boolean {
-    const oldPath = oldSlug.startsWith("/") ? oldSlug : `/${oldSlug}`;
-    return redirects.some((redirect) => {
-        const source = removeTrailingSlash(withBasepath(redirect.source, basePath));
-        return matchPath(source, oldPath) !== false;
-    });
 }
 
 export const MissingRedirectsRule: Rule = {
@@ -144,29 +113,8 @@ export const MissingRedirectsRule: Rule = {
         }
 
         const root = FernNavigation.migrate.FernNavigationV1ToLatest.create().root(resolvedDocsDefinition.config.root);
-        const collector = FernNavigation.NodeCollector.collect(root);
-
-        const localPageIdToSlug = new Map<string, string>();
-        collector.slugMap.forEach((node, slug) => {
-            if (node == null || !FernNavigation.isPage(node)) {
-                return;
-            }
-
-            const pageId = FernNavigation.getPageId(node);
-            if (pageId != null) {
-                localPageIdToSlug.set(pageId, slug);
-            }
-        });
-
-        const removedSlugs: RemovedSlug[] = [];
-        for (const entry of result.entries) {
-            const newSlug = localPageIdToSlug.get(entry.pageId);
-            if (newSlug === undefined) {
-                removedSlugs.push({ pageId: entry.pageId, oldSlug: entry.slug, newSlug: undefined });
-            } else if (newSlug !== entry.slug) {
-                removedSlugs.push({ pageId: entry.pageId, oldSlug: entry.slug, newSlug });
-            }
-        }
+        const localPageIdToSlug = buildPageIdToSlugMap(root);
+        const removedSlugs = findRemovedSlugs(result.entries, localPageIdToSlug);
 
         if (removedSlugs.length === 0) {
             return {};
@@ -174,40 +122,11 @@ export const MissingRedirectsRule: Rule = {
 
         return {
             file: async ({ config }) => {
-                const violations: RuleViolation[] = [];
                 const redirects = (config.redirects ?? []).map((redirect) => ({
                     source: redirect.source,
                     destination: redirect.destination
                 }));
-
-                for (const removed of removedSlugs) {
-                    if (isSlugCoveredByRedirect(removed.oldSlug, redirects, baseUrl.basePath)) {
-                        continue;
-                    }
-
-                    const oldPath = removed.oldSlug.startsWith("/") ? removed.oldSlug : `/${removed.oldSlug}`;
-
-                    if (removed.newSlug != null) {
-                        const newPath = removed.newSlug.startsWith("/") ? removed.newSlug : `/${removed.newSlug}`;
-                        violations.push({
-                            severity: "warning",
-                            message:
-                                `Page "${removed.pageId}" was moved from "${oldPath}" to "${newPath}". ` +
-                                `The old URL will return 404 without a redirect. ` +
-                                `Add to docs.yml: redirects: [{source: "${oldPath}", destination: "${newPath}"}]`
-                        });
-                    } else {
-                        violations.push({
-                            severity: "warning",
-                            message:
-                                `Page "${removed.pageId}" was removed. ` +
-                                `The previously published URL "${oldPath}" will return 404 without a redirect. ` +
-                                `Consider adding a redirect in docs.yml to preserve existing links.`
-                        });
-                    }
-                }
-
-                return violations;
+                return checkMissingRedirects(removedSlugs, redirects, baseUrl.basePath);
             }
         };
     }

--- a/packages/cli/yaml/docs-validator/src/rules/missing-redirects/missing-redirects.ts
+++ b/packages/cli/yaml/docs-validator/src/rules/missing-redirects/missing-redirects.ts
@@ -1,0 +1,253 @@
+import { getToken } from "@fern-api/auth";
+import { noop } from "@fern-api/core-utils";
+import { DocsDefinitionResolver } from "@fern-api/docs-resolver";
+import { FernNavigation } from "@fern-api/fdr-sdk";
+import { createLogger } from "@fern-api/logger";
+import { createMockTaskContext } from "@fern-api/task-context";
+
+import { Rule, RuleViolation } from "../../Rule.js";
+import { matchPath } from "../valid-markdown-link/redirect-for-path.js";
+import { getInstanceUrls, removeTrailingSlash, toBaseUrl } from "../valid-markdown-link/url-utils.js";
+
+const NOOP_CONTEXT = createMockTaskContext({ logger: createLogger(noop) });
+
+interface MarkdownEntry {
+    pageId: string;
+    slug: string;
+}
+
+interface RemovedSlug {
+    pageId: string;
+    oldSlug: string;
+    newSlug: string | undefined;
+}
+
+type FetchResult =
+    | { type: "success"; entries: MarkdownEntry[] }
+    | { type: "no-token" }
+    | { type: "no-instance-url" }
+    | { type: "fetch-failed"; reason: string }
+    | { type: "first-publish" };
+
+/**
+ * Fetches the currently published markdown entries from FDR's slug table.
+ *
+ * Uses `POST /slugs/markdowns` which returns one entry per tracked markdown
+ * page, keyed by pageId. The table is populated during `finishDocsRegister`
+ * and always reflects the most recently published state.
+ */
+async function fetchMarkdownEntries(
+    fdrOrigin: string,
+    domain: string,
+    basepath: string | undefined,
+    authToken: string
+): Promise<{ entries: MarkdownEntry[] } | { error: string }> {
+    try {
+        const response = await fetch(`${fdrOrigin}/slugs/markdowns`, {
+            method: "POST",
+            headers: {
+                "Content-Type": "application/json",
+                Authorization: `Bearer ${authToken}`
+            },
+            body: JSON.stringify({ domain, basepath: basepath ?? "" })
+        });
+        if (!response.ok) {
+            return { error: `FDR returned ${response.status}` };
+        }
+        const data = (await response.json()) as {
+            entries?: Array<{ pageId: string; slug: string }>;
+        };
+        return {
+            entries: (data.entries ?? []).map((entry) => ({
+                pageId: entry.pageId,
+                slug: entry.slug
+            }))
+        };
+    } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        return { error: message };
+    }
+}
+
+function getFdrOrigin(): string {
+    return (
+        process.env.FERN_FDR_ORIGIN ??
+        process.env.OVERRIDE_FDR_ORIGIN ??
+        process.env.DEFAULT_FDR_ORIGIN ??
+        "https://registry.buildwithfern.com"
+    );
+}
+
+function withBasepath(source: string, basePath: string | undefined): string {
+    if (basePath == null) {
+        return source;
+    }
+
+    return source.startsWith(basePath)
+        ? source
+        : `${removeTrailingSlash(basePath)}${source.startsWith("/") ? "" : "/"}${source}`;
+}
+
+function isSlugCoveredByRedirect(
+    oldSlug: string,
+    redirects: { source: string; destination: string }[],
+    basePath: string | undefined
+): boolean {
+    const oldPath = oldSlug.startsWith("/") ? oldSlug : `/${oldSlug}`;
+    return redirects.some((redirect) => {
+        const source = removeTrailingSlash(withBasepath(redirect.source, basePath));
+        return matchPath(source, oldPath) !== false;
+    });
+}
+
+export const MissingRedirectsRule: Rule = {
+    name: "missing-redirects",
+    create: async ({ workspace, apiWorkspaces, ossWorkspaces, logger }) => {
+        const instanceUrls = getInstanceUrls(workspace);
+        const url = instanceUrls[0];
+        if (url == null) {
+            return makeSkipVisitor({ type: "no-instance-url" });
+        }
+
+        const baseUrl = toBaseUrl(url);
+
+        const token = await getToken();
+        if (token == null) {
+            return makeSkipVisitor({ type: "no-token" });
+        }
+
+        const result = await fetchMarkdownEntries(getFdrOrigin(), baseUrl.domain, baseUrl.basePath, token.value);
+        if ("error" in result) {
+            logger.debug(`[missing-redirects] FDR fetch failed: ${result.error}`);
+            return makeSkipVisitor({ type: "fetch-failed", reason: result.error });
+        }
+        if (result.entries.length === 0) {
+            logger.debug("[missing-redirects] No markdown entries found (first publish or empty slug table)");
+            return makeSkipVisitor({ type: "first-publish" });
+        }
+
+        const docsDefinitionResolver = new DocsDefinitionResolver({
+            domain: url,
+            docsWorkspace: workspace,
+            ossWorkspaces,
+            apiWorkspaces,
+            taskContext: NOOP_CONTEXT,
+            editThisPage: undefined,
+            uploadFiles: undefined,
+            registerApi: undefined,
+            targetAudiences: undefined
+        });
+
+        const resolvedDocsDefinition = await docsDefinitionResolver.resolve();
+        if (!resolvedDocsDefinition.config.root) {
+            return {};
+        }
+
+        const root = FernNavigation.migrate.FernNavigationV1ToLatest.create().root(resolvedDocsDefinition.config.root);
+        const collector = FernNavigation.NodeCollector.collect(root);
+
+        const localPageIdToSlug = new Map<string, string>();
+        collector.slugMap.forEach((node, slug) => {
+            if (node == null || !FernNavigation.isPage(node)) {
+                return;
+            }
+
+            const pageId = FernNavigation.getPageId(node);
+            if (pageId != null) {
+                localPageIdToSlug.set(pageId, slug);
+            }
+        });
+
+        const removedSlugs: RemovedSlug[] = [];
+        for (const entry of result.entries) {
+            const newSlug = localPageIdToSlug.get(entry.pageId);
+            if (newSlug === undefined) {
+                removedSlugs.push({ pageId: entry.pageId, oldSlug: entry.slug, newSlug: undefined });
+            } else if (newSlug !== entry.slug) {
+                removedSlugs.push({ pageId: entry.pageId, oldSlug: entry.slug, newSlug });
+            }
+        }
+
+        if (removedSlugs.length === 0) {
+            return {};
+        }
+
+        return {
+            file: async ({ config }) => {
+                const violations: RuleViolation[] = [];
+                const redirects = (config.redirects ?? []).map((redirect) => ({
+                    source: redirect.source,
+                    destination: redirect.destination
+                }));
+
+                for (const removed of removedSlugs) {
+                    if (isSlugCoveredByRedirect(removed.oldSlug, redirects, baseUrl.basePath)) {
+                        continue;
+                    }
+
+                    const oldPath = removed.oldSlug.startsWith("/") ? removed.oldSlug : `/${removed.oldSlug}`;
+
+                    if (removed.newSlug != null) {
+                        const newPath = removed.newSlug.startsWith("/") ? removed.newSlug : `/${removed.newSlug}`;
+                        violations.push({
+                            severity: "warning",
+                            message:
+                                `Page "${removed.pageId}" was moved from "${oldPath}" to "${newPath}". ` +
+                                `The old URL will return 404 without a redirect. ` +
+                                `Add to docs.yml: redirects: [{source: "${oldPath}", destination: "${newPath}"}]`
+                        });
+                    } else {
+                        violations.push({
+                            severity: "warning",
+                            message:
+                                `Page "${removed.pageId}" was removed. ` +
+                                `The previously published URL "${oldPath}" will return 404 without a redirect. ` +
+                                `Consider adding a redirect in docs.yml to preserve existing links.`
+                        });
+                    }
+                }
+
+                return violations;
+            }
+        };
+    }
+};
+
+/**
+ * Returns a visitor that emits a single warning explaining why the check
+ * was skipped. The severity override system promotes this to "error" when
+ * the user has configured `missing-redirects: error`, which makes the CLI
+ * exit with code 1 — matching the expectation that error-mode checks must
+ * either pass or fail, never silently skip.
+ *
+ * In the default "warn" mode the message simply surfaces as a warning.
+ */
+function makeSkipVisitor(fetchResult: Exclude<FetchResult, { type: "success" }>): ReturnType<Rule["create"]> {
+    switch (fetchResult.type) {
+        case "no-instance-url":
+        case "first-publish":
+            return {};
+        case "no-token":
+            return {
+                file: () => [
+                    {
+                        severity: "warning",
+                        message:
+                            "Missing redirects check skipped: not authenticated. " +
+                            "Run 'fern login' or set the FERN_TOKEN environment variable to enable this check."
+                    }
+                ]
+            };
+        case "fetch-failed":
+            return {
+                file: () => [
+                    {
+                        severity: "warning",
+                        message:
+                            `Missing redirects check skipped: could not reach FDR (${fetchResult.reason}). ` +
+                            "The check requires network access to compare against previously published docs."
+                    }
+                ]
+            };
+    }
+}

--- a/packages/cli/yaml/docs-validator/src/validateDocsWorkspace.ts
+++ b/packages/cli/yaml/docs-validator/src/validateDocsWorkspace.ts
@@ -12,6 +12,7 @@ import {
 import { visitDocsConfigFileYamlAst } from "./docsAst/visitDocsConfigFileYamlAst.js";
 import { getAllRules } from "./getAllRules.js";
 import { Rule } from "./Rule.js";
+import { MissingRedirectsRule } from "./rules/missing-redirects/index.js";
 import { NoCircularRedirectsRule } from "./rules/no-circular-redirects/index.js";
 import { NoNonComponentRefsRule } from "./rules/no-non-component-refs/index.js";
 import { ValidDocsEndpoints } from "./rules/valid-docs-endpoints/index.js";
@@ -37,7 +38,8 @@ const CHECK_RULE_CONFIG_TO_RULE_NAME = {
     noNonComponentRefs: NoNonComponentRefsRule.name,
     validLocalReferences: ValidLocalReferencesRule.name,
     noCircularRedirects: NoCircularRedirectsRule.name,
-    validDocsEndpoints: ValidDocsEndpoints.name
+    validDocsEndpoints: ValidDocsEndpoints.name,
+    missingRedirects: MissingRedirectsRule.name
 } satisfies Record<keyof docsYml.RawSchemas.CheckRulesConfig, string>;
 
 function buildSeverityOverrides(

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7576,6 +7576,9 @@ importers:
       '@fern-api/api-workspace-commons':
         specifier: workspace:*
         version: link:../../../commons/api-workspace-commons
+      '@fern-api/auth':
+        specifier: workspace:*
+        version: link:../../auth
       '@fern-api/cli-source-resolver':
         specifier: workspace:*
         version: link:../../cli-source-resolver


### PR DESCRIPTION
## Description
Linear ticket: [FER-9171](https://linear.app/buildwithfern/issue/FER-9171/implement-missing-redirects-fern-check-rule) 
<!-- Use "Closes" to automatically close the ticket when PR merges, or "Refs" to link without closing -->
<!-- Provide a clear and concise description of the changes made in this PR -->

Add a new `fern check` rule, `missing-redirects`, that compares the current docs navigation against the previously published markdown slug table stored in FDR. The rule detects when a page that was previously published has either been removed entirely or moved to a new slug without a corresponding redirect in `docs.yml`, helping prevent broken historical docs URLs after publish.

The rule is configurable through `check.rules` in `docs.yml`, where users can set it to `warn` or `error`, and it follows the standard docs check severity behavior. In practice this means the rule defaults to warning behavior, but can be promoted to an error when teams want redirect coverage to be enforced before publishing.

Because the rule depends on prior published state, it makes an authenticated network call to FDR during validation. The implementation handles first-publish, missing auth, offline/network failure, and timeout cases gracefully so the behavior remains consistent with the configured severity. This PR also extracts the core diffing and redirect-matching logic into unit-testable helpers and aligns slug generation behavior with the backend, including changelog-specific handling.

## Changes Made
<!-- List the main changes and updates implemented in this PR -->
- Added a new `missing-redirects` docs validation rule and wired it into `check.rules` configuration in `docs.yml`
- Fetches previously published markdown slug entries from FDR and compares them against the current resolved docs navigation
- Reports pages that were removed or moved without redirect coverage, with suggested redirect entries for moved pages
- Handles first-publish, missing auth, offline/network failure, and timeout scenarios according to the configured rule severity
- Extracted pure diffing and redirect-coverage logic into testable helpers and added unit tests for removed, moved, wildcard redirect, and basepath cases
- Reused shared pageId-to-slug behavior for changelog entries to avoid drift with backend slug table generation

## Testing
<!-- Describe how you tested these changes -->
- [x] Unit tests added/updated
- [x] Manual testing completed