### PR TITLE
chore(go): format Go files in memory using WASM gofmt before writing to disk

### DIFF
--- a/generators/go-v2/base/package.json
+++ b/generators/go-v2/base/package.json
@@ -41,6 +41,7 @@
     "@fern-api/core-utils": "workspace:*",
     "@fern-api/fs-utils": "workspace:*",
     "@fern-api/go-ast": "workspace:*",
+    "@fern-api/go-formatter": "workspace:*",
     "@fern-api/logging-execa": "workspace:*",
     "@fern-fern/generator-exec-sdk": "catalog:",
     "@fern-fern/ir-sdk": "^61.7.0",

--- a/generators/go-v2/base/src/project/GoProject.ts
+++ b/generators/go-v2/base/src/project/GoProject.ts
@@ -2,6 +2,7 @@ import { AbstractProject, FernGeneratorExec, File } from "@fern-api/base-generat
 import { assertNever, extractErrorMessage } from "@fern-api/core-utils";
 import { AbsoluteFilePath, RelativeFilePath } from "@fern-api/fs-utils";
 import { BaseGoCustomConfigSchema, resolveRootImportPath, resolveRootModulePath } from "@fern-api/go-ast";
+import { GoFormatter } from "@fern-api/go-formatter";
 import { loggingExeca } from "@fern-api/logging-execa";
 import { OutputMode } from "@fern-fern/generator-exec-sdk/api";
 import { copyFile, mkdir, readFile } from "fs/promises";
@@ -61,7 +62,7 @@ export class GoProject extends AbstractProject<AbstractGoGeneratorContext<BaseGo
         if (moduleConfig == null) {
             return;
         }
-        // We write the go.mod file to disk upfront so that 'go fmt' can be run on the project.
+        // We write the go.mod file to disk upfront so that 'go mod tidy' can be run on the project.
         const moduleConfigWriter = new ModuleConfigWriter({ context: this.context, moduleConfig });
         await this.writeRawFile(moduleConfigWriter.generate());
     }
@@ -81,21 +82,23 @@ export class GoProject extends AbstractProject<AbstractGoGeneratorContext<BaseGo
             )
         );
 
-        await Promise.all(files.map(async (file) => await file.write(AbsoluteFilePath.of(outputDir))));
-        const isModule = this.getModuleConfig({ config: this.context.config }) != null;
-        if (files.length > 0 && isModule) {
-            try {
-                await loggingExeca(this.context.logger, "go", ["fmt", "./..."], {
-                    doNotPipeOutput: true,
-                    cwd: this.absolutePathToOutputDirectory
-                });
-            } catch (error) {
-                this.context.logger.warn(
-                    `Failed to format Go files with 'go fmt': ${extractErrorMessage(error)}. ` +
-                        "The generated files have been written but may not be properly formatted."
-                );
-            }
-        }
+        const formatter = new GoFormatter();
+        await Promise.all(
+            files.map(async (file) => {
+                const f = file.toFile();
+                if (typeof f.fileContents === "string") {
+                    try {
+                        f.fileContents = await formatter.format(f.fileContents);
+                    } catch (error) {
+                        this.context.logger.warn(
+                            `Failed to format Go file '${file.getFullyQualifiedName()}' in memory: ${extractErrorMessage(error)}. ` +
+                                "The file will be written without formatting."
+                        );
+                    }
+                }
+                await f.write(AbsoluteFilePath.of(outputDir));
+            })
+        );
         return this.absolutePathToOutputDirectory;
     }
 

--- a/generators/go/sdk/versions.yml
+++ b/generators/go/sdk/versions.yml
@@ -1,4 +1,15 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 1.31.5
+  changelogEntry:
+    - summary: |
+        Format Go files in memory using WASM gofmt before writing to disk instead
+        of running `go fmt ./...` as a subprocess after writing. This eliminates one
+        full disk read-write pass over all generated Go files, improving generation
+        performance.
+      type: chore
+  createdAt: "2026-03-27"
+  irVersion: 61
+
 - version: 1.31.4
   changelogEntry:
     - summary: |

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1064,6 +1064,9 @@ importers:
       '@fern-api/go-ast':
         specifier: workspace:*
         version: link:../ast
+      '@fern-api/go-formatter':
+        specifier: workspace:*
+        version: link:../formatter
       '@fern-api/logging-execa':
         specifier: workspace:*
         version: link:../../../packages/commons/logging-execa


### PR DESCRIPTION
## Description

Optimizes the Go v2 generator by formatting Go files in memory using the `@wasm-fmt/gofmt` WASM package before writing to disk, instead of running `go fmt ./...` as a subprocess after writing all files. This eliminates one full disk read-write pass over all generated Go files.

## Changes Made

- **`GoProject.writeGoFiles()`**: Each `GoFile` is now formatted in memory via `GoFormatter.format()` (async WASM gofmt) before being written to disk. The `go fmt ./...` subprocess call is removed.
- **`go mod tidy`** subprocess is preserved as-is since it requires actual module resolution.
- Added `@fern-api/go-formatter` as a dependency of `@fern-api/go-base`.
- Updated stale comment on `writeGoMod()` (referenced `go fmt`, now references `go mod tidy`).
- Added `versions.yml` entry (1.31.5).

## Reviewer Checklist

- [ ] **`isModule` guard removed**: Previously, `go fmt` only ran when the project was a Go module (had a `go.mod`). Now formatting happens unconditionally for all files. This is likely correct (formatting shouldn't depend on module status), but verify this is intentional.
- [ ] **Concurrent WASM init**: `GoFormatter.format()` calls `await init()` internally on every call, and all files are formatted in parallel via `Promise.all`. Confirm `@wasm-fmt/gofmt`'s `init()` is safe to call concurrently/repeatedly.
- [ ] **Output parity**: WASM gofmt should produce identical output to native `go fmt ./...`. Seed tests should confirm no diff in generated output.

## Testing

- [ ] Biome lint passes (`pnpm run check`)
- [ ] No new TypeScript errors introduced (pre-existing errors in go-base are unrelated)
- [ ] Seed tests should be run to verify generated Go output is unchanged

Link to Devin session: https://app.devin.ai/sessions/2f6c6c0ff7074fbdbfe0bfb7fe0da8ce
Requested by: @Swimburger
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/14151" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
