### PR TITLE
fix(csharp,php,ruby): support multiple basic auth schemes with AuthSchemesRequirement.Any

### DIFF
--- a/generators/csharp/sdk/src/root-client/RootClientGenerator.ts
+++ b/generators/csharp/sdk/src/root-client/RootClientGenerator.ts
@@ -449,8 +449,12 @@ export class RootClientGenerator extends FileGenerator<CSharpFile, SdkGeneratorC
 
                     // Add Basic Auth header if applicable
                     if (hasBasicAuth) {
-                        const basicScheme = this.context.ir.auth.schemes.find((s) => s.type === "basic");
-                        if (basicScheme != null && basicScheme.type === "basic") {
+                        const basicSchemes = this.context.ir.auth.schemes.filter(
+                            (s): s is typeof s & { type: "basic" } => s.type === "basic"
+                        );
+                        const isAuthOptional = !this.context.ir.sdkConfig.isAuthMandatory;
+                        for (let i = 0; i < basicSchemes.length; i++) {
+                            const basicScheme = basicSchemes[i];
                             const usernameName = basicScheme.username.camelCase.safeName;
                             const passwordName = basicScheme.password.camelCase.safeName;
                             const usernameAccess = unified
@@ -459,17 +463,17 @@ export class RootClientGenerator extends FileGenerator<CSharpFile, SdkGeneratorC
                             const passwordAccess = unified
                                 ? `clientOptions.${this.toPascalCase(passwordName)}`
                                 : passwordName;
-                            const isAuthOptional = !this.context.ir.sdkConfig.isAuthMandatory;
-                            if (isAuthOptional) {
+                            if (isAuthOptional || basicSchemes.length > 1) {
+                                const controlFlowKeyword = i === 0 ? "if" : "else if";
                                 innerWriter.controlFlow(
-                                    "if",
+                                    controlFlowKeyword,
                                     this.csharp.codeblock(`${usernameAccess} != null && ${passwordAccess} != null`)
                                 );
                             }
                             innerWriter.writeTextStatement(
                                 `clientOptionsWithAuth.Headers["Authorization"] = $"Basic {Convert.ToBase64String(global::System.Text.Encoding.UTF8.GetBytes($"{${usernameAccess}}:{${passwordAccess}}"))}"`
                             );
-                            if (isAuthOptional) {
+                            if (isAuthOptional || basicSchemes.length > 1) {
                                 innerWriter.endControlFlow();
                             }
                         }

--- a/generators/csharp/sdk/src/root-client/RootClientGenerator.ts
+++ b/generators/csharp/sdk/src/root-client/RootClientGenerator.ts
@@ -455,6 +455,9 @@ export class RootClientGenerator extends FileGenerator<CSharpFile, SdkGeneratorC
                         const isAuthOptional = !this.context.ir.sdkConfig.isAuthMandatory;
                         for (let i = 0; i < basicSchemes.length; i++) {
                             const basicScheme = basicSchemes[i];
+                            if (basicScheme == null) {
+                                continue;
+                            }
                             const usernameName = basicScheme.username.camelCase.safeName;
                             const passwordName = basicScheme.password.camelCase.safeName;
                             const usernameAccess = unified

--- a/generators/csharp/sdk/versions.yml
+++ b/generators/csharp/sdk/versions.yml
@@ -1,4 +1,17 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 2.55.2
+  changelogEntry:
+    - summary: |
+        Support multiple Basic Auth schemes with `AuthSchemesRequirement.Any`.
+        When an API defines more than one basic auth scheme (e.g.,
+        accountId/authToken and apiKey/apiKeySecret), the generated client now
+        produces conditional if/else if blocks that check which credential pair
+        was provided and sets the Authorization header accordingly. Previously,
+        only the first basic auth scheme was used.
+      type: fix
+  createdAt: "2026-03-30"
+  irVersion: 65
+
 - version: 2.55.1
   changelogEntry:
     - summary: |

--- a/generators/php/sdk/src/root-client/RootClientGenerator.ts
+++ b/generators/php/sdk/src/root-client/RootClientGenerator.ts
@@ -344,22 +344,28 @@ export class RootClientGenerator extends FileGenerator<PhpFile, SdkCustomConfigS
                 }
 
                 // Add Basic Auth header if applicable
-                const basicAuthScheme = this.context.ir.auth.schemes.find((s) => s.type === "basic");
-                if (basicAuthScheme != null && basicAuthScheme.type === "basic") {
-                    const usernameName = this.context.getParameterName(basicAuthScheme.username);
-                    const passwordName = this.context.getParameterName(basicAuthScheme.password);
+                const basicAuthSchemes = this.context.ir.auth.schemes.filter(
+                    (s): s is typeof s & { type: "basic" } => s.type === "basic"
+                );
+                if (basicAuthSchemes.length > 0) {
                     const isAuthOptional = !this.context.ir.sdkConfig.isAuthMandatory;
-                    if (isAuthOptional) {
-                        writer.controlFlow(
-                            "if",
-                            php.codeblock(`$${usernameName} !== null && $${passwordName} !== null`)
+                    for (let i = 0; i < basicAuthSchemes.length; i++) {
+                        const basicAuthScheme = basicAuthSchemes[i];
+                        const usernameName = this.context.getParameterName(basicAuthScheme.username);
+                        const passwordName = this.context.getParameterName(basicAuthScheme.password);
+                        if (isAuthOptional || basicAuthSchemes.length > 1) {
+                            const controlFlowKeyword = i === 0 ? "if" : "else if";
+                            writer.controlFlow(
+                                controlFlowKeyword,
+                                php.codeblock(`$${usernameName} !== null && $${passwordName} !== null`)
+                            );
+                        }
+                        writer.writeLine(
+                            `$defaultHeaders['Authorization'] = "Basic " . base64_encode($${usernameName} . ":" . $${passwordName});`
                         );
-                    }
-                    writer.writeLine(
-                        `$defaultHeaders['Authorization'] = "Basic " . base64_encode($${usernameName} . ":" . $${passwordName});`
-                    );
-                    if (isAuthOptional) {
-                        writer.endControlFlow();
+                        if (isAuthOptional || basicAuthSchemes.length > 1) {
+                            writer.endControlFlow();
+                        }
                     }
                 }
 

--- a/generators/php/sdk/src/root-client/RootClientGenerator.ts
+++ b/generators/php/sdk/src/root-client/RootClientGenerator.ts
@@ -351,6 +351,9 @@ export class RootClientGenerator extends FileGenerator<PhpFile, SdkCustomConfigS
                     const isAuthOptional = !this.context.ir.sdkConfig.isAuthMandatory;
                     for (let i = 0; i < basicAuthSchemes.length; i++) {
                         const basicAuthScheme = basicAuthSchemes[i];
+                        if (basicAuthScheme == null) {
+                            continue;
+                        }
                         const usernameName = this.context.getParameterName(basicAuthScheme.username);
                         const passwordName = this.context.getParameterName(basicAuthScheme.password);
                         if (isAuthOptional || basicAuthSchemes.length > 1) {

--- a/generators/php/sdk/versions.yml
+++ b/generators/php/sdk/versions.yml
@@ -1,4 +1,17 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 2.2.6
+  changelogEntry:
+    - summary: |
+        Support multiple Basic Auth schemes with `AuthSchemesRequirement.Any`.
+        When an API defines more than one basic auth scheme (e.g.,
+        accountId/authToken and apiKey/apiKeySecret), the generated client now
+        produces conditional if/else if blocks that check which credential pair
+        was provided and sets the Authorization header accordingly. Previously,
+        only the first basic auth scheme was used.
+      type: fix
+  createdAt: "2026-03-30"
+  irVersion: 62
+
 - version: 2.2.5
   changelogEntry:
     - summary: |

--- a/generators/ruby-v2/sdk/src/root-client/RootClientGenerator.ts
+++ b/generators/ruby-v2/sdk/src/root-client/RootClientGenerator.ts
@@ -102,8 +102,10 @@ export class RootClientGenerator extends FileGenerator<RubyFile, SdkCustomConfig
         const defaultEnvironmentReference = this.context.getDefaultEnvironmentClassReference();
 
         // Check if basic auth is configured so we can conditionally add the Authorization header
-        const basicAuthScheme = this.context.ir.auth.schemes.find((s) => s.type === "basic");
-        const hasBasicAuth = basicAuthScheme != null && basicAuthScheme.type === "basic";
+        const basicAuthSchemes = this.context.ir.auth.schemes.filter(
+            (s): s is typeof s & { type: "basic" } => s.type === "basic"
+        );
+        const hasBasicAuth = basicAuthSchemes.length > 0;
         const isAuthOptional = !this.context.ir.sdkConfig.isAuthMandatory;
 
         method.addStatement(
@@ -113,16 +115,27 @@ export class RootClientGenerator extends FileGenerator<RubyFile, SdkCustomConfig
                     writer.write(`headers = `);
                     writer.writeNode(this.getRawClientHeaders());
                     writer.newLine();
-                    const usernameName = basicAuthScheme.username.snakeCase.safeName;
-                    const passwordName = basicAuthScheme.password.snakeCase.safeName;
-                    if (isAuthOptional) {
-                        writer.writeLine(
-                            `headers["Authorization"] = "Basic #{Base64.strict_encode64("#{${usernameName}}:#{${passwordName}}")}" if !${usernameName}.nil? && !${passwordName}.nil?`
-                        );
-                    } else {
-                        writer.writeLine(
-                            `headers["Authorization"] = "Basic #{Base64.strict_encode64("#{${usernameName}}:#{${passwordName}}")}"`
-                        );
+                    for (let i = 0; i < basicAuthSchemes.length; i++) {
+                        const basicAuthScheme = basicAuthSchemes[i];
+                        const usernameName = basicAuthScheme.username.snakeCase.safeName;
+                        const passwordName = basicAuthScheme.password.snakeCase.safeName;
+                        if (isAuthOptional || basicAuthSchemes.length > 1) {
+                            if (i === 0) {
+                                writer.writeLine(`if !${usernameName}.nil? && !${passwordName}.nil?`);
+                            } else {
+                                writer.writeLine(`elsif !${usernameName}.nil? && !${passwordName}.nil?`);
+                            }
+                            writer.writeLine(
+                                `  headers["Authorization"] = "Basic #{Base64.strict_encode64("#{${usernameName}}:#{${passwordName}}")}"`
+                            );
+                            if (i === basicAuthSchemes.length - 1) {
+                                writer.writeLine(`end`);
+                            }
+                        } else {
+                            writer.writeLine(
+                                `headers["Authorization"] = "Basic #{Base64.strict_encode64("#{${usernameName}}:#{${passwordName}}")}"`
+                            );
+                        }
                     }
                 }
                 writer.write(`@raw_client = `);

--- a/generators/ruby-v2/sdk/src/root-client/RootClientGenerator.ts
+++ b/generators/ruby-v2/sdk/src/root-client/RootClientGenerator.ts
@@ -117,6 +117,9 @@ export class RootClientGenerator extends FileGenerator<RubyFile, SdkCustomConfig
                     writer.newLine();
                     for (let i = 0; i < basicAuthSchemes.length; i++) {
                         const basicAuthScheme = basicAuthSchemes[i];
+                        if (basicAuthScheme == null) {
+                            continue;
+                        }
                         const usernameName = basicAuthScheme.username.snakeCase.safeName;
                         const passwordName = basicAuthScheme.password.snakeCase.safeName;
                         if (isAuthOptional || basicAuthSchemes.length > 1) {

--- a/generators/ruby-v2/sdk/versions.yml
+++ b/generators/ruby-v2/sdk/versions.yml
@@ -1,5 +1,18 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 
+- version: 1.1.8
+  changelogEntry:
+    - summary: |
+        Support multiple Basic Auth schemes with `AuthSchemesRequirement.Any`.
+        When an API defines more than one basic auth scheme (e.g.,
+        accountId/authToken and apiKey/apiKeySecret), the generated client now
+        produces conditional if/elsif blocks that check which credential pair
+        was provided and sets the Authorization header accordingly. Previously,
+        only the first basic auth scheme was used.
+      type: fix
+  createdAt: "2026-03-30"
+  irVersion: 61
+
 - version: 1.1.7
   changelogEntry:
     - summary: |


### PR DESCRIPTION
## Description

Refs: Twilio multi-auth scheme support

When an API defines multiple basic auth schemes with `AuthSchemesRequirement.Any` (e.g., `accountId/authToken` **and** `apiKey/apiKeySecret`), the generated SDK client should check which credential pair was provided and set the `Authorization` header accordingly. Previously, all three generators used `.find()` which silently picked only the **first** basic auth scheme, ignoring any additional ones.

## Changes Made

- **C# generator** (`RootClientGenerator.ts`): Replace `.find()` with `.filter()` + loop; generate `if`/`else if` blocks per scheme
- **PHP generator** (`RootClientGenerator.ts`): Same pattern — `.filter()` + loop with `if`/`else if` control flow
- **Ruby generator** (`RootClientGenerator.ts`): Same pattern using Ruby's `if`/`elsif`/`end` syntax via raw `writeLine()` calls
- Added null guards on array-indexed `basicAuthScheme` to satisfy strict TypeScript checks
- Updated `versions.yml` for all three generators (C# 2.55.2, PHP 2.2.6, Ruby 1.1.8)
- [ ] Updated README.md generator (if applicable) — N/A

### Generated output (C# example)
```csharp
// Before (only first scheme):
if (accountId != null && authToken != null)
    Headers["Authorization"] = "Basic ...accountId:authToken...";

// After (all schemes):
if (apiKey != null && apiKeySecret != null)
    Headers["Authorization"] = "Basic ...apiKey:apiKeySecret...";
else if (accountId != null && authToken != null)
    Headers["Authorization"] = "Basic ...accountId:authToken...";
```

## ⚠️ Human Review Checklist

1. **`controlFlow("else if", ...)`** — Verify the C# and PHP AST writers accept `"else if"` as a control flow keyword. Existing seed tests pass, but **no multi-basic-auth fixture exercises this path**, so a broken `controlFlow` call would only surface at generation time for customers with multiple basic schemes.
2. **Ruby manual indentation** — The Ruby path manually writes `  headers["Authorization"]` with a hardcoded 2-space indent inside the `if`/`elsif` block (instead of using the writer's indent helpers). Confirm the generated Ruby is properly indented.
3. **No seed test fixture** — There are no snapshot updates validating the generated output for a multi-basic-auth IR. Consider whether a seed fixture should be added to prevent regressions.
4. **Single-scheme backward compatibility** — When only one basic scheme exists and auth is mandatory, the `isAuthOptional || basicSchemes.length > 1` guard evaluates to `false`, so no conditional is generated (matches previous behavior).

## Testing

- [x] Lint/format passes (`pnpm run check`)
- [x] TypeScript compilation passes (all compile errors in CI were pre-existing, unrelated to changed files)
- [x] All CI checks pass (35/35)
- [ ] Seed tests for multi-basic-auth fixture (not yet added)
- [ ] Manual testing completed

Link to Devin session: https://app.devin.ai/sessions/a20d6f8e007f48b4b5e79812b7b713c4
Requested by: @iamnamananand996
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/14296" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
