### PR TITLE
fix(typescript): include client-level default headers in WebSocket connections

### DIFF
--- a/generators/typescript/sdk/client-class-generator/src/websocket/GeneratedDefaultWebsocketImplementation.ts
+++ b/generators/typescript/sdk/client-class-generator/src/websocket/GeneratedDefaultWebsocketImplementation.ts
@@ -442,6 +442,18 @@ export class GeneratedDefaultWebsocketImplementation implements GeneratedWebsock
             );
             mergeHeaders.push(ts.factory.createIdentifier("_authRequest.headers"));
         }
+        // Include client-level default headers (this._options?.headers)
+        mergeHeaders.push(
+            ts.factory.createPropertyAccessChain(
+                ts.factory.createPropertyAccessChain(
+                    ts.factory.createThis(),
+                    undefined,
+                    GeneratedSdkClientClassImpl.OPTIONS_PRIVATE_MEMBER
+                ),
+                ts.factory.createToken(ts.SyntaxKind.QuestionDotToken),
+                "headers"
+            )
+        );
         mergeOnlyDefinedHeaders.push(
             ...this.channel.headers.map((header) => {
                 return ts.factory.createPropertyAssignment(
@@ -462,11 +474,9 @@ export class GeneratedDefaultWebsocketImplementation implements GeneratedWebsock
         }
         mergeHeaders.push(ts.factory.createIdentifier(GeneratedDefaultWebsocketImplementation.HEADERS_PROPERTY_NAME));
 
-        if (mergeHeaders.length > 1) {
-            context.importsManager.addImportFromRoot("core/headers", {
-                namedImports: ["mergeHeaders"]
-            });
-        }
+        context.importsManager.addImportFromRoot("core/headers", {
+            namedImports: ["mergeHeaders"]
+        });
 
         return [
             destructuringStatement,
@@ -483,16 +493,9 @@ export class GeneratedDefaultWebsocketImplementation implements GeneratedWebsock
                                 ts.factory.createKeywordTypeNode(ts.SyntaxKind.StringKeyword),
                                 ts.factory.createTypeReferenceNode(ts.factory.createIdentifier("unknown"))
                             ]),
-                            mergeHeaders.length > 1
-                                ? ts.factory.createCallExpression(
-                                      ts.factory.createIdentifier("mergeHeaders"),
-                                      undefined,
-                                      [...mergeHeaders]
-                                  )
-                                : ts.factory.createObjectLiteralExpression(
-                                      [ts.factory.createSpreadAssignment(mergeHeaders[0] as ts.Expression)],
-                                      false
-                                  )
+                            ts.factory.createCallExpression(ts.factory.createIdentifier("mergeHeaders"), undefined, [
+                                ...mergeHeaders
+                            ])
                         )
                     ],
                     ts.NodeFlags.Let

--- a/generators/typescript/sdk/versions.yml
+++ b/generators/typescript/sdk/versions.yml
@@ -1,4 +1,16 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 3.60.1
+  changelogEntry:
+    - summary: |
+        Fix WebSocket connections missing client-level default headers. The generated
+        `connect` method now includes `this._options?.headers` in the merged headers,
+        matching the behavior of HTTP endpoint methods. Previously, only auth headers
+        and user-provided connect-time headers were sent, causing Authorization and
+        other client-configured headers to be silently dropped on WebSocket connections.
+      type: fix
+  createdAt: "2026-03-30"
+  irVersion: 65
+
 - version: 3.60.0
   changelogEntry:
     - summary: |

--- a/seed/ts-sdk/websocket-bearer-auth/websockets/src/api/resources/realtime/client/Client.ts
+++ b/seed/ts-sdk/websocket-bearer-auth/websockets/src/api/resources/realtime/client/Client.ts
@@ -55,7 +55,7 @@ export class RealtimeClient {
             temperature,
         };
         const _authRequest: core.AuthRequest = await this._options.authProvider.getAuthRequest();
-        const _headers: Record<string, unknown> = mergeHeaders(_authRequest.headers, headers);
+        const _headers: Record<string, unknown> = mergeHeaders(_authRequest.headers, this._options?.headers, headers);
         const socket = new core.ReconnectingWebSocket({
             url: core.url.join(
                 (await core.Supplier.get(this._options.baseUrl)) ??

--- a/seed/ts-sdk/websocket-bearer-auth/websockets/src/api/resources/realtimeNoAuth/client/Client.ts
+++ b/seed/ts-sdk/websocket-bearer-auth/websockets/src/api/resources/realtimeNoAuth/client/Client.ts
@@ -2,6 +2,7 @@
 
 import type { BaseClientOptions } from "../../../../BaseClient.js";
 import { type NormalizedClientOptions, normalizeClientOptions } from "../../../../BaseClient.js";
+import { mergeHeaders } from "../../../../core/headers.js";
 import * as core from "../../../../core/index.js";
 import { RealtimeNoAuthSocket } from "./Socket.js";
 
@@ -50,7 +51,7 @@ export class RealtimeNoAuthClient {
         const _queryParams: Record<string, unknown> = {
             model,
         };
-        const _headers: Record<string, unknown> = { ...headers };
+        const _headers: Record<string, unknown> = mergeHeaders(this._options?.headers, headers);
         const socket = new core.ReconnectingWebSocket({
             url: core.url.join(
                 (await core.Supplier.get(this._options.baseUrl)) ??

--- a/seed/ts-sdk/websocket-inferred-auth/websockets/src/api/resources/realtime/client/Client.ts
+++ b/seed/ts-sdk/websocket-inferred-auth/websockets/src/api/resources/realtime/client/Client.ts
@@ -55,7 +55,7 @@ export class RealtimeClient {
             temperature,
         };
         const _authRequest: core.AuthRequest = await this._options.authProvider.getAuthRequest();
-        const _headers: Record<string, unknown> = mergeHeaders(_authRequest.headers, headers);
+        const _headers: Record<string, unknown> = mergeHeaders(_authRequest.headers, this._options?.headers, headers);
         const socket = new core.ReconnectingWebSocket({
             url: core.url.join(
                 (await core.Supplier.get(this._options.baseUrl)) ??

--- a/seed/ts-sdk/websocket/no-serde/src/api/resources/empty/resources/emptyRealtime/client/Client.ts
+++ b/seed/ts-sdk/websocket/no-serde/src/api/resources/empty/resources/emptyRealtime/client/Client.ts
@@ -2,6 +2,7 @@
 
 import type { BaseClientOptions } from "../../../../../../BaseClient.js";
 import { type NormalizedClientOptions, normalizeClientOptions } from "../../../../../../BaseClient.js";
+import { mergeHeaders } from "../../../../../../core/headers.js";
 import * as core from "../../../../../../core/index.js";
 import { EmptyRealtimeSocket } from "./Socket.js";
 
@@ -36,7 +37,7 @@ export class EmptyRealtimeClient {
     public async connect(args: EmptyRealtimeClient.ConnectArgs = {}): Promise<EmptyRealtimeSocket> {
         const { protocols, queryParams, headers, debug, reconnectAttempts, connectionTimeoutInSeconds, abortSignal } =
             args;
-        const _headers: Record<string, unknown> = { ...headers };
+        const _headers: Record<string, unknown> = mergeHeaders(this._options?.headers, headers);
         const socket = new core.ReconnectingWebSocket({
             url: core.url.join(
                 (await core.Supplier.get(this._options.baseUrl)) ??

--- a/seed/ts-sdk/websocket/no-serde/src/api/resources/realtime/client/Client.ts
+++ b/seed/ts-sdk/websocket/no-serde/src/api/resources/realtime/client/Client.ts
@@ -2,6 +2,7 @@
 
 import type { BaseClientOptions } from "../../../../BaseClient.js";
 import { type NormalizedClientOptions, normalizeClientOptions } from "../../../../BaseClient.js";
+import { mergeHeaders } from "../../../../core/headers.js";
 import * as core from "../../../../core/index.js";
 import { RealtimeSocket } from "./Socket.js";
 
@@ -56,7 +57,7 @@ export class RealtimeClient {
             temperature,
             "language-code": languageCode,
         };
-        const _headers: Record<string, unknown> = { ...headers };
+        const _headers: Record<string, unknown> = mergeHeaders(this._options?.headers, headers);
         const socket = new core.ReconnectingWebSocket({
             url: core.url.join(
                 (await core.Supplier.get(this._options.baseUrl)) ??

--- a/seed/ts-sdk/websocket/serde/src/api/resources/empty/resources/emptyRealtime/client/Client.ts
+++ b/seed/ts-sdk/websocket/serde/src/api/resources/empty/resources/emptyRealtime/client/Client.ts
@@ -2,6 +2,7 @@
 
 import type { BaseClientOptions } from "../../../../../../BaseClient.js";
 import { type NormalizedClientOptions, normalizeClientOptions } from "../../../../../../BaseClient.js";
+import { mergeHeaders } from "../../../../../../core/headers.js";
 import * as core from "../../../../../../core/index.js";
 import { EmptyRealtimeSocket } from "./Socket.js";
 
@@ -36,7 +37,7 @@ export class EmptyRealtimeClient {
     public async connect(args: EmptyRealtimeClient.ConnectArgs = {}): Promise<EmptyRealtimeSocket> {
         const { protocols, queryParams, headers, debug, reconnectAttempts, connectionTimeoutInSeconds, abortSignal } =
             args;
-        const _headers: Record<string, unknown> = { ...headers };
+        const _headers: Record<string, unknown> = mergeHeaders(this._options?.headers, headers);
         const socket = new core.ReconnectingWebSocket({
             url: core.url.join(
                 (await core.Supplier.get(this._options.baseUrl)) ??

--- a/seed/ts-sdk/websocket/serde/src/api/resources/realtime/client/Client.ts
+++ b/seed/ts-sdk/websocket/serde/src/api/resources/realtime/client/Client.ts
@@ -2,6 +2,7 @@
 
 import type { BaseClientOptions } from "../../../../BaseClient.js";
 import { type NormalizedClientOptions, normalizeClientOptions } from "../../../../BaseClient.js";
+import { mergeHeaders } from "../../../../core/headers.js";
 import * as core from "../../../../core/index.js";
 import { RealtimeSocket } from "./Socket.js";
 
@@ -56,7 +57,7 @@ export class RealtimeClient {
             temperature,
             "language-code": languageCode,
         };
-        const _headers: Record<string, unknown> = { ...headers };
+        const _headers: Record<string, unknown> = mergeHeaders(this._options?.headers, headers);
         const socket = new core.ReconnectingWebSocket({
             url: core.url.join(
                 (await core.Supplier.get(this._options.baseUrl)) ??


### PR DESCRIPTION
## Description

Refs: https://github.com/Phonic-Co/phonic-node/pull/171/commits/f086510d5185677b7b44483422cd6fc18f928f19

Generated WebSocket `connect` methods were missing `this._options?.headers` (client-level default headers), causing Authorization and other client-configured headers to be silently dropped on WebSocket connections. HTTP endpoints already included these headers via `generateHeaders.ts`; this change brings WebSocket connections into parity.

## Changes Made

- Added `this._options?.headers` to the `mergeHeaders` array in `GeneratedDefaultWebsocketImplementation.ts`, positioned after auth headers and before channel-specific/user-provided headers (matching the HTTP endpoint pattern in `generateHeaders.ts`)
- Simplified the header variable construction to always use `mergeHeaders()` (since we now always have ≥2 items to merge), removing the conditional spread fallback
- Regenerated all 4 WebSocket seed fixtures (`websocket`, `websocket-bearer-auth`, `websocket-inferred-auth`, `websocket-multi-url`)

Generated output now produces:
- **With auth**: `mergeHeaders(_authRequest.headers, this._options?.headers, headers)`
- **Without auth**: `mergeHeaders(this._options?.headers, headers)`

## Testing

- [x] All 538 unit tests in `@fern-typescript/sdk-client-class-generator` pass
- [x] All WebSocket seed fixtures regenerated and pass (`websocket`, `websocket-bearer-auth`, `websocket-inferred-auth`, `websocket-multi-url`)
- [x] Lint/format checks pass

## Reviewer Checklist

- Verify the header merge order preserves correct precedence: auth → client defaults → channel headers → connect-time user headers (later entries win)
- The `mergeHeaders` import is now unconditional — confirm `mergeHeaders` handles `undefined` arguments gracefully (it does; this is the same function used by HTTP endpoints with optional-chained values)

Link to Devin session: https://app.devin.ai/sessions/9fa0c5965e0e4734a6eec1f54c8ae807
Requested by: @tstanmay13
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/14265" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
