### PR TITLE
fix(csharp,php,ruby): use contiguousControlFlow for else-if chains and proper Ruby indentation

### DIFF
--- a/generators/csharp/sdk/src/root-client/RootClientGenerator.ts
+++ b/generators/csharp/sdk/src/root-client/RootClientGenerator.ts
@@ -467,16 +467,22 @@ export class RootClientGenerator extends FileGenerator<CSharpFile, SdkGeneratorC
                                 ? `clientOptions.${this.toPascalCase(passwordName)}`
                                 : passwordName;
                             if (isAuthOptional || basicSchemes.length > 1) {
-                                const controlFlowKeyword = i === 0 ? "if" : "else if";
-                                innerWriter.controlFlow(
-                                    controlFlowKeyword,
-                                    this.csharp.codeblock(`${usernameAccess} != null && ${passwordAccess} != null`)
-                                );
+                                if (i === 0) {
+                                    innerWriter.controlFlow(
+                                        "if",
+                                        this.csharp.codeblock(`${usernameAccess} != null && ${passwordAccess} != null`)
+                                    );
+                                } else {
+                                    innerWriter.contiguousControlFlow(
+                                        "else if",
+                                        this.csharp.codeblock(`${usernameAccess} != null && ${passwordAccess} != null`)
+                                    );
+                                }
                             }
                             innerWriter.writeTextStatement(
                                 `clientOptionsWithAuth.Headers["Authorization"] = $"Basic {Convert.ToBase64String(global::System.Text.Encoding.UTF8.GetBytes($"{${usernameAccess}}:{${passwordAccess}}"))}"`
                             );
-                            if (isAuthOptional || basicSchemes.length > 1) {
+                            if ((isAuthOptional || basicSchemes.length > 1) && i === basicSchemes.length - 1) {
                                 innerWriter.endControlFlow();
                             }
                         }

--- a/generators/php/sdk/src/root-client/RootClientGenerator.ts
+++ b/generators/php/sdk/src/root-client/RootClientGenerator.ts
@@ -357,16 +357,22 @@ export class RootClientGenerator extends FileGenerator<PhpFile, SdkCustomConfigS
                         const usernameName = this.context.getParameterName(basicAuthScheme.username);
                         const passwordName = this.context.getParameterName(basicAuthScheme.password);
                         if (isAuthOptional || basicAuthSchemes.length > 1) {
-                            const controlFlowKeyword = i === 0 ? "if" : "else if";
-                            writer.controlFlow(
-                                controlFlowKeyword,
-                                php.codeblock(`$${usernameName} !== null && $${passwordName} !== null`)
-                            );
+                            if (i === 0) {
+                                writer.controlFlow(
+                                    "if",
+                                    php.codeblock(`$${usernameName} !== null && $${passwordName} !== null`)
+                                );
+                            } else {
+                                writer.contiguousControlFlow(
+                                    "elseif",
+                                    php.codeblock(`$${usernameName} !== null && $${passwordName} !== null`)
+                                );
+                            }
                         }
                         writer.writeLine(
                             `$defaultHeaders['Authorization'] = "Basic " . base64_encode($${usernameName} . ":" . $${passwordName});`
                         );
-                        if (isAuthOptional || basicAuthSchemes.length > 1) {
+                        if ((isAuthOptional || basicAuthSchemes.length > 1) && i === basicAuthSchemes.length - 1) {
                             writer.endControlFlow();
                         }
                     }

--- a/generators/ruby-v2/sdk/src/root-client/RootClientGenerator.ts
+++ b/generators/ruby-v2/sdk/src/root-client/RootClientGenerator.ts
@@ -128,9 +128,11 @@ export class RootClientGenerator extends FileGenerator<RubyFile, SdkCustomConfig
                             } else {
                                 writer.writeLine(`elsif !${usernameName}.nil? && !${passwordName}.nil?`);
                             }
+                            writer.indent();
                             writer.writeLine(
-                                `  headers["Authorization"] = "Basic #{Base64.strict_encode64("#{${usernameName}}:#{${passwordName}}")}"`
+                                `headers["Authorization"] = "Basic #{Base64.strict_encode64("#{${usernameName}}:#{${passwordName}}")}"`
                             );
+                            writer.dedent();
                             if (i === basicAuthSchemes.length - 1) {
                                 writer.writeLine(`end`);
                             }


### PR DESCRIPTION
## Description

Refs: Follow-up to #14296 (multi-basic-auth scheme support)

Fixes code style issues in the multi-basic-auth `if`/`else if` generation introduced in #14296. The previous implementation used separate `endControlFlow()` + `controlFlow("else if", ...)` calls which produce `}\nelse if (...)` on separate lines instead of proper contiguous `} else if (...)` blocks.

## Changes Made

- **C# generator**: Use `contiguousControlFlow("else if", ...)` for non-first basic auth schemes instead of `controlFlow("else if", ...)`. Only call `endControlFlow()` on the last iteration since `contiguousControlFlow` implicitly closes the preceding block.
- **PHP generator**: Same pattern, using `"elseif"` (single keyword) to match PHP convention and existing codebase usage (see `UnionGenerator.ts`).
- **Ruby generator**: Replace hardcoded 2-space prefix string (`"  headers[...]"`) with proper `writer.indent()` / `writer.dedent()` calls around the body inside `if`/`elsif` blocks.
- [ ] Updated README.md generator (if applicable) — N/A

## ⚠️ Human Review Checklist

1. **`contiguousControlFlow` semantics** — This method writes `} <prefix> (<statement>) {` (closing the previous block and opening a new one). Therefore `endControlFlow()` must only be called once, after the last scheme. Verify the `i === basicSchemes.length - 1` guard is correct for both single-scheme-optional and multi-scheme cases.
2. **PHP `"elseif"` keyword** — PHP accepts both `elseif` and `else if`, but `elseif` is the convention in this codebase (see `generators/php/model/src/union/UnionGenerator.ts:925`). Confirm this is correct.
3. **No seed test fixture** — There is still no multi-basic-auth seed fixture exercising this code path. These changes will only be validated at generation time for customers with multiple basic auth schemes.

## Testing

- [x] Lint/format passes (`pnpm run check`)
- [ ] Unit tests added/updated — no multi-basic-auth seed fixture exists
- [ ] Manual testing completed

Link to Devin session: https://app.devin.ai/sessions/a20d6f8e007f48b4b5e79812b7b713c4
Requested by: @iamnamananand996