### PR TITLE
fix(csharp): handle extraProperties in mock object examples

### DIFF
--- a/generators/csharp/sdk/src/test-generation/mock-server/MockEndpointGenerator.ts
+++ b/generators/csharp/sdk/src/test-generation/mock-server/MockEndpointGenerator.ts
@@ -513,7 +513,11 @@ export class MockEndpointGenerator extends WithGeneration {
             type: "named";
             typeName: { typeId: TypeId };
             shape:
-                | { type: "object"; properties: Array<{ name: { wireValue: string }; value: ExampleTypeReference }> }
+                | {
+                      type: "object";
+                      properties: Array<{ name: { wireValue: string }; value: ExampleTypeReference }>;
+                      extraProperties?: Array<{ name: { wireValue: string }; value: ExampleTypeReference }>;
+                  }
                 | { type: "union"; discriminant: { wireValue: string }; singleUnionType: unknown }
                 | { type: "enum"; value: { wireValue: string } }
                 | { type: "alias"; value: ExampleTypeReference }
@@ -526,7 +530,7 @@ export class MockEndpointGenerator extends WithGeneration {
 
         switch (innerShape.type) {
             case "object":
-                return this.filterObjectExample(typeId, innerShape.properties, options);
+                return this.filterObjectExample(typeId, innerShape.properties, options, innerShape.extraProperties);
 
             case "alias":
                 return this.filterExampleTypeReference(innerShape.value, options);
@@ -554,7 +558,8 @@ export class MockEndpointGenerator extends WithGeneration {
     private filterObjectExample(
         typeId: TypeId,
         properties: Array<{ name: { wireValue: string }; value: ExampleTypeReference }>,
-        options: { filterWriteOnly?: boolean } = {}
+        options: { filterWriteOnly?: boolean } = {},
+        extraProperties?: Array<{ name: { wireValue: string }; value: ExampleTypeReference }>
     ): Record<string, unknown> {
         const typeDeclaration = this.context.model.dereferenceType(typeId).typeDeclaration;
         const readOnlyNames = this.getReadOnlyPropertyNamesForType(typeDeclaration);
@@ -578,6 +583,14 @@ export class MockEndpointGenerator extends WithGeneration {
             }
             result[prop.name.wireValue] = filteredValue;
         }
+
+        // Include extra properties (AdditionalProperties) inline — they serialize via [JsonExtensionData]
+        if (extraProperties != null) {
+            for (const extraProp of extraProperties) {
+                result[extraProp.name.wireValue] = this.filterExampleTypeReference(extraProp.value, options);
+            }
+        }
+
         return result;
     }
 

--- a/generators/csharp/sdk/versions.yml
+++ b/generators/csharp/sdk/versions.yml
@@ -1,4 +1,15 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 2.55.1
+  changelogEntry:
+    - summary: |
+        Include extraProperties (AdditionalProperties) in WireMock mock server
+        response objects. Previously, object types with `[JsonExtensionData]`
+        additional properties were missing those properties in generated mock
+        responses, causing incomplete WireMock stubs.
+      type: fix
+  createdAt: "2026-03-30"
+  irVersion: 65
+
 - version: 2.55.0
   changelogEntry:
     - summary: |


### PR DESCRIPTION
Allow object shapes to carry optional `extraProperties` and propagate them through example filtering. The shape union now accepts an optional `extraProperties` array; the switch passes this into `filterObjectExample` and the method signature was extended to accept it. `filterObjectExample` now merges `extraProperties` into the returned object, filtering each value via `filterExampleTypeReference` (used for AdditionalProperties / `[JsonExtensionData]` serialization).

## Description

When an object type uses additional properties (serialized via `[JsonExtensionData]` in C#), the mock server example generation was not including those extra properties in the response JSON. This meant WireMock stubs could return incomplete responses for types that rely on additional properties.

This PR threads `extraProperties` through the mock endpoint generator so that additional properties are included inline in the generated mock response objects.

## Changes Made

- Extended the object shape type in `MockEndpointGenerator.ts` to include an optional `extraProperties` array
- Updated the `"object"` switch case to forward `extraProperties` into `filterObjectExample`
- Extended `filterObjectExample` signature to accept optional `extraProperties` parameter
- Added logic to merge extra properties inline into the result object, filtering each value through `filterExampleTypeReference`
- Added `versions.yml` entry for C# SDK generator v2.55.1
- [ ] Updated README.md generator (if applicable)

## Testing

- [ ] Unit tests added/updated
- [ ] Manual testing completed

## Human Review Checklist

- [ ] Verify no key collisions can occur between regular `properties` and `extraProperties` (both write to the same `result` object by wire value)
- [ ] Confirm that `extraProperties` only applies to object shapes and doesn't need handling in other shape cases (union, enum, alias)
- [ ] Validate that generated WireMock stubs correctly serialize additional properties for a type using `[JsonExtensionData]`

Link to Devin session: https://app.devin.ai/sessions/a6a1ff96dde34d768b71e6e131be3399
Requested by: @iamnamananand996