### PR TITLE
chore(typescript): update @biomejs/biome from 2.4.9 to 2.4.10

### DIFF
--- a/generators/typescript/asIs/biome.json
+++ b/generators/typescript/asIs/biome.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "https://biomejs.dev/schemas/2.4.9/schema.json",
+    "$schema": "https://biomejs.dev/schemas/2.4.10/schema.json",
     "root": true,
     "vcs": {
         "enabled": false

--- a/generators/typescript/express/cli/Dockerfile
+++ b/generators/typescript/express/cli/Dockerfile
@@ -14,7 +14,7 @@ RUN npm install -g pnpm@10.33.0 --force && \
 RUN pnpm add -g \
   prettier@3.8.1 \
   oxfmt@0.42.0 \
-  @biomejs/biome@2.4.9 \
+  @biomejs/biome@2.4.10 \
   oxlint@1.57.0 \
   oxlint-tsgolint@0.17.4
 
@@ -30,7 +30,7 @@ RUN echo '{ \
     "axios": "0.27.2", \
     "esbuild": "0.16.15", \
     "express": "4.18.2", \
-    "@biomejs/biome": "2.4.9", \
+    "@biomejs/biome": "2.4.10", \
     "prettier": "3.8.1", \
     "oxfmt": "0.42.0", \
     "oxlint": "1.57.0", \

--- a/generators/typescript/express/versions.yml
+++ b/generators/typescript/express/versions.yml
@@ -1,4 +1,12 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 0.19.13
+  changelogEntry:
+    - summary: |
+        Update @biomejs/biome from 2.4.9 to 2.4.10.
+      type: chore
+  irVersion: 65
+  createdAt: "2026-03-30"
+
 - version: 0.19.12
   changelogEntry:
     - summary: |

--- a/generators/typescript/sdk/cli/Dockerfile
+++ b/generators/typescript/sdk/cli/Dockerfile
@@ -14,7 +14,7 @@ RUN npm install -g yarn@1.22.22 --force
 RUN pnpm add -g typescript@~5.9.3 \
   prettier@3.8.1 \
   oxfmt@0.42.0 \
-  @biomejs/biome@2.4.9 \
+  @biomejs/biome@2.4.10 \
   oxlint@1.57.0 \
   oxlint-tsgolint@0.17.4 \
   @types/node@^18.19.70 \

--- a/generators/typescript/sdk/versions.yml
+++ b/generators/typescript/sdk/versions.yml
@@ -1,4 +1,12 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 3.60.3
+  changelogEntry:
+    - summary: |
+        Update @biomejs/biome from 2.4.9 to 2.4.10.
+      type: chore
+  createdAt: "2026-03-30"
+  irVersion: 65
+
 - version: 3.60.2
   changelogEntry:
     - summary: |

--- a/generators/typescript/utils/commons/src/typescript-project/TypescriptProject.ts
+++ b/generators/typescript/utils/commons/src/typescript-project/TypescriptProject.ts
@@ -49,7 +49,7 @@ type COMMON_SCRIPTS = (typeof COMMON_SCRIPTS)[keyof typeof COMMON_SCRIPTS];
 
 /** Shared version constants for formatter / linter packages. */
 const TOOL_VERSIONS = {
-    BIOME: "2.4.9",
+    BIOME: "2.4.10",
     PRETTIER: "3.8.1",
     OXFMT: "0.42.0",
     OXLINT: "1.57.0",


### PR DESCRIPTION
## Description

Bumps `@biomejs/biome` from **2.4.9** to **2.4.10** in the TypeScript SDK and Express generators. The [2.4.10 release](https://github.com/biomejs/biome/releases/tag/%40biomejs%2Fbiome%402.4.10) is a patch with performance improvements (notably lazy LSP code actions for large files) and bug fixes. No breaking changes; all new rules are nursery (off by default).

## Changes Made

- Updated `TOOL_VERSIONS.BIOME` constant in `TypescriptProject.ts`
- Updated `biome.json` schema URL to `2.4.10`
- Updated `@biomejs/biome` in both SDK and Express Dockerfiles
- Added `versions.yml` entries: SDK **3.60.3**, Express **0.19.13**

## Testing

- No behavioral changes to generated code — this is a tool version bump only
- [ ] CI seed tests pass (confirms no formatting/linting output changes)

## Human Review Checklist

- [ ] Verify all 5 locations referencing the biome version are updated consistently (TypescriptProject.ts, biome.json, SDK Dockerfile, Express Dockerfile ×2)
- [ ] Confirm `versions.yml` version numbers (3.60.3, 0.19.13) don't conflict with any in-flight PRs

Link to Devin session: https://app.devin.ai/sessions/8fe0405e80c74c788b8848051e6a1d1d
Requested by: @Swimburger