### PR TITLE
fix(java): stop JSON-encoding multipart form string fields

### DIFF
--- a/generators/java/sdk/src/main/java/com/fern/java/client/generators/endpoint/WrappedRequestEndpointWriter.java
+++ b/generators/java/sdk/src/main/java/com/fern/java/client/generators/endpoint/WrappedRequestEndpointWriter.java
@@ -24,6 +24,7 @@ import com.fern.ir.model.types.Literal;
 import com.fern.ir.model.types.MapType;
 import com.fern.ir.model.types.NamedType;
 import com.fern.ir.model.types.PrimitiveType;
+import com.fern.ir.model.types.ResolvedTypeReference;
 import com.fern.ir.model.types.TypeDeclaration;
 import com.fern.ir.model.types.TypeReference;
 import com.fern.java.AbstractGeneratorContext;
@@ -346,6 +347,14 @@ public final class WrappedRequestEndpointWriter extends AbstractEndpointWriter {
                             requestParameterName + "." + jsonProperty.getterProperty().name + "()"
                                     + (isOptional ? ".get()" : ""));
                 } else {
+                    // Determine if this type needs JSON serialization or can use simple string conversion.
+                    // Simple types (strings, primitives, enums) should NOT be JSON-serialized in multipart
+                    // form data because writeValueAsString() wraps strings in quotes.
+                    boolean needsJsonSerialization = ((JsonFileUploadProperty) fileUploadProperty)
+                            .rawProperty()
+                            .getValueType()
+                            .visit(new TypeReferenceNeedsJsonSerialization(clientGeneratorContext));
+
                     CodeBlock.Builder dataPartBuilder = CodeBlock.builder();
                     String writeValueParameter = requestParameterName + "." + jsonProperty.getterProperty().name + "()"
                             + (isOptional ? ".get()" : "");
@@ -363,23 +372,48 @@ public final class WrappedRequestEndpointWriter extends AbstractEndpointWriter {
                         writeValueParameter = "item";
                         dataPartBuilder.add("$L.forEach($L -> {\n", collection, writeValueParameter);
                         dataPartBuilder.indent();
-                        dataPartBuilder.beginControlFlow("try");
+                        if (needsJsonSerialization) {
+                            dataPartBuilder.beginControlFlow("try");
+                        }
                     }
 
-                    dataPartBuilder.add(
-                            "$L.addFormDataPart($S, $T.$L.writeValueAsString($L))" + (isCollection ? ";\n" : ""),
-                            variables.getMultipartBodyPropertiesName(),
-                            jsonProperty.wireKey().get(),
-                            generatedObjectMapper.getClassName(),
-                            generatedObjectMapper.jsonMapperStaticField().name,
-                            writeValueParameter);
+                    if (needsJsonSerialization) {
+                        dataPartBuilder.add(
+                                "$L.addFormDataPart($S, $T.$L.writeValueAsString($L))" + (isCollection ? ";\n" : ""),
+                                variables.getMultipartBodyPropertiesName(),
+                                jsonProperty.wireKey().get(),
+                                generatedObjectMapper.getClassName(),
+                                generatedObjectMapper.jsonMapperStaticField().name,
+                                writeValueParameter);
+                    } else if (isCollection) {
+                        // For collection items of simple types, use String.valueOf()
+                        dataPartBuilder.add(
+                                "$L.addFormDataPart($S, $T.valueOf($L));\n",
+                                variables.getMultipartBodyPropertiesName(),
+                                jsonProperty.wireKey().get(),
+                                String.class,
+                                writeValueParameter);
+                    } else {
+                        // For non-collection simple types, use PoetTypeNameStringifier
+                        TypeName rawTypeName = jsonProperty.poetTypeName();
+                        if (isOptional) {
+                            rawTypeName = ((ParameterizedTypeName) rawTypeName).typeArguments.get(0);
+                        }
+                        dataPartBuilder.add(
+                                "$L.addFormDataPart($S, $L)",
+                                variables.getMultipartBodyPropertiesName(),
+                                jsonProperty.wireKey().get(),
+                                PoetTypeNameStringifier.stringify(writeValueParameter, rawTypeName));
+                    }
 
                     if (isCollection) {
-                        dataPartBuilder.endControlFlow();
-                        dataPartBuilder.beginControlFlow("catch ($T e)", JsonProcessingException.class);
-                        dataPartBuilder.add(
-                                "throw new $T($S, e);\n", RuntimeException.class, "Failed to write value as JSON");
-                        dataPartBuilder.endControlFlow();
+                        if (needsJsonSerialization) {
+                            dataPartBuilder.endControlFlow();
+                            dataPartBuilder.beginControlFlow("catch ($T e)", JsonProcessingException.class);
+                            dataPartBuilder.add(
+                                    "throw new $T($S, e);\n", RuntimeException.class, "Failed to write value as JSON");
+                            dataPartBuilder.endControlFlow();
+                        }
                         dataPartBuilder.unindent();
                         dataPartBuilder.add("})");
                     }
@@ -505,6 +539,108 @@ public final class WrappedRequestEndpointWriter extends AbstractEndpointWriter {
     private static boolean typeNameIsOptional(TypeName typeName) {
         return typeName instanceof ParameterizedTypeName
                 && ((ParameterizedTypeName) typeName).rawType.equals(ClassName.get(Optional.class));
+    }
+
+    /**
+     * Determines whether a type needs JSON serialization (writeValueAsString) for multipart form data, or can use
+     * simple string conversion. Returns true for complex types (objects, unions, maps, unknown) that need JSON
+     * serialization. Returns false for simple types (primitives, enums) that can be converted to strings directly. For
+     * collections, checks the element type.
+     */
+    private static final class TypeReferenceNeedsJsonSerialization
+            implements TypeReference.Visitor<Boolean>, ContainerType.Visitor<Boolean> {
+
+        private final AbstractGeneratorContext<?, ?> context;
+
+        private TypeReferenceNeedsJsonSerialization(AbstractGeneratorContext<?, ?> context) {
+            this.context = context;
+        }
+
+        @Override
+        public Boolean visitContainer(ContainerType containerType) {
+            return containerType.visit(this);
+        }
+
+        @Override
+        public Boolean visitNamed(NamedType namedType) {
+            TypeDeclaration declaration = Optional.ofNullable(
+                            context.getTypeDeclarations().get(namedType.getTypeId()))
+                    .orElseThrow(() -> new IllegalArgumentException(
+                            "Received type id " + namedType.getTypeId() + " with no corresponding type declaration."));
+            if (declaration.getShape().getEnum().isPresent()) {
+                return false; // Enums can use toString()
+            }
+            if (declaration.getShape().getAlias().isPresent()) {
+                ResolvedTypeReference resolved =
+                        declaration.getShape().getAlias().get().getResolvedType();
+                if (resolved.isPrimitive()) {
+                    return false;
+                }
+                if (resolved.isContainer()) {
+                    return resolved.getContainer().get().visit(this);
+                }
+                if (resolved.isNamed()) {
+                    // Resolve the named type from the alias by looking up its declaration
+                    TypeDeclaration namedDeclaration = Optional.ofNullable(context.getTypeDeclarations()
+                                    .get(resolved.getNamed().get().getName().getTypeId()))
+                            .orElse(null);
+                    if (namedDeclaration != null
+                            && namedDeclaration.getShape().getEnum().isPresent()) {
+                        return false;
+                    }
+                    // Non-enum named types need JSON
+                }
+                return true;
+            }
+            return true; // Objects, unions, undiscriminated unions need JSON
+        }
+
+        @Override
+        public Boolean visitPrimitive(PrimitiveType primitiveType) {
+            return false; // All primitives can be stringified
+        }
+
+        @Override
+        public Boolean visitUnknown() {
+            return true; // Unknown types need JSON
+        }
+
+        @Override
+        public Boolean visitLiteral(Literal literal) {
+            return false; // Literals are simple values
+        }
+
+        // ContainerType visitor methods:
+
+        @Override
+        public Boolean visitList(TypeReference typeReference) {
+            return typeReference.visit(this); // Check element type
+        }
+
+        @Override
+        public Boolean visitMap(MapType mapType) {
+            return true; // Maps always need JSON
+        }
+
+        @Override
+        public Boolean visitNullable(TypeReference typeReference) {
+            return typeReference.visit(this);
+        }
+
+        @Override
+        public Boolean visitOptional(TypeReference typeReference) {
+            return typeReference.visit(this);
+        }
+
+        @Override
+        public Boolean visitSet(TypeReference typeReference) {
+            return typeReference.visit(this); // Check element type
+        }
+
+        @Override
+        public Boolean _visitUnknown(Object o) {
+            return true;
+        }
     }
 
     private static final class TypeReferenceIsCollection

--- a/generators/java/sdk/versions.yml
+++ b/generators/java/sdk/versions.yml
@@ -1,4 +1,16 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 4.0.8
+  changelogEntry:
+    - summary: |
+        Fix multipart form data string fields being JSON-encoded with
+        `writeValueAsString()`, which wraps values in literal quote characters.
+        String fields, primitives, and enums now use plain string conversion
+        instead of JSON serialization. Complex types (objects, maps) continue
+        to use JSON serialization as before.
+      type: fix
+  createdAt: "2026-03-27"
+  irVersion: 65
+
 - version: 4.0.7
   changelogEntry:
     - summary: |

--- a/seed/java-sdk/file-upload-openapi/src/main/java/com/seed/api/resources/fileuploadexample/AsyncRawFileUploadExampleClient.java
+++ b/seed/java-sdk/file-upload-openapi/src/main/java/com/seed/api/resources/fileuploadexample/AsyncRawFileUploadExampleClient.java
@@ -59,8 +59,7 @@ public class AsyncRawFileUploadExampleClient {
         }
         MultipartBody.Builder multipartBodyBuilder = new MultipartBody.Builder().setType(MultipartBody.FORM);
         try {
-            multipartBodyBuilder.addFormDataPart(
-                    "name", ObjectMappers.JSON_MAPPER.writeValueAsString(request.getName()));
+            multipartBodyBuilder.addFormDataPart("name", request.getName());
             if (file.isPresent()) {
                 String fileMimeType = Files.probeContentType(file.get().toPath());
                 MediaType fileMimeTypeMediaType = fileMimeType != null ? MediaType.parse(fileMimeType) : null;

--- a/seed/java-sdk/file-upload-openapi/src/main/java/com/seed/api/resources/fileuploadexample/RawFileUploadExampleClient.java
+++ b/seed/java-sdk/file-upload-openapi/src/main/java/com/seed/api/resources/fileuploadexample/RawFileUploadExampleClient.java
@@ -55,8 +55,7 @@ public class RawFileUploadExampleClient {
         }
         MultipartBody.Builder multipartBodyBuilder = new MultipartBody.Builder().setType(MultipartBody.FORM);
         try {
-            multipartBodyBuilder.addFormDataPart(
-                    "name", ObjectMappers.JSON_MAPPER.writeValueAsString(request.getName()));
+            multipartBodyBuilder.addFormDataPart("name", request.getName());
             if (file.isPresent()) {
                 String fileMimeType = Files.probeContentType(file.get().toPath());
                 MediaType fileMimeTypeMediaType = fileMimeType != null ? MediaType.parse(fileMimeType) : null;

--- a/seed/java-sdk/file-upload/inline-file-properties/src/main/java/com/seed/fileUpload/resources/service/AsyncRawServiceClient.java
+++ b/seed/java-sdk/file-upload/inline-file-properties/src/main/java/com/seed/fileUpload/resources/service/AsyncRawServiceClient.java
@@ -64,12 +64,9 @@ public class AsyncRawServiceClient {
         try {
             if (request.getMaybeString().isPresent()) {
                 multipartBodyBuilder.addFormDataPart(
-                        "maybe_string",
-                        ObjectMappers.JSON_MAPPER.writeValueAsString(
-                                request.getMaybeString().get()));
+                        "maybe_string", request.getMaybeString().get());
             }
-            multipartBodyBuilder.addFormDataPart(
-                    "integer", ObjectMappers.JSON_MAPPER.writeValueAsString(request.getInteger()));
+            multipartBodyBuilder.addFormDataPart("integer", Integer.toString(request.getInteger()));
             String fileMimeType = Files.probeContentType(request.getFile().toPath());
             MediaType fileMimeTypeMediaType = fileMimeType != null ? MediaType.parse(fileMimeType) : null;
             multipartBodyBuilder.addFormDataPart(
@@ -103,18 +100,11 @@ public class AsyncRawServiceClient {
             }
             if (request.getMaybeInteger().isPresent()) {
                 multipartBodyBuilder.addFormDataPart(
-                        "maybe_integer",
-                        ObjectMappers.JSON_MAPPER.writeValueAsString(
-                                request.getMaybeInteger().get()));
+                        "maybe_integer", request.getMaybeInteger().get().toString());
             }
             if (request.getOptionalListOfStrings().isPresent()) {
                 request.getOptionalListOfStrings().get().forEach(item -> {
-                    try {
-                        multipartBodyBuilder.addFormDataPart(
-                                "optional_list_of_strings", ObjectMappers.JSON_MAPPER.writeValueAsString(item));
-                    } catch (JsonProcessingException e) {
-                        throw new RuntimeException("Failed to write value as JSON", e);
-                    }
+                    multipartBodyBuilder.addFormDataPart("optional_list_of_strings", String.valueOf(item));
                 });
             }
             request.getListOfObjects().forEach(item -> {
@@ -134,14 +124,11 @@ public class AsyncRawServiceClient {
             if (request.getOptionalObjectType().isPresent()) {
                 multipartBodyBuilder.addFormDataPart(
                         "optional_object_type",
-                        ObjectMappers.JSON_MAPPER.writeValueAsString(
-                                request.getOptionalObjectType().get()));
+                        request.getOptionalObjectType().get().toString());
             }
             if (request.getOptionalId().isPresent()) {
                 multipartBodyBuilder.addFormDataPart(
-                        "optional_id",
-                        ObjectMappers.JSON_MAPPER.writeValueAsString(
-                                request.getOptionalId().get()));
+                        "optional_id", request.getOptionalId().get());
             }
             multipartBodyBuilder.addFormDataPart(
                     "alias_object", ObjectMappers.JSON_MAPPER.writeValueAsString(request.getAliasObject()));
@@ -615,7 +602,7 @@ public class AsyncRawServiceClient {
             MediaType fileMimeTypeMediaType = fileMimeType != null ? MediaType.parse(fileMimeType) : null;
             multipartBodyBuilder.addFormDataPart(
                     "file", request.getFile().getName(), RequestBody.create(request.getFile(), fileMimeTypeMediaType));
-            multipartBodyBuilder.addFormDataPart("foo", ObjectMappers.JSON_MAPPER.writeValueAsString(request.getFoo()));
+            multipartBodyBuilder.addFormDataPart("foo", request.getFoo());
             multipartBodyBuilder.addFormDataPart("bar", ObjectMappers.JSON_MAPPER.writeValueAsString(request.getBar()));
             if (request.getFooBar().isPresent()) {
                 multipartBodyBuilder.addFormDataPart(
@@ -2100,21 +2087,15 @@ public class AsyncRawServiceClient {
                     "file", request.getFile().getName(), RequestBody.create(request.getFile(), fileMimeTypeMediaType));
             if (request.getModelType().isPresent()) {
                 multipartBodyBuilder.addFormDataPart(
-                        "model_type",
-                        ObjectMappers.JSON_MAPPER.writeValueAsString(
-                                request.getModelType().get()));
+                        "model_type", request.getModelType().get());
             }
             if (request.getOpenEnum().isPresent()) {
                 multipartBodyBuilder.addFormDataPart(
-                        "open_enum",
-                        ObjectMappers.JSON_MAPPER.writeValueAsString(
-                                request.getOpenEnum().get()));
+                        "open_enum", request.getOpenEnum().get().toString());
             }
             if (request.getMaybeName().isPresent()) {
                 multipartBodyBuilder.addFormDataPart(
-                        "maybe_name",
-                        ObjectMappers.JSON_MAPPER.writeValueAsString(
-                                request.getMaybeName().get()));
+                        "maybe_name", request.getMaybeName().get());
             }
         } catch (Exception e) {
             throw new RuntimeException(e);

--- a/seed/java-sdk/file-upload/inline-file-properties/src/main/java/com/seed/fileUpload/resources/service/RawServiceClient.java
+++ b/seed/java-sdk/file-upload/inline-file-properties/src/main/java/com/seed/fileUpload/resources/service/RawServiceClient.java
@@ -60,12 +60,9 @@ public class RawServiceClient {
         try {
             if (request.getMaybeString().isPresent()) {
                 multipartBodyBuilder.addFormDataPart(
-                        "maybe_string",
-                        ObjectMappers.JSON_MAPPER.writeValueAsString(
-                                request.getMaybeString().get()));
+                        "maybe_string", request.getMaybeString().get());
             }
-            multipartBodyBuilder.addFormDataPart(
-                    "integer", ObjectMappers.JSON_MAPPER.writeValueAsString(request.getInteger()));
+            multipartBodyBuilder.addFormDataPart("integer", Integer.toString(request.getInteger()));
             String fileMimeType = Files.probeContentType(request.getFile().toPath());
             MediaType fileMimeTypeMediaType = fileMimeType != null ? MediaType.parse(fileMimeType) : null;
             multipartBodyBuilder.addFormDataPart(
@@ -99,18 +96,11 @@ public class RawServiceClient {
             }
             if (request.getMaybeInteger().isPresent()) {
                 multipartBodyBuilder.addFormDataPart(
-                        "maybe_integer",
-                        ObjectMappers.JSON_MAPPER.writeValueAsString(
-                                request.getMaybeInteger().get()));
+                        "maybe_integer", request.getMaybeInteger().get().toString());
             }
             if (request.getOptionalListOfStrings().isPresent()) {
                 request.getOptionalListOfStrings().get().forEach(item -> {
-                    try {
-                        multipartBodyBuilder.addFormDataPart(
-                                "optional_list_of_strings", ObjectMappers.JSON_MAPPER.writeValueAsString(item));
-                    } catch (JsonProcessingException e) {
-                        throw new RuntimeException("Failed to write value as JSON", e);
-                    }
+                    multipartBodyBuilder.addFormDataPart("optional_list_of_strings", String.valueOf(item));
                 });
             }
             request.getListOfObjects().forEach(item -> {
@@ -130,14 +120,11 @@ public class RawServiceClient {
             if (request.getOptionalObjectType().isPresent()) {
                 multipartBodyBuilder.addFormDataPart(
                         "optional_object_type",
-                        ObjectMappers.JSON_MAPPER.writeValueAsString(
-                                request.getOptionalObjectType().get()));
+                        request.getOptionalObjectType().get().toString());
             }
             if (request.getOptionalId().isPresent()) {
                 multipartBodyBuilder.addFormDataPart(
-                        "optional_id",
-                        ObjectMappers.JSON_MAPPER.writeValueAsString(
-                                request.getOptionalId().get()));
+                        "optional_id", request.getOptionalId().get());
             }
             multipartBodyBuilder.addFormDataPart(
                     "alias_object", ObjectMappers.JSON_MAPPER.writeValueAsString(request.getAliasObject()));
@@ -496,7 +483,7 @@ public class RawServiceClient {
             MediaType fileMimeTypeMediaType = fileMimeType != null ? MediaType.parse(fileMimeType) : null;
             multipartBodyBuilder.addFormDataPart(
                     "file", request.getFile().getName(), RequestBody.create(request.getFile(), fileMimeTypeMediaType));
-            multipartBodyBuilder.addFormDataPart("foo", ObjectMappers.JSON_MAPPER.writeValueAsString(request.getFoo()));
+            multipartBodyBuilder.addFormDataPart("foo", request.getFoo());
             multipartBodyBuilder.addFormDataPart("bar", ObjectMappers.JSON_MAPPER.writeValueAsString(request.getBar()));
             if (request.getFooBar().isPresent()) {
                 multipartBodyBuilder.addFormDataPart(
@@ -1597,21 +1584,15 @@ public class RawServiceClient {
                     "file", request.getFile().getName(), RequestBody.create(request.getFile(), fileMimeTypeMediaType));
             if (request.getModelType().isPresent()) {
                 multipartBodyBuilder.addFormDataPart(
-                        "model_type",
-                        ObjectMappers.JSON_MAPPER.writeValueAsString(
-                                request.getModelType().get()));
+                        "model_type", request.getModelType().get());
             }
             if (request.getOpenEnum().isPresent()) {
                 multipartBodyBuilder.addFormDataPart(
-                        "open_enum",
-                        ObjectMappers.JSON_MAPPER.writeValueAsString(
-                                request.getOpenEnum().get()));
+                        "open_enum", request.getOpenEnum().get().toString());
             }
             if (request.getMaybeName().isPresent()) {
                 multipartBodyBuilder.addFormDataPart(
-                        "maybe_name",
-                        ObjectMappers.JSON_MAPPER.writeValueAsString(
-                                request.getMaybeName().get()));
+                        "maybe_name", request.getMaybeName().get());
             }
         } catch (Exception e) {
             throw new RuntimeException(e);

--- a/seed/java-sdk/file-upload/no-custom-config/src/main/java/com/seed/fileUpload/resources/service/AsyncRawServiceClient.java
+++ b/seed/java-sdk/file-upload/no-custom-config/src/main/java/com/seed/fileUpload/resources/service/AsyncRawServiceClient.java
@@ -73,12 +73,9 @@ public class AsyncRawServiceClient {
         try {
             if (request.getMaybeString().isPresent()) {
                 multipartBodyBuilder.addFormDataPart(
-                        "maybe_string",
-                        ObjectMappers.JSON_MAPPER.writeValueAsString(
-                                request.getMaybeString().get()));
+                        "maybe_string", request.getMaybeString().get());
             }
-            multipartBodyBuilder.addFormDataPart(
-                    "integer", ObjectMappers.JSON_MAPPER.writeValueAsString(request.getInteger()));
+            multipartBodyBuilder.addFormDataPart("integer", Integer.toString(request.getInteger()));
             String fileMimeType = Files.probeContentType(file.toPath());
             MediaType fileMimeTypeMediaType = fileMimeType != null ? MediaType.parse(fileMimeType) : null;
             multipartBodyBuilder.addFormDataPart(
@@ -109,18 +106,11 @@ public class AsyncRawServiceClient {
             }
             if (request.getMaybeInteger().isPresent()) {
                 multipartBodyBuilder.addFormDataPart(
-                        "maybe_integer",
-                        ObjectMappers.JSON_MAPPER.writeValueAsString(
-                                request.getMaybeInteger().get()));
+                        "maybe_integer", request.getMaybeInteger().get().toString());
             }
             if (request.getOptionalListOfStrings().isPresent()) {
                 request.getOptionalListOfStrings().get().forEach(item -> {
-                    try {
-                        multipartBodyBuilder.addFormDataPart(
-                                "optional_list_of_strings", ObjectMappers.JSON_MAPPER.writeValueAsString(item));
-                    } catch (JsonProcessingException e) {
-                        throw new RuntimeException("Failed to write value as JSON", e);
-                    }
+                    multipartBodyBuilder.addFormDataPart("optional_list_of_strings", String.valueOf(item));
                 });
             }
             request.getListOfObjects().forEach(item -> {
@@ -140,14 +130,11 @@ public class AsyncRawServiceClient {
             if (request.getOptionalObjectType().isPresent()) {
                 multipartBodyBuilder.addFormDataPart(
                         "optional_object_type",
-                        ObjectMappers.JSON_MAPPER.writeValueAsString(
-                                request.getOptionalObjectType().get()));
+                        request.getOptionalObjectType().get().toString());
             }
             if (request.getOptionalId().isPresent()) {
                 multipartBodyBuilder.addFormDataPart(
-                        "optional_id",
-                        ObjectMappers.JSON_MAPPER.writeValueAsString(
-                                request.getOptionalId().get()));
+                        "optional_id", request.getOptionalId().get());
             }
             multipartBodyBuilder.addFormDataPart(
                     "alias_object", ObjectMappers.JSON_MAPPER.writeValueAsString(request.getAliasObject()));
@@ -622,7 +609,7 @@ public class AsyncRawServiceClient {
             MediaType fileMimeTypeMediaType = fileMimeType != null ? MediaType.parse(fileMimeType) : null;
             multipartBodyBuilder.addFormDataPart(
                     "file", file.getName(), RequestBody.create(file, fileMimeTypeMediaType));
-            multipartBodyBuilder.addFormDataPart("foo", ObjectMappers.JSON_MAPPER.writeValueAsString(request.getFoo()));
+            multipartBodyBuilder.addFormDataPart("foo", request.getFoo());
             multipartBodyBuilder.addFormDataPart("bar", ObjectMappers.JSON_MAPPER.writeValueAsString(request.getBar()));
             if (request.getFooBar().isPresent()) {
                 multipartBodyBuilder.addFormDataPart(
@@ -2120,21 +2107,15 @@ public class AsyncRawServiceClient {
                     "file", file.getName(), RequestBody.create(file, fileMimeTypeMediaType));
             if (request.getModelType().isPresent()) {
                 multipartBodyBuilder.addFormDataPart(
-                        "model_type",
-                        ObjectMappers.JSON_MAPPER.writeValueAsString(
-                                request.getModelType().get()));
+                        "model_type", request.getModelType().get());
             }
             if (request.getOpenEnum().isPresent()) {
                 multipartBodyBuilder.addFormDataPart(
-                        "open_enum",
-                        ObjectMappers.JSON_MAPPER.writeValueAsString(
-                                request.getOpenEnum().get()));
+                        "open_enum", request.getOpenEnum().get().toString());
             }
             if (request.getMaybeName().isPresent()) {
                 multipartBodyBuilder.addFormDataPart(
-                        "maybe_name",
-                        ObjectMappers.JSON_MAPPER.writeValueAsString(
-                                request.getMaybeName().get()));
+                        "maybe_name", request.getMaybeName().get());
             }
         } catch (Exception e) {
             throw new RuntimeException(e);

--- a/seed/java-sdk/file-upload/no-custom-config/src/main/java/com/seed/fileUpload/resources/service/RawServiceClient.java
+++ b/seed/java-sdk/file-upload/no-custom-config/src/main/java/com/seed/fileUpload/resources/service/RawServiceClient.java
@@ -69,12 +69,9 @@ public class RawServiceClient {
         try {
             if (request.getMaybeString().isPresent()) {
                 multipartBodyBuilder.addFormDataPart(
-                        "maybe_string",
-                        ObjectMappers.JSON_MAPPER.writeValueAsString(
-                                request.getMaybeString().get()));
+                        "maybe_string", request.getMaybeString().get());
             }
-            multipartBodyBuilder.addFormDataPart(
-                    "integer", ObjectMappers.JSON_MAPPER.writeValueAsString(request.getInteger()));
+            multipartBodyBuilder.addFormDataPart("integer", Integer.toString(request.getInteger()));
             String fileMimeType = Files.probeContentType(file.toPath());
             MediaType fileMimeTypeMediaType = fileMimeType != null ? MediaType.parse(fileMimeType) : null;
             multipartBodyBuilder.addFormDataPart(
@@ -105,18 +102,11 @@ public class RawServiceClient {
             }
             if (request.getMaybeInteger().isPresent()) {
                 multipartBodyBuilder.addFormDataPart(
-                        "maybe_integer",
-                        ObjectMappers.JSON_MAPPER.writeValueAsString(
-                                request.getMaybeInteger().get()));
+                        "maybe_integer", request.getMaybeInteger().get().toString());
             }
             if (request.getOptionalListOfStrings().isPresent()) {
                 request.getOptionalListOfStrings().get().forEach(item -> {
-                    try {
-                        multipartBodyBuilder.addFormDataPart(
-                                "optional_list_of_strings", ObjectMappers.JSON_MAPPER.writeValueAsString(item));
-                    } catch (JsonProcessingException e) {
-                        throw new RuntimeException("Failed to write value as JSON", e);
-                    }
+                    multipartBodyBuilder.addFormDataPart("optional_list_of_strings", String.valueOf(item));
                 });
             }
             request.getListOfObjects().forEach(item -> {
@@ -136,14 +126,11 @@ public class RawServiceClient {
             if (request.getOptionalObjectType().isPresent()) {
                 multipartBodyBuilder.addFormDataPart(
                         "optional_object_type",
-                        ObjectMappers.JSON_MAPPER.writeValueAsString(
-                                request.getOptionalObjectType().get()));
+                        request.getOptionalObjectType().get().toString());
             }
             if (request.getOptionalId().isPresent()) {
                 multipartBodyBuilder.addFormDataPart(
-                        "optional_id",
-                        ObjectMappers.JSON_MAPPER.writeValueAsString(
-                                request.getOptionalId().get()));
+                        "optional_id", request.getOptionalId().get());
             }
             multipartBodyBuilder.addFormDataPart(
                     "alias_object", ObjectMappers.JSON_MAPPER.writeValueAsString(request.getAliasObject()));
@@ -503,7 +490,7 @@ public class RawServiceClient {
             MediaType fileMimeTypeMediaType = fileMimeType != null ? MediaType.parse(fileMimeType) : null;
             multipartBodyBuilder.addFormDataPart(
                     "file", file.getName(), RequestBody.create(file, fileMimeTypeMediaType));
-            multipartBodyBuilder.addFormDataPart("foo", ObjectMappers.JSON_MAPPER.writeValueAsString(request.getFoo()));
+            multipartBodyBuilder.addFormDataPart("foo", request.getFoo());
             multipartBodyBuilder.addFormDataPart("bar", ObjectMappers.JSON_MAPPER.writeValueAsString(request.getBar()));
             if (request.getFooBar().isPresent()) {
                 multipartBodyBuilder.addFormDataPart(
@@ -1615,21 +1602,15 @@ public class RawServiceClient {
                     "file", file.getName(), RequestBody.create(file, fileMimeTypeMediaType));
             if (request.getModelType().isPresent()) {
                 multipartBodyBuilder.addFormDataPart(
-                        "model_type",
-                        ObjectMappers.JSON_MAPPER.writeValueAsString(
-                                request.getModelType().get()));
+                        "model_type", request.getModelType().get());
             }
             if (request.getOpenEnum().isPresent()) {
                 multipartBodyBuilder.addFormDataPart(
-                        "open_enum",
-                        ObjectMappers.JSON_MAPPER.writeValueAsString(
-                                request.getOpenEnum().get()));
+                        "open_enum", request.getOpenEnum().get().toString());
             }
             if (request.getMaybeName().isPresent()) {
                 multipartBodyBuilder.addFormDataPart(
-                        "maybe_name",
-                        ObjectMappers.JSON_MAPPER.writeValueAsString(
-                                request.getMaybeName().get()));
+                        "maybe_name", request.getMaybeName().get());
             }
         } catch (Exception e) {
             throw new RuntimeException(e);

--- a/seed/java-sdk/file-upload/wrapped-aliases/src/main/java/com/seed/fileUpload/resources/service/AsyncRawServiceClient.java
+++ b/seed/java-sdk/file-upload/wrapped-aliases/src/main/java/com/seed/fileUpload/resources/service/AsyncRawServiceClient.java
@@ -73,12 +73,9 @@ public class AsyncRawServiceClient {
         try {
             if (request.getMaybeString().isPresent()) {
                 multipartBodyBuilder.addFormDataPart(
-                        "maybe_string",
-                        ObjectMappers.JSON_MAPPER.writeValueAsString(
-                                request.getMaybeString().get()));
+                        "maybe_string", request.getMaybeString().get());
             }
-            multipartBodyBuilder.addFormDataPart(
-                    "integer", ObjectMappers.JSON_MAPPER.writeValueAsString(request.getInteger()));
+            multipartBodyBuilder.addFormDataPart("integer", Integer.toString(request.getInteger()));
             String fileMimeType = Files.probeContentType(file.toPath());
             MediaType fileMimeTypeMediaType = fileMimeType != null ? MediaType.parse(fileMimeType) : null;
             multipartBodyBuilder.addFormDataPart(
@@ -109,18 +106,11 @@ public class AsyncRawServiceClient {
             }
             if (request.getMaybeInteger().isPresent()) {
                 multipartBodyBuilder.addFormDataPart(
-                        "maybe_integer",
-                        ObjectMappers.JSON_MAPPER.writeValueAsString(
-                                request.getMaybeInteger().get()));
+                        "maybe_integer", request.getMaybeInteger().get().toString());
             }
             if (request.getOptionalListOfStrings().isPresent()) {
                 request.getOptionalListOfStrings().get().forEach(item -> {
-                    try {
-                        multipartBodyBuilder.addFormDataPart(
-                                "optional_list_of_strings", ObjectMappers.JSON_MAPPER.writeValueAsString(item));
-                    } catch (JsonProcessingException e) {
-                        throw new RuntimeException("Failed to write value as JSON", e);
-                    }
+                    multipartBodyBuilder.addFormDataPart("optional_list_of_strings", String.valueOf(item));
                 });
             }
             request.getListOfObjects().forEach(item -> {
@@ -140,14 +130,11 @@ public class AsyncRawServiceClient {
             if (request.getOptionalObjectType().isPresent()) {
                 multipartBodyBuilder.addFormDataPart(
                         "optional_object_type",
-                        ObjectMappers.JSON_MAPPER.writeValueAsString(
-                                request.getOptionalObjectType().get()));
+                        request.getOptionalObjectType().get().toString());
             }
             if (request.getOptionalId().isPresent()) {
                 multipartBodyBuilder.addFormDataPart(
-                        "optional_id",
-                        ObjectMappers.JSON_MAPPER.writeValueAsString(
-                                request.getOptionalId().get()));
+                        "optional_id", request.getOptionalId().get().toString());
             }
             multipartBodyBuilder.addFormDataPart(
                     "alias_object", ObjectMappers.JSON_MAPPER.writeValueAsString(request.getAliasObject()));
@@ -622,7 +609,7 @@ public class AsyncRawServiceClient {
             MediaType fileMimeTypeMediaType = fileMimeType != null ? MediaType.parse(fileMimeType) : null;
             multipartBodyBuilder.addFormDataPart(
                     "file", file.getName(), RequestBody.create(file, fileMimeTypeMediaType));
-            multipartBodyBuilder.addFormDataPart("foo", ObjectMappers.JSON_MAPPER.writeValueAsString(request.getFoo()));
+            multipartBodyBuilder.addFormDataPart("foo", request.getFoo());
             multipartBodyBuilder.addFormDataPart("bar", ObjectMappers.JSON_MAPPER.writeValueAsString(request.getBar()));
             if (request.getFooBar().isPresent()) {
                 multipartBodyBuilder.addFormDataPart(
@@ -2120,21 +2107,15 @@ public class AsyncRawServiceClient {
                     "file", file.getName(), RequestBody.create(file, fileMimeTypeMediaType));
             if (request.getModelType().isPresent()) {
                 multipartBodyBuilder.addFormDataPart(
-                        "model_type",
-                        ObjectMappers.JSON_MAPPER.writeValueAsString(
-                                request.getModelType().get()));
+                        "model_type", request.getModelType().get().toString());
             }
             if (request.getOpenEnum().isPresent()) {
                 multipartBodyBuilder.addFormDataPart(
-                        "open_enum",
-                        ObjectMappers.JSON_MAPPER.writeValueAsString(
-                                request.getOpenEnum().get()));
+                        "open_enum", request.getOpenEnum().get().toString());
             }
             if (request.getMaybeName().isPresent()) {
                 multipartBodyBuilder.addFormDataPart(
-                        "maybe_name",
-                        ObjectMappers.JSON_MAPPER.writeValueAsString(
-                                request.getMaybeName().get()));
+                        "maybe_name", request.getMaybeName().get());
             }
         } catch (Exception e) {
             throw new RuntimeException(e);

--- a/seed/java-sdk/file-upload/wrapped-aliases/src/main/java/com/seed/fileUpload/resources/service/RawServiceClient.java
+++ b/seed/java-sdk/file-upload/wrapped-aliases/src/main/java/com/seed/fileUpload/resources/service/RawServiceClient.java
@@ -69,12 +69,9 @@ public class RawServiceClient {
         try {
             if (request.getMaybeString().isPresent()) {
                 multipartBodyBuilder.addFormDataPart(
-                        "maybe_string",
-                        ObjectMappers.JSON_MAPPER.writeValueAsString(
-                                request.getMaybeString().get()));
+                        "maybe_string", request.getMaybeString().get());
             }
-            multipartBodyBuilder.addFormDataPart(
-                    "integer", ObjectMappers.JSON_MAPPER.writeValueAsString(request.getInteger()));
+            multipartBodyBuilder.addFormDataPart("integer", Integer.toString(request.getInteger()));
             String fileMimeType = Files.probeContentType(file.toPath());
             MediaType fileMimeTypeMediaType = fileMimeType != null ? MediaType.parse(fileMimeType) : null;
             multipartBodyBuilder.addFormDataPart(
@@ -105,18 +102,11 @@ public class RawServiceClient {
             }
             if (request.getMaybeInteger().isPresent()) {
                 multipartBodyBuilder.addFormDataPart(
-                        "maybe_integer",
-                        ObjectMappers.JSON_MAPPER.writeValueAsString(
-                                request.getMaybeInteger().get()));
+                        "maybe_integer", request.getMaybeInteger().get().toString());
             }
             if (request.getOptionalListOfStrings().isPresent()) {
                 request.getOptionalListOfStrings().get().forEach(item -> {
-                    try {
-                        multipartBodyBuilder.addFormDataPart(
-                                "optional_list_of_strings", ObjectMappers.JSON_MAPPER.writeValueAsString(item));
-                    } catch (JsonProcessingException e) {
-                        throw new RuntimeException("Failed to write value as JSON", e);
-                    }
+                    multipartBodyBuilder.addFormDataPart("optional_list_of_strings", String.valueOf(item));
                 });
             }
             request.getListOfObjects().forEach(item -> {
@@ -136,14 +126,11 @@ public class RawServiceClient {
             if (request.getOptionalObjectType().isPresent()) {
                 multipartBodyBuilder.addFormDataPart(
                         "optional_object_type",
-                        ObjectMappers.JSON_MAPPER.writeValueAsString(
-                                request.getOptionalObjectType().get()));
+                        request.getOptionalObjectType().get().toString());
             }
             if (request.getOptionalId().isPresent()) {
                 multipartBodyBuilder.addFormDataPart(
-                        "optional_id",
-                        ObjectMappers.JSON_MAPPER.writeValueAsString(
-                                request.getOptionalId().get()));
+                        "optional_id", request.getOptionalId().get().toString());
             }
             multipartBodyBuilder.addFormDataPart(
                     "alias_object", ObjectMappers.JSON_MAPPER.writeValueAsString(request.getAliasObject()));
@@ -503,7 +490,7 @@ public class RawServiceClient {
             MediaType fileMimeTypeMediaType = fileMimeType != null ? MediaType.parse(fileMimeType) : null;
             multipartBodyBuilder.addFormDataPart(
                     "file", file.getName(), RequestBody.create(file, fileMimeTypeMediaType));
-            multipartBodyBuilder.addFormDataPart("foo", ObjectMappers.JSON_MAPPER.writeValueAsString(request.getFoo()));
+            multipartBodyBuilder.addFormDataPart("foo", request.getFoo());
             multipartBodyBuilder.addFormDataPart("bar", ObjectMappers.JSON_MAPPER.writeValueAsString(request.getBar()));
             if (request.getFooBar().isPresent()) {
                 multipartBodyBuilder.addFormDataPart(
@@ -1615,21 +1602,15 @@ public class RawServiceClient {
                     "file", file.getName(), RequestBody.create(file, fileMimeTypeMediaType));
             if (request.getModelType().isPresent()) {
                 multipartBodyBuilder.addFormDataPart(
-                        "model_type",
-                        ObjectMappers.JSON_MAPPER.writeValueAsString(
-                                request.getModelType().get()));
+                        "model_type", request.getModelType().get().toString());
             }
             if (request.getOpenEnum().isPresent()) {
                 multipartBodyBuilder.addFormDataPart(
-                        "open_enum",
-                        ObjectMappers.JSON_MAPPER.writeValueAsString(
-                                request.getOpenEnum().get()));
+                        "open_enum", request.getOpenEnum().get().toString());
             }
             if (request.getMaybeName().isPresent()) {
                 multipartBodyBuilder.addFormDataPart(
-                        "maybe_name",
-                        ObjectMappers.JSON_MAPPER.writeValueAsString(
-                                request.getMaybeName().get()));
+                        "maybe_name", request.getMaybeName().get());
             }
         } catch (Exception e) {
             throw new RuntimeException(e);


### PR DESCRIPTION
## Description

Linear ticket: Closes FER-9228

The Java SDK generator was wrapping **all** multipart form data fields in `ObjectMappers.JSON_MAPPER.writeValueAsString()`, which is correct for JSON request bodies but wrong for multipart form data. For string-typed fields, `writeValueAsString("value")` produces `"\"value\""` (with embedded literal quotes), causing servers to receive malformed values and return 404 errors (e.g. in the Cohere Java SDK).

## Changes Made

- Added a `TypeReferenceNeedsJsonSerialization` visitor in `WrappedRequestEndpointWriter.java` that inspects the IR type of each multipart form field to decide the serialization strategy:
  - **Primitives** (string, int, double, boolean, etc.) → plain string conversion via `PoetTypeNameStringifier`
  - **Enums** → `.toString()` (returns wire value)
  - **Aliases** → resolved through to the underlying type
  - **Collections of simple types** → `String.valueOf(item)` (no try-catch needed)
  - **Complex types** (objects, unions, maps, unknown) → `writeValueAsString()` (unchanged)
- Updated `initializeMultipartBody` to branch on the visitor result, conditionally omitting the `try/catch` for `JsonProcessingException` in collection lambdas when JSON serialization isn't used
- Regenerated seed snapshots for `file-upload`, `file-upload-openapi` fixtures (3 configs each)
- Added `versions.yml` entry (4.0.8)

## Reviewer Checklist — things to look closely at

1. **Enum `toString()` correctness** — the fix assumes Fern-generated Java enums return the wire value from `toString()`. If any enum class doesn't override `toString()`, this would produce the Java class name instead.
2. **Wrapped alias `toString()`** — in the `wrapped-aliases` seed config, fields like `optional_id` and `model_type` now call `.toString()` on the wrapper class (because `PoetTypeNameStringifier` sees the alias ClassName, not String). Verify this produces the correct wire value, not `MyAliasType@hashcode`.
3. **Alias resolution depth** — `TypeReferenceNeedsJsonSerialization.visitNamed()` resolves one level of alias via `getResolvedType()`. If a resolved named type is itself an alias-of-alias, the IR's `ResolvedTypeReference` should already be fully resolved, but worth confirming.

## Testing

- [x] Java generator compiles (`./gradlew :sdk:compileJava`)
- [x] Seed tests regenerated and pass for `file-upload` (3 configs) and `file-upload-openapi` (1 config)
- [x] `exhaustive` fixture regenerated with no changes (confirms non-multipart endpoints are unaffected)

Link to Devin session: https://app.devin.ai/sessions/a9d1f517cbf448adbc28324c4b918c9b
Requested by: @jsklan
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/14253" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
