### PR TITLE
fix(cli): server-side replay init PR creation

### DIFF
--- a/packages/cli/cli/src/cli.ts
+++ b/packages/cli/cli/src/cli.ts
@@ -12,6 +12,7 @@ import {
     loadProjectConfig,
     PROJECT_CONFIG_FILENAME
 } from "@fern-api/configuration-loader";
+import { getFiddleOrigin } from "@fern-api/core";
 import {
     ContainerRunner,
     extractErrorMessage,
@@ -80,7 +81,7 @@ import { writeDocsDefinitionForProject } from "./commands/write-docs-definition/
 import { writeTranslationForProject } from "./commands/write-translation/writeTranslationForProject.js";
 import { FERN_CWD_ENV_VAR } from "./cwd.js";
 import { rerunFernCliAtVersion } from "./rerunFernCliAtVersion.js";
-import { fetchInstallationToken, resolveGroupGithubConfig } from "./resolveGroupGithubConfig.js";
+import { resolveGroupGithubConfig } from "./resolveGroupGithubConfig.js";
 import { RUNTIME } from "./runtime.js";
 
 void runCli();
@@ -2303,25 +2304,10 @@ function addReplayInitCommand(cli: Argv<GlobalCliOptions>, cliContext: CliContex
                 token = token ?? resolved.token;
             }
 
-            // Always try to get Fern App installation token for write operations (push + PR).
-            // The user's GITHUB_TOKEN may not have write access to the target repo,
-            // but the Fern GitHub App installation token will.
-            let writeToken: string | undefined;
-            if (githubRepo != null) {
-                try {
-                    const fernToken = await cliContext.runTask((context) => askToLogin(context));
-                    writeToken = await fetchInstallationToken(cliContext, githubRepo, fernToken);
-                } catch {
-                    cliContext.logger.debug("Could not obtain Fern App installation token for write operations.");
-                }
-            }
-
-            // Need at least one token (for clone) and writeToken or token (for push)
-            const readToken = token ?? writeToken;
-            if (githubRepo == null || readToken == null) {
+            if (githubRepo == null || token == null) {
                 const hint =
                     githubRepo != null
-                        ? "Repository found but no token. Ensure the Fern GitHub App (https://github.com/apps/fern-api) is installed on the repository, or pass --token / set GITHUB_TOKEN."
+                        ? "Repository found but no token. Pass --token or set GITHUB_TOKEN environment variable."
                         : "Either use --group to read from generators.yml, or provide --github and --token directly.";
                 return cliContext.failAndThrow(`Missing required github config. ${hint}`);
             }
@@ -2334,8 +2320,7 @@ function addReplayInitCommand(cli: Argv<GlobalCliOptions>, cliContext: CliContex
             try {
                 const result = await replayInit({
                     githubRepo,
-                    token: readToken,
-                    writeToken,
+                    token,
                     dryRun: argv.dryRun,
                     maxCommitsToScan: argv.maxCommits,
                     force: argv.force
@@ -2356,7 +2341,48 @@ function addReplayInitCommand(cli: Argv<GlobalCliOptions>, cliContext: CliContex
 
                 if (argv.dryRun) {
                     cliContext.logger.info("\nDry run complete. No changes made.");
+                    return;
                 }
+
+                if (result.lockfileContent == null) {
+                    return cliContext.failAndThrow("Bootstrap succeeded but lockfile content is missing.");
+                }
+
+                // Send lockfile to Fiddle for server-side PR creation
+                const fernToken = await cliContext.runTask((context) => askToLogin(context));
+
+                const { owner, repo } = parseOwnerRepo(githubRepo);
+                const fiddleOrigin = getFiddleOrigin();
+
+                const response = await fetch(`${fiddleOrigin}/api/remote-gen/replay/init`, {
+                    method: "POST",
+                    headers: {
+                        "Content-Type": "application/json",
+                        Authorization: `Bearer ${fernToken.value}`
+                    },
+                    body: JSON.stringify({
+                        owner,
+                        repo,
+                        lockfileContents: result.lockfileContent,
+                        fernignoreEntries: result.fernignoreEntries,
+                        prBody: result.prBody
+                    })
+                });
+
+                if (!response.ok) {
+                    if (response.status === 404) {
+                        return cliContext.failAndThrow(
+                            "The Fern GitHub App is not installed on this repository. " +
+                                "Install it at https://github.com/apps/fern-api to enable server-side PR creation."
+                        );
+                    }
+                    const body = await response.text();
+                    return cliContext.failAndThrow(`Failed to create PR via Fern: ${body}`);
+                }
+
+                const data = (await response.json()) as { prUrl: string };
+                cliContext.logger.info(`\nPR created: ${data.prUrl}`);
+                cliContext.logger.info("Merge the PR to enable Replay for this repository.");
             } catch (error) {
                 cliContext.failAndThrow(`Failed to initialize Replay: ${extractErrorMessage(error)}`);
             }
@@ -2434,4 +2460,18 @@ function addReplayResolveCommand(cli: Argv<GlobalCliOptions>, cliContext: CliCon
             }
         }
     );
+}
+
+function parseOwnerRepo(githubRepo: string): { owner: string; repo: string } {
+    const cleaned = githubRepo
+        .replace(/^https?:\/\//, "")
+        .replace(/\.git$/, "")
+        .replace(/^github\.com\//, "");
+    const parts = cleaned.split("/");
+    const owner = parts[parts.length - 2];
+    const repo = parts[parts.length - 1];
+    if (owner == null || repo == null) {
+        throw new Error(`Could not parse owner/repo from: ${githubRepo}`);
+    }
+    return { owner, repo };
 }

--- a/packages/cli/cli/src/cli.ts
+++ b/packages/cli/cli/src/cli.ts
@@ -2,6 +2,7 @@
 import type { ReadStream, WriteStream } from "node:tty";
 import { fromBinary, toBinary } from "@bufbuild/protobuf";
 import { CodeGeneratorRequestSchema, CodeGeneratorResponseSchema } from "@bufbuild/protobuf/wkt";
+import type { FernToken } from "@fern-api/auth";
 import { runCliV2 } from "@fern-api/cli-v2";
 import {
     correctIncorrectDockerOrg,
@@ -2297,7 +2298,19 @@ function addReplayInitCommand(cli: Argv<GlobalCliOptions>, cliContext: CliContex
 
             // If --group is provided, load config from generators.yml
             if (argv.group != null) {
-                const resolved = await resolveGroupGithubConfig(cliContext, argv.group, argv.api);
+                // Get Fern token as fallback when GITHUB_TOKEN is not set
+                let fernToken: FernToken | undefined;
+                if (token == null && process.env.GITHUB_TOKEN == null) {
+                    try {
+                        fernToken = await cliContext.runTask((context) => {
+                            return askToLogin(context);
+                        });
+                    } catch {
+                        cliContext.logger.debug("Could not obtain Fern token for GitHub App fallback.");
+                    }
+                }
+
+                const resolved = await resolveGroupGithubConfig(cliContext, argv.group, argv.api, fernToken);
                 // Use group config as defaults, allow --github/--token to override
                 githubRepo = githubRepo ?? resolved.githubRepo;
                 token = token ?? resolved.token;
@@ -2306,7 +2319,7 @@ function addReplayInitCommand(cli: Argv<GlobalCliOptions>, cliContext: CliContex
             if (githubRepo == null || token == null) {
                 const hint =
                     githubRepo != null
-                        ? "Repository found but no token. Pass --token or set GITHUB_TOKEN environment variable."
+                        ? "Repository found but no token. Ensure the Fern GitHub App (https://github.com/apps/fern-api) is installed on the repository, or pass --token / set GITHUB_TOKEN."
                         : "Either use --group to read from generators.yml, or provide --github and --token directly.";
                 return cliContext.failAndThrow(`Missing required github config. ${hint}`);
             }

--- a/packages/cli/cli/src/cli.ts
+++ b/packages/cli/cli/src/cli.ts
@@ -2,7 +2,6 @@
 import type { ReadStream, WriteStream } from "node:tty";
 import { fromBinary, toBinary } from "@bufbuild/protobuf";
 import { CodeGeneratorRequestSchema, CodeGeneratorResponseSchema } from "@bufbuild/protobuf/wkt";
-import type { FernToken } from "@fern-api/auth";
 import { runCliV2 } from "@fern-api/cli-v2";
 import {
     correctIncorrectDockerOrg,
@@ -81,7 +80,7 @@ import { writeDocsDefinitionForProject } from "./commands/write-docs-definition/
 import { writeTranslationForProject } from "./commands/write-translation/writeTranslationForProject.js";
 import { FERN_CWD_ENV_VAR } from "./cwd.js";
 import { rerunFernCliAtVersion } from "./rerunFernCliAtVersion.js";
-import { resolveGroupGithubConfig } from "./resolveGroupGithubConfig.js";
+import { fetchInstallationToken, resolveGroupGithubConfig } from "./resolveGroupGithubConfig.js";
 import { RUNTIME } from "./runtime.js";
 
 void runCli();
@@ -2298,25 +2297,28 @@ function addReplayInitCommand(cli: Argv<GlobalCliOptions>, cliContext: CliContex
 
             // If --group is provided, load config from generators.yml
             if (argv.group != null) {
-                // Get Fern token as fallback when GITHUB_TOKEN is not set
-                let fernToken: FernToken | undefined;
-                if (token == null && process.env.GITHUB_TOKEN == null) {
-                    try {
-                        fernToken = await cliContext.runTask((context) => {
-                            return askToLogin(context);
-                        });
-                    } catch {
-                        cliContext.logger.debug("Could not obtain Fern token for GitHub App fallback.");
-                    }
-                }
-
-                const resolved = await resolveGroupGithubConfig(cliContext, argv.group, argv.api, fernToken);
+                const resolved = await resolveGroupGithubConfig(cliContext, argv.group, argv.api);
                 // Use group config as defaults, allow --github/--token to override
                 githubRepo = githubRepo ?? resolved.githubRepo;
                 token = token ?? resolved.token;
             }
 
-            if (githubRepo == null || token == null) {
+            // Always try to get Fern App installation token for write operations (push + PR).
+            // The user's GITHUB_TOKEN may not have write access to the target repo,
+            // but the Fern GitHub App installation token will.
+            let writeToken: string | undefined;
+            if (githubRepo != null) {
+                try {
+                    const fernToken = await cliContext.runTask((context) => askToLogin(context));
+                    writeToken = await fetchInstallationToken(cliContext, githubRepo, fernToken);
+                } catch {
+                    cliContext.logger.debug("Could not obtain Fern App installation token for write operations.");
+                }
+            }
+
+            // Need at least one token (for clone) and writeToken or token (for push)
+            const readToken = token ?? writeToken;
+            if (githubRepo == null || readToken == null) {
                 const hint =
                     githubRepo != null
                         ? "Repository found but no token. Ensure the Fern GitHub App (https://github.com/apps/fern-api) is installed on the repository, or pass --token / set GITHUB_TOKEN."
@@ -2332,7 +2334,8 @@ function addReplayInitCommand(cli: Argv<GlobalCliOptions>, cliContext: CliContex
             try {
                 const result = await replayInit({
                     githubRepo,
-                    token,
+                    token: readToken,
+                    writeToken,
                     dryRun: argv.dryRun,
                     maxCommitsToScan: argv.maxCommits,
                     force: argv.force

--- a/packages/cli/cli/src/resolveGroupGithubConfig.ts
+++ b/packages/cli/cli/src/resolveGroupGithubConfig.ts
@@ -1,4 +1,6 @@
+import { FernToken } from "@fern-api/auth";
 import { isGithubSelfhosted } from "@fern-api/configuration-loader";
+import { getFiddleOrigin } from "@fern-api/core";
 import { replaceEnvVariables } from "@fern-api/core-utils";
 import { CliContext } from "./cli-context/CliContext.js";
 import { loadProjectAndRegisterWorkspacesWithContext } from "./cliCommons.js";
@@ -13,7 +15,8 @@ export interface ResolvedGithubConfig {
 export async function resolveGroupGithubConfig(
     cliContext: CliContext,
     groupName: string,
-    apiWorkspace: string | undefined
+    apiWorkspace: string | undefined,
+    fernToken?: FernToken
 ): Promise<ResolvedGithubConfig> {
     const project = await loadProjectAndRegisterWorkspacesWithContext(cliContext, {
         commandLineApiWorkspace: apiWorkspace,
@@ -64,12 +67,19 @@ export async function resolveGroupGithubConfig(
 
     if (generatorWithRepo?.raw?.github != null && "repository" in generatorWithRepo.raw.github) {
         const githubConfig = resolveEnv(generatorWithRepo.raw.github);
-        const token = process.env.GITHUB_TOKEN;
+        let token: string | undefined = process.env.GITHUB_TOKEN;
 
-        cliContext.logger.info(
-            `Using repository config from group "${groupName}" generator "${generatorWithRepo.name}"` +
-                (token != null ? ". Using GITHUB_TOKEN from environment." : ".")
-        );
+        if (token != null) {
+            cliContext.logger.info(
+                `Using repository config from group "${groupName}" generator "${generatorWithRepo.name}". Using GITHUB_TOKEN from environment.`
+            );
+        } else if (fernToken != null) {
+            token = await fetchInstallationToken(cliContext, githubConfig.repository, fernToken);
+        } else {
+            cliContext.logger.info(
+                `Using repository config from group "${groupName}" generator "${generatorWithRepo.name}".`
+            );
+        }
 
         return {
             githubRepo: githubConfig.repository,
@@ -80,4 +90,48 @@ export async function resolveGroupGithubConfig(
     }
 
     return cliContext.failAndThrow(`No generator in group "${groupName}" has a github configuration.`);
+}
+
+async function fetchInstallationToken(
+    cliContext: CliContext,
+    repository: string,
+    fernToken: FernToken
+): Promise<string | undefined> {
+    // Parse "owner/repo" from the repository string (may include github.com prefix)
+    const parts = repository
+        .replace(/^https?:\/\//, "")
+        .replace(/\.git$/, "")
+        .split("/");
+    const owner = parts.length >= 2 ? parts[parts.length - 2] : undefined;
+    const repo = parts.length >= 2 ? parts[parts.length - 1] : undefined;
+
+    if (owner == null || repo == null) {
+        cliContext.logger.debug(`Could not parse owner/repo from repository: ${repository}`);
+        return undefined;
+    }
+
+    try {
+        const fiddleOrigin = getFiddleOrigin();
+        const response = await fetch(`${fiddleOrigin}/api/remote-gen/github/installation-token`, {
+            method: "POST",
+            headers: {
+                "Content-Type": "application/json",
+                Authorization: `Bearer ${fernToken.value}`
+            },
+            body: JSON.stringify({ owner, repo })
+        });
+
+        if (!response.ok) {
+            const body = await response.text();
+            cliContext.logger.debug(`Failed to get installation token from Fiddle (${response.status}): ${body}`);
+            return undefined;
+        }
+
+        const data = (await response.json()) as { token: string };
+        cliContext.logger.info("Using Fern GitHub App installation token.");
+        return data.token;
+    } catch (error) {
+        cliContext.logger.debug(`Failed to fetch installation token from Fiddle: ${error}`);
+        return undefined;
+    }
 }

--- a/packages/cli/cli/src/resolveGroupGithubConfig.ts
+++ b/packages/cli/cli/src/resolveGroupGithubConfig.ts
@@ -15,8 +15,7 @@ export interface ResolvedGithubConfig {
 export async function resolveGroupGithubConfig(
     cliContext: CliContext,
     groupName: string,
-    apiWorkspace: string | undefined,
-    fernToken?: FernToken
+    apiWorkspace: string | undefined
 ): Promise<ResolvedGithubConfig> {
     const project = await loadProjectAndRegisterWorkspacesWithContext(cliContext, {
         commandLineApiWorkspace: apiWorkspace,
@@ -67,19 +66,12 @@ export async function resolveGroupGithubConfig(
 
     if (generatorWithRepo?.raw?.github != null && "repository" in generatorWithRepo.raw.github) {
         const githubConfig = resolveEnv(generatorWithRepo.raw.github);
-        let token: string | undefined = process.env.GITHUB_TOKEN;
+        const token: string | undefined = process.env.GITHUB_TOKEN;
 
-        if (token != null) {
-            cliContext.logger.info(
-                `Using repository config from group "${groupName}" generator "${generatorWithRepo.name}". Using GITHUB_TOKEN from environment.`
-            );
-        } else if (fernToken != null) {
-            token = await fetchInstallationToken(cliContext, githubConfig.repository, fernToken);
-        } else {
-            cliContext.logger.info(
-                `Using repository config from group "${groupName}" generator "${generatorWithRepo.name}".`
-            );
-        }
+        cliContext.logger.info(
+            `Using repository config from group "${groupName}" generator "${generatorWithRepo.name}"` +
+                (token != null ? ". Using GITHUB_TOKEN from environment." : ".")
+        );
 
         return {
             githubRepo: githubConfig.repository,
@@ -92,7 +84,7 @@ export async function resolveGroupGithubConfig(
     return cliContext.failAndThrow(`No generator in group "${groupName}" has a github configuration.`);
 }
 
-async function fetchInstallationToken(
+export async function fetchInstallationToken(
     cliContext: CliContext,
     repository: string,
     fernToken: FernToken

--- a/packages/cli/cli/src/resolveGroupGithubConfig.ts
+++ b/packages/cli/cli/src/resolveGroupGithubConfig.ts
@@ -1,6 +1,4 @@
-import { FernToken } from "@fern-api/auth";
 import { isGithubSelfhosted } from "@fern-api/configuration-loader";
-import { getFiddleOrigin } from "@fern-api/core";
 import { replaceEnvVariables } from "@fern-api/core-utils";
 import { CliContext } from "./cli-context/CliContext.js";
 import { loadProjectAndRegisterWorkspacesWithContext } from "./cliCommons.js";
@@ -66,7 +64,7 @@ export async function resolveGroupGithubConfig(
 
     if (generatorWithRepo?.raw?.github != null && "repository" in generatorWithRepo.raw.github) {
         const githubConfig = resolveEnv(generatorWithRepo.raw.github);
-        const token: string | undefined = process.env.GITHUB_TOKEN;
+        const token = process.env.GITHUB_TOKEN;
 
         cliContext.logger.info(
             `Using repository config from group "${groupName}" generator "${generatorWithRepo.name}"` +
@@ -82,48 +80,4 @@ export async function resolveGroupGithubConfig(
     }
 
     return cliContext.failAndThrow(`No generator in group "${groupName}" has a github configuration.`);
-}
-
-export async function fetchInstallationToken(
-    cliContext: CliContext,
-    repository: string,
-    fernToken: FernToken
-): Promise<string | undefined> {
-    // Parse "owner/repo" from the repository string (may include github.com prefix)
-    const parts = repository
-        .replace(/^https?:\/\//, "")
-        .replace(/\.git$/, "")
-        .split("/");
-    const owner = parts.length >= 2 ? parts[parts.length - 2] : undefined;
-    const repo = parts.length >= 2 ? parts[parts.length - 1] : undefined;
-
-    if (owner == null || repo == null) {
-        cliContext.logger.debug(`Could not parse owner/repo from repository: ${repository}`);
-        return undefined;
-    }
-
-    try {
-        const fiddleOrigin = getFiddleOrigin();
-        const response = await fetch(`${fiddleOrigin}/api/remote-gen/github/installation-token`, {
-            method: "POST",
-            headers: {
-                "Content-Type": "application/json",
-                Authorization: `Bearer ${fernToken.value}`
-            },
-            body: JSON.stringify({ owner, repo })
-        });
-
-        if (!response.ok) {
-            const body = await response.text();
-            cliContext.logger.debug(`Failed to get installation token from Fiddle (${response.status}): ${body}`);
-            return undefined;
-        }
-
-        const data = (await response.json()) as { token: string };
-        cliContext.logger.info("Using Fern GitHub App installation token.");
-        return data.token;
-    } catch (error) {
-        cliContext.logger.debug(`Failed to fetch installation token from Fiddle: ${error}`);
-        return undefined;
-    }
 }

--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -1,4 +1,12 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 4.46.5
+  changelogEntry:
+    - summary: |
+        Internal improvements to GitHub integration for server-side operations.
+      type: fix
+  createdAt: "2026-03-27"
+  irVersion: 65
+
 - version: 4.46.4
   changelogEntry:
     - summary: |
@@ -25,7 +33,7 @@
       type: fix
   createdAt: "2026-03-26"
   irVersion: 65
-      
+
 - version: 4.46.2
   changelogEntry:
     - summary: |

--- a/packages/generator-cli/src/cli.ts
+++ b/packages/generator-cli/src/cli.ts
@@ -284,14 +284,6 @@ void yargs(hideBin(process.argv))
                                 type: "number",
                                 description: "Max commits to scan for generation history"
                             })
-                            .option("pr-title", {
-                                type: "string",
-                                description: "Custom title for the PR"
-                            })
-                            .option("pr-body", {
-                                type: "string",
-                                description: "Custom body for the PR"
-                            })
                             .option("force", {
                                 type: "boolean",
                                 default: false,
@@ -317,8 +309,6 @@ void yargs(hideBin(process.argv))
                                 token: argv.token,
                                 dryRun: argv["dry-run"],
                                 maxCommitsToScan: argv["max-commits"],
-                                prTitle: argv["pr-title"],
-                                prBody: argv["pr-body"],
                                 force: argv.force,
                                 importHistory: argv["import-history"]
                             });

--- a/packages/generator-cli/src/replay/fernignore.ts
+++ b/packages/generator-cli/src/replay/fernignore.ts
@@ -2,7 +2,7 @@ import { existsSync, readFileSync, writeFileSync } from "fs";
 import { readFile, writeFile } from "fs/promises";
 import { join } from "path";
 
-export const REPLAY_FERNIGNORE_ENTRIES = [".fern/replay.lock", ".fern/replay.yml"];
+export const REPLAY_FERNIGNORE_ENTRIES = [".fern/replay.lock"];
 
 export async function ensureReplayFernignoreEntries(outputDir: string): Promise<boolean> {
     const fernignorePath = join(outputDir, ".fernignore");

--- a/packages/generator-cli/src/replay/replay-init.ts
+++ b/packages/generator-cli/src/replay/replay-init.ts
@@ -1,26 +1,19 @@
-import { cloneRepository, parseRepository } from "@fern-api/github";
-import { type BootstrapResult, bootstrap, FERN_BOT_EMAIL, FERN_BOT_NAME, GitClient } from "@fern-api/replay";
-import { Octokit } from "@octokit/rest";
-import { existsSync } from "fs";
+import { cloneRepository } from "@fern-api/github";
+import { type BootstrapResult, bootstrap } from "@fern-api/replay";
+import { existsSync, readFileSync } from "fs";
 import { join } from "path";
 import tmp from "tmp-promise";
-import { ensureReplayFernignoreEntriesSync } from "./fernignore";
+import { ensureReplayFernignoreEntriesSync, REPLAY_FERNIGNORE_ENTRIES } from "./fernignore";
 
 export interface ReplayInitParams {
     /** GitHub repo URI (e.g., "fern-demo/fern-replay-testbed-java-sdk") */
     githubRepo: string;
-    /** GitHub token for clone (read access). Falls back to writeToken if not set. */
+    /** GitHub token for clone (read access) */
     token: string;
-    /** Fern GitHub App installation token for push + PR (write access). Falls back to token if not set. */
-    writeToken?: string;
     /** Report what would happen but don't create PR */
     dryRun?: boolean;
     /** Max commits to scan for generation history */
     maxCommitsToScan?: number;
-    /** Title for the PR */
-    prTitle?: string;
-    /** Body for the PR */
-    prBody?: string;
     /** Overwrite existing lockfile if present. Default: false */
     force?: boolean;
     /** Scan git history for existing patches (migration). Default: false */
@@ -30,26 +23,27 @@ export interface ReplayInitParams {
 export interface ReplayInitResult {
     /** Bootstrap result from fern-replay */
     bootstrap: BootstrapResult;
-    /** URL of the created PR, if not dry-run */
-    prUrl?: string;
-    /** Branch name used for the PR */
-    branch?: string;
+    /** Raw lockfile YAML content, present when bootstrap succeeded and not dry-run */
+    lockfileContent?: string;
+    /** Raw replay.yml content, present only when fernignore migration created it */
+    replayYmlContent?: string;
+    /** Fernignore entries that the server should ensure exist */
+    fernignoreEntries: string[];
+    /** Generated PR body markdown for the server to use */
+    prBody?: string;
 }
 
 /**
  * Initialize Replay for an SDK repository.
  *
- * Creates a branch and opens a PR with the replay lockfile.
+ * Runs bootstrap locally (read-only) and returns the lockfile content
+ * for the caller to send to Fiddle for server-side PR creation.
  *
  * Flow:
- * 1. Clone the SDK repo
+ * 1. Clone the SDK repo (read-only)
  * 2. Run bootstrap() to scan history and create lockfile
  * 3. Ensure .fernignore has replay entries
- * 4. Commit with [fern-replay] prefix (recognized by isGenerationCommit)
- * 5. Push branch and open PR
- *
- * The [fern-replay] commit message prefix ensures the bootstrap commit
- * is NOT treated as a user customization patch by ReplayDetector.
+ * 4. Read lockfile content from disk and return it
  */
 export async function replayInit(params: ReplayInitParams): Promise<ReplayInitResult> {
     const { githubRepo, token, dryRun } = params;
@@ -57,13 +51,11 @@ export async function replayInit(params: ReplayInitParams): Promise<ReplayInitRe
     // 1. Clone the repo into a temp directory
     const tmpDir = await tmp.dir({ unsafeCleanup: true });
     const repoPath = tmpDir.path;
-    const repository = await cloneRepository({
+    await cloneRepository({
         githubRepository: githubRepo,
         installationToken: token,
         targetDirectory: repoPath
     });
-
-    const defaultBranch = await repository.getDefaultBranch();
 
     // 2. Run bootstrap
     const bootstrapResult = await bootstrap(repoPath, {
@@ -75,71 +67,29 @@ export async function replayInit(params: ReplayInitParams): Promise<ReplayInitRe
     });
 
     if (!bootstrapResult.generationCommit) {
-        return { bootstrap: bootstrapResult };
+        return { bootstrap: bootstrapResult, fernignoreEntries: [] };
     }
 
     if (dryRun) {
-        return { bootstrap: bootstrapResult };
+        return { bootstrap: bootstrapResult, fernignoreEntries: [] };
     }
 
     // 3. Ensure .fernignore has replay entries
     ensureReplayFernignoreEntriesSync(repoPath);
 
-    const commitMessage = `[fern-replay] Initialize Replay\n\nTracked ${bootstrapResult.patchesCreated} customization patch(es).\nBase generation: ${bootstrapResult.generationCommit.sha.slice(0, 7)}`;
+    // 4. Read lockfile content from disk
+    const lockfilePath = join(repoPath, ".fern", "replay.lock");
+    const lockfileContent = existsSync(lockfilePath) ? readFileSync(lockfilePath, "utf-8") : undefined;
 
-    // Only add files that actually exist (replay.yml is only created during fernignore migration)
-    const filesToAdd = [".fern/replay.lock", ".fern/replay.yml", ".fernignore"].filter((f) =>
-        existsSync(join(repoPath, f))
-    );
-
-    // Create branch, commit, push, create PR
-    const branchName = `fern-replay/init-${Date.now()}`;
-    await repository.checkoutOrCreateLocal(branchName);
-
-    const git = new GitClient(repoPath);
-    await git.exec(["add", ...filesToAdd]);
-    await git.exec([
-        "-c",
-        `user.name=${FERN_BOT_NAME}`,
-        "-c",
-        `user.email=${FERN_BOT_EMAIL}`,
-        "-c",
-        "commit.gpgsign=false",
-        "commit",
-        "--no-verify",
-        "-m",
-        commitMessage
-    ]);
-
-    // Use installation token for write operations if available
-    const effectiveWriteToken = params.writeToken ?? token;
-    if (params.writeToken != null) {
-        const parsed = parseRepository(githubRepo);
-        const writeUrl = `https://x-access-token:${params.writeToken}@${parsed.remote}/${parsed.owner}/${parsed.repo}.git`;
-        await git.exec(["remote", "set-url", "origin", writeUrl]);
-    }
-
-    await repository.pushUpstream(branchName);
-
-    // Create PR
-    const parsed = parseRepository(githubRepo);
-    const octokit = new Octokit({ auth: effectiveWriteToken });
-    const prTitle = params.prTitle ?? "[fern-replay] Initialize Replay for SDK customizations";
-    const prBody = params.prBody ?? buildPrBody(bootstrapResult);
-
-    const { data: pr } = await octokit.pulls.create({
-        owner: parsed.owner,
-        repo: parsed.repo,
-        head: branchName,
-        base: defaultBranch,
-        title: prTitle,
-        body: prBody
-    });
+    const replayYmlPath = join(repoPath, ".fern", "replay.yml");
+    const replayYmlContent = existsSync(replayYmlPath) ? readFileSync(replayYmlPath, "utf-8") : undefined;
 
     return {
         bootstrap: bootstrapResult,
-        prUrl: pr.html_url,
-        branch: branchName
+        lockfileContent,
+        replayYmlContent,
+        fernignoreEntries: REPLAY_FERNIGNORE_ENTRIES,
+        prBody: buildPrBody(bootstrapResult)
     };
 }
 
@@ -212,13 +162,6 @@ export function formatBootstrapSummary(result: ReplayInitResult): BootstrapLogEn
         for (const w of bs.warnings) {
             entries.push({ level: "warn", message: `  ${w}` });
         }
-    }
-
-    if (result.prUrl) {
-        entries.push({ level: "info", message: `\nPR created: ${result.prUrl}` });
-        entries.push({ level: "info", message: "Merge the PR to enable Replay for this repository." });
-    } else if (result.branch) {
-        entries.push({ level: "info", message: `\nPushed to branch: ${result.branch}` });
     }
 
     return entries;

--- a/packages/generator-cli/src/replay/replay-init.ts
+++ b/packages/generator-cli/src/replay/replay-init.ts
@@ -9,8 +9,10 @@ import { ensureReplayFernignoreEntriesSync } from "./fernignore";
 export interface ReplayInitParams {
     /** GitHub repo URI (e.g., "fern-demo/fern-replay-testbed-java-sdk") */
     githubRepo: string;
-    /** GitHub token with push + PR permissions */
+    /** GitHub token for clone (read access). Falls back to writeToken if not set. */
     token: string;
+    /** Fern GitHub App installation token for push + PR (write access). Falls back to token if not set. */
+    writeToken?: string;
     /** Report what would happen but don't create PR */
     dryRun?: boolean;
     /** Max commits to scan for generation history */
@@ -109,11 +111,19 @@ export async function replayInit(params: ReplayInitParams): Promise<ReplayInitRe
         commitMessage
     ]);
 
+    // Use installation token for write operations if available
+    const effectiveWriteToken = params.writeToken ?? token;
+    if (params.writeToken != null) {
+        const parsed = parseRepository(githubRepo);
+        const writeUrl = `https://x-access-token:${params.writeToken}@${parsed.remote}/${parsed.owner}/${parsed.repo}.git`;
+        await git.exec(["remote", "set-url", "origin", writeUrl]);
+    }
+
     await repository.pushUpstream(branchName);
 
     // Create PR
     const parsed = parseRepository(githubRepo);
-    const octokit = new Octokit({ auth: token });
+    const octokit = new Octokit({ auth: effectiveWriteToken });
     const prTitle = params.prTitle ?? "[fern-replay] Initialize Replay for SDK customizations";
     const prBody = params.prBody ?? buildPrBody(bootstrapResult);
 


### PR DESCRIPTION
## Summary
- Moves git write operations (commit, push, PR creation) from the CLI to the Fiddle backend for `replay init`
- CLI now runs bootstrap locally (read-only) and sends lockfile content to Fiddle's `/api/remote-gen/replay/init` endpoint
- Removes `fetchInstallationToken` — no GitHub write token needed client-side
- Only adds `.fern/replay.lock` to `.fernignore` (drops `replay.yml`)

## Test plan
- [x] `pnpm compile` passes (170/170 tasks)
- [ ] Manual test with Fiddle endpoint once deployed