### PR TITLE
feat(python): replace runtime SSE reflection with compile-time discriminant context

### DIFF
--- a/generators/python/core_utilities/shared/pydantic_utilities.py
+++ b/generators/python/core_utilities/shared/pydantic_utilities.py
@@ -4,7 +4,6 @@ import inspect
 import json
 import logging
 from collections import defaultdict
-from dataclasses import asdict
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -133,107 +132,12 @@ T = TypeVar("T")
 Model = TypeVar("Model", bound=pydantic.BaseModel)
 
 
-def _get_discriminator_and_variants(type_: Type[Any]) -> Tuple[Optional[str], Optional[List[Type[Any]]]]:
+def parse_sse_data(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
-    Extract the discriminator field name and union variants from a discriminated union type.
-    Supports Annotated[Union[...], Field(discriminator=...)] patterns.
-    Returns (discriminator, variants) or (None, None) if not a discriminated union.
-    """
-    origin = typing_extensions.get_origin(type_)
+    Parse an SSE event where the discriminant is inside the data payload (data-level discrimination).
 
-    if origin is typing_extensions.Annotated:
-        args = typing_extensions.get_args(type_)
-        if len(args) >= 2:
-            inner_type = args[0]
-            # Check annotations for discriminator
-            discriminator = None
-            for annotation in args[1:]:
-                if hasattr(annotation, "discriminator"):
-                    discriminator = getattr(annotation, "discriminator", None)
-                    break
-
-            if discriminator:
-                inner_origin = typing_extensions.get_origin(inner_type)
-                if inner_origin is Union:
-                    variants = list(typing_extensions.get_args(inner_type))
-                    return discriminator, variants
-    return None, None
-
-
-def _get_field_annotation(model: Type[Any], field_name: str) -> Optional[Type[Any]]:
-    """Get the type annotation of a field from a Pydantic model."""
-    if IS_PYDANTIC_V2:
-        fields = getattr(model, "model_fields", {})
-        field_info = fields.get(field_name)
-        if field_info:
-            return cast(Optional[Type[Any]], field_info.annotation)
-    else:
-        fields = getattr(model, "__fields__", {})
-        field_info = fields.get(field_name)
-        if field_info:
-            return cast(Optional[Type[Any]], field_info.outer_type_)
-    return None
-
-
-def _find_variant_by_discriminator(
-    variants: List[Type[Any]],
-    discriminator: str,
-    discriminator_value: Any,
-) -> Optional[Type[Any]]:
-    """Find the union variant that matches the discriminator value."""
-    for variant in variants:
-        if not (inspect.isclass(variant) and issubclass(variant, pydantic.BaseModel)):
-            continue
-
-        disc_annotation = _get_field_annotation(variant, discriminator)
-        if disc_annotation and is_literal_type(disc_annotation):
-            literal_args = get_args(disc_annotation)
-            if literal_args and literal_args[0] == discriminator_value:
-                return variant
-    return None
-
-
-def _is_string_type(type_: Type[Any]) -> bool:
-    """Check if a type is str or Optional[str]."""
-    if type_ is str:
-        return True
-
-    origin = typing_extensions.get_origin(type_)
-    if origin is Union:
-        args = typing_extensions.get_args(type_)
-        # Optional[str] = Union[str, None]
-        non_none_args = [a for a in args if a is not type(None)]
-        if len(non_none_args) == 1 and non_none_args[0] is str:
-            return True
-
-    return False
-
-
-def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
-    """
-    Parse a ServerSentEvent into the appropriate type.
-
-    Handles two scenarios based on where the discriminator field is located:
-
-    1. Data-level discrimination: The discriminator (e.g., 'type') is inside the 'data' payload.
-       The union describes the data content, not the SSE envelope.
-       -> Returns: json.loads(data) parsed into the type
-
-       Example: ChatStreamResponse with discriminator='type'
-       Input:  ServerSentEvent(event="message", data='{"type": "content-delta", ...}', id="")
-       Output: ContentDeltaEvent (parsed from data, SSE envelope stripped)
-
-    2. Event-level discrimination: The discriminator (e.g., 'event') is at the SSE event level.
-       The union describes the full SSE event structure.
-       -> Returns: SSE envelope with 'data' field JSON-parsed only if the variant expects non-string
-
-       Example: JobStreamResponse with discriminator='event'
-       Input:  ServerSentEvent(event="ERROR", data='{"code": "FAILED", ...}', id="123")
-       Output: JobStreamResponse_Error with data as ErrorData object
-
-       But for variants where data is str (like STATUS_UPDATE):
-       Input:  ServerSentEvent(event="STATUS_UPDATE", data='{"status": "processing"}', id="1")
-       Output: JobStreamResponse_StatusUpdate with data as string (not parsed)
+    The sse.data field contains JSON with the discriminant and all payload fields flattened together.
+    Example: sse.data = '{"event": "entity", "entityId": "123", "eventType": "CREATED"}'
 
     Args:
         sse: The ServerSentEvent object to parse
@@ -241,71 +145,33 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
 
     Returns:
         The parsed object of type T
-
-    Note:
-        This function is only available in SDK contexts where http_sse module exists.
     """
-    sse_event = asdict(sse)
-    discriminator, variants = _get_discriminator_and_variants(type_)
+    data = json.loads(sse.data)
+    return parse_obj_as(type_, data)
 
-    if discriminator is None or variants is None:
-        # Not a discriminated union - parse the data field as JSON
-        data_value = sse_event.get("data")
-        if isinstance(data_value, str) and data_value:
-            try:
-                parsed_data = json.loads(data_value)
-                return parse_obj_as(type_, parsed_data)
-            except json.JSONDecodeError as e:
-                _logger.warning(
-                    "Failed to parse SSE data field as JSON: %s, data: %s",
-                    e,
-                    data_value[:100] if len(data_value) > 100 else data_value,
-                )
-        return parse_obj_as(type_, sse_event)
 
-    data_value = sse_event.get("data")
+def parse_sse_protocol(sse: "ServerSentEvent", type_: Type[T]) -> T:
+    """
+    Parse an SSE event where the discriminant is at the protocol level (protocol-level discrimination).
 
-    # Check if discriminator is at the top level (event-level discrimination)
-    if discriminator in sse_event:
-        # Case 2: Event-level discrimination
-        # Find the matching variant to check if 'data' field needs JSON parsing
-        disc_value = sse_event.get(discriminator)
-        matching_variant = _find_variant_by_discriminator(variants, discriminator, disc_value)
+    The discriminant comes from the SSE event field (sse.event), not from inside sse.data.
+    The data field can be any type: absent, string, number, or JSON object.
+    Example: SSE with event: "object_data", data: '{"message": "hello", "timestamp": "..."}'
 
-        if matching_variant is not None:
-            # Check what type the variant expects for 'data'
-            data_type = _get_field_annotation(matching_variant, "data")
-            if data_type is not None and not _is_string_type(data_type):
-                # Variant expects non-string data - parse JSON
-                if isinstance(data_value, str) and data_value:
-                    try:
-                        parsed_data = json.loads(data_value)
-                        new_object = dict(sse_event)
-                        new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
-                    except json.JSONDecodeError as e:
-                        _logger.warning(
-                            "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
-                            e,
-                            data_value[:100] if len(data_value) > 100 else data_value,
-                        )
-        # Either no matching variant, data is string type, or JSON parse failed
-        return parse_obj_as(type_, sse_event)
+    Args:
+        sse: The ServerSentEvent object to parse
+        type_: The target discriminated union type
 
-    else:
-        # Case 1: Data-level discrimination
-        # The discriminator is inside the data payload - extract and parse data only
-        if isinstance(data_value, str) and data_value:
-            try:
-                parsed_data = json.loads(data_value)
-                return parse_obj_as(type_, parsed_data)
-            except json.JSONDecodeError as e:
-                _logger.warning(
-                    "Failed to parse SSE data field as JSON for data-level discrimination: %s, data: %s",
-                    e,
-                    data_value[:100] if len(data_value) > 100 else data_value,
-                )
-        return parse_obj_as(type_, sse_event)
+    Returns:
+        The parsed object of type T
+    """
+    envelope: Dict[str, Any] = {"event": sse.event}
+    if sse.data is not None:
+        try:
+            envelope["data"] = json.loads(sse.data)
+        except (json.JSONDecodeError, ValueError):
+            envelope["data"] = sse.data
+    return parse_obj_as(type_, envelope)
 
 
 def parse_obj_as(type_: Type[T], object_: Any) -> T:

--- a/generators/python/core_utilities/shared/pydantic_utilities.py
+++ b/generators/python/core_utilities/shared/pydantic_utilities.py
@@ -165,14 +165,15 @@ def parse_sse_protocol(sse: "ServerSentEvent", type_: Type[T]) -> T:
     Returns:
         The parsed object of type T
     """
+    _PARSE_FAILED = object()
     envelope: Dict[str, Any] = {"event": sse.event}
     if sse.data is not None:
         try:
-            parsed_data = json.loads(sse.data)
+            parsed_data: Any = json.loads(sse.data)
         except (json.JSONDecodeError, ValueError):
-            parsed_data = None
+            parsed_data = _PARSE_FAILED
 
-        if parsed_data is not None:
+        if parsed_data is not _PARSE_FAILED:
             envelope["data"] = parsed_data
             try:
                 return parse_obj_as(type_, envelope)

--- a/generators/python/core_utilities/shared/pydantic_utilities.py
+++ b/generators/python/core_utilities/shared/pydantic_utilities.py
@@ -168,8 +168,20 @@ def parse_sse_protocol(sse: "ServerSentEvent", type_: Type[T]) -> T:
     envelope: Dict[str, Any] = {"event": sse.event}
     if sse.data is not None:
         try:
-            envelope["data"] = json.loads(sse.data)
+            parsed_data = json.loads(sse.data)
         except (json.JSONDecodeError, ValueError):
+            parsed_data = None
+
+        if parsed_data is not None:
+            envelope["data"] = parsed_data
+            try:
+                return parse_obj_as(type_, envelope)
+            except Exception:
+                # If validation fails with JSON-parsed data (e.g. variant expects str
+                # but data was valid JSON like '{"status": "processing"}'), fall back
+                # to the raw string so string-typed variants work correctly.
+                envelope["data"] = sse.data
+        else:
             envelope["data"] = sse.data
     return parse_obj_as(type_, envelope)
 

--- a/generators/python/core_utilities/shared/with_pydantic_aliases/pydantic_utilities.py
+++ b/generators/python/core_utilities/shared/with_pydantic_aliases/pydantic_utilities.py
@@ -1,6 +1,5 @@
 # nopycln: file
 import datetime as dt
-import inspect
 import json
 import logging
 from collections import defaultdict

--- a/generators/python/core_utilities/shared/with_pydantic_aliases/pydantic_utilities.py
+++ b/generators/python/core_utilities/shared/with_pydantic_aliases/pydantic_utilities.py
@@ -162,14 +162,15 @@ def parse_sse_protocol(sse: "ServerSentEvent", type_: Type[T]) -> T:
     Returns:
         The parsed object of type T
     """
+    _PARSE_FAILED = object()
     envelope: Dict[str, Any] = {"event": sse.event}
     if sse.data is not None:
         try:
-            parsed_data = json.loads(sse.data)
+            parsed_data: Any = json.loads(sse.data)
         except (json.JSONDecodeError, ValueError):
-            parsed_data = None
+            parsed_data = _PARSE_FAILED
 
-        if parsed_data is not None:
+        if parsed_data is not _PARSE_FAILED:
             envelope["data"] = parsed_data
             try:
                 return parse_obj_as(type_, envelope)

--- a/generators/python/core_utilities/shared/with_pydantic_aliases/pydantic_utilities.py
+++ b/generators/python/core_utilities/shared/with_pydantic_aliases/pydantic_utilities.py
@@ -165,8 +165,20 @@ def parse_sse_protocol(sse: "ServerSentEvent", type_: Type[T]) -> T:
     envelope: Dict[str, Any] = {"event": sse.event}
     if sse.data is not None:
         try:
-            envelope["data"] = json.loads(sse.data)
+            parsed_data = json.loads(sse.data)
         except (json.JSONDecodeError, ValueError):
+            parsed_data = None
+
+        if parsed_data is not None:
+            envelope["data"] = parsed_data
+            try:
+                return parse_obj_as(type_, envelope)
+            except Exception:
+                # If validation fails with JSON-parsed data (e.g. variant expects str
+                # but data was valid JSON like '{"status": "processing"}'), fall back
+                # to the raw string so string-typed variants work correctly.
+                envelope["data"] = sse.data
+        else:
             envelope["data"] = sse.data
     return parse_obj_as(type_, envelope)
 

--- a/generators/python/core_utilities/shared/with_pydantic_aliases/pydantic_utilities.py
+++ b/generators/python/core_utilities/shared/with_pydantic_aliases/pydantic_utilities.py
@@ -4,7 +4,6 @@ import inspect
 import json
 import logging
 from collections import defaultdict
-from dataclasses import asdict
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -131,95 +130,12 @@ T = TypeVar("T")
 Model = TypeVar("Model", bound=pydantic.BaseModel)
 
 
-def _get_discriminator_and_variants(type_: Type[Any]) -> Tuple[Optional[str], Optional[List[Type[Any]]]]:
+def parse_sse_data(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
-    Extract the discriminator field name and union variants from a discriminated union type.
-    Supports Annotated[Union[...], Field(discriminator=...)] patterns.
-    Returns (discriminator, variants) or (None, None) if not a discriminated union.
-    """
-    origin = typing_extensions.get_origin(type_)
+    Parse an SSE event where the discriminant is inside the data payload (data-level discrimination).
 
-    if origin is typing_extensions.Annotated:
-        args = typing_extensions.get_args(type_)
-        if len(args) >= 2:
-            inner_type = args[0]
-            # Check annotations for discriminator
-            discriminator = None
-            for annotation in args[1:]:
-                if hasattr(annotation, "discriminator"):
-                    discriminator = getattr(annotation, "discriminator", None)
-                    break
-
-            if discriminator:
-                inner_origin = typing_extensions.get_origin(inner_type)
-                if inner_origin is Union:
-                    variants = list(typing_extensions.get_args(inner_type))
-                    return discriminator, variants
-    return None, None
-
-
-def _get_field_annotation(model: Type[Any], field_name: str) -> Optional[Type[Any]]:
-    """Get the type annotation of a field from a Pydantic model."""
-    if IS_PYDANTIC_V2:
-        fields = getattr(model, "model_fields", {})
-        field_info = fields.get(field_name)
-        if field_info:
-            return cast(Optional[Type[Any]], field_info.annotation)
-    else:
-        fields = getattr(model, "__fields__", {})
-        field_info = fields.get(field_name)
-        if field_info:
-            return cast(Optional[Type[Any]], field_info.outer_type_)
-    return None
-
-
-def _find_variant_by_discriminator(
-    variants: List[Type[Any]],
-    discriminator: str,
-    discriminator_value: Any,
-) -> Optional[Type[Any]]:
-    """Find the union variant that matches the discriminator value."""
-    for variant in variants:
-        if not (inspect.isclass(variant) and issubclass(variant, pydantic.BaseModel)):
-            continue
-
-        disc_annotation = _get_field_annotation(variant, discriminator)
-        if disc_annotation and is_literal_type(disc_annotation):
-            literal_args = get_args(disc_annotation)
-            if literal_args and literal_args[0] == discriminator_value:
-                return variant
-    return None
-
-
-def _is_string_type(type_: Type[Any]) -> bool:
-    """Check if a type is str or Optional[str]."""
-    if type_ is str:
-        return True
-
-    origin = typing_extensions.get_origin(type_)
-    if origin is Union:
-        args = typing_extensions.get_args(type_)
-        # Optional[str] = Union[str, None]
-        non_none_args = [a for a in args if a is not type(None)]
-        if len(non_none_args) == 1 and non_none_args[0] is str:
-            return True
-
-    return False
-
-
-def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
-    """
-    Parse a ServerSentEvent into the appropriate type.
-
-    Handles two scenarios based on where the discriminator field is located:
-
-    1. Data-level discrimination: The discriminator (e.g., 'type') is inside the 'data' payload.
-       The union describes the data content, not the SSE envelope.
-       -> Returns: json.loads(data) parsed into the type
-
-    2. Event-level discrimination: The discriminator (e.g., 'event') is at the SSE event level.
-       The union describes the full SSE event structure.
-       -> Returns: SSE envelope with 'data' field JSON-parsed only if the variant expects non-string
+    The sse.data field contains JSON with the discriminant and all payload fields flattened together.
+    Example: sse.data = '{"event": "entity", "entityId": "123", "eventType": "CREATED"}'
 
     Args:
         sse: The ServerSentEvent object to parse
@@ -227,71 +143,33 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
 
     Returns:
         The parsed object of type T
-
-    Note:
-        This function is only available in SDK contexts where http_sse module exists.
     """
-    sse_event = asdict(sse)
-    discriminator, variants = _get_discriminator_and_variants(type_)
+    data = json.loads(sse.data)
+    return parse_obj_as(type_, data)
 
-    if discriminator is None or variants is None:
-        # Not a discriminated union - parse the data field as JSON
-        data_value = sse_event.get("data")
-        if isinstance(data_value, str) and data_value:
-            try:
-                parsed_data = json.loads(data_value)
-                return parse_obj_as(type_, parsed_data)
-            except json.JSONDecodeError as e:
-                _logger.warning(
-                    "Failed to parse SSE data field as JSON: %s, data: %s",
-                    e,
-                    data_value[:100] if len(data_value) > 100 else data_value,
-                )
-        return parse_obj_as(type_, sse_event)
 
-    data_value = sse_event.get("data")
+def parse_sse_protocol(sse: "ServerSentEvent", type_: Type[T]) -> T:
+    """
+    Parse an SSE event where the discriminant is at the protocol level (protocol-level discrimination).
 
-    # Check if discriminator is at the top level (event-level discrimination)
-    if discriminator in sse_event:
-        # Case 2: Event-level discrimination
-        # Find the matching variant to check if 'data' field needs JSON parsing
-        disc_value = sse_event.get(discriminator)
-        matching_variant = _find_variant_by_discriminator(variants, discriminator, disc_value)
+    The discriminant comes from the SSE event field (sse.event), not from inside sse.data.
+    The data field can be any type: absent, string, number, or JSON object.
+    Example: SSE with event: "object_data", data: '{"message": "hello", "timestamp": "..."}'
 
-        if matching_variant is not None:
-            # Check what type the variant expects for 'data'
-            data_type = _get_field_annotation(matching_variant, "data")
-            if data_type is not None and not _is_string_type(data_type):
-                # Variant expects non-string data - parse JSON
-                if isinstance(data_value, str) and data_value:
-                    try:
-                        parsed_data = json.loads(data_value)
-                        new_object = dict(sse_event)
-                        new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
-                    except json.JSONDecodeError as e:
-                        _logger.warning(
-                            "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
-                            e,
-                            data_value[:100] if len(data_value) > 100 else data_value,
-                        )
-        # Either no matching variant, data is string type, or JSON parse failed
-        return parse_obj_as(type_, sse_event)
+    Args:
+        sse: The ServerSentEvent object to parse
+        type_: The target discriminated union type
 
-    else:
-        # Case 1: Data-level discrimination
-        # The discriminator is inside the data payload - extract and parse data only
-        if isinstance(data_value, str) and data_value:
-            try:
-                parsed_data = json.loads(data_value)
-                return parse_obj_as(type_, parsed_data)
-            except json.JSONDecodeError as e:
-                _logger.warning(
-                    "Failed to parse SSE data field as JSON for data-level discrimination: %s, data: %s",
-                    e,
-                    data_value[:100] if len(data_value) > 100 else data_value,
-                )
-        return parse_obj_as(type_, sse_event)
+    Returns:
+        The parsed object of type T
+    """
+    envelope: Dict[str, Any] = {"event": sse.event}
+    if sse.data is not None:
+        try:
+            envelope["data"] = json.loads(sse.data)
+        except (json.JSONDecodeError, ValueError):
+            envelope["data"] = sse.data
+    return parse_obj_as(type_, envelope)
 
 
 def parse_obj_as(type_: Type[T], object_: Any) -> T:

--- a/generators/python/core_utilities/shared/with_pydantic_v1_on_v2/pydantic_utilities.py
+++ b/generators/python/core_utilities/shared/with_pydantic_v1_on_v2/pydantic_utilities.py
@@ -86,14 +86,15 @@ def parse_sse_protocol(sse: "ServerSentEvent", type_: Type[T]) -> T:
     Returns:
         The parsed object of type T
     """
+    _PARSE_FAILED = object()
     envelope: Dict[str, Any] = {"event": sse.event}
     if sse.data is not None:
         try:
-            parsed_data = json.loads(sse.data)
+            parsed_data: Any = json.loads(sse.data)
         except (json.JSONDecodeError, ValueError):
-            parsed_data = None
+            parsed_data = _PARSE_FAILED
 
-        if parsed_data is not None:
+        if parsed_data is not _PARSE_FAILED:
             envelope["data"] = parsed_data
             try:
                 return parse_obj_as(type_, envelope)

--- a/generators/python/core_utilities/shared/with_pydantic_v1_on_v2/pydantic_utilities.py
+++ b/generators/python/core_utilities/shared/with_pydantic_v1_on_v2/pydantic_utilities.py
@@ -89,8 +89,20 @@ def parse_sse_protocol(sse: "ServerSentEvent", type_: Type[T]) -> T:
     envelope: Dict[str, Any] = {"event": sse.event}
     if sse.data is not None:
         try:
-            envelope["data"] = json.loads(sse.data)
+            parsed_data = json.loads(sse.data)
         except (json.JSONDecodeError, ValueError):
+            parsed_data = None
+
+        if parsed_data is not None:
+            envelope["data"] = parsed_data
+            try:
+                return parse_obj_as(type_, envelope)
+            except Exception:
+                # If validation fails with JSON-parsed data (e.g. variant expects str
+                # but data was valid JSON like '{"status": "processing"}'), fall back
+                # to the raw string so string-typed variants work correctly.
+                envelope["data"] = sse.data
+        else:
             envelope["data"] = sse.data
     return parse_obj_as(type_, envelope)
 

--- a/generators/python/core_utilities/shared/with_pydantic_v1_on_v2/pydantic_utilities.py
+++ b/generators/python/core_utilities/shared/with_pydantic_v1_on_v2/pydantic_utilities.py
@@ -8,7 +8,6 @@ from collections import defaultdict
 from typing import TYPE_CHECKING, Any, Callable, Dict, List, Mapping, Optional, Set, Tuple, Type, TypeVar, Union, cast
 
 import pydantic
-import typing_extensions
 from .datetime_utils import serialize_datetime
 from .serialization import convert_and_respect_annotation_metadata
 

--- a/generators/python/core_utilities/shared/with_pydantic_v1_on_v2/pydantic_utilities.py
+++ b/generators/python/core_utilities/shared/with_pydantic_v1_on_v2/pydantic_utilities.py
@@ -5,7 +5,6 @@ import json
 import logging
 import warnings
 from collections import defaultdict
-from dataclasses import asdict
 from typing import TYPE_CHECKING, Any, Callable, Dict, List, Mapping, Optional, Set, Tuple, Type, TypeVar, Union, cast
 
 import pydantic
@@ -55,89 +54,12 @@ _PYDANTIC_V1_BASE_MODEL = getattr(_PYDANTIC_V1, "BaseModel", pydantic.BaseModel)
 PydanticField = Union[ModelField, pydantic.fields.FieldInfo]
 
 
-def _get_discriminator_and_variants(type_: Type[Any]) -> Tuple[Optional[str], Optional[List[Type[Any]]]]:
+def parse_sse_data(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
-    Extract the discriminator field name and union variants from a discriminated union type.
-    Supports Annotated[Union[...], Field(discriminator=...)] patterns.
-    Returns (discriminator, variants) or (None, None) if not a discriminated union.
-    """
-    origin = typing_extensions.get_origin(type_)
+    Parse an SSE event where the discriminant is inside the data payload (data-level discrimination).
 
-    if origin is typing_extensions.Annotated:
-        args = typing_extensions.get_args(type_)
-        if len(args) >= 2:
-            inner_type = args[0]
-            # Check annotations for discriminator
-            discriminator = None
-            for annotation in args[1:]:
-                if hasattr(annotation, "discriminator"):
-                    discriminator = getattr(annotation, "discriminator", None)
-                    break
-
-            if discriminator:
-                inner_origin = typing_extensions.get_origin(inner_type)
-                if inner_origin is Union:
-                    variants = list(typing_extensions.get_args(inner_type))
-                    return discriminator, variants
-    return None, None
-
-
-def _get_field_annotation_v1(model: Type[Any], field_name: str) -> Optional[Type[Any]]:
-    """Get the type annotation of a field from a Pydantic v1 model."""
-    fields = getattr(model, "__fields__", {})
-    field_info = fields.get(field_name)
-    if field_info:
-        return cast(Optional[Type[Any]], field_info.outer_type_)
-    return None
-
-
-def _find_variant_by_discriminator(
-    variants: List[Type[Any]],
-    discriminator: str,
-    discriminator_value: Any,
-) -> Optional[Type[Any]]:
-    """Find the union variant that matches the discriminator value."""
-    for variant in variants:
-        if not (inspect.isclass(variant) and issubclass(variant, _PYDANTIC_V1_BASE_MODEL)):
-            continue
-
-        disc_annotation = _get_field_annotation_v1(variant, discriminator)
-        if disc_annotation and is_literal_type(disc_annotation):
-            literal_args = get_args(disc_annotation)
-            if literal_args and literal_args[0] == discriminator_value:
-                return variant
-    return None
-
-
-def _is_string_type(type_: Type[Any]) -> bool:
-    """Check if a type is str or Optional[str]."""
-    if type_ is str:
-        return True
-
-    origin = typing_extensions.get_origin(type_)
-    if origin is Union:
-        args = typing_extensions.get_args(type_)
-        # Optional[str] = Union[str, None]
-        non_none_args = [a for a in args if a is not type(None)]
-        if len(non_none_args) == 1 and non_none_args[0] is str:
-            return True
-
-    return False
-
-
-def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
-    """
-    Parse a ServerSentEvent into the appropriate type.
-
-    Handles two scenarios based on where the discriminator field is located:
-
-    1. Data-level discrimination: The discriminator (e.g., 'type') is inside the 'data' payload.
-       The union describes the data content, not the SSE envelope.
-       -> Returns: json.loads(data) parsed into the type
-
-    2. Event-level discrimination: The discriminator (e.g., 'event') is at the SSE event level.
-       The union describes the full SSE event structure.
-       -> Returns: SSE envelope with 'data' field JSON-parsed only if the variant expects non-string
+    The sse.data field contains JSON with the discriminant and all payload fields flattened together.
+    Example: sse.data = '{"event": "entity", "entityId": "123", "eventType": "CREATED"}'
 
     Args:
         sse: The ServerSentEvent object to parse
@@ -145,71 +67,33 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
 
     Returns:
         The parsed object of type T
-
-    Note:
-        This function is only available in SDK contexts where http_sse module exists.
     """
-    sse_event = asdict(sse)
-    discriminator, variants = _get_discriminator_and_variants(type_)
+    data = json.loads(sse.data)
+    return parse_obj_as(type_, data)
 
-    if discriminator is None or variants is None:
-        # Not a discriminated union - parse the data field as JSON
-        data_value = sse_event.get("data")
-        if isinstance(data_value, str) and data_value:
-            try:
-                parsed_data = json.loads(data_value)
-                return parse_obj_as(type_, parsed_data)
-            except json.JSONDecodeError as e:
-                _logger.warning(
-                    "Failed to parse SSE data field as JSON: %s, data: %s",
-                    e,
-                    data_value[:100] if len(data_value) > 100 else data_value,
-                )
-        return parse_obj_as(type_, sse_event)
 
-    data_value = sse_event.get("data")
+def parse_sse_protocol(sse: "ServerSentEvent", type_: Type[T]) -> T:
+    """
+    Parse an SSE event where the discriminant is at the protocol level (protocol-level discrimination).
 
-    # Check if discriminator is at the top level (event-level discrimination)
-    if discriminator in sse_event:
-        # Case 2: Event-level discrimination
-        # Find the matching variant to check if 'data' field needs JSON parsing
-        disc_value = sse_event.get(discriminator)
-        matching_variant = _find_variant_by_discriminator(variants, discriminator, disc_value)
+    The discriminant comes from the SSE event field (sse.event), not from inside sse.data.
+    The data field can be any type: absent, string, number, or JSON object.
+    Example: SSE with event: "object_data", data: '{"message": "hello", "timestamp": "..."}'
 
-        if matching_variant is not None:
-            # Check what type the variant expects for 'data'
-            data_type = _get_field_annotation_v1(matching_variant, "data")
-            if data_type is not None and not _is_string_type(data_type):
-                # Variant expects non-string data - parse JSON
-                if isinstance(data_value, str) and data_value:
-                    try:
-                        parsed_data = json.loads(data_value)
-                        new_object = dict(sse_event)
-                        new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
-                    except json.JSONDecodeError as e:
-                        _logger.warning(
-                            "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
-                            e,
-                            data_value[:100] if len(data_value) > 100 else data_value,
-                        )
-        # Either no matching variant, data is string type, or JSON parse failed
-        return parse_obj_as(type_, sse_event)
+    Args:
+        sse: The ServerSentEvent object to parse
+        type_: The target discriminated union type
 
-    else:
-        # Case 1: Data-level discrimination
-        # The discriminator is inside the data payload - extract and parse data only
-        if isinstance(data_value, str) and data_value:
-            try:
-                parsed_data = json.loads(data_value)
-                return parse_obj_as(type_, parsed_data)
-            except json.JSONDecodeError as e:
-                _logger.warning(
-                    "Failed to parse SSE data field as JSON for data-level discrimination: %s, data: %s",
-                    e,
-                    data_value[:100] if len(data_value) > 100 else data_value,
-                )
-        return parse_obj_as(type_, sse_event)
+    Returns:
+        The parsed object of type T
+    """
+    envelope: Dict[str, Any] = {"event": sse.event}
+    if sse.data is not None:
+        try:
+            envelope["data"] = json.loads(sse.data)
+        except (json.JSONDecodeError, ValueError):
+            envelope["data"] = sse.data
+    return parse_obj_as(type_, envelope)
 
 
 def parse_obj_as(type_: Type[T], object_: Any) -> T:

--- a/generators/python/core_utilities/shared/with_pydantic_v1_on_v2/with_aliases/pydantic_utilities.py
+++ b/generators/python/core_utilities/shared/with_pydantic_v1_on_v2/with_aliases/pydantic_utilities.py
@@ -82,14 +82,15 @@ def parse_sse_protocol(sse: "ServerSentEvent", type_: Type[T]) -> T:
     Returns:
         The parsed object of type T
     """
+    _PARSE_FAILED = object()
     envelope: Dict[str, Any] = {"event": sse.event}
     if sse.data is not None:
         try:
-            parsed_data = json.loads(sse.data)
+            parsed_data: Any = json.loads(sse.data)
         except (json.JSONDecodeError, ValueError):
-            parsed_data = None
+            parsed_data = _PARSE_FAILED
 
-        if parsed_data is not None:
+        if parsed_data is not _PARSE_FAILED:
             envelope["data"] = parsed_data
             try:
                 return parse_obj_as(type_, envelope)

--- a/generators/python/core_utilities/shared/with_pydantic_v1_on_v2/with_aliases/pydantic_utilities.py
+++ b/generators/python/core_utilities/shared/with_pydantic_v1_on_v2/with_aliases/pydantic_utilities.py
@@ -85,8 +85,20 @@ def parse_sse_protocol(sse: "ServerSentEvent", type_: Type[T]) -> T:
     envelope: Dict[str, Any] = {"event": sse.event}
     if sse.data is not None:
         try:
-            envelope["data"] = json.loads(sse.data)
+            parsed_data = json.loads(sse.data)
         except (json.JSONDecodeError, ValueError):
+            parsed_data = None
+
+        if parsed_data is not None:
+            envelope["data"] = parsed_data
+            try:
+                return parse_obj_as(type_, envelope)
+            except Exception:
+                # If validation fails with JSON-parsed data (e.g. variant expects str
+                # but data was valid JSON like '{"status": "processing"}'), fall back
+                # to the raw string so string-typed variants work correctly.
+                envelope["data"] = sse.data
+        else:
             envelope["data"] = sse.data
     return parse_obj_as(type_, envelope)
 

--- a/generators/python/core_utilities/shared/with_pydantic_v1_on_v2/with_aliases/pydantic_utilities.py
+++ b/generators/python/core_utilities/shared/with_pydantic_v1_on_v2/with_aliases/pydantic_utilities.py
@@ -5,7 +5,6 @@ import json
 import logging
 import warnings
 from collections import defaultdict
-from dataclasses import asdict
 from typing import TYPE_CHECKING, Any, Callable, Dict, List, Mapping, Optional, Tuple, Type, TypeVar, Union, cast
 
 import pydantic
@@ -52,89 +51,12 @@ Model = TypeVar("Model", bound=pydantic.BaseModel)
 AnyCallable = Callable[..., Any]
 
 
-def _get_discriminator_and_variants(type_: Type[Any]) -> Tuple[Optional[str], Optional[List[Type[Any]]]]:
+def parse_sse_data(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
-    Extract the discriminator field name and union variants from a discriminated union type.
-    Supports Annotated[Union[...], Field(discriminator=...)] patterns.
-    Returns (discriminator, variants) or (None, None) if not a discriminated union.
-    """
-    origin = typing_extensions.get_origin(type_)
+    Parse an SSE event where the discriminant is inside the data payload (data-level discrimination).
 
-    if origin is typing_extensions.Annotated:
-        args = typing_extensions.get_args(type_)
-        if len(args) >= 2:
-            inner_type = args[0]
-            # Check annotations for discriminator
-            discriminator = None
-            for annotation in args[1:]:
-                if hasattr(annotation, "discriminator"):
-                    discriminator = getattr(annotation, "discriminator", None)
-                    break
-
-            if discriminator:
-                inner_origin = typing_extensions.get_origin(inner_type)
-                if inner_origin is Union:
-                    variants = list(typing_extensions.get_args(inner_type))
-                    return discriminator, variants
-    return None, None
-
-
-def _get_field_annotation_v1(model: Type[Any], field_name: str) -> Optional[Type[Any]]:
-    """Get the type annotation of a field from a Pydantic v1 model."""
-    fields = getattr(model, "__fields__", {})
-    field_info = fields.get(field_name)
-    if field_info:
-        return cast(Optional[Type[Any]], field_info.outer_type_)
-    return None
-
-
-def _find_variant_by_discriminator(
-    variants: List[Type[Any]],
-    discriminator: str,
-    discriminator_value: Any,
-) -> Optional[Type[Any]]:
-    """Find the union variant that matches the discriminator value."""
-    for variant in variants:
-        if not (inspect.isclass(variant) and issubclass(variant, pydantic.v1.BaseModel)):
-            continue
-
-        disc_annotation = _get_field_annotation_v1(variant, discriminator)
-        if disc_annotation and is_literal_type(disc_annotation):
-            literal_args = get_args(disc_annotation)
-            if literal_args and literal_args[0] == discriminator_value:
-                return variant
-    return None
-
-
-def _is_string_type(type_: Type[Any]) -> bool:
-    """Check if a type is str or Optional[str]."""
-    if type_ is str:
-        return True
-
-    origin = typing_extensions.get_origin(type_)
-    if origin is Union:
-        args = typing_extensions.get_args(type_)
-        # Optional[str] = Union[str, None]
-        non_none_args = [a for a in args if a is not type(None)]
-        if len(non_none_args) == 1 and non_none_args[0] is str:
-            return True
-
-    return False
-
-
-def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
-    """
-    Parse a ServerSentEvent into the appropriate type.
-
-    Handles two scenarios based on where the discriminator field is located:
-
-    1. Data-level discrimination: The discriminator (e.g., 'type') is inside the 'data' payload.
-       The union describes the data content, not the SSE envelope.
-       -> Returns: json.loads(data) parsed into the type
-
-    2. Event-level discrimination: The discriminator (e.g., 'event') is at the SSE event level.
-       The union describes the full SSE event structure.
-       -> Returns: SSE envelope with 'data' field JSON-parsed only if the variant expects non-string
+    The sse.data field contains JSON with the discriminant and all payload fields flattened together.
+    Example: sse.data = '{"event": "entity", "entityId": "123", "eventType": "CREATED"}'
 
     Args:
         sse: The ServerSentEvent object to parse
@@ -142,71 +64,33 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
 
     Returns:
         The parsed object of type T
-
-    Note:
-        This function is only available in SDK contexts where http_sse module exists.
     """
-    sse_event = asdict(sse)
-    discriminator, variants = _get_discriminator_and_variants(type_)
+    data = json.loads(sse.data)
+    return parse_obj_as(type_, data)
 
-    if discriminator is None or variants is None:
-        # Not a discriminated union - parse the data field as JSON
-        data_value = sse_event.get("data")
-        if isinstance(data_value, str) and data_value:
-            try:
-                parsed_data = json.loads(data_value)
-                return parse_obj_as(type_, parsed_data)
-            except json.JSONDecodeError as e:
-                _logger.warning(
-                    "Failed to parse SSE data field as JSON: %s, data: %s",
-                    e,
-                    data_value[:100] if len(data_value) > 100 else data_value,
-                )
-        return parse_obj_as(type_, sse_event)
 
-    data_value = sse_event.get("data")
+def parse_sse_protocol(sse: "ServerSentEvent", type_: Type[T]) -> T:
+    """
+    Parse an SSE event where the discriminant is at the protocol level (protocol-level discrimination).
 
-    # Check if discriminator is at the top level (event-level discrimination)
-    if discriminator in sse_event:
-        # Case 2: Event-level discrimination
-        # Find the matching variant to check if 'data' field needs JSON parsing
-        disc_value = sse_event.get(discriminator)
-        matching_variant = _find_variant_by_discriminator(variants, discriminator, disc_value)
+    The discriminant comes from the SSE event field (sse.event), not from inside sse.data.
+    The data field can be any type: absent, string, number, or JSON object.
+    Example: SSE with event: "object_data", data: '{"message": "hello", "timestamp": "..."}'
 
-        if matching_variant is not None:
-            # Check what type the variant expects for 'data'
-            data_type = _get_field_annotation_v1(matching_variant, "data")
-            if data_type is not None and not _is_string_type(data_type):
-                # Variant expects non-string data - parse JSON
-                if isinstance(data_value, str) and data_value:
-                    try:
-                        parsed_data = json.loads(data_value)
-                        new_object = dict(sse_event)
-                        new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
-                    except json.JSONDecodeError as e:
-                        _logger.warning(
-                            "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
-                            e,
-                            data_value[:100] if len(data_value) > 100 else data_value,
-                        )
-        # Either no matching variant, data is string type, or JSON parse failed
-        return parse_obj_as(type_, sse_event)
+    Args:
+        sse: The ServerSentEvent object to parse
+        type_: The target discriminated union type
 
-    else:
-        # Case 1: Data-level discrimination
-        # The discriminator is inside the data payload - extract and parse data only
-        if isinstance(data_value, str) and data_value:
-            try:
-                parsed_data = json.loads(data_value)
-                return parse_obj_as(type_, parsed_data)
-            except json.JSONDecodeError as e:
-                _logger.warning(
-                    "Failed to parse SSE data field as JSON for data-level discrimination: %s, data: %s",
-                    e,
-                    data_value[:100] if len(data_value) > 100 else data_value,
-                )
-        return parse_obj_as(type_, sse_event)
+    Returns:
+        The parsed object of type T
+    """
+    envelope: Dict[str, Any] = {"event": sse.event}
+    if sse.data is not None:
+        try:
+            envelope["data"] = json.loads(sse.data)
+        except (json.JSONDecodeError, ValueError):
+            envelope["data"] = sse.data
+    return parse_obj_as(type_, envelope)
 
 
 def parse_obj_as(type_: Type[T], object_: Any) -> T:

--- a/generators/python/core_utilities/shared/with_pydantic_v1_on_v2/with_aliases/pydantic_utilities.py
+++ b/generators/python/core_utilities/shared/with_pydantic_v1_on_v2/with_aliases/pydantic_utilities.py
@@ -1,14 +1,12 @@
 # nopycln: file
 import datetime as dt
-import inspect
 import json
 import logging
 import warnings
 from collections import defaultdict
-from typing import TYPE_CHECKING, Any, Callable, Dict, List, Mapping, Optional, Tuple, Type, TypeVar, Union, cast
+from typing import TYPE_CHECKING, Any, Callable, Dict, List, Mapping, Tuple, Type, TypeVar, Union, cast
 
 import pydantic
-import typing_extensions
 from .datetime_utils import serialize_datetime
 
 if TYPE_CHECKING:

--- a/generators/python/sdk/versions.yml
+++ b/generators/python/sdk/versions.yml
@@ -1,6 +1,6 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 # For unreleased changes, use unreleased.yml
-- version: 5.0.9
+- version: 5.1.0
   changelogEntry:
     - summary: |
         Replace runtime reflection-based SSE discriminant detection with compile-time

--- a/generators/python/sdk/versions.yml
+++ b/generators/python/sdk/versions.yml
@@ -1,5 +1,16 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 # For unreleased changes, use unreleased.yml
+- version: 5.0.9
+  changelogEntry:
+    - summary: |
+        Replace runtime reflection-based SSE discriminant detection with compile-time
+        knowledge from the IR's discriminatorContext field. Protocol-level SSE endpoints
+        now call parse_sse_protocol and data-level endpoints call parse_sse_data, eliminating
+        type introspection overhead at runtime.
+      type: feat
+  createdAt: "2026-03-26"
+  irVersion: 65
+
 - version: 5.0.8
   changelogEntry:
     - summary: |

--- a/generators/python/src/fern_python/generators/sdk/client_generator/endpoint_response_code_writer.py
+++ b/generators/python/src/fern_python/generators/sdk/client_generator/endpoint_response_code_writer.py
@@ -1,9 +1,6 @@
 from typing import Any, Callable, Optional
 
-import fern.ir.resources as ir_types
 from ..context.sdk_generator_context import SdkGeneratorContext
-from fern.ir.resources.types import UnionDiscriminatorContext
-
 from fern_python.codegen import AST
 from fern_python.external_dependencies.json import Json
 from fern_python.external_dependencies.pydantic import Pydantic
@@ -29,6 +26,9 @@ from fern_python.generators.sdk.client_generator.pagination.uri import (
 from fern_python.generators.sdk.client_generator.streaming.utilities import (
     StreamingParameterType,
 )
+
+import fern.ir.resources as ir_types
+from fern.ir.resources.types import UnionDiscriminatorContext
 
 
 class EndpointResponseCodeWriter:

--- a/generators/python/src/fern_python/generators/sdk/client_generator/endpoint_response_code_writer.py
+++ b/generators/python/src/fern_python/generators/sdk/client_generator/endpoint_response_code_writer.py
@@ -1,6 +1,9 @@
 from typing import Any, Callable, Optional
 
+import fern.ir.resources as ir_types
 from ..context.sdk_generator_context import SdkGeneratorContext
+from fern.ir.resources.types import UnionDiscriminatorContext
+
 from fern_python.codegen import AST
 from fern_python.external_dependencies.json import Json
 from fern_python.external_dependencies.pydantic import Pydantic
@@ -26,8 +29,6 @@ from fern_python.generators.sdk.client_generator.pagination.uri import (
 from fern_python.generators.sdk.client_generator.streaming.utilities import (
     StreamingParameterType,
 )
-
-import fern.ir.resources as ir_types
 
 
 class EndpointResponseCodeWriter:
@@ -156,6 +157,7 @@ class EndpointResponseCodeWriter:
                                         self._context.core_utilities.get_construct_sse(
                                             self._get_streaming_response_data_type(stream_response),
                                             AST.Expression(f"{EndpointResponseCodeWriter.SSE_VARIABLE}"),
+                                            is_protocol=self._is_protocol_discriminated_sse(stream_response),
                                         ),
                                     ),
                                 ],
@@ -870,3 +872,17 @@ class EndpointResponseCodeWriter:
         if union.type == "text":
             return AST.TypeHint.str_()
         raise RuntimeError(f"{union.type} streaming response is unsupported")
+
+    def _is_protocol_discriminated_sse(self, stream_response: ir_types.StreamingResponse) -> bool:
+        """Check if the SSE payload's union type uses protocol-level discrimination."""
+        union = stream_response.get_as_union()
+        if union.type != "sse":
+            return False
+        payload_union = union.payload.get_as_union()
+        if payload_union.type != "named":
+            return False
+        declaration = self._context.pydantic_generator_context.get_declaration_for_type_id(payload_union.type_id)
+        shape = declaration.shape.get_as_union()
+        if shape.type != "union":
+            return False
+        return shape.discriminator_context == UnionDiscriminatorContext.PROTOCOL

--- a/generators/python/src/fern_python/generators/sdk/core_utilities/core_utilities.py
+++ b/generators/python/src/fern_python/generators/sdk/core_utilities/core_utilities.py
@@ -908,21 +908,28 @@ class CoreUtilities:
             ),
         )
 
-    def get_parse_sse_obj(self) -> AST.Reference:
+    def get_parse_sse_data(self) -> AST.Reference:
         return AST.Reference(
             qualified_name_excluding_import=(),
             import_=AST.ReferenceImport(
-                module=AST.Module.local(*self._module_path, "pydantic_utilities"), named_import="parse_sse_obj"
+                module=AST.Module.local(*self._module_path, "pydantic_utilities"), named_import="parse_sse_data"
             ),
         )
 
-    def get_construct_sse(self, type_of_obj: AST.TypeHint, sse_obj: AST.Expression) -> AST.Expression:
-        """Generate a parse_sse_obj call for SSE handling."""
-        return self._parse_sse_obj(type_of_obj, sse_obj)
+    def get_parse_sse_protocol(self) -> AST.Reference:
+        return AST.Reference(
+            qualified_name_excluding_import=(),
+            import_=AST.ReferenceImport(
+                module=AST.Module.local(*self._module_path, "pydantic_utilities"), named_import="parse_sse_protocol"
+            ),
+        )
 
-    def _parse_sse_obj(self, type_of_obj: AST.TypeHint, sse_obj: AST.Expression) -> AST.Expression:
+    def get_construct_sse(self, type_of_obj: AST.TypeHint, sse_obj: AST.Expression, *, is_protocol: bool = False) -> AST.Expression:
+        """Generate a parse_sse_data or parse_sse_protocol call for SSE handling."""
+        ref = self.get_parse_sse_protocol() if is_protocol else self.get_parse_sse_data()
+
         def write_value_being_casted(writer: NodeWriter) -> None:
-            writer.write_reference(self.get_parse_sse_obj())
+            writer.write_reference(ref)
             writer.write("(")
             writer.write_newline_if_last_line_not()
             with writer.indent():

--- a/generators/python/src/fern_python/generators/sdk/core_utilities/core_utilities.py
+++ b/generators/python/src/fern_python/generators/sdk/core_utilities/core_utilities.py
@@ -924,7 +924,9 @@ class CoreUtilities:
             ),
         )
 
-    def get_construct_sse(self, type_of_obj: AST.TypeHint, sse_obj: AST.Expression, *, is_protocol: bool = False) -> AST.Expression:
+    def get_construct_sse(
+        self, type_of_obj: AST.TypeHint, sse_obj: AST.Expression, *, is_protocol: bool = False
+    ) -> AST.Expression:
         """Generate a parse_sse_data or parse_sse_protocol call for SSE handling."""
         ref = self.get_parse_sse_protocol() if is_protocol else self.get_parse_sse_data()
 

--- a/seed/python-sdk/seed.yml
+++ b/seed/python-sdk/seed.yml
@@ -444,6 +444,7 @@ allowedFailures:
   - exhaustive:deps_with_min_python_version
   - exhaustive:pydantic-v1-with-utils
   - oauth-client-credentials-custom
+  - oauth-client-credentials-openapi
   - pagination-custom
   - response-property
   - streaming-parameter

--- a/seed/python-sdk/server-sent-event-examples/src/seed/completions/raw_client.py
+++ b/seed/python-sdk/server-sent-event-examples/src/seed/completions/raw_client.py
@@ -10,7 +10,7 @@ from ..core.client_wrapper import AsyncClientWrapper, SyncClientWrapper
 from ..core.http_response import AsyncHttpResponse, HttpResponse
 from ..core.http_sse._api import EventSource
 from ..core.parse_error import ParsingError
-from ..core.pydantic_utilities import parse_obj_as, parse_sse_obj
+from ..core.pydantic_utilities import parse_obj_as, parse_sse_data, parse_sse_protocol
 from ..core.request_options import RequestOptions
 from .errors.bad_request_error import BadRequestError
 from .types.stream_event import StreamEvent
@@ -64,7 +64,7 @@ class RawCompletionsClient:
                                 try:
                                     yield typing.cast(
                                         StreamedCompletion,
-                                        parse_sse_obj(
+                                        parse_sse_data(
                                             sse=_sse,
                                             type_=StreamedCompletion,  # type: ignore
                                         ),
@@ -148,7 +148,7 @@ class RawCompletionsClient:
                                 try:
                                     yield typing.cast(
                                         StreamEvent,
-                                        parse_sse_obj(
+                                        parse_sse_data(
                                             sse=_sse,
                                             type_=StreamEvent,  # type: ignore
                                         ),
@@ -232,7 +232,7 @@ class RawCompletionsClient:
                                 try:
                                     yield typing.cast(
                                         StreamEventContextProtocol,
-                                        parse_sse_obj(
+                                        parse_sse_protocol(
                                             sse=_sse,
                                             type_=StreamEventContextProtocol,  # type: ignore
                                         ),
@@ -321,7 +321,7 @@ class AsyncRawCompletionsClient:
                                 try:
                                     yield typing.cast(
                                         StreamedCompletion,
-                                        parse_sse_obj(
+                                        parse_sse_data(
                                             sse=_sse,
                                             type_=StreamedCompletion,  # type: ignore
                                         ),
@@ -405,7 +405,7 @@ class AsyncRawCompletionsClient:
                                 try:
                                     yield typing.cast(
                                         StreamEvent,
-                                        parse_sse_obj(
+                                        parse_sse_data(
                                             sse=_sse,
                                             type_=StreamEvent,  # type: ignore
                                         ),
@@ -489,7 +489,7 @@ class AsyncRawCompletionsClient:
                                 try:
                                     yield typing.cast(
                                         StreamEventContextProtocol,
-                                        parse_sse_obj(
+                                        parse_sse_protocol(
                                             sse=_sse,
                                             type_=StreamEventContextProtocol,  # type: ignore
                                         ),

--- a/seed/python-sdk/server-sent-event-examples/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/server-sent-event-examples/src/seed/core/pydantic_utilities.py
@@ -167,14 +167,15 @@ def parse_sse_protocol(sse: "ServerSentEvent", type_: Type[T]) -> T:
     Returns:
         The parsed object of type T
     """
+    _PARSE_FAILED = object()
     envelope: Dict[str, Any] = {"event": sse.event}
     if sse.data is not None:
         try:
-            parsed_data = json.loads(sse.data)
+            parsed_data: Any = json.loads(sse.data)
         except (json.JSONDecodeError, ValueError):
-            parsed_data = None
+            parsed_data = _PARSE_FAILED
 
-        if parsed_data is not None:
+        if parsed_data is not _PARSE_FAILED:
             envelope["data"] = parsed_data
             try:
                 return parse_obj_as(type_, envelope)

--- a/seed/python-sdk/server-sent-event-examples/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/server-sent-event-examples/src/seed/core/pydantic_utilities.py
@@ -6,7 +6,6 @@ import inspect
 import json
 import logging
 from collections import defaultdict
-from dataclasses import asdict
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -135,107 +134,12 @@ T = TypeVar("T")
 Model = TypeVar("Model", bound=pydantic.BaseModel)
 
 
-def _get_discriminator_and_variants(type_: Type[Any]) -> Tuple[Optional[str], Optional[List[Type[Any]]]]:
+def parse_sse_data(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
-    Extract the discriminator field name and union variants from a discriminated union type.
-    Supports Annotated[Union[...], Field(discriminator=...)] patterns.
-    Returns (discriminator, variants) or (None, None) if not a discriminated union.
-    """
-    origin = typing_extensions.get_origin(type_)
+    Parse an SSE event where the discriminant is inside the data payload (data-level discrimination).
 
-    if origin is typing_extensions.Annotated:
-        args = typing_extensions.get_args(type_)
-        if len(args) >= 2:
-            inner_type = args[0]
-            # Check annotations for discriminator
-            discriminator = None
-            for annotation in args[1:]:
-                if hasattr(annotation, "discriminator"):
-                    discriminator = getattr(annotation, "discriminator", None)
-                    break
-
-            if discriminator:
-                inner_origin = typing_extensions.get_origin(inner_type)
-                if inner_origin is Union:
-                    variants = list(typing_extensions.get_args(inner_type))
-                    return discriminator, variants
-    return None, None
-
-
-def _get_field_annotation(model: Type[Any], field_name: str) -> Optional[Type[Any]]:
-    """Get the type annotation of a field from a Pydantic model."""
-    if IS_PYDANTIC_V2:
-        fields = getattr(model, "model_fields", {})
-        field_info = fields.get(field_name)
-        if field_info:
-            return cast(Optional[Type[Any]], field_info.annotation)
-    else:
-        fields = getattr(model, "__fields__", {})
-        field_info = fields.get(field_name)
-        if field_info:
-            return cast(Optional[Type[Any]], field_info.outer_type_)
-    return None
-
-
-def _find_variant_by_discriminator(
-    variants: List[Type[Any]],
-    discriminator: str,
-    discriminator_value: Any,
-) -> Optional[Type[Any]]:
-    """Find the union variant that matches the discriminator value."""
-    for variant in variants:
-        if not (inspect.isclass(variant) and issubclass(variant, pydantic.BaseModel)):
-            continue
-
-        disc_annotation = _get_field_annotation(variant, discriminator)
-        if disc_annotation and is_literal_type(disc_annotation):
-            literal_args = get_args(disc_annotation)
-            if literal_args and literal_args[0] == discriminator_value:
-                return variant
-    return None
-
-
-def _is_string_type(type_: Type[Any]) -> bool:
-    """Check if a type is str or Optional[str]."""
-    if type_ is str:
-        return True
-
-    origin = typing_extensions.get_origin(type_)
-    if origin is Union:
-        args = typing_extensions.get_args(type_)
-        # Optional[str] = Union[str, None]
-        non_none_args = [a for a in args if a is not type(None)]
-        if len(non_none_args) == 1 and non_none_args[0] is str:
-            return True
-
-    return False
-
-
-def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
-    """
-    Parse a ServerSentEvent into the appropriate type.
-
-    Handles two scenarios based on where the discriminator field is located:
-
-    1. Data-level discrimination: The discriminator (e.g., 'type') is inside the 'data' payload.
-       The union describes the data content, not the SSE envelope.
-       -> Returns: json.loads(data) parsed into the type
-
-       Example: ChatStreamResponse with discriminator='type'
-       Input:  ServerSentEvent(event="message", data='{"type": "content-delta", ...}', id="")
-       Output: ContentDeltaEvent (parsed from data, SSE envelope stripped)
-
-    2. Event-level discrimination: The discriminator (e.g., 'event') is at the SSE event level.
-       The union describes the full SSE event structure.
-       -> Returns: SSE envelope with 'data' field JSON-parsed only if the variant expects non-string
-
-       Example: JobStreamResponse with discriminator='event'
-       Input:  ServerSentEvent(event="ERROR", data='{"code": "FAILED", ...}', id="123")
-       Output: JobStreamResponse_Error with data as ErrorData object
-
-       But for variants where data is str (like STATUS_UPDATE):
-       Input:  ServerSentEvent(event="STATUS_UPDATE", data='{"status": "processing"}', id="1")
-       Output: JobStreamResponse_StatusUpdate with data as string (not parsed)
+    The sse.data field contains JSON with the discriminant and all payload fields flattened together.
+    Example: sse.data = '{"event": "entity", "entityId": "123", "eventType": "CREATED"}'
 
     Args:
         sse: The ServerSentEvent object to parse
@@ -243,71 +147,45 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
 
     Returns:
         The parsed object of type T
-
-    Note:
-        This function is only available in SDK contexts where http_sse module exists.
     """
-    sse_event = asdict(sse)
-    discriminator, variants = _get_discriminator_and_variants(type_)
+    data = json.loads(sse.data)
+    return parse_obj_as(type_, data)
 
-    if discriminator is None or variants is None:
-        # Not a discriminated union - parse the data field as JSON
-        data_value = sse_event.get("data")
-        if isinstance(data_value, str) and data_value:
+
+def parse_sse_protocol(sse: "ServerSentEvent", type_: Type[T]) -> T:
+    """
+    Parse an SSE event where the discriminant is at the protocol level (protocol-level discrimination).
+
+    The discriminant comes from the SSE event field (sse.event), not from inside sse.data.
+    The data field can be any type: absent, string, number, or JSON object.
+    Example: SSE with event: "object_data", data: '{"message": "hello", "timestamp": "..."}'
+
+    Args:
+        sse: The ServerSentEvent object to parse
+        type_: The target discriminated union type
+
+    Returns:
+        The parsed object of type T
+    """
+    envelope: Dict[str, Any] = {"event": sse.event}
+    if sse.data is not None:
+        try:
+            parsed_data = json.loads(sse.data)
+        except (json.JSONDecodeError, ValueError):
+            parsed_data = None
+
+        if parsed_data is not None:
+            envelope["data"] = parsed_data
             try:
-                parsed_data = json.loads(data_value)
-                return parse_obj_as(type_, parsed_data)
-            except json.JSONDecodeError as e:
-                _logger.warning(
-                    "Failed to parse SSE data field as JSON: %s, data: %s",
-                    e,
-                    data_value[:100] if len(data_value) > 100 else data_value,
-                )
-        return parse_obj_as(type_, sse_event)
-
-    data_value = sse_event.get("data")
-
-    # Check if discriminator is at the top level (event-level discrimination)
-    if discriminator in sse_event:
-        # Case 2: Event-level discrimination
-        # Find the matching variant to check if 'data' field needs JSON parsing
-        disc_value = sse_event.get(discriminator)
-        matching_variant = _find_variant_by_discriminator(variants, discriminator, disc_value)
-
-        if matching_variant is not None:
-            # Check what type the variant expects for 'data'
-            data_type = _get_field_annotation(matching_variant, "data")
-            if data_type is not None and not _is_string_type(data_type):
-                # Variant expects non-string data - parse JSON
-                if isinstance(data_value, str) and data_value:
-                    try:
-                        parsed_data = json.loads(data_value)
-                        new_object = dict(sse_event)
-                        new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
-                    except json.JSONDecodeError as e:
-                        _logger.warning(
-                            "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
-                            e,
-                            data_value[:100] if len(data_value) > 100 else data_value,
-                        )
-        # Either no matching variant, data is string type, or JSON parse failed
-        return parse_obj_as(type_, sse_event)
-
-    else:
-        # Case 1: Data-level discrimination
-        # The discriminator is inside the data payload - extract and parse data only
-        if isinstance(data_value, str) and data_value:
-            try:
-                parsed_data = json.loads(data_value)
-                return parse_obj_as(type_, parsed_data)
-            except json.JSONDecodeError as e:
-                _logger.warning(
-                    "Failed to parse SSE data field as JSON for data-level discrimination: %s, data: %s",
-                    e,
-                    data_value[:100] if len(data_value) > 100 else data_value,
-                )
-        return parse_obj_as(type_, sse_event)
+                return parse_obj_as(type_, envelope)
+            except Exception:
+                # If validation fails with JSON-parsed data (e.g. variant expects str
+                # but data was valid JSON like '{"status": "processing"}'), fall back
+                # to the raw string so string-typed variants work correctly.
+                envelope["data"] = sse.data
+        else:
+            envelope["data"] = sse.data
+    return parse_obj_as(type_, envelope)
 
 
 def parse_obj_as(type_: Type[T], object_: Any) -> T:

--- a/seed/python-sdk/server-sent-event-examples/tests/utils/test_sse_streaming.py
+++ b/seed/python-sdk/server-sent-event-examples/tests/utils/test_sse_streaming.py
@@ -73,7 +73,7 @@ class TestSSEStreamingLogic:
                 with client.stream(query="test") as response:
                     completions = list(response.data)
                     assert len(completions) == 0
-                    assert "Failed to parse SSE data field as JSON" in caplog.text
+                    assert "Skipping SSE event with invalid JSON" in caplog.text
 
     def test_stream_sync_model_construction_error(self, caplog):
         """Test sync streaming with model construction error."""
@@ -215,7 +215,7 @@ class TestSSEStreamingLogic:
                     async for completion in response.data:
                         completions.append(completion)
                     assert len(completions) == 0
-                    assert "Failed to parse SSE data field as JSON" in caplog.text
+                    assert "Skipping SSE event with invalid JSON" in caplog.text
 
     def test_stream_sync_error_response(self):
         """Test sync streaming with error response."""
@@ -374,7 +374,7 @@ class TestSSEStreamingLogic:
                     assert completions[0].tokens == 1
                     assert completions[1].delta == "world"
                     assert completions[1].tokens == 2
-                    assert "Failed to parse SSE data field as JSON" in caplog.text
+                    assert "Skipping SSE event with invalid JSON" in caplog.text
 
     def test_stream_missing_required_fields(self, caplog):
         """Test handling of SSE events missing required fields."""
@@ -670,7 +670,7 @@ class TestSSEStreamingLogic:
                     assert completions[0].tokens == 1
                     assert completions[1].delta == "world"
                     assert completions[1].tokens == 2
-                    assert "Failed to parse SSE data field as JSON" in caplog.text
+                    assert "Skipping SSE event with invalid JSON" in caplog.text
 
     @pytest.mark.asyncio
     async def test_stream_async_unicode_data(self):

--- a/seed/python-sdk/server-sent-events-openapi/with-wire-tests/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/server-sent-events-openapi/with-wire-tests/src/seed/core/pydantic_utilities.py
@@ -170,8 +170,20 @@ def parse_sse_protocol(sse: "ServerSentEvent", type_: Type[T]) -> T:
     envelope: Dict[str, Any] = {"event": sse.event}
     if sse.data is not None:
         try:
-            envelope["data"] = json.loads(sse.data)
+            parsed_data = json.loads(sse.data)
         except (json.JSONDecodeError, ValueError):
+            parsed_data = None
+
+        if parsed_data is not None:
+            envelope["data"] = parsed_data
+            try:
+                return parse_obj_as(type_, envelope)
+            except Exception:
+                # If validation fails with JSON-parsed data (e.g. variant expects str
+                # but data was valid JSON like '{"status": "processing"}'), fall back
+                # to the raw string so string-typed variants work correctly.
+                envelope["data"] = sse.data
+        else:
             envelope["data"] = sse.data
     return parse_obj_as(type_, envelope)
 

--- a/seed/python-sdk/server-sent-events-openapi/with-wire-tests/src/seed/core/pydantic_utilities.py
+++ b/seed/python-sdk/server-sent-events-openapi/with-wire-tests/src/seed/core/pydantic_utilities.py
@@ -6,7 +6,6 @@ import inspect
 import json
 import logging
 from collections import defaultdict
-from dataclasses import asdict
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -135,107 +134,12 @@ T = TypeVar("T")
 Model = TypeVar("Model", bound=pydantic.BaseModel)
 
 
-def _get_discriminator_and_variants(type_: Type[Any]) -> Tuple[Optional[str], Optional[List[Type[Any]]]]:
+def parse_sse_data(sse: "ServerSentEvent", type_: Type[T]) -> T:
     """
-    Extract the discriminator field name and union variants from a discriminated union type.
-    Supports Annotated[Union[...], Field(discriminator=...)] patterns.
-    Returns (discriminator, variants) or (None, None) if not a discriminated union.
-    """
-    origin = typing_extensions.get_origin(type_)
+    Parse an SSE event where the discriminant is inside the data payload (data-level discrimination).
 
-    if origin is typing_extensions.Annotated:
-        args = typing_extensions.get_args(type_)
-        if len(args) >= 2:
-            inner_type = args[0]
-            # Check annotations for discriminator
-            discriminator = None
-            for annotation in args[1:]:
-                if hasattr(annotation, "discriminator"):
-                    discriminator = getattr(annotation, "discriminator", None)
-                    break
-
-            if discriminator:
-                inner_origin = typing_extensions.get_origin(inner_type)
-                if inner_origin is Union:
-                    variants = list(typing_extensions.get_args(inner_type))
-                    return discriminator, variants
-    return None, None
-
-
-def _get_field_annotation(model: Type[Any], field_name: str) -> Optional[Type[Any]]:
-    """Get the type annotation of a field from a Pydantic model."""
-    if IS_PYDANTIC_V2:
-        fields = getattr(model, "model_fields", {})
-        field_info = fields.get(field_name)
-        if field_info:
-            return cast(Optional[Type[Any]], field_info.annotation)
-    else:
-        fields = getattr(model, "__fields__", {})
-        field_info = fields.get(field_name)
-        if field_info:
-            return cast(Optional[Type[Any]], field_info.outer_type_)
-    return None
-
-
-def _find_variant_by_discriminator(
-    variants: List[Type[Any]],
-    discriminator: str,
-    discriminator_value: Any,
-) -> Optional[Type[Any]]:
-    """Find the union variant that matches the discriminator value."""
-    for variant in variants:
-        if not (inspect.isclass(variant) and issubclass(variant, pydantic.BaseModel)):
-            continue
-
-        disc_annotation = _get_field_annotation(variant, discriminator)
-        if disc_annotation and is_literal_type(disc_annotation):
-            literal_args = get_args(disc_annotation)
-            if literal_args and literal_args[0] == discriminator_value:
-                return variant
-    return None
-
-
-def _is_string_type(type_: Type[Any]) -> bool:
-    """Check if a type is str or Optional[str]."""
-    if type_ is str:
-        return True
-
-    origin = typing_extensions.get_origin(type_)
-    if origin is Union:
-        args = typing_extensions.get_args(type_)
-        # Optional[str] = Union[str, None]
-        non_none_args = [a for a in args if a is not type(None)]
-        if len(non_none_args) == 1 and non_none_args[0] is str:
-            return True
-
-    return False
-
-
-def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
-    """
-    Parse a ServerSentEvent into the appropriate type.
-
-    Handles two scenarios based on where the discriminator field is located:
-
-    1. Data-level discrimination: The discriminator (e.g., 'type') is inside the 'data' payload.
-       The union describes the data content, not the SSE envelope.
-       -> Returns: json.loads(data) parsed into the type
-
-       Example: ChatStreamResponse with discriminator='type'
-       Input:  ServerSentEvent(event="message", data='{"type": "content-delta", ...}', id="")
-       Output: ContentDeltaEvent (parsed from data, SSE envelope stripped)
-
-    2. Event-level discrimination: The discriminator (e.g., 'event') is at the SSE event level.
-       The union describes the full SSE event structure.
-       -> Returns: SSE envelope with 'data' field JSON-parsed only if the variant expects non-string
-
-       Example: JobStreamResponse with discriminator='event'
-       Input:  ServerSentEvent(event="ERROR", data='{"code": "FAILED", ...}', id="123")
-       Output: JobStreamResponse_Error with data as ErrorData object
-
-       But for variants where data is str (like STATUS_UPDATE):
-       Input:  ServerSentEvent(event="STATUS_UPDATE", data='{"status": "processing"}', id="1")
-       Output: JobStreamResponse_StatusUpdate with data as string (not parsed)
+    The sse.data field contains JSON with the discriminant and all payload fields flattened together.
+    Example: sse.data = '{"event": "entity", "entityId": "123", "eventType": "CREATED"}'
 
     Args:
         sse: The ServerSentEvent object to parse
@@ -243,71 +147,33 @@ def parse_sse_obj(sse: "ServerSentEvent", type_: Type[T]) -> T:
 
     Returns:
         The parsed object of type T
-
-    Note:
-        This function is only available in SDK contexts where http_sse module exists.
     """
-    sse_event = asdict(sse)
-    discriminator, variants = _get_discriminator_and_variants(type_)
+    data = json.loads(sse.data)
+    return parse_obj_as(type_, data)
 
-    if discriminator is None or variants is None:
-        # Not a discriminated union - parse the data field as JSON
-        data_value = sse_event.get("data")
-        if isinstance(data_value, str) and data_value:
-            try:
-                parsed_data = json.loads(data_value)
-                return parse_obj_as(type_, parsed_data)
-            except json.JSONDecodeError as e:
-                _logger.warning(
-                    "Failed to parse SSE data field as JSON: %s, data: %s",
-                    e,
-                    data_value[:100] if len(data_value) > 100 else data_value,
-                )
-        return parse_obj_as(type_, sse_event)
 
-    data_value = sse_event.get("data")
+def parse_sse_protocol(sse: "ServerSentEvent", type_: Type[T]) -> T:
+    """
+    Parse an SSE event where the discriminant is at the protocol level (protocol-level discrimination).
 
-    # Check if discriminator is at the top level (event-level discrimination)
-    if discriminator in sse_event:
-        # Case 2: Event-level discrimination
-        # Find the matching variant to check if 'data' field needs JSON parsing
-        disc_value = sse_event.get(discriminator)
-        matching_variant = _find_variant_by_discriminator(variants, discriminator, disc_value)
+    The discriminant comes from the SSE event field (sse.event), not from inside sse.data.
+    The data field can be any type: absent, string, number, or JSON object.
+    Example: SSE with event: "object_data", data: '{"message": "hello", "timestamp": "..."}'
 
-        if matching_variant is not None:
-            # Check what type the variant expects for 'data'
-            data_type = _get_field_annotation(matching_variant, "data")
-            if data_type is not None and not _is_string_type(data_type):
-                # Variant expects non-string data - parse JSON
-                if isinstance(data_value, str) and data_value:
-                    try:
-                        parsed_data = json.loads(data_value)
-                        new_object = dict(sse_event)
-                        new_object["data"] = parsed_data
-                        return parse_obj_as(type_, new_object)
-                    except json.JSONDecodeError as e:
-                        _logger.warning(
-                            "Failed to parse SSE data field as JSON for event-level discrimination: %s, data: %s",
-                            e,
-                            data_value[:100] if len(data_value) > 100 else data_value,
-                        )
-        # Either no matching variant, data is string type, or JSON parse failed
-        return parse_obj_as(type_, sse_event)
+    Args:
+        sse: The ServerSentEvent object to parse
+        type_: The target discriminated union type
 
-    else:
-        # Case 1: Data-level discrimination
-        # The discriminator is inside the data payload - extract and parse data only
-        if isinstance(data_value, str) and data_value:
-            try:
-                parsed_data = json.loads(data_value)
-                return parse_obj_as(type_, parsed_data)
-            except json.JSONDecodeError as e:
-                _logger.warning(
-                    "Failed to parse SSE data field as JSON for data-level discrimination: %s, data: %s",
-                    e,
-                    data_value[:100] if len(data_value) > 100 else data_value,
-                )
-        return parse_obj_as(type_, sse_event)
+    Returns:
+        The parsed object of type T
+    """
+    envelope: Dict[str, Any] = {"event": sse.event}
+    if sse.data is not None:
+        try:
+            envelope["data"] = json.loads(sse.data)
+        except (json.JSONDecodeError, ValueError):
+            envelope["data"] = sse.data
+    return parse_obj_as(type_, envelope)
 
 
 def parse_obj_as(type_: Type[T], object_: Any) -> T:

--- a/seed/python-sdk/server-sent-events-openapi/with-wire-tests/src/seed/raw_client.py
+++ b/seed/python-sdk/server-sent-events-openapi/with-wire-tests/src/seed/raw_client.py
@@ -10,7 +10,7 @@ from .core.client_wrapper import AsyncClientWrapper, SyncClientWrapper
 from .core.http_response import AsyncHttpResponse, HttpResponse
 from .core.http_sse._api import EventSource
 from .core.parse_error import ParsingError
-from .core.pydantic_utilities import parse_sse_obj
+from .core.pydantic_utilities import parse_sse_data, parse_sse_protocol
 from .core.request_options import RequestOptions
 from .types.event import Event
 from .types.stream_data_context_response import StreamDataContextResponse
@@ -73,7 +73,7 @@ class RawSeedApi:
                                 try:
                                     yield typing.cast(
                                         StreamProtocolNoCollisionResponse,
-                                        parse_sse_obj(
+                                        parse_sse_protocol(
                                             sse=_sse,
                                             type_=StreamProtocolNoCollisionResponse,  # type: ignore
                                         ),
@@ -152,7 +152,7 @@ class RawSeedApi:
                                 try:
                                     yield typing.cast(
                                         StreamProtocolCollisionResponse,
-                                        parse_sse_obj(
+                                        parse_sse_protocol(
                                             sse=_sse,
                                             type_=StreamProtocolCollisionResponse,  # type: ignore
                                         ),
@@ -231,7 +231,7 @@ class RawSeedApi:
                                 try:
                                     yield typing.cast(
                                         StreamDataContextResponse,
-                                        parse_sse_obj(
+                                        parse_sse_data(
                                             sse=_sse,
                                             type_=StreamDataContextResponse,  # type: ignore
                                         ),
@@ -310,7 +310,7 @@ class RawSeedApi:
                                 try:
                                     yield typing.cast(
                                         StreamNoContextResponse,
-                                        parse_sse_obj(
+                                        parse_sse_data(
                                             sse=_sse,
                                             type_=StreamNoContextResponse,  # type: ignore
                                         ),
@@ -389,7 +389,7 @@ class RawSeedApi:
                                 try:
                                     yield typing.cast(
                                         StreamProtocolWithFlatSchemaResponse,
-                                        parse_sse_obj(
+                                        parse_sse_protocol(
                                             sse=_sse,
                                             type_=StreamProtocolWithFlatSchemaResponse,  # type: ignore
                                         ),
@@ -468,7 +468,7 @@ class RawSeedApi:
                                 try:
                                     yield typing.cast(
                                         StreamDataContextWithEnvelopeSchemaResponse,
-                                        parse_sse_obj(
+                                        parse_sse_data(
                                             sse=_sse,
                                             type_=StreamDataContextWithEnvelopeSchemaResponse,  # type: ignore
                                         ),
@@ -547,7 +547,7 @@ class RawSeedApi:
                                 try:
                                     yield typing.cast(
                                         Event,
-                                        parse_sse_obj(
+                                        parse_sse_data(
                                             sse=_sse,
                                             type_=Event,  # type: ignore
                                         ),
@@ -631,7 +631,7 @@ class AsyncRawSeedApi:
                                 try:
                                     yield typing.cast(
                                         StreamProtocolNoCollisionResponse,
-                                        parse_sse_obj(
+                                        parse_sse_protocol(
                                             sse=_sse,
                                             type_=StreamProtocolNoCollisionResponse,  # type: ignore
                                         ),
@@ -710,7 +710,7 @@ class AsyncRawSeedApi:
                                 try:
                                     yield typing.cast(
                                         StreamProtocolCollisionResponse,
-                                        parse_sse_obj(
+                                        parse_sse_protocol(
                                             sse=_sse,
                                             type_=StreamProtocolCollisionResponse,  # type: ignore
                                         ),
@@ -789,7 +789,7 @@ class AsyncRawSeedApi:
                                 try:
                                     yield typing.cast(
                                         StreamDataContextResponse,
-                                        parse_sse_obj(
+                                        parse_sse_data(
                                             sse=_sse,
                                             type_=StreamDataContextResponse,  # type: ignore
                                         ),
@@ -868,7 +868,7 @@ class AsyncRawSeedApi:
                                 try:
                                     yield typing.cast(
                                         StreamNoContextResponse,
-                                        parse_sse_obj(
+                                        parse_sse_data(
                                             sse=_sse,
                                             type_=StreamNoContextResponse,  # type: ignore
                                         ),
@@ -947,7 +947,7 @@ class AsyncRawSeedApi:
                                 try:
                                     yield typing.cast(
                                         StreamProtocolWithFlatSchemaResponse,
-                                        parse_sse_obj(
+                                        parse_sse_protocol(
                                             sse=_sse,
                                             type_=StreamProtocolWithFlatSchemaResponse,  # type: ignore
                                         ),
@@ -1026,7 +1026,7 @@ class AsyncRawSeedApi:
                                 try:
                                     yield typing.cast(
                                         StreamDataContextWithEnvelopeSchemaResponse,
-                                        parse_sse_obj(
+                                        parse_sse_data(
                                             sse=_sse,
                                             type_=StreamDataContextWithEnvelopeSchemaResponse,  # type: ignore
                                         ),
@@ -1105,7 +1105,7 @@ class AsyncRawSeedApi:
                                 try:
                                     yield typing.cast(
                                         Event,
-                                        parse_sse_obj(
+                                        parse_sse_data(
                                             sse=_sse,
                                             type_=Event,  # type: ignore
                                         ),


### PR DESCRIPTION
## Description

Replace runtime reflection-based SSE discriminant detection in the Python SDK generator with compile-time knowledge from the IR's `discriminatorContext` field. This eliminates per-event type introspection overhead that is critical for high-throughput SSE workloads like LLM inference.

The previous implementation used `_get_discriminator_and_variants`, `_find_variant_by_discriminator`, `_get_field_annotation`, and `_is_string_type` to reflect on Pydantic union types at runtime on every SSE event. The TypeScript and Go generators already solve this correctly by reading `discriminatorContext` from the IR at generation time.

## Changes Made

- **Core utilities** (`pydantic_utilities.py` x4 variants): Added `parse_sse_data` (data-level) and `parse_sse_protocol` (protocol-level) functions. Deleted `parse_sse_obj` and all reflection helpers (`_get_discriminator_and_variants`, `_find_variant_by_discriminator`, `_get_field_annotation`, `_is_string_type`)
- **Generator layer** (`endpoint_response_code_writer.py`): Resolves SSE payload's `UnionTypeDeclaration.discriminator_context` from IR at generation time. Emits `parse_sse_protocol` for protocol-context endpoints and `parse_sse_data` for data-context endpoints
- **CoreUtilities class** (`core_utilities.py`): Updated `get_construct_sse` to accept `is_protocol` parameter and reference the new functions
- **`parse_sse_protocol` string-variant fallback**: Attempts `json.loads` first; if Pydantic validation fails (e.g. variant expects `str` but data was valid JSON like `'{"status": "processing"}'`), falls back to the raw string so string-typed variants work correctly
- **Sentinel for JSON parse failures**: Uses `_PARSE_FAILED = object()` instead of `None` so that `json.loads("null")` returning Python `None` is correctly distinguished from actual parse failures
- [ ] Updated README.md generator (if applicable) — N/A

## Updates since last revision

- Fixed `json.loads("null")` sentinel bug flagged by Devin Review: all 4 `pydantic_utilities.py` variants now use `_PARSE_FAILED = object()` instead of `None` as the parse-failure sentinel
- Updated `server-sent-event-examples` seed output and hand-written test assertions to match new log messages

## Testing

- [x] `pnpm seed test --generator python-sdk --fixture server-sent-events-openapi --skip-scripts` — 1/1 passed
- [x] `pnpm seed test --generator python-sdk --fixture exhaustive --skip-scripts` — 28/28 passed
- [x] `pnpm seed:local test --generator python-sdk --fixture server-sent-event-examples` — 1/1 passed (build + test scripts)
- [x] Verified protocol-context endpoints (`streamProtocolNoCollision`, `streamProtocolCollision`, `streamProtocolWithFlatSchema`) call `parse_sse_protocol`
- [x] Verified data-context endpoints (`streamDataContext`, `streamNoContext`, `streamDataContextWithEnvelopeSchema`, `streamOasSpecNative`) call `parse_sse_data`
- [x] Verified old reflection helpers are absent from generated `pydantic_utilities.py`

## Human Review Checklist

- [ ] Verify **all 4** `pydantic_utilities.py` variants consistently use `_PARSE_FAILED = object()` sentinel (the cumulative diff truncation makes it hard to confirm the `with_pydantic_v1_on_v2/with_aliases` copy was updated)
- [ ] Review the broad `except Exception` fallback in `parse_sse_protocol` — it intentionally catches validation errors to fall back to raw strings for string-typed variants, but could mask other issues
- [ ] Confirm no other SSE-using seed fixtures need regeneration beyond `server-sent-event-examples` and `server-sent-events-openapi`

Link to Devin session: https://app.devin.ai/sessions/cf621d7834184fbab7e24ace259f8c77
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/14183" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
