### PR TITLE
fix(java): create separate `ExponentialBackoff` instance per request

### DIFF
--- a/generators/java/sdk/src/main/resources/RetryInterceptor.java
+++ b/generators/java/sdk/src/main/resources/RetryInterceptor.java
@@ -14,11 +14,11 @@ public class RetryInterceptor implements Interceptor {
     private static final Duration MAX_RETRY_DELAY = Duration.ofMillis(60000);
     private static final double JITTER_FACTOR = 0.2;
 
-    private final ExponentialBackoff backoff;
+    private final int maxRetries;
     private final Random random = new Random();
 
     public RetryInterceptor(int maxRetries) {
-        this.backoff = new ExponentialBackoff(maxRetries);
+        this.maxRetries = maxRetries;
     }
 
     @Override
@@ -33,7 +33,8 @@ public class RetryInterceptor implements Interceptor {
     }
 
     private Response retryChain(Response response, Chain chain) throws IOException {
-        Optional<Duration> nextBackoff = this.backoff.nextBackoff(response);
+        ExponentialBackoff backoff = new ExponentialBackoff(this.maxRetries);
+        Optional<Duration> nextBackoff = backoff.nextBackoff(response);
         while (nextBackoff.isPresent()) {
             try {
                 Thread.sleep(nextBackoff.get().toMillis());
@@ -43,7 +44,7 @@ public class RetryInterceptor implements Interceptor {
             response.close();
             response = chain.proceed(chain.request());
             if (shouldRetry(response.code())) {
-                nextBackoff = this.backoff.nextBackoff(response);
+                nextBackoff = backoff.nextBackoff(response);
             } else {
                 return response;
             }

--- a/generators/java/sdk/versions.yml
+++ b/generators/java/sdk/versions.yml
@@ -1,4 +1,15 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 4.0.9
+  changelogEntry:
+    - summary: |
+        Fix RetryInterceptor sharing a single ExponentialBackoff instance across
+        all requests. Once the retry budget was exhausted by any request, no further
+        retries were attempted for the lifetime of the client. Each request now gets
+        its own backoff instance.
+      type: fix
+  createdAt: "2026-03-30"
+  irVersion: 65
+
 - version: 4.0.8
   changelogEntry:
     - summary: |

--- a/seed/java-sdk/exhaustive/custom-client-class-name/src/main/java/com/seed/exhaustive/core/RetryInterceptor.java
+++ b/seed/java-sdk/exhaustive/custom-client-class-name/src/main/java/com/seed/exhaustive/core/RetryInterceptor.java
@@ -19,11 +19,11 @@ public class RetryInterceptor implements Interceptor {
     private static final Duration MAX_RETRY_DELAY = Duration.ofMillis(60000);
     private static final double JITTER_FACTOR = 0.2;
 
-    private final ExponentialBackoff backoff;
+    private final int maxRetries;
     private final Random random = new Random();
 
     public RetryInterceptor(int maxRetries) {
-        this.backoff = new ExponentialBackoff(maxRetries);
+        this.maxRetries = maxRetries;
     }
 
     @Override
@@ -38,7 +38,8 @@ public class RetryInterceptor implements Interceptor {
     }
 
     private Response retryChain(Response response, Chain chain) throws IOException {
-        Optional<Duration> nextBackoff = this.backoff.nextBackoff(response);
+        ExponentialBackoff backoff = new ExponentialBackoff(this.maxRetries);
+        Optional<Duration> nextBackoff = backoff.nextBackoff(response);
         while (nextBackoff.isPresent()) {
             try {
                 Thread.sleep(nextBackoff.get().toMillis());
@@ -48,7 +49,7 @@ public class RetryInterceptor implements Interceptor {
             response.close();
             response = chain.proceed(chain.request());
             if (shouldRetry(response.code())) {
-                nextBackoff = this.backoff.nextBackoff(response);
+                nextBackoff = backoff.nextBackoff(response);
             } else {
                 return response;
             }

--- a/seed/java-sdk/exhaustive/custom-dependency/src/main/java/com/seed/exhaustive/core/RetryInterceptor.java
+++ b/seed/java-sdk/exhaustive/custom-dependency/src/main/java/com/seed/exhaustive/core/RetryInterceptor.java
@@ -19,11 +19,11 @@ public class RetryInterceptor implements Interceptor {
     private static final Duration MAX_RETRY_DELAY = Duration.ofMillis(60000);
     private static final double JITTER_FACTOR = 0.2;
 
-    private final ExponentialBackoff backoff;
+    private final int maxRetries;
     private final Random random = new Random();
 
     public RetryInterceptor(int maxRetries) {
-        this.backoff = new ExponentialBackoff(maxRetries);
+        this.maxRetries = maxRetries;
     }
 
     @Override
@@ -38,7 +38,8 @@ public class RetryInterceptor implements Interceptor {
     }
 
     private Response retryChain(Response response, Chain chain) throws IOException {
-        Optional<Duration> nextBackoff = this.backoff.nextBackoff(response);
+        ExponentialBackoff backoff = new ExponentialBackoff(this.maxRetries);
+        Optional<Duration> nextBackoff = backoff.nextBackoff(response);
         while (nextBackoff.isPresent()) {
             try {
                 Thread.sleep(nextBackoff.get().toMillis());
@@ -48,7 +49,7 @@ public class RetryInterceptor implements Interceptor {
             response.close();
             response = chain.proceed(chain.request());
             if (shouldRetry(response.code())) {
-                nextBackoff = this.backoff.nextBackoff(response);
+                nextBackoff = backoff.nextBackoff(response);
             } else {
                 return response;
             }

--- a/seed/java-sdk/exhaustive/custom-error-names/src/main/java/com/seed/exhaustive/core/RetryInterceptor.java
+++ b/seed/java-sdk/exhaustive/custom-error-names/src/main/java/com/seed/exhaustive/core/RetryInterceptor.java
@@ -19,11 +19,11 @@ public class RetryInterceptor implements Interceptor {
     private static final Duration MAX_RETRY_DELAY = Duration.ofMillis(60000);
     private static final double JITTER_FACTOR = 0.2;
 
-    private final ExponentialBackoff backoff;
+    private final int maxRetries;
     private final Random random = new Random();
 
     public RetryInterceptor(int maxRetries) {
-        this.backoff = new ExponentialBackoff(maxRetries);
+        this.maxRetries = maxRetries;
     }
 
     @Override
@@ -38,7 +38,8 @@ public class RetryInterceptor implements Interceptor {
     }
 
     private Response retryChain(Response response, Chain chain) throws IOException {
-        Optional<Duration> nextBackoff = this.backoff.nextBackoff(response);
+        ExponentialBackoff backoff = new ExponentialBackoff(this.maxRetries);
+        Optional<Duration> nextBackoff = backoff.nextBackoff(response);
         while (nextBackoff.isPresent()) {
             try {
                 Thread.sleep(nextBackoff.get().toMillis());
@@ -48,7 +49,7 @@ public class RetryInterceptor implements Interceptor {
             response.close();
             response = chain.proceed(chain.request());
             if (shouldRetry(response.code())) {
-                nextBackoff = this.backoff.nextBackoff(response);
+                nextBackoff = backoff.nextBackoff(response);
             } else {
                 return response;
             }

--- a/seed/java-sdk/exhaustive/custom-interceptors/src/main/java/com/seed/exhaustive/core/RetryInterceptor.java
+++ b/seed/java-sdk/exhaustive/custom-interceptors/src/main/java/com/seed/exhaustive/core/RetryInterceptor.java
@@ -19,11 +19,11 @@ public class RetryInterceptor implements Interceptor {
     private static final Duration MAX_RETRY_DELAY = Duration.ofMillis(60000);
     private static final double JITTER_FACTOR = 0.2;
 
-    private final ExponentialBackoff backoff;
+    private final int maxRetries;
     private final Random random = new Random();
 
     public RetryInterceptor(int maxRetries) {
-        this.backoff = new ExponentialBackoff(maxRetries);
+        this.maxRetries = maxRetries;
     }
 
     @Override
@@ -38,7 +38,8 @@ public class RetryInterceptor implements Interceptor {
     }
 
     private Response retryChain(Response response, Chain chain) throws IOException {
-        Optional<Duration> nextBackoff = this.backoff.nextBackoff(response);
+        ExponentialBackoff backoff = new ExponentialBackoff(this.maxRetries);
+        Optional<Duration> nextBackoff = backoff.nextBackoff(response);
         while (nextBackoff.isPresent()) {
             try {
                 Thread.sleep(nextBackoff.get().toMillis());
@@ -48,7 +49,7 @@ public class RetryInterceptor implements Interceptor {
             response.close();
             response = chain.proceed(chain.request());
             if (shouldRetry(response.code())) {
-                nextBackoff = this.backoff.nextBackoff(response);
+                nextBackoff = backoff.nextBackoff(response);
             } else {
                 return response;
             }

--- a/seed/java-sdk/exhaustive/custom-license/src/main/java/com/seed/exhaustive/core/RetryInterceptor.java
+++ b/seed/java-sdk/exhaustive/custom-license/src/main/java/com/seed/exhaustive/core/RetryInterceptor.java
@@ -19,11 +19,11 @@ public class RetryInterceptor implements Interceptor {
     private static final Duration MAX_RETRY_DELAY = Duration.ofMillis(60000);
     private static final double JITTER_FACTOR = 0.2;
 
-    private final ExponentialBackoff backoff;
+    private final int maxRetries;
     private final Random random = new Random();
 
     public RetryInterceptor(int maxRetries) {
-        this.backoff = new ExponentialBackoff(maxRetries);
+        this.maxRetries = maxRetries;
     }
 
     @Override
@@ -38,7 +38,8 @@ public class RetryInterceptor implements Interceptor {
     }
 
     private Response retryChain(Response response, Chain chain) throws IOException {
-        Optional<Duration> nextBackoff = this.backoff.nextBackoff(response);
+        ExponentialBackoff backoff = new ExponentialBackoff(this.maxRetries);
+        Optional<Duration> nextBackoff = backoff.nextBackoff(response);
         while (nextBackoff.isPresent()) {
             try {
                 Thread.sleep(nextBackoff.get().toMillis());
@@ -48,7 +49,7 @@ public class RetryInterceptor implements Interceptor {
             response.close();
             response = chain.proceed(chain.request());
             if (shouldRetry(response.code())) {
-                nextBackoff = this.backoff.nextBackoff(response);
+                nextBackoff = backoff.nextBackoff(response);
             } else {
                 return response;
             }

--- a/seed/java-sdk/exhaustive/custom-plugins/src/main/java/com/seed/exhaustive/core/RetryInterceptor.java
+++ b/seed/java-sdk/exhaustive/custom-plugins/src/main/java/com/seed/exhaustive/core/RetryInterceptor.java
@@ -19,11 +19,11 @@ public class RetryInterceptor implements Interceptor {
     private static final Duration MAX_RETRY_DELAY = Duration.ofMillis(60000);
     private static final double JITTER_FACTOR = 0.2;
 
-    private final ExponentialBackoff backoff;
+    private final int maxRetries;
     private final Random random = new Random();
 
     public RetryInterceptor(int maxRetries) {
-        this.backoff = new ExponentialBackoff(maxRetries);
+        this.maxRetries = maxRetries;
     }
 
     @Override
@@ -38,7 +38,8 @@ public class RetryInterceptor implements Interceptor {
     }
 
     private Response retryChain(Response response, Chain chain) throws IOException {
-        Optional<Duration> nextBackoff = this.backoff.nextBackoff(response);
+        ExponentialBackoff backoff = new ExponentialBackoff(this.maxRetries);
+        Optional<Duration> nextBackoff = backoff.nextBackoff(response);
         while (nextBackoff.isPresent()) {
             try {
                 Thread.sleep(nextBackoff.get().toMillis());
@@ -48,7 +49,7 @@ public class RetryInterceptor implements Interceptor {
             response.close();
             response = chain.proceed(chain.request());
             if (shouldRetry(response.code())) {
-                nextBackoff = this.backoff.nextBackoff(response);
+                nextBackoff = backoff.nextBackoff(response);
             } else {
                 return response;
             }

--- a/seed/java-sdk/exhaustive/enable-public-constructors/src/main/java/com/seed/exhaustive/core/RetryInterceptor.java
+++ b/seed/java-sdk/exhaustive/enable-public-constructors/src/main/java/com/seed/exhaustive/core/RetryInterceptor.java
@@ -19,11 +19,11 @@ public class RetryInterceptor implements Interceptor {
     private static final Duration MAX_RETRY_DELAY = Duration.ofMillis(60000);
     private static final double JITTER_FACTOR = 0.2;
 
-    private final ExponentialBackoff backoff;
+    private final int maxRetries;
     private final Random random = new Random();
 
     public RetryInterceptor(int maxRetries) {
-        this.backoff = new ExponentialBackoff(maxRetries);
+        this.maxRetries = maxRetries;
     }
 
     @Override
@@ -38,7 +38,8 @@ public class RetryInterceptor implements Interceptor {
     }
 
     private Response retryChain(Response response, Chain chain) throws IOException {
-        Optional<Duration> nextBackoff = this.backoff.nextBackoff(response);
+        ExponentialBackoff backoff = new ExponentialBackoff(this.maxRetries);
+        Optional<Duration> nextBackoff = backoff.nextBackoff(response);
         while (nextBackoff.isPresent()) {
             try {
                 Thread.sleep(nextBackoff.get().toMillis());
@@ -48,7 +49,7 @@ public class RetryInterceptor implements Interceptor {
             response.close();
             response = chain.proceed(chain.request());
             if (shouldRetry(response.code())) {
-                nextBackoff = this.backoff.nextBackoff(response);
+                nextBackoff = backoff.nextBackoff(response);
             } else {
                 return response;
             }

--- a/seed/java-sdk/exhaustive/flat-package-layout/src/main/java/com/seed/exhaustive/core/RetryInterceptor.java
+++ b/seed/java-sdk/exhaustive/flat-package-layout/src/main/java/com/seed/exhaustive/core/RetryInterceptor.java
@@ -19,11 +19,11 @@ public class RetryInterceptor implements Interceptor {
     private static final Duration MAX_RETRY_DELAY = Duration.ofMillis(60000);
     private static final double JITTER_FACTOR = 0.2;
 
-    private final ExponentialBackoff backoff;
+    private final int maxRetries;
     private final Random random = new Random();
 
     public RetryInterceptor(int maxRetries) {
-        this.backoff = new ExponentialBackoff(maxRetries);
+        this.maxRetries = maxRetries;
     }
 
     @Override
@@ -38,7 +38,8 @@ public class RetryInterceptor implements Interceptor {
     }
 
     private Response retryChain(Response response, Chain chain) throws IOException {
-        Optional<Duration> nextBackoff = this.backoff.nextBackoff(response);
+        ExponentialBackoff backoff = new ExponentialBackoff(this.maxRetries);
+        Optional<Duration> nextBackoff = backoff.nextBackoff(response);
         while (nextBackoff.isPresent()) {
             try {
                 Thread.sleep(nextBackoff.get().toMillis());
@@ -48,7 +49,7 @@ public class RetryInterceptor implements Interceptor {
             response.close();
             response = chain.proceed(chain.request());
             if (shouldRetry(response.code())) {
-                nextBackoff = this.backoff.nextBackoff(response);
+                nextBackoff = backoff.nextBackoff(response);
             } else {
                 return response;
             }

--- a/seed/java-sdk/exhaustive/forward-compatible-enums/src/main/java/com/seed/exhaustive/core/RetryInterceptor.java
+++ b/seed/java-sdk/exhaustive/forward-compatible-enums/src/main/java/com/seed/exhaustive/core/RetryInterceptor.java
@@ -19,11 +19,11 @@ public class RetryInterceptor implements Interceptor {
     private static final Duration MAX_RETRY_DELAY = Duration.ofMillis(60000);
     private static final double JITTER_FACTOR = 0.2;
 
-    private final ExponentialBackoff backoff;
+    private final int maxRetries;
     private final Random random = new Random();
 
     public RetryInterceptor(int maxRetries) {
-        this.backoff = new ExponentialBackoff(maxRetries);
+        this.maxRetries = maxRetries;
     }
 
     @Override
@@ -38,7 +38,8 @@ public class RetryInterceptor implements Interceptor {
     }
 
     private Response retryChain(Response response, Chain chain) throws IOException {
-        Optional<Duration> nextBackoff = this.backoff.nextBackoff(response);
+        ExponentialBackoff backoff = new ExponentialBackoff(this.maxRetries);
+        Optional<Duration> nextBackoff = backoff.nextBackoff(response);
         while (nextBackoff.isPresent()) {
             try {
                 Thread.sleep(nextBackoff.get().toMillis());
@@ -48,7 +49,7 @@ public class RetryInterceptor implements Interceptor {
             response.close();
             response = chain.proceed(chain.request());
             if (shouldRetry(response.code())) {
-                nextBackoff = this.backoff.nextBackoff(response);
+                nextBackoff = backoff.nextBackoff(response);
             } else {
                 return response;
             }

--- a/seed/java-sdk/exhaustive/json-include-non-empty/src/main/java/com/seed/exhaustive/core/RetryInterceptor.java
+++ b/seed/java-sdk/exhaustive/json-include-non-empty/src/main/java/com/seed/exhaustive/core/RetryInterceptor.java
@@ -19,11 +19,11 @@ public class RetryInterceptor implements Interceptor {
     private static final Duration MAX_RETRY_DELAY = Duration.ofMillis(60000);
     private static final double JITTER_FACTOR = 0.2;
 
-    private final ExponentialBackoff backoff;
+    private final int maxRetries;
     private final Random random = new Random();
 
     public RetryInterceptor(int maxRetries) {
-        this.backoff = new ExponentialBackoff(maxRetries);
+        this.maxRetries = maxRetries;
     }
 
     @Override
@@ -38,7 +38,8 @@ public class RetryInterceptor implements Interceptor {
     }
 
     private Response retryChain(Response response, Chain chain) throws IOException {
-        Optional<Duration> nextBackoff = this.backoff.nextBackoff(response);
+        ExponentialBackoff backoff = new ExponentialBackoff(this.maxRetries);
+        Optional<Duration> nextBackoff = backoff.nextBackoff(response);
         while (nextBackoff.isPresent()) {
             try {
                 Thread.sleep(nextBackoff.get().toMillis());
@@ -48,7 +49,7 @@ public class RetryInterceptor implements Interceptor {
             response.close();
             response = chain.proceed(chain.request());
             if (shouldRetry(response.code())) {
-                nextBackoff = this.backoff.nextBackoff(response);
+                nextBackoff = backoff.nextBackoff(response);
             } else {
                 return response;
             }

--- a/seed/java-sdk/exhaustive/local-files/src/main/java/core/RetryInterceptor.java
+++ b/seed/java-sdk/exhaustive/local-files/src/main/java/core/RetryInterceptor.java
@@ -20,11 +20,11 @@ public class RetryInterceptor implements Interceptor {
     private static final Duration MAX_RETRY_DELAY = Duration.ofMillis(60000);
     private static final double JITTER_FACTOR = 0.2;
 
-    private final ExponentialBackoff backoff;
+    private final int maxRetries;
     private final Random random = new Random();
 
     public RetryInterceptor(int maxRetries) {
-        this.backoff = new ExponentialBackoff(maxRetries);
+        this.maxRetries = maxRetries;
     }
 
     @Override
@@ -39,7 +39,8 @@ public class RetryInterceptor implements Interceptor {
     }
 
     private Response retryChain(Response response, Chain chain) throws IOException {
-        Optional<Duration> nextBackoff = this.backoff.nextBackoff(response);
+        ExponentialBackoff backoff = new ExponentialBackoff(this.maxRetries);
+        Optional<Duration> nextBackoff = backoff.nextBackoff(response);
         while (nextBackoff.isPresent()) {
             try {
                 Thread.sleep(nextBackoff.get().toMillis());
@@ -49,7 +50,7 @@ public class RetryInterceptor implements Interceptor {
             response.close();
             response = chain.proceed(chain.request());
             if (shouldRetry(response.code())) {
-                nextBackoff = this.backoff.nextBackoff(response);
+                nextBackoff = backoff.nextBackoff(response);
             } else {
                 return response;
             }

--- a/seed/java-sdk/exhaustive/no-custom-config/src/main/java/com/seed/exhaustive/core/RetryInterceptor.java
+++ b/seed/java-sdk/exhaustive/no-custom-config/src/main/java/com/seed/exhaustive/core/RetryInterceptor.java
@@ -19,11 +19,11 @@ public class RetryInterceptor implements Interceptor {
     private static final Duration MAX_RETRY_DELAY = Duration.ofMillis(60000);
     private static final double JITTER_FACTOR = 0.2;
 
-    private final ExponentialBackoff backoff;
+    private final int maxRetries;
     private final Random random = new Random();
 
     public RetryInterceptor(int maxRetries) {
-        this.backoff = new ExponentialBackoff(maxRetries);
+        this.maxRetries = maxRetries;
     }
 
     @Override
@@ -38,7 +38,8 @@ public class RetryInterceptor implements Interceptor {
     }
 
     private Response retryChain(Response response, Chain chain) throws IOException {
-        Optional<Duration> nextBackoff = this.backoff.nextBackoff(response);
+        ExponentialBackoff backoff = new ExponentialBackoff(this.maxRetries);
+        Optional<Duration> nextBackoff = backoff.nextBackoff(response);
         while (nextBackoff.isPresent()) {
             try {
                 Thread.sleep(nextBackoff.get().toMillis());
@@ -48,7 +49,7 @@ public class RetryInterceptor implements Interceptor {
             response.close();
             response = chain.proceed(chain.request());
             if (shouldRetry(response.code())) {
-                nextBackoff = this.backoff.nextBackoff(response);
+                nextBackoff = backoff.nextBackoff(response);
             } else {
                 return response;
             }

--- a/seed/java-sdk/exhaustive/publish-to/src/main/java/com/seed/exhaustive/core/RetryInterceptor.java
+++ b/seed/java-sdk/exhaustive/publish-to/src/main/java/com/seed/exhaustive/core/RetryInterceptor.java
@@ -19,11 +19,11 @@ public class RetryInterceptor implements Interceptor {
     private static final Duration MAX_RETRY_DELAY = Duration.ofMillis(60000);
     private static final double JITTER_FACTOR = 0.2;
 
-    private final ExponentialBackoff backoff;
+    private final int maxRetries;
     private final Random random = new Random();
 
     public RetryInterceptor(int maxRetries) {
-        this.backoff = new ExponentialBackoff(maxRetries);
+        this.maxRetries = maxRetries;
     }
 
     @Override
@@ -38,7 +38,8 @@ public class RetryInterceptor implements Interceptor {
     }
 
     private Response retryChain(Response response, Chain chain) throws IOException {
-        Optional<Duration> nextBackoff = this.backoff.nextBackoff(response);
+        ExponentialBackoff backoff = new ExponentialBackoff(this.maxRetries);
+        Optional<Duration> nextBackoff = backoff.nextBackoff(response);
         while (nextBackoff.isPresent()) {
             try {
                 Thread.sleep(nextBackoff.get().toMillis());
@@ -48,7 +49,7 @@ public class RetryInterceptor implements Interceptor {
             response.close();
             response = chain.proceed(chain.request());
             if (shouldRetry(response.code())) {
-                nextBackoff = this.backoff.nextBackoff(response);
+                nextBackoff = backoff.nextBackoff(response);
             } else {
                 return response;
             }

--- a/seed/java-sdk/exhaustive/signed_publish/src/main/java/com/seed/exhaustive/core/RetryInterceptor.java
+++ b/seed/java-sdk/exhaustive/signed_publish/src/main/java/com/seed/exhaustive/core/RetryInterceptor.java
@@ -19,11 +19,11 @@ public class RetryInterceptor implements Interceptor {
     private static final Duration MAX_RETRY_DELAY = Duration.ofMillis(60000);
     private static final double JITTER_FACTOR = 0.2;
 
-    private final ExponentialBackoff backoff;
+    private final int maxRetries;
     private final Random random = new Random();
 
     public RetryInterceptor(int maxRetries) {
-        this.backoff = new ExponentialBackoff(maxRetries);
+        this.maxRetries = maxRetries;
     }
 
     @Override
@@ -38,7 +38,8 @@ public class RetryInterceptor implements Interceptor {
     }
 
     private Response retryChain(Response response, Chain chain) throws IOException {
-        Optional<Duration> nextBackoff = this.backoff.nextBackoff(response);
+        ExponentialBackoff backoff = new ExponentialBackoff(this.maxRetries);
+        Optional<Duration> nextBackoff = backoff.nextBackoff(response);
         while (nextBackoff.isPresent()) {
             try {
                 Thread.sleep(nextBackoff.get().toMillis());
@@ -48,7 +49,7 @@ public class RetryInterceptor implements Interceptor {
             response.close();
             response = chain.proceed(chain.request());
             if (shouldRetry(response.code())) {
-                nextBackoff = this.backoff.nextBackoff(response);
+                nextBackoff = backoff.nextBackoff(response);
             } else {
                 return response;
             }


### PR DESCRIPTION
## Description
Exactly as the title says; before, requests shared a single `ExponentialBackoff` instance, so `retryNumber` never went down until the process died.

## Testing
`exhaustive` fixtures; Auth0 MyOrg SDK.
- [X] Unit tests added/updated
- [X] Manual testing completed
