### PR TITLE
fix(ir): omit password from basic auth snippets when passwordOmit is set

### DIFF
--- a/generators/csharp/dynamic-snippets/src/EndpointSnippetGenerator.ts
+++ b/generators/csharp/dynamic-snippets/src/EndpointSnippetGenerator.ts
@@ -385,16 +385,19 @@ export class EndpointSnippetGenerator extends WithGeneration {
         auth: FernIr.dynamic.BasicAuth;
         values: FernIr.dynamic.BasicAuthValues;
     }): NamedArgument[] {
-        return [
+        const args: NamedArgument[] = [
             {
                 name: this.context.getParameterName(auth.username),
                 assignment: this.csharp.Literal.string(values.username)
-            },
-            {
-                name: this.context.getParameterName(auth.password),
-                assignment: this.csharp.Literal.string(values.password)
             }
         ];
+        if (!auth.passwordOmit) {
+            args.push({
+                name: this.context.getParameterName(auth.password),
+                assignment: this.csharp.Literal.string(values.password)
+            });
+        }
+        return args;
     }
 
     private getConstructorBearerAuthArgs({

--- a/generators/csharp/dynamic-snippets/src/EndpointSnippetGenerator.ts
+++ b/generators/csharp/dynamic-snippets/src/EndpointSnippetGenerator.ts
@@ -391,7 +391,7 @@ export class EndpointSnippetGenerator extends WithGeneration {
                 assignment: this.csharp.Literal.string(values.username)
             }
         ];
-        if (!auth.passwordOmit) {
+        if (!(auth as FernIr.dynamic.BasicAuth & { passwordOmit?: boolean }).passwordOmit) {
             args.push({
                 name: this.context.getParameterName(auth.password),
                 assignment: this.csharp.Literal.string(values.password)

--- a/generators/go-v2/dynamic-snippets/src/EndpointSnippetGenerator.ts
+++ b/generators/go-v2/dynamic-snippets/src/EndpointSnippetGenerator.ts
@@ -385,7 +385,7 @@ export class EndpointSnippetGenerator {
         auth: FernIr.dynamic.BasicAuth;
         values: FernIr.dynamic.BasicAuthValues;
     }): go.AstNode {
-        const arguments_ = auth.passwordOmit
+        const arguments_ = (auth as FernIr.dynamic.BasicAuth & { passwordOmit?: boolean }).passwordOmit
             ? [go.TypeInstantiation.string(values.username)]
             : [go.TypeInstantiation.string(values.username), go.TypeInstantiation.string(values.password)];
         return go.codeblock((writer) => {

--- a/generators/go-v2/dynamic-snippets/src/EndpointSnippetGenerator.ts
+++ b/generators/go-v2/dynamic-snippets/src/EndpointSnippetGenerator.ts
@@ -385,6 +385,9 @@ export class EndpointSnippetGenerator {
         auth: FernIr.dynamic.BasicAuth;
         values: FernIr.dynamic.BasicAuthValues;
     }): go.AstNode {
+        const arguments_ = auth.passwordOmit
+            ? [go.TypeInstantiation.string(values.username)]
+            : [go.TypeInstantiation.string(values.username), go.TypeInstantiation.string(values.password)];
         return go.codeblock((writer) => {
             writer.writeNode(
                 go.invokeFunc({
@@ -392,10 +395,7 @@ export class EndpointSnippetGenerator {
                         name: "WithBasicAuth",
                         importPath: this.context.getOptionImportPath()
                     }),
-                    arguments_: [
-                        go.TypeInstantiation.string(values.username),
-                        go.TypeInstantiation.string(values.password)
-                    ]
+                    arguments_
                 })
             );
         });

--- a/generators/java-v2/sdk/src/readme/ReadmeSnippetBuilder.ts
+++ b/generators/java-v2/sdk/src/readme/ReadmeSnippetBuilder.ts
@@ -906,14 +906,18 @@ ${clientClassName} client = ${clientClassName}.builder()
                     value: java.TypeLiteral.string("<token>")
                 });
             } else if (authScheme?.type === "basic") {
-                builderParameters.push({
-                    name: "username",
-                    value: java.TypeLiteral.string("<username>")
-                });
-                builderParameters.push({
-                    name: "password",
-                    value: java.TypeLiteral.string("<password>")
-                });
+                if (!authScheme.usernameOmit) {
+                    builderParameters.push({
+                        name: "username",
+                        value: java.TypeLiteral.string("<username>")
+                    });
+                }
+                if (!authScheme.passwordOmit) {
+                    builderParameters.push({
+                        name: "password",
+                        value: java.TypeLiteral.string("<password>")
+                    });
+                }
             } else if (authScheme?.type === "header") {
                 const headerName = authScheme.name.name?.camelCase?.unsafeName ?? "apiKey";
                 builderParameters.push({

--- a/generators/php/dynamic-snippets/src/EndpointSnippetGenerator.ts
+++ b/generators/php/dynamic-snippets/src/EndpointSnippetGenerator.ts
@@ -327,7 +327,7 @@ export class EndpointSnippetGenerator {
                 assignment: php.TypeLiteral.string(values.username)
             }
         ];
-        if (!auth.passwordOmit) {
+        if (!(auth as FernIr.dynamic.BasicAuth & { passwordOmit?: boolean }).passwordOmit) {
             args.push({
                 name: this.context.getPropertyName(auth.password),
                 assignment: php.TypeLiteral.string(values.password)

--- a/generators/php/dynamic-snippets/src/EndpointSnippetGenerator.ts
+++ b/generators/php/dynamic-snippets/src/EndpointSnippetGenerator.ts
@@ -321,16 +321,19 @@ export class EndpointSnippetGenerator {
         auth: FernIr.dynamic.BasicAuth;
         values: FernIr.dynamic.BasicAuthValues;
     }): NamedArgument[] {
-        return [
+        const args: NamedArgument[] = [
             {
                 name: this.context.getPropertyName(auth.username),
                 assignment: php.TypeLiteral.string(values.username)
-            },
-            {
-                name: this.context.getPropertyName(auth.password),
-                assignment: php.TypeLiteral.string(values.password)
             }
         ];
+        if (!auth.passwordOmit) {
+            args.push({
+                name: this.context.getPropertyName(auth.password),
+                assignment: php.TypeLiteral.string(values.password)
+            });
+        }
+        return args;
     }
 
     private getConstructorEnvironmentArg({

--- a/generators/python-v2/dynamic-snippets/src/EndpointSnippetGenerator.ts
+++ b/generators/python-v2/dynamic-snippets/src/EndpointSnippetGenerator.ts
@@ -299,7 +299,7 @@ export class EndpointSnippetGenerator {
                 value: python.TypeInstantiation.str(values.username)
             }
         ];
-        if (!auth.passwordOmit) {
+        if (!(auth as FernIr.dynamic.BasicAuth & { passwordOmit?: boolean }).passwordOmit) {
             fields.push({
                 name: this.context.getPropertyName(auth.password),
                 value: python.TypeInstantiation.str(values.password)

--- a/generators/python-v2/dynamic-snippets/src/EndpointSnippetGenerator.ts
+++ b/generators/python-v2/dynamic-snippets/src/EndpointSnippetGenerator.ts
@@ -293,16 +293,19 @@ export class EndpointSnippetGenerator {
         auth: FernIr.dynamic.BasicAuth;
         values: FernIr.dynamic.BasicAuthValues;
     }): python.NamedValue[] {
-        return [
+        const fields: python.NamedValue[] = [
             {
                 name: this.context.getPropertyName(auth.username),
                 value: python.TypeInstantiation.str(values.username)
-            },
-            {
-                name: this.context.getPropertyName(auth.password),
-                value: python.TypeInstantiation.str(values.password)
             }
         ];
+        if (!auth.passwordOmit) {
+            fields.push({
+                name: this.context.getPropertyName(auth.password),
+                value: python.TypeInstantiation.str(values.password)
+            });
+        }
+        return fields;
     }
 
     private getConstructorBearerAuthArgs({

--- a/generators/typescript-v2/dynamic-snippets/src/EndpointSnippetGenerator.ts
+++ b/generators/typescript-v2/dynamic-snippets/src/EndpointSnippetGenerator.ts
@@ -275,16 +275,19 @@ export class EndpointSnippetGenerator {
         auth: FernIr.dynamic.BasicAuth;
         values: FernIr.dynamic.BasicAuthValues;
     }): ts.ObjectField[] {
-        return [
+        const fields: ts.ObjectField[] = [
             {
                 name: this.context.getPropertyName(auth.username),
                 value: ts.TypeLiteral.string(values.username)
-            },
-            {
-                name: this.context.getPropertyName(auth.password),
-                value: ts.TypeLiteral.string(values.password)
             }
         ];
+        if (!auth.passwordOmit) {
+            fields.push({
+                name: this.context.getPropertyName(auth.password),
+                value: ts.TypeLiteral.string(values.password)
+            });
+        }
+        return fields;
     }
 
     private getConstructorBearerAuthArgs({

--- a/generators/typescript-v2/dynamic-snippets/src/EndpointSnippetGenerator.ts
+++ b/generators/typescript-v2/dynamic-snippets/src/EndpointSnippetGenerator.ts
@@ -281,7 +281,7 @@ export class EndpointSnippetGenerator {
                 value: ts.TypeLiteral.string(values.username)
             }
         ];
-        if (!auth.passwordOmit) {
+        if (!(auth as FernIr.dynamic.BasicAuth & { passwordOmit?: boolean }).passwordOmit) {
             fields.push({
                 name: this.context.getPropertyName(auth.password),
                 value: ts.TypeLiteral.string(values.password)

--- a/packages/cli/generation/ir-generator/src/dynamic-snippets/DynamicSnippetsConverter.ts
+++ b/packages/cli/generation/ir-generator/src/dynamic-snippets/DynamicSnippetsConverter.ts
@@ -697,7 +697,10 @@ export class DynamicSnippetsConverter {
         const scheme = auth.schemes[0];
         switch (scheme.type) {
             case "basic":
-                return DynamicSnippets.Auth.basic(scheme);
+                return DynamicSnippets.Auth.basic({
+                    ...scheme,
+                    passwordOmit: scheme.passwordOmit ?? undefined
+                });
             case "bearer":
                 return DynamicSnippets.Auth.bearer(scheme);
             case "header":
@@ -736,7 +739,7 @@ export class DynamicSnippetsConverter {
             case "basic":
                 return DynamicSnippets.AuthValues.basic({
                     username: "<username>",
-                    password: "<password>"
+                    password: scheme.passwordOmit ? "" : "<password>"
                 });
             case "header":
                 return DynamicSnippets.AuthValues.header({

--- a/packages/ir-sdk/fern/apis/ir-types-latest/definition/dynamic/auth.yml
+++ b/packages/ir-sdk/fern/apis/ir-types-latest/definition/dynamic/auth.yml
@@ -23,6 +23,9 @@ types:
     properties:
       username: commons.Name
       password: commons.Name
+      passwordOmit:
+        type: optional<boolean>
+        docs: If true, the password should be omitted from the snippet.
 
   BasicAuthValues:
     properties:

--- a/packages/ir-sdk/src/sdk/api/resources/dynamic/resources/auth/types/BasicAuth.ts
+++ b/packages/ir-sdk/src/sdk/api/resources/dynamic/resources/auth/types/BasicAuth.ts
@@ -5,4 +5,5 @@ import type * as FernIr from "../../../../../index.js";
 export interface BasicAuth {
     username: FernIr.dynamic.Name;
     password: FernIr.dynamic.Name;
+    passwordOmit?: boolean;
 }

--- a/packages/ir-sdk/src/sdk/serialization/resources/dynamic/resources/auth/types/BasicAuth.ts
+++ b/packages/ir-sdk/src/sdk/serialization/resources/dynamic/resources/auth/types/BasicAuth.ts
@@ -6,14 +6,16 @@ import type * as serializers from "../../../../../index.js";
 import { Name } from "../../commons/types/Name.js";
 
 export const BasicAuth: core.serialization.ObjectSchema<serializers.dynamic.BasicAuth.Raw, FernIr.dynamic.BasicAuth> =
-    core.serialization.objectWithoutOptionalProperties({
+    core.serialization.object({
         username: Name,
         password: Name,
+        passwordOmit: core.serialization.boolean().optional(),
     });
 
 export declare namespace BasicAuth {
     export interface Raw {
         username: Name.Raw;
         password: Name.Raw;
+        passwordOmit?: boolean | null;
     }
 }


### PR DESCRIPTION
## Description

When basic auth is configured with `passwordOmit: true` (e.g. via `omit: true` in generators.yml), the `passwordOmit` flag was set in the main IR's `BasicAuthScheme` but was not propagated to the dynamic snippets IR. This caused all generated code snippets to still include `<password>` in basic auth constructors.

## Changes Made

- Added `passwordOmit` optional boolean field to the dynamic IR's `BasicAuth` type (Fern definition, generated API type, and serialization)
- Updated `DynamicSnippetsConverter` to propagate `passwordOmit` from the main IR to the dynamic IR (via spread) and set password value to empty string when omitted
- Updated all 5 language dynamic snippet generators (TypeScript, Python, C#, PHP, Go) to conditionally skip the password field when `passwordOmit` is true
- Updated Java `ReadmeSnippetBuilder` to check both `usernameOmit` and `passwordOmit` before including credentials in builder snippets

### Updates since last revision
- Generators import `FernIr` from the **published** `@fern-api/dynamic-ir-sdk` package (not the local `@fern-api/ir-sdk`), so `passwordOmit` is not yet in the external type. Changed to use inline type assertions (`auth as FernIr.dynamic.BasicAuth & { passwordOmit?: boolean }`) in all 5 generators so they compile against the current published SDK.
- Verified locally that compile errors in each generator's `EndpointSnippetGenerator.ts` are resolved; remaining compile errors in each package are pre-existing on `main`.

## Important Review Notes — Human Review Checklist

- [ ] **Type assertion reliance**: Generators cast `auth` to access `passwordOmit` at runtime. This works because `DynamicSnippetsConverter` spreads the full `BasicAuthScheme` (`...scheme`) into the dynamic `BasicAuth` object. If serialization/deserialization between the converter and generators ever strips unknown fields, `passwordOmit` would silently be `undefined` and the password would still appear (safe fallback, but the feature wouldn't work). Once `@fern-api/dynamic-ir-sdk` is republished with the new field, the type assertions can be removed.
- [ ] **Go generator**: When `passwordOmit` is true, only the username arg is passed to `WithBasicAuth()`. Verify the Go SDK's `WithBasicAuth` function can accept a single argument.
- [ ] **Serialization change**: `BasicAuth` serialization changed from `objectWithoutOptionalProperties` to `object` to support the new optional field. This should be backward-compatible with existing data that lacks the field.
- [ ] **Java README builder**: Also adds `usernameOmit` check (bonus), which the dynamic snippet generators don't need since they receive auth/values separately.

## Testing
- [ ] Unit tests added/updated
- [x] Lint passes (`pnpm run check`)
- [x] Local compile verified for all affected generators
- [ ] Manual testing completed

Link to Devin session: https://app.devin.ai/sessions/50993aca57b742408f458c94e94b7a21
Requested by: @jon-fern