### PR TITLE
feat(internal): upgrade generator-cli to 0.8.0 with replay 0.8.0

### DIFF
--- a/packages/generator-cli/package.json
+++ b/packages/generator-cli/package.json
@@ -24,7 +24,7 @@
   "files": ["bin", "dist", "lib"],
   "dependencies": {
     "@fern-api/core-utils": "workspace:*",
-    "@fern-api/replay": "^0.7.0",
+    "@fern-api/replay": "^0.8.0",
     "@octokit/rest": "catalog:",
     "es-toolkit": "catalog:",
     "tmp-promise": "catalog:"

--- a/packages/generator-cli/versions.yml
+++ b/packages/generator-cli/versions.yml
@@ -1,6 +1,13 @@
 # yaml-language-server: $schema=../../versions-yml.schema.json
 - changelogEntry:
     - summary: |
+        Upgrade replay to 0.8.0 with support for detecting git revert commits and cancelling matching patches.
+      type: feat
+  createdAt: "2026-03-30"
+  version: 0.8.0
+
+- changelogEntry:
+    - summary: |
         Update generator-cli to trigger new publish after changing to oidc auth for publish action.
       type: chore
   createdAt: "2026-03-25"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8152,8 +8152,8 @@ importers:
         specifier: workspace:*
         version: link:../commons/core-utils
       '@fern-api/replay':
-        specifier: ^0.7.0
-        version: 0.7.0
+        specifier: ^0.8.0
+        version: 0.8.0
       '@octokit/rest':
         specifier: 'catalog:'
         version: 22.0.1
@@ -9672,8 +9672,8 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
-  '@fern-api/replay@0.7.0':
-    resolution: {integrity: sha512-NJrnacvCtc8Uy/k056KKR/6/8WJvsPC7yf+cJHIQGWRe8MZRUnEDGC5k76NIuq6c3/YWrVJW0+jUbjOWNLw9jg==}
+  '@fern-api/replay@0.8.0':
+    resolution: {integrity: sha512-NMuVNGoGGTFLE63WMGL19jKulnQ1XcKe5son94WCt3md3sWGMNRQz+rIE9riaK1wTlnIbrd5v6aJ8t2ZQT/wrQ==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -16628,7 +16628,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@fern-api/replay@0.7.0':
+  '@fern-api/replay@0.8.0':
     dependencies:
       minimatch: 10.2.4
       node-diff3: 3.2.0


### PR DESCRIPTION
## Summary
- Upgrades `@fern-api/replay` from `^0.7.0` to `^0.8.0`
- Bumps generator-cli version to `0.8.0`
- Replay 0.8.0 adds support for detecting git revert commits and cancelling matching patches

## Test plan
- [ ] CI passes
- [ ] generator-cli publishes successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)