### PR TITLE
chore(ci): remove redundant buf/go/protoc-gen-openapi setup from seed workflow

### DIFF
--- a/.github/actions/cached-seed/action.yaml
+++ b/.github/actions/cached-seed/action.yaml
@@ -27,18 +27,6 @@ runs:
     - name: Install
       uses: ./.github/actions/install
 
-    - uses: bufbuild/buf-setup-action@v1.50.0
-      with:
-        github_token: ${{ github.token }}
-
-    - uses: actions/setup-go@v6
-      with:
-        go-version: "stable"
-
-    - name: Install protoc-gen-openapi
-      shell: bash
-      run: go install github.com/fern-api/protoc-gen-openapi/cmd/protoc-gen-openapi@latest
-
     - name: Seed Test
       shell: bash
       env:

--- a/.github/workflows/seed.yml
+++ b/.github/workflows/seed.yml
@@ -119,18 +119,6 @@ jobs:
       - name: Install
         uses: ./.github/actions/install
 
-      - uses: bufbuild/buf-setup-action@v1.50.0
-        with:
-          github_token: ${{ github.token }}
-
-      - uses: actions/setup-go@v6
-        with:
-          go-version: "stable"
-
-      - name: Install protoc-gen-openapi
-        shell: bash
-        run: go install github.com/fern-api/protoc-gen-openapi/cmd/protoc-gen-openapi@latest
-
       - name: Build Seed CLI
         shell: bash
         env:
@@ -1095,18 +1083,6 @@ jobs:
 
       - name: Install
         uses: ./.github/actions/install
-
-      - uses: bufbuild/buf-setup-action@v1.50.0
-        with:
-          github_token: ${{ github.token }}
-
-      - uses: actions/setup-go@v6
-        with:
-          go-version: "stable"
-
-      - name: Install protoc-gen-openapi
-        shell: bash
-        run: go install github.com/fern-api/protoc-gen-openapi/cmd/protoc-gen-openapi@latest
 
       - name: Build Seed CLI
         shell: bash


### PR DESCRIPTION
## Description

Removes the explicit `bufbuild/buf-setup-action`, `actions/setup-go`, and `go install protoc-gen-openapi` steps from the seed CI workflow. The Fern CLI already auto-downloads both `buf` (via `BufDownloader.ts`) and `protoc-gen-openapi` (via `ProtocGenOpenAPIDownloader.ts`) on demand with versioned caching, making these CI setup steps redundant.

## Changes Made

- Removed `bufbuild/buf-setup-action@v1.50.0` from 3 locations: `cached-seed` action, `get-all-test-matrices` job, and `collect-allowed-failures` job
- Removed `actions/setup-go@v6` from the same 3 locations
- Removed `go install protoc-gen-openapi@latest` from the same 3 locations

This eliminates a source of intermittent CI failures (buf GitHub API rate limiting) and speeds up every seed job by removing the Go toolchain install + compile step.

## Testing

- [ ] CI seed tests pass (specifically the proto-based fixtures `csharp-grpc-proto` and `csharp-grpc-proto-exhaustive` which exercise `buf generate`)

## ⚠️ Key review points

1. **Auto-download reliability in CI**: Previously `buf` was guaranteed on PATH via the GitHub Action. Now the CLI will auto-download it from GitHub Releases via unauthenticated `fetch()` (no `github_token`). Confirm this doesn't hit stricter rate limits than the action did.
2. **`protoc-gen-openapi` resolution**: Previously installed via `go install` and available on PATH. Now resolved by `ProtocGenOpenAPIDownloader.ts` which downloads a pre-built binary. Verify the CLI doesn't check for it on PATH first with different behavior (it uses `FERN_USE_LOCAL_PROTOC_GEN_OPENAPI` env var, which is not set in CI).
3. **Build-time vs runtime**: The `pnpm seed:build` step runs before seed tests. Confirm buf/protoc-gen-openapi are only needed at test runtime (when processing proto fixtures), not at build time.

Link to Devin session: https://app.devin.ai/sessions/9b9560e22b3347aba111d437a5181f96
Requested by: @Swimburger
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/14149" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
