### PR TITLE
fix(ruby): `additional_headers` protection, HTTP protection

### DIFF
--- a/generators/ruby-v2/base/src/asIs/internal/http/base_request.Template.rb
+++ b/generators/ruby-v2/base/src/asIs/internal/http/base_request.Template.rb
@@ -31,6 +31,20 @@ module <%= gem_namespace %>
         # Child classes should implement:
         # - encode_headers: Returns the encoded HTTP request headers.
         # - encode_body: Returns the encoded HTTP request body.
+
+        private
+
+        # Merges additional_headers from request_options into sdk_headers, filtering out
+        # any keys that collide with SDK-set or client-protected headers (case-insensitive).
+        # @param sdk_headers [Hash] Headers set by the SDK for this request type.
+        # @param protected_keys [Array<String>] Additional header keys that must not be overridden.
+        # @return [Hash] The merged headers.
+        def merge_additional_headers(sdk_headers, protected_keys: [])
+          additional_headers = @request_options&.dig(:additional_headers) || @request_options&.dig("additional_headers") || {}
+          all_protected = (sdk_headers.keys + protected_keys).map { |k| k.to_s.downcase }.to_set
+          filtered = additional_headers.reject { |key, _| all_protected.include?(key.to_s.downcase) }
+          sdk_headers.merge(filtered)
+        end
       end
     end
   end

--- a/generators/ruby-v2/base/src/asIs/internal/http/raw_client.Template.rb
+++ b/generators/ruby-v2/base/src/asIs/internal/http/raw_client.Template.rb
@@ -43,7 +43,7 @@ module <%= gem_namespace %>
             http_request = build_http_request(
               url:,
               method: request.method,
-              headers: request.encode_headers,
+              headers: request.encode_headers(protected_keys: @default_headers.keys),
               body: request.encode_body
             )
 
@@ -121,6 +121,8 @@ module <%= gem_namespace %>
           [delay + jitter, 0].max
         end
 
+        LOCALHOST_HOSTS = %w[localhost 127.0.0.1 [::1]].freeze
+
         # @param request [<%= gem_namespace %>::Internal::Http::BaseRequest] The HTTP request.
         # @return [URI::Generic] The URL.
         def build_url(request)
@@ -130,14 +132,29 @@ module <%= gem_namespace %>
           if request.path.start_with?("http://", "https://")
             url = request.path
             url = "#{url}?#{encode_query(encoded_query)}" if encoded_query&.any?
-            return URI.parse(url)
+            parsed = URI.parse(url)
+            validate_https!(parsed)
+            return parsed
           end
 
           path = request.path.start_with?("/") ? request.path[1..] : request.path
           base = request.base_url || @base_url
           url = "#{base.chomp("/")}/#{path}"
           url = "#{url}?#{encode_query(encoded_query)}" if encoded_query&.any?
-          URI.parse(url)
+          parsed = URI.parse(url)
+          validate_https!(parsed)
+          parsed
+        end
+
+        # Raises if the URL uses http:// for a non-localhost host, which would
+        # send authentication credentials in plaintext.
+        # @param url [URI::Generic] The parsed URL.
+        def validate_https!(url)
+          return if url.scheme != "http"
+          return if LOCALHOST_HOSTS.include?(url.host)
+
+          raise ArgumentError, "Refusing to send request to non-HTTPS URL: #{url}. " \
+            "HTTP is only allowed for localhost. Use HTTPS or pass a localhost URL."
         end
 
         # @param url [URI::Generic] The url to the resource.
@@ -181,6 +198,7 @@ module <%= gem_namespace %>
 
           http = Net::HTTP.new(url.host, port)
           http.use_ssl = is_https
+          http.verify_mode = OpenSSL::SSL::VERIFY_PEER if is_https
           # Note: We handle retries at the application level with HTTP status code awareness,
           # so we set max_retries to 0 to disable Net::HTTP's built-in network-level retries.
           http.max_retries = 0

--- a/generators/ruby-v2/base/src/asIs/internal/json/request.Template.rb
+++ b/generators/ruby-v2/base/src/asIs/internal/json/request.Template.rb
@@ -21,12 +21,14 @@ module <%= gem_namespace %>
         end
 
         # @return [Hash] The encoded HTTP request headers.
-        def encode_headers
-          additional_headers = @request_options&.dig(:additional_headers) || @request_options&.dig("additional_headers") || {}
-          {
+        # @param protected_keys [Array<String>] Header keys set by the SDK client (e.g. auth, metadata)
+        #   that must not be overridden by additional_headers from request_options.
+        def encode_headers(protected_keys: [])
+          sdk_headers = {
             "Content-Type" => "application/json",
             "Accept" => "application/json"
-          }.merge(@headers).merge(additional_headers)
+          }.merge(@headers)
+          merge_additional_headers(sdk_headers, protected_keys:)
         end
 
         # @return [String, nil] The encoded HTTP request body.

--- a/generators/ruby-v2/base/src/asIs/internal/multipart/multipart_request.Template.rb
+++ b/generators/ruby-v2/base/src/asIs/internal/multipart/multipart_request.Template.rb
@@ -21,11 +21,13 @@ module <%= gem_namespace %>
         end
 
         # @return [Hash] The encoded HTTP request headers.
-        def encode_headers
-          additional_headers = @request_options&.dig(:additional_headers) || @request_options&.dig("additional_headers") || {}
-          {
+        # @param protected_keys [Array<String>] Header keys set by the SDK client (e.g. auth, metadata)
+        #   that must not be overridden by additional_headers from request_options.
+        def encode_headers(protected_keys: [])
+          sdk_headers = {
             "Content-Type" => @body.content_type
-          }.merge(@headers).merge(additional_headers)
+          }.merge(@headers)
+          merge_additional_headers(sdk_headers, protected_keys:)
         end
 
         # @return [String, nil] The encoded HTTP request body.

--- a/generators/ruby-v2/sdk/versions.yml
+++ b/generators/ruby-v2/sdk/versions.yml
@@ -1,5 +1,28 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 
+- version: 1.1.5
+  changelogEntry:
+    - summary: |
+        Prevent `additional_headers` in request options from overriding
+        SDK-set headers such as Authorization, Content-Type, and SDK
+        metadata. Headers set by the SDK or the API definition are now
+        protected (case-insensitively) and silently filtered from
+        additional_headers.
+      type: fix
+    - summary: |
+        Reject HTTP URLs for non-localhost hosts. Requests to `http://`
+        URLs now raise `ArgumentError` unless the host is localhost,
+        127.0.0.1, or [::1], preventing accidental transmission of
+        authentication credentials in plaintext.
+      type: fix
+    - summary: |
+        Explicitly set `verify_mode = OpenSSL::SSL::VERIFY_PEER` on
+        HTTPS connections. This was already the Ruby default but is now
+        stated in code to satisfy security audits.
+      type: fix
+  createdAt: "2026-03-27"
+  irVersion: 61
+
 - version: 1.1.4
   changelogEntry:
     - summary: |

--- a/seed/ruby-sdk-v2/bearer-token-environment-variable/lib/seed/internal/http/base_request.rb
+++ b/seed/ruby-sdk-v2/bearer-token-environment-variable/lib/seed/internal/http/base_request.rb
@@ -31,6 +31,20 @@ module Seed
         # Child classes should implement:
         # - encode_headers: Returns the encoded HTTP request headers.
         # - encode_body: Returns the encoded HTTP request body.
+
+        private
+
+        # Merges additional_headers from request_options into sdk_headers, filtering out
+        # any keys that collide with SDK-set or client-protected headers (case-insensitive).
+        # @param sdk_headers [Hash] Headers set by the SDK for this request type.
+        # @param protected_keys [Array<String>] Additional header keys that must not be overridden.
+        # @return [Hash] The merged headers.
+        def merge_additional_headers(sdk_headers, protected_keys: [])
+          additional_headers = @request_options&.dig(:additional_headers) || @request_options&.dig("additional_headers") || {}
+          all_protected = (sdk_headers.keys + protected_keys).to_set { |k| k.to_s.downcase }
+          filtered = additional_headers.reject { |key, _| all_protected.include?(key.to_s.downcase) }
+          sdk_headers.merge(filtered)
+        end
       end
     end
   end

--- a/seed/ruby-sdk-v2/bearer-token-environment-variable/lib/seed/internal/http/raw_client.rb
+++ b/seed/ruby-sdk-v2/bearer-token-environment-variable/lib/seed/internal/http/raw_client.rb
@@ -43,7 +43,7 @@ module Seed
             http_request = build_http_request(
               url:,
               method: request.method,
-              headers: request.encode_headers,
+              headers: request.encode_headers(protected_keys: @default_headers.keys),
               body: request.encode_body
             )
 
@@ -120,6 +120,8 @@ module Seed
           [delay + jitter, 0].max
         end
 
+        LOCALHOST_HOSTS = %w[localhost 127.0.0.1 [::1]].freeze
+
         # @param request [Seed::Internal::Http::BaseRequest] The HTTP request.
         # @return [URI::Generic] The URL.
         def build_url(request)
@@ -129,14 +131,29 @@ module Seed
           if request.path.start_with?("http://", "https://")
             url = request.path
             url = "#{url}?#{encode_query(encoded_query)}" if encoded_query&.any?
-            return URI.parse(url)
+            parsed = URI.parse(url)
+            validate_https!(parsed)
+            return parsed
           end
 
           path = request.path.start_with?("/") ? request.path[1..] : request.path
           base = request.base_url || @base_url
           url = "#{base.chomp("/")}/#{path}"
           url = "#{url}?#{encode_query(encoded_query)}" if encoded_query&.any?
-          URI.parse(url)
+          parsed = URI.parse(url)
+          validate_https!(parsed)
+          parsed
+        end
+
+        # Raises if the URL uses http:// for a non-localhost host, which would
+        # send authentication credentials in plaintext.
+        # @param url [URI::Generic] The parsed URL.
+        def validate_https!(url)
+          return if url.scheme != "http"
+          return if LOCALHOST_HOSTS.include?(url.host)
+
+          raise ArgumentError, "Refusing to send request to non-HTTPS URL: #{url}. " \
+                               "HTTP is only allowed for localhost. Use HTTPS or pass a localhost URL."
         end
 
         # @param url [URI::Generic] The url to the resource.
@@ -180,6 +197,7 @@ module Seed
 
           http = Net::HTTP.new(url.host, port)
           http.use_ssl = is_https
+          http.verify_mode = OpenSSL::SSL::VERIFY_PEER if is_https
           # NOTE: We handle retries at the application level with HTTP status code awareness,
           # so we set max_retries to 0 to disable Net::HTTP's built-in network-level retries.
           http.max_retries = 0

--- a/seed/ruby-sdk-v2/bearer-token-environment-variable/lib/seed/internal/json/request.rb
+++ b/seed/ruby-sdk-v2/bearer-token-environment-variable/lib/seed/internal/json/request.rb
@@ -21,12 +21,14 @@ module Seed
         end
 
         # @return [Hash] The encoded HTTP request headers.
-        def encode_headers
-          additional_headers = @request_options&.dig(:additional_headers) || @request_options&.dig("additional_headers") || {}
-          {
+        # @param protected_keys [Array<String>] Header keys set by the SDK client (e.g. auth, metadata)
+        #   that must not be overridden by additional_headers from request_options.
+        def encode_headers(protected_keys: [])
+          sdk_headers = {
             "Content-Type" => "application/json",
             "Accept" => "application/json"
-          }.merge(@headers).merge(additional_headers)
+          }.merge(@headers)
+          merge_additional_headers(sdk_headers, protected_keys:)
         end
 
         # @return [String, nil] The encoded HTTP request body.

--- a/seed/ruby-sdk-v2/bearer-token-environment-variable/lib/seed/internal/multipart/multipart_request.rb
+++ b/seed/ruby-sdk-v2/bearer-token-environment-variable/lib/seed/internal/multipart/multipart_request.rb
@@ -21,11 +21,13 @@ module Seed
         end
 
         # @return [Hash] The encoded HTTP request headers.
-        def encode_headers
-          additional_headers = @request_options&.dig(:additional_headers) || @request_options&.dig("additional_headers") || {}
-          {
+        # @param protected_keys [Array<String>] Header keys set by the SDK client (e.g. auth, metadata)
+        #   that must not be overridden by additional_headers from request_options.
+        def encode_headers(protected_keys: [])
+          sdk_headers = {
             "Content-Type" => @body.content_type
-          }.merge(@headers).merge(additional_headers)
+          }.merge(@headers)
+          merge_additional_headers(sdk_headers, protected_keys:)
         end
 
         # @return [String, nil] The encoded HTTP request body.


### PR DESCRIPTION
## Description
A trio of security issues fixed in Ruby:
1. `additional_headers` in request options is now prevented from overriding any header the SDK sets under the hood.
2. `http://` requests sent to hosts other than localhost (i.e. other than `localhost`, `127.0.0.1`, or `[::1]`) are rejected; you'll need `https://`.
3. `verify_mode = OpenSSL::SSL::VERIFY_PEER` is written explicitly.

## Changes Made
To the `ruby-v2` generator.

## Testing
The `bearer-token-environment-variable` fixture shows all three changes; also integration tested against Auth0's MyOrg API.
- [X] Unit tests added/updated
- [X] Manual testing completed
