### PR TITLE
fix(ts-sdk): use JSON.stringify for non-primitive path params in encodePathParam

### DIFF
--- a/generators/typescript/sdk/versions.yml
+++ b/generators/typescript/sdk/versions.yml
@@ -1,4 +1,16 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 3.60.4
+  changelogEntry:
+    - summary: |
+        Fix `encodePathParam` to use `JSON.stringify` instead of `String()` for
+        non-primitive path parameter values. Previously, passing an object as a path
+        parameter produced `[object Object]` in the URL instead of the JSON-serialized
+        representation, causing URL mismatches in wire tests for auto-generated error
+        examples.
+      type: fix
+  createdAt: "2026-03-30"
+  irVersion: 65
+
 - version: 3.60.3
   changelogEntry:
     - summary: |

--- a/generators/typescript/utils/core-utilities/src/core/url/encodePathParam.ts
+++ b/generators/typescript/utils/core-utilities/src/core/url/encodePathParam.ts
@@ -11,7 +11,7 @@ export function encodePathParam(param: unknown): string {
         case "boolean":
             break;
         default:
-            param = String(param);
+            param = JSON.stringify(param);
             break;
     }
     return encodeURIComponent(param as string | number | boolean);

--- a/seed/ts-sdk/accept-header/src/core/url/encodePathParam.ts
+++ b/seed/ts-sdk/accept-header/src/core/url/encodePathParam.ts
@@ -11,7 +11,7 @@ export function encodePathParam(param: unknown): string {
         case "boolean":
             break;
         default:
-            param = String(param);
+            param = JSON.stringify(param);
             break;
     }
     return encodeURIComponent(param as string | number | boolean);

--- a/seed/ts-sdk/alias-extends/src/core/url/encodePathParam.ts
+++ b/seed/ts-sdk/alias-extends/src/core/url/encodePathParam.ts
@@ -11,7 +11,7 @@ export function encodePathParam(param: unknown): string {
         case "boolean":
             break;
         default:
-            param = String(param);
+            param = JSON.stringify(param);
             break;
     }
     return encodeURIComponent(param as string | number | boolean);

--- a/seed/ts-sdk/alias/src/core/url/encodePathParam.ts
+++ b/seed/ts-sdk/alias/src/core/url/encodePathParam.ts
@@ -11,7 +11,7 @@ export function encodePathParam(param: unknown): string {
         case "boolean":
             break;
         default:
-            param = String(param);
+            param = JSON.stringify(param);
             break;
     }
     return encodeURIComponent(param as string | number | boolean);

--- a/seed/ts-sdk/any-auth/generate-endpoint-metadata/src/core/url/encodePathParam.ts
+++ b/seed/ts-sdk/any-auth/generate-endpoint-metadata/src/core/url/encodePathParam.ts
@@ -11,7 +11,7 @@ export function encodePathParam(param: unknown): string {
         case "boolean":
             break;
         default:
-            param = String(param);
+            param = JSON.stringify(param);
             break;
     }
     return encodeURIComponent(param as string | number | boolean);

--- a/seed/ts-sdk/any-auth/no-custom-config/src/core/url/encodePathParam.ts
+++ b/seed/ts-sdk/any-auth/no-custom-config/src/core/url/encodePathParam.ts
@@ -11,7 +11,7 @@ export function encodePathParam(param: unknown): string {
         case "boolean":
             break;
         default:
-            param = String(param);
+            param = JSON.stringify(param);
             break;
     }
     return encodeURIComponent(param as string | number | boolean);

--- a/seed/ts-sdk/api-wide-base-path/src/core/url/encodePathParam.ts
+++ b/seed/ts-sdk/api-wide-base-path/src/core/url/encodePathParam.ts
@@ -11,7 +11,7 @@ export function encodePathParam(param: unknown): string {
         case "boolean":
             break;
         default:
-            param = String(param);
+            param = JSON.stringify(param);
             break;
     }
     return encodeURIComponent(param as string | number | boolean);

--- a/seed/ts-sdk/audiences/no-custom-config/src/core/url/encodePathParam.ts
+++ b/seed/ts-sdk/audiences/no-custom-config/src/core/url/encodePathParam.ts
@@ -11,7 +11,7 @@ export function encodePathParam(param: unknown): string {
         case "boolean":
             break;
         default:
-            param = String(param);
+            param = JSON.stringify(param);
             break;
     }
     return encodeURIComponent(param as string | number | boolean);

--- a/seed/ts-sdk/audiences/with-partner-audience/src/core/url/encodePathParam.ts
+++ b/seed/ts-sdk/audiences/with-partner-audience/src/core/url/encodePathParam.ts
@@ -11,7 +11,7 @@ export function encodePathParam(param: unknown): string {
         case "boolean":
             break;
         default:
-            param = String(param);
+            param = JSON.stringify(param);
             break;
     }
     return encodeURIComponent(param as string | number | boolean);

--- a/seed/ts-sdk/basic-auth-environment-variables/src/core/url/encodePathParam.ts
+++ b/seed/ts-sdk/basic-auth-environment-variables/src/core/url/encodePathParam.ts
@@ -11,7 +11,7 @@ export function encodePathParam(param: unknown): string {
         case "boolean":
             break;
         default:
-            param = String(param);
+            param = JSON.stringify(param);
             break;
     }
     return encodeURIComponent(param as string | number | boolean);

--- a/seed/ts-sdk/basic-auth/src/core/url/encodePathParam.ts
+++ b/seed/ts-sdk/basic-auth/src/core/url/encodePathParam.ts
@@ -11,7 +11,7 @@ export function encodePathParam(param: unknown): string {
         case "boolean":
             break;
         default:
-            param = String(param);
+            param = JSON.stringify(param);
             break;
     }
     return encodeURIComponent(param as string | number | boolean);

--- a/seed/ts-sdk/bearer-token-environment-variable/src/core/url/encodePathParam.ts
+++ b/seed/ts-sdk/bearer-token-environment-variable/src/core/url/encodePathParam.ts
@@ -11,7 +11,7 @@ export function encodePathParam(param: unknown): string {
         case "boolean":
             break;
         default:
-            param = String(param);
+            param = JSON.stringify(param);
             break;
     }
     return encodeURIComponent(param as string | number | boolean);

--- a/seed/ts-sdk/bytes-download/src/core/url/encodePathParam.ts
+++ b/seed/ts-sdk/bytes-download/src/core/url/encodePathParam.ts
@@ -11,7 +11,7 @@ export function encodePathParam(param: unknown): string {
         case "boolean":
             break;
         default:
-            param = String(param);
+            param = JSON.stringify(param);
             break;
     }
     return encodeURIComponent(param as string | number | boolean);

--- a/seed/ts-sdk/bytes-upload/src/core/url/encodePathParam.ts
+++ b/seed/ts-sdk/bytes-upload/src/core/url/encodePathParam.ts
@@ -11,7 +11,7 @@ export function encodePathParam(param: unknown): string {
         case "boolean":
             break;
         default:
-            param = String(param);
+            param = JSON.stringify(param);
             break;
     }
     return encodeURIComponent(param as string | number | boolean);

--- a/seed/ts-sdk/circular-references-advanced/src/core/url/encodePathParam.ts
+++ b/seed/ts-sdk/circular-references-advanced/src/core/url/encodePathParam.ts
@@ -11,7 +11,7 @@ export function encodePathParam(param: unknown): string {
         case "boolean":
             break;
         default:
-            param = String(param);
+            param = JSON.stringify(param);
             break;
     }
     return encodeURIComponent(param as string | number | boolean);

--- a/seed/ts-sdk/circular-references/src/core/url/encodePathParam.ts
+++ b/seed/ts-sdk/circular-references/src/core/url/encodePathParam.ts
@@ -11,7 +11,7 @@ export function encodePathParam(param: unknown): string {
         case "boolean":
             break;
         default:
-            param = String(param);
+            param = JSON.stringify(param);
             break;
     }
     return encodeURIComponent(param as string | number | boolean);

--- a/seed/ts-sdk/client-side-params/src/core/url/encodePathParam.ts
+++ b/seed/ts-sdk/client-side-params/src/core/url/encodePathParam.ts
@@ -11,7 +11,7 @@ export function encodePathParam(param: unknown): string {
         case "boolean":
             break;
         default:
-            param = String(param);
+            param = JSON.stringify(param);
             break;
     }
     return encodeURIComponent(param as string | number | boolean);

--- a/seed/ts-sdk/content-type/src/core/url/encodePathParam.ts
+++ b/seed/ts-sdk/content-type/src/core/url/encodePathParam.ts
@@ -11,7 +11,7 @@ export function encodePathParam(param: unknown): string {
         case "boolean":
             break;
         default:
-            param = String(param);
+            param = JSON.stringify(param);
             break;
     }
     return encodeURIComponent(param as string | number | boolean);

--- a/seed/ts-sdk/cross-package-type-names/no-custom-config/src/core/url/encodePathParam.ts
+++ b/seed/ts-sdk/cross-package-type-names/no-custom-config/src/core/url/encodePathParam.ts
@@ -11,7 +11,7 @@ export function encodePathParam(param: unknown): string {
         case "boolean":
             break;
         default:
-            param = String(param);
+            param = JSON.stringify(param);
             break;
     }
     return encodeURIComponent(param as string | number | boolean);

--- a/seed/ts-sdk/cross-package-type-names/serde-layer/src/core/url/encodePathParam.ts
+++ b/seed/ts-sdk/cross-package-type-names/serde-layer/src/core/url/encodePathParam.ts
@@ -11,7 +11,7 @@ export function encodePathParam(param: unknown): string {
         case "boolean":
             break;
         default:
-            param = String(param);
+            param = JSON.stringify(param);
             break;
     }
     return encodeURIComponent(param as string | number | boolean);

--- a/seed/ts-sdk/dollar-string-examples/src/core/url/encodePathParam.ts
+++ b/seed/ts-sdk/dollar-string-examples/src/core/url/encodePathParam.ts
@@ -11,7 +11,7 @@ export function encodePathParam(param: unknown): string {
         case "boolean":
             break;
         default:
-            param = String(param);
+            param = JSON.stringify(param);
             break;
     }
     return encodeURIComponent(param as string | number | boolean);

--- a/seed/ts-sdk/empty-clients/src/core/url/encodePathParam.ts
+++ b/seed/ts-sdk/empty-clients/src/core/url/encodePathParam.ts
@@ -11,7 +11,7 @@ export function encodePathParam(param: unknown): string {
         case "boolean":
             break;
         default:
-            param = String(param);
+            param = JSON.stringify(param);
             break;
     }
     return encodeURIComponent(param as string | number | boolean);

--- a/seed/ts-sdk/endpoint-security-auth/src/core/url/encodePathParam.ts
+++ b/seed/ts-sdk/endpoint-security-auth/src/core/url/encodePathParam.ts
@@ -11,7 +11,7 @@ export function encodePathParam(param: unknown): string {
         case "boolean":
             break;
         default:
-            param = String(param);
+            param = JSON.stringify(param);
             break;
     }
     return encodeURIComponent(param as string | number | boolean);

--- a/seed/ts-sdk/enum/forward-compatible-enums-with-serde/src/core/url/encodePathParam.ts
+++ b/seed/ts-sdk/enum/forward-compatible-enums-with-serde/src/core/url/encodePathParam.ts
@@ -11,7 +11,7 @@ export function encodePathParam(param: unknown): string {
         case "boolean":
             break;
         default:
-            param = String(param);
+            param = JSON.stringify(param);
             break;
     }
     return encodeURIComponent(param as string | number | boolean);

--- a/seed/ts-sdk/enum/forward-compatible-enums/src/core/url/encodePathParam.ts
+++ b/seed/ts-sdk/enum/forward-compatible-enums/src/core/url/encodePathParam.ts
@@ -11,7 +11,7 @@ export function encodePathParam(param: unknown): string {
         case "boolean":
             break;
         default:
-            param = String(param);
+            param = JSON.stringify(param);
             break;
     }
     return encodeURIComponent(param as string | number | boolean);

--- a/seed/ts-sdk/enum/no-custom-config/src/core/url/encodePathParam.ts
+++ b/seed/ts-sdk/enum/no-custom-config/src/core/url/encodePathParam.ts
@@ -11,7 +11,7 @@ export function encodePathParam(param: unknown): string {
         case "boolean":
             break;
         default:
-            param = String(param);
+            param = JSON.stringify(param);
             break;
     }
     return encodeURIComponent(param as string | number | boolean);

--- a/seed/ts-sdk/enum/serde/src/core/url/encodePathParam.ts
+++ b/seed/ts-sdk/enum/serde/src/core/url/encodePathParam.ts
@@ -11,7 +11,7 @@ export function encodePathParam(param: unknown): string {
         case "boolean":
             break;
         default:
-            param = String(param);
+            param = JSON.stringify(param);
             break;
     }
     return encodeURIComponent(param as string | number | boolean);

--- a/seed/ts-sdk/error-property/no-custom-config/src/core/url/encodePathParam.ts
+++ b/seed/ts-sdk/error-property/no-custom-config/src/core/url/encodePathParam.ts
@@ -11,7 +11,7 @@ export function encodePathParam(param: unknown): string {
         case "boolean":
             break;
         default:
-            param = String(param);
+            param = JSON.stringify(param);
             break;
     }
     return encodeURIComponent(param as string | number | boolean);

--- a/seed/ts-sdk/error-property/union-utils/src/core/url/encodePathParam.ts
+++ b/seed/ts-sdk/error-property/union-utils/src/core/url/encodePathParam.ts
@@ -11,7 +11,7 @@ export function encodePathParam(param: unknown): string {
         case "boolean":
             break;
         default:
-            param = String(param);
+            param = JSON.stringify(param);
             break;
     }
     return encodeURIComponent(param as string | number | boolean);

--- a/seed/ts-sdk/errors/src/core/url/encodePathParam.ts
+++ b/seed/ts-sdk/errors/src/core/url/encodePathParam.ts
@@ -11,7 +11,7 @@ export function encodePathParam(param: unknown): string {
         case "boolean":
             break;
         default:
-            param = String(param);
+            param = JSON.stringify(param);
             break;
     }
     return encodeURIComponent(param as string | number | boolean);

--- a/seed/ts-sdk/examples/examples-with-api-reference/src/core/url/encodePathParam.ts
+++ b/seed/ts-sdk/examples/examples-with-api-reference/src/core/url/encodePathParam.ts
@@ -11,7 +11,7 @@ export function encodePathParam(param: unknown): string {
         case "boolean":
             break;
         default:
-            param = String(param);
+            param = JSON.stringify(param);
             break;
     }
     return encodeURIComponent(param as string | number | boolean);

--- a/seed/ts-sdk/examples/retain-original-casing/src/core/url/encodePathParam.ts
+++ b/seed/ts-sdk/examples/retain-original-casing/src/core/url/encodePathParam.ts
@@ -11,7 +11,7 @@ export function encodePathParam(param: unknown): string {
         case "boolean":
             break;
         default:
-            param = String(param);
+            param = JSON.stringify(param);
             break;
     }
     return encodeURIComponent(param as string | number | boolean);

--- a/seed/ts-sdk/exhaustive/allow-extra-fields/src/core/url/encodePathParam.ts
+++ b/seed/ts-sdk/exhaustive/allow-extra-fields/src/core/url/encodePathParam.ts
@@ -11,7 +11,7 @@ export function encodePathParam(param: unknown): string {
         case "boolean":
             break;
         default:
-            param = String(param);
+            param = JSON.stringify(param);
             break;
     }
     return encodeURIComponent(param as string | number | boolean);

--- a/seed/ts-sdk/exhaustive/bigint-serde-layer/src/core/url/encodePathParam.ts
+++ b/seed/ts-sdk/exhaustive/bigint-serde-layer/src/core/url/encodePathParam.ts
@@ -11,7 +11,7 @@ export function encodePathParam(param: unknown): string {
         case "boolean":
             break;
         default:
-            param = String(param);
+            param = JSON.stringify(param);
             break;
     }
     return encodeURIComponent(param as string | number | boolean);

--- a/seed/ts-sdk/exhaustive/bigint/src/core/url/encodePathParam.ts
+++ b/seed/ts-sdk/exhaustive/bigint/src/core/url/encodePathParam.ts
@@ -11,7 +11,7 @@ export function encodePathParam(param: unknown): string {
         case "boolean":
             break;
         default:
-            param = String(param);
+            param = JSON.stringify(param);
             break;
     }
     return encodeURIComponent(param as string | number | boolean);

--- a/seed/ts-sdk/exhaustive/consolidate-type-files/src/core/url/encodePathParam.ts
+++ b/seed/ts-sdk/exhaustive/consolidate-type-files/src/core/url/encodePathParam.ts
@@ -11,7 +11,7 @@ export function encodePathParam(param: unknown): string {
         case "boolean":
             break;
         default:
-            param = String(param);
+            param = JSON.stringify(param);
             break;
     }
     return encodeURIComponent(param as string | number | boolean);

--- a/seed/ts-sdk/exhaustive/export-all-requests-at-root/src/core/url/encodePathParam.ts
+++ b/seed/ts-sdk/exhaustive/export-all-requests-at-root/src/core/url/encodePathParam.ts
@@ -11,7 +11,7 @@ export function encodePathParam(param: unknown): string {
         case "boolean":
             break;
         default:
-            param = String(param);
+            param = JSON.stringify(param);
             break;
     }
     return encodeURIComponent(param as string | number | boolean);

--- a/seed/ts-sdk/exhaustive/local-files-no-source/cjs/core/url/encodePathParam.js
+++ b/seed/ts-sdk/exhaustive/local-files-no-source/cjs/core/url/encodePathParam.js
@@ -14,7 +14,7 @@ function encodePathParam(param) {
         case "boolean":
             break;
         default:
-            param = String(param);
+            param = JSON.stringify(param);
             break;
     }
     return encodeURIComponent(param);

--- a/seed/ts-sdk/exhaustive/local-files-no-source/esm/core/url/encodePathParam.mjs
+++ b/seed/ts-sdk/exhaustive/local-files-no-source/esm/core/url/encodePathParam.mjs
@@ -11,7 +11,7 @@ export function encodePathParam(param) {
         case "boolean":
             break;
         default:
-            param = String(param);
+            param = JSON.stringify(param);
             break;
     }
     return encodeURIComponent(param);

--- a/seed/ts-sdk/exhaustive/local-files/core/url/encodePathParam.ts
+++ b/seed/ts-sdk/exhaustive/local-files/core/url/encodePathParam.ts
@@ -11,7 +11,7 @@ export function encodePathParam(param: unknown): string {
         case "boolean":
             break;
         default:
-            param = String(param);
+            param = JSON.stringify(param);
             break;
     }
     return encodeURIComponent(param as string | number | boolean);

--- a/seed/ts-sdk/exhaustive/multiple-exports/src/core/url/encodePathParam.ts
+++ b/seed/ts-sdk/exhaustive/multiple-exports/src/core/url/encodePathParam.ts
@@ -11,7 +11,7 @@ export function encodePathParam(param: unknown): string {
         case "boolean":
             break;
         default:
-            param = String(param);
+            param = JSON.stringify(param);
             break;
     }
     return encodeURIComponent(param as string | number | boolean);

--- a/seed/ts-sdk/exhaustive/never-throw-errors/src/core/url/encodePathParam.ts
+++ b/seed/ts-sdk/exhaustive/never-throw-errors/src/core/url/encodePathParam.ts
@@ -11,7 +11,7 @@ export function encodePathParam(param: unknown): string {
         case "boolean":
             break;
         default:
-            param = String(param);
+            param = JSON.stringify(param);
             break;
     }
     return encodeURIComponent(param as string | number | boolean);

--- a/seed/ts-sdk/exhaustive/no-custom-config/src/core/url/encodePathParam.ts
+++ b/seed/ts-sdk/exhaustive/no-custom-config/src/core/url/encodePathParam.ts
@@ -11,7 +11,7 @@ export function encodePathParam(param: unknown): string {
         case "boolean":
             break;
         default:
-            param = String(param);
+            param = JSON.stringify(param);
             break;
     }
     return encodeURIComponent(param as string | number | boolean);

--- a/seed/ts-sdk/exhaustive/node-fetch/src/core/url/encodePathParam.ts
+++ b/seed/ts-sdk/exhaustive/node-fetch/src/core/url/encodePathParam.ts
@@ -11,7 +11,7 @@ export function encodePathParam(param: unknown): string {
         case "boolean":
             break;
         default:
-            param = String(param);
+            param = JSON.stringify(param);
             break;
     }
     return encodeURIComponent(param as string | number | boolean);

--- a/seed/ts-sdk/exhaustive/output-src-only/core/url/encodePathParam.ts
+++ b/seed/ts-sdk/exhaustive/output-src-only/core/url/encodePathParam.ts
@@ -11,7 +11,7 @@ export function encodePathParam(param: unknown): string {
         case "boolean":
             break;
         default:
-            param = String(param);
+            param = JSON.stringify(param);
             break;
     }
     return encodeURIComponent(param as string | number | boolean);

--- a/seed/ts-sdk/exhaustive/package-path/src/test-packagePath/core/url/encodePathParam.ts
+++ b/seed/ts-sdk/exhaustive/package-path/src/test-packagePath/core/url/encodePathParam.ts
@@ -11,7 +11,7 @@ export function encodePathParam(param: unknown): string {
         case "boolean":
             break;
         default:
-            param = String(param);
+            param = JSON.stringify(param);
             break;
     }
     return encodeURIComponent(param as string | number | boolean);

--- a/seed/ts-sdk/exhaustive/parameter-naming-camel-case/src/core/url/encodePathParam.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-camel-case/src/core/url/encodePathParam.ts
@@ -11,7 +11,7 @@ export function encodePathParam(param: unknown): string {
         case "boolean":
             break;
         default:
-            param = String(param);
+            param = JSON.stringify(param);
             break;
     }
     return encodeURIComponent(param as string | number | boolean);

--- a/seed/ts-sdk/exhaustive/parameter-naming-original-name/src/core/url/encodePathParam.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-original-name/src/core/url/encodePathParam.ts
@@ -11,7 +11,7 @@ export function encodePathParam(param: unknown): string {
         case "boolean":
             break;
         default:
-            param = String(param);
+            param = JSON.stringify(param);
             break;
     }
     return encodeURIComponent(param as string | number | boolean);

--- a/seed/ts-sdk/exhaustive/parameter-naming-snake-case/src/core/url/encodePathParam.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-snake-case/src/core/url/encodePathParam.ts
@@ -11,7 +11,7 @@ export function encodePathParam(param: unknown): string {
         case "boolean":
             break;
         default:
-            param = String(param);
+            param = JSON.stringify(param);
             break;
     }
     return encodeURIComponent(param as string | number | boolean);

--- a/seed/ts-sdk/exhaustive/parameter-naming-wire-value/src/core/url/encodePathParam.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-wire-value/src/core/url/encodePathParam.ts
@@ -11,7 +11,7 @@ export function encodePathParam(param: unknown): string {
         case "boolean":
             break;
         default:
-            param = String(param);
+            param = JSON.stringify(param);
             break;
     }
     return encodeURIComponent(param as string | number | boolean);

--- a/seed/ts-sdk/exhaustive/retain-original-casing/src/core/url/encodePathParam.ts
+++ b/seed/ts-sdk/exhaustive/retain-original-casing/src/core/url/encodePathParam.ts
@@ -11,7 +11,7 @@ export function encodePathParam(param: unknown): string {
         case "boolean":
             break;
         default:
-            param = String(param);
+            param = JSON.stringify(param);
             break;
     }
     return encodeURIComponent(param as string | number | boolean);

--- a/seed/ts-sdk/exhaustive/serde-layer/src/core/url/encodePathParam.ts
+++ b/seed/ts-sdk/exhaustive/serde-layer/src/core/url/encodePathParam.ts
@@ -11,7 +11,7 @@ export function encodePathParam(param: unknown): string {
         case "boolean":
             break;
         default:
-            param = String(param);
+            param = JSON.stringify(param);
             break;
     }
     return encodeURIComponent(param as string | number | boolean);

--- a/seed/ts-sdk/exhaustive/use-jest/src/core/url/encodePathParam.ts
+++ b/seed/ts-sdk/exhaustive/use-jest/src/core/url/encodePathParam.ts
@@ -11,7 +11,7 @@ export function encodePathParam(param: unknown): string {
         case "boolean":
             break;
         default:
-            param = String(param);
+            param = JSON.stringify(param);
             break;
     }
     return encodeURIComponent(param as string | number | boolean);

--- a/seed/ts-sdk/exhaustive/web-stream-wrapper/src/core/url/encodePathParam.ts
+++ b/seed/ts-sdk/exhaustive/web-stream-wrapper/src/core/url/encodePathParam.ts
@@ -11,7 +11,7 @@ export function encodePathParam(param: unknown): string {
         case "boolean":
             break;
         default:
-            param = String(param);
+            param = JSON.stringify(param);
             break;
     }
     return encodeURIComponent(param as string | number | boolean);

--- a/seed/ts-sdk/exhaustive/with-audiences/src/core/url/encodePathParam.ts
+++ b/seed/ts-sdk/exhaustive/with-audiences/src/core/url/encodePathParam.ts
@@ -11,7 +11,7 @@ export function encodePathParam(param: unknown): string {
         case "boolean":
             break;
         default:
-            param = String(param);
+            param = JSON.stringify(param);
             break;
     }
     return encodeURIComponent(param as string | number | boolean);

--- a/seed/ts-sdk/extends/src/core/url/encodePathParam.ts
+++ b/seed/ts-sdk/extends/src/core/url/encodePathParam.ts
@@ -11,7 +11,7 @@ export function encodePathParam(param: unknown): string {
         case "boolean":
             break;
         default:
-            param = String(param);
+            param = JSON.stringify(param);
             break;
     }
     return encodeURIComponent(param as string | number | boolean);

--- a/seed/ts-sdk/extra-properties/src/core/url/encodePathParam.ts
+++ b/seed/ts-sdk/extra-properties/src/core/url/encodePathParam.ts
@@ -11,7 +11,7 @@ export function encodePathParam(param: unknown): string {
         case "boolean":
             break;
         default:
-            param = String(param);
+            param = JSON.stringify(param);
             break;
     }
     return encodeURIComponent(param as string | number | boolean);

--- a/seed/ts-sdk/file-download/file-download-response-headers/src/core/url/encodePathParam.ts
+++ b/seed/ts-sdk/file-download/file-download-response-headers/src/core/url/encodePathParam.ts
@@ -11,7 +11,7 @@ export function encodePathParam(param: unknown): string {
         case "boolean":
             break;
         default:
-            param = String(param);
+            param = JSON.stringify(param);
             break;
     }
     return encodeURIComponent(param as string | number | boolean);

--- a/seed/ts-sdk/file-download/no-custom-config/src/core/url/encodePathParam.ts
+++ b/seed/ts-sdk/file-download/no-custom-config/src/core/url/encodePathParam.ts
@@ -11,7 +11,7 @@ export function encodePathParam(param: unknown): string {
         case "boolean":
             break;
         default:
-            param = String(param);
+            param = JSON.stringify(param);
             break;
     }
     return encodeURIComponent(param as string | number | boolean);

--- a/seed/ts-sdk/file-download/stream-wrapper/src/core/url/encodePathParam.ts
+++ b/seed/ts-sdk/file-download/stream-wrapper/src/core/url/encodePathParam.ts
@@ -11,7 +11,7 @@ export function encodePathParam(param: unknown): string {
         case "boolean":
             break;
         default:
-            param = String(param);
+            param = JSON.stringify(param);
             break;
     }
     return encodeURIComponent(param as string | number | boolean);

--- a/seed/ts-sdk/file-upload-openapi/src/core/url/encodePathParam.ts
+++ b/seed/ts-sdk/file-upload-openapi/src/core/url/encodePathParam.ts
@@ -11,7 +11,7 @@ export function encodePathParam(param: unknown): string {
         case "boolean":
             break;
         default:
-            param = String(param);
+            param = JSON.stringify(param);
             break;
     }
     return encodeURIComponent(param as string | number | boolean);

--- a/seed/ts-sdk/file-upload/form-data-node16/src/core/url/encodePathParam.ts
+++ b/seed/ts-sdk/file-upload/form-data-node16/src/core/url/encodePathParam.ts
@@ -11,7 +11,7 @@ export function encodePathParam(param: unknown): string {
         case "boolean":
             break;
         default:
-            param = String(param);
+            param = JSON.stringify(param);
             break;
     }
     return encodeURIComponent(param as string | number | boolean);

--- a/seed/ts-sdk/file-upload/inline/src/core/url/encodePathParam.ts
+++ b/seed/ts-sdk/file-upload/inline/src/core/url/encodePathParam.ts
@@ -11,7 +11,7 @@ export function encodePathParam(param: unknown): string {
         case "boolean":
             break;
         default:
-            param = String(param);
+            param = JSON.stringify(param);
             break;
     }
     return encodeURIComponent(param as string | number | boolean);

--- a/seed/ts-sdk/file-upload/no-custom-config/src/core/url/encodePathParam.ts
+++ b/seed/ts-sdk/file-upload/no-custom-config/src/core/url/encodePathParam.ts
@@ -11,7 +11,7 @@ export function encodePathParam(param: unknown): string {
         case "boolean":
             break;
         default:
-            param = String(param);
+            param = JSON.stringify(param);
             break;
     }
     return encodeURIComponent(param as string | number | boolean);

--- a/seed/ts-sdk/file-upload/serde/src/core/url/encodePathParam.ts
+++ b/seed/ts-sdk/file-upload/serde/src/core/url/encodePathParam.ts
@@ -11,7 +11,7 @@ export function encodePathParam(param: unknown): string {
         case "boolean":
             break;
         default:
-            param = String(param);
+            param = JSON.stringify(param);
             break;
     }
     return encodeURIComponent(param as string | number | boolean);

--- a/seed/ts-sdk/file-upload/use-jest/src/core/url/encodePathParam.ts
+++ b/seed/ts-sdk/file-upload/use-jest/src/core/url/encodePathParam.ts
@@ -11,7 +11,7 @@ export function encodePathParam(param: unknown): string {
         case "boolean":
             break;
         default:
-            param = String(param);
+            param = JSON.stringify(param);
             break;
     }
     return encodeURIComponent(param as string | number | boolean);

--- a/seed/ts-sdk/file-upload/wrapper/src/core/url/encodePathParam.ts
+++ b/seed/ts-sdk/file-upload/wrapper/src/core/url/encodePathParam.ts
@@ -11,7 +11,7 @@ export function encodePathParam(param: unknown): string {
         case "boolean":
             break;
         default:
-            param = String(param);
+            param = JSON.stringify(param);
             break;
     }
     return encodeURIComponent(param as string | number | boolean);

--- a/seed/ts-sdk/folders/src/core/url/encodePathParam.ts
+++ b/seed/ts-sdk/folders/src/core/url/encodePathParam.ts
@@ -11,7 +11,7 @@ export function encodePathParam(param: unknown): string {
         case "boolean":
             break;
         default:
-            param = String(param);
+            param = JSON.stringify(param);
             break;
     }
     return encodeURIComponent(param as string | number | boolean);

--- a/seed/ts-sdk/header-auth-environment-variable/src/core/url/encodePathParam.ts
+++ b/seed/ts-sdk/header-auth-environment-variable/src/core/url/encodePathParam.ts
@@ -11,7 +11,7 @@ export function encodePathParam(param: unknown): string {
         case "boolean":
             break;
         default:
-            param = String(param);
+            param = JSON.stringify(param);
             break;
     }
     return encodeURIComponent(param as string | number | boolean);

--- a/seed/ts-sdk/header-auth/src/core/url/encodePathParam.ts
+++ b/seed/ts-sdk/header-auth/src/core/url/encodePathParam.ts
@@ -11,7 +11,7 @@ export function encodePathParam(param: unknown): string {
         case "boolean":
             break;
         default:
-            param = String(param);
+            param = JSON.stringify(param);
             break;
     }
     return encodeURIComponent(param as string | number | boolean);

--- a/seed/ts-sdk/http-head/src/core/url/encodePathParam.ts
+++ b/seed/ts-sdk/http-head/src/core/url/encodePathParam.ts
@@ -11,7 +11,7 @@ export function encodePathParam(param: unknown): string {
         case "boolean":
             break;
         default:
-            param = String(param);
+            param = JSON.stringify(param);
             break;
     }
     return encodeURIComponent(param as string | number | boolean);

--- a/seed/ts-sdk/idempotency-headers/src/core/url/encodePathParam.ts
+++ b/seed/ts-sdk/idempotency-headers/src/core/url/encodePathParam.ts
@@ -11,7 +11,7 @@ export function encodePathParam(param: unknown): string {
         case "boolean":
             break;
         default:
-            param = String(param);
+            param = JSON.stringify(param);
             break;
     }
     return encodeURIComponent(param as string | number | boolean);

--- a/seed/ts-sdk/imdb/branded-string-aliases/src/core/url/encodePathParam.ts
+++ b/seed/ts-sdk/imdb/branded-string-aliases/src/core/url/encodePathParam.ts
@@ -11,7 +11,7 @@ export function encodePathParam(param: unknown): string {
         case "boolean":
             break;
         default:
-            param = String(param);
+            param = JSON.stringify(param);
             break;
     }
     return encodeURIComponent(param as string | number | boolean);

--- a/seed/ts-sdk/imdb/no-custom-config/src/core/url/encodePathParam.ts
+++ b/seed/ts-sdk/imdb/no-custom-config/src/core/url/encodePathParam.ts
@@ -11,7 +11,7 @@ export function encodePathParam(param: unknown): string {
         case "boolean":
             break;
         default:
-            param = String(param);
+            param = JSON.stringify(param);
             break;
     }
     return encodeURIComponent(param as string | number | boolean);

--- a/seed/ts-sdk/imdb/omit-undefined/src/core/url/encodePathParam.ts
+++ b/seed/ts-sdk/imdb/omit-undefined/src/core/url/encodePathParam.ts
@@ -11,7 +11,7 @@ export function encodePathParam(param: unknown): string {
         case "boolean":
             break;
         default:
-            param = String(param);
+            param = JSON.stringify(param);
             break;
     }
     return encodeURIComponent(param as string | number | boolean);

--- a/seed/ts-sdk/inferred-auth-explicit/src/core/url/encodePathParam.ts
+++ b/seed/ts-sdk/inferred-auth-explicit/src/core/url/encodePathParam.ts
@@ -11,7 +11,7 @@ export function encodePathParam(param: unknown): string {
         case "boolean":
             break;
         default:
-            param = String(param);
+            param = JSON.stringify(param);
             break;
     }
     return encodeURIComponent(param as string | number | boolean);

--- a/seed/ts-sdk/inferred-auth-implicit-api-key/src/core/url/encodePathParam.ts
+++ b/seed/ts-sdk/inferred-auth-implicit-api-key/src/core/url/encodePathParam.ts
@@ -11,7 +11,7 @@ export function encodePathParam(param: unknown): string {
         case "boolean":
             break;
         default:
-            param = String(param);
+            param = JSON.stringify(param);
             break;
     }
     return encodeURIComponent(param as string | number | boolean);

--- a/seed/ts-sdk/inferred-auth-implicit-no-expiry/src/core/url/encodePathParam.ts
+++ b/seed/ts-sdk/inferred-auth-implicit-no-expiry/src/core/url/encodePathParam.ts
@@ -11,7 +11,7 @@ export function encodePathParam(param: unknown): string {
         case "boolean":
             break;
         default:
-            param = String(param);
+            param = JSON.stringify(param);
             break;
     }
     return encodeURIComponent(param as string | number | boolean);

--- a/seed/ts-sdk/inferred-auth-implicit/src/core/url/encodePathParam.ts
+++ b/seed/ts-sdk/inferred-auth-implicit/src/core/url/encodePathParam.ts
@@ -11,7 +11,7 @@ export function encodePathParam(param: unknown): string {
         case "boolean":
             break;
         default:
-            param = String(param);
+            param = JSON.stringify(param);
             break;
     }
     return encodeURIComponent(param as string | number | boolean);

--- a/seed/ts-sdk/license/src/core/url/encodePathParam.ts
+++ b/seed/ts-sdk/license/src/core/url/encodePathParam.ts
@@ -11,7 +11,7 @@ export function encodePathParam(param: unknown): string {
         case "boolean":
             break;
         default:
-            param = String(param);
+            param = JSON.stringify(param);
             break;
     }
     return encodeURIComponent(param as string | number | boolean);

--- a/seed/ts-sdk/literal/src/core/url/encodePathParam.ts
+++ b/seed/ts-sdk/literal/src/core/url/encodePathParam.ts
@@ -11,7 +11,7 @@ export function encodePathParam(param: unknown): string {
         case "boolean":
             break;
         default:
-            param = String(param);
+            param = JSON.stringify(param);
             break;
     }
     return encodeURIComponent(param as string | number | boolean);

--- a/seed/ts-sdk/literals-unions/src/core/url/encodePathParam.ts
+++ b/seed/ts-sdk/literals-unions/src/core/url/encodePathParam.ts
@@ -11,7 +11,7 @@ export function encodePathParam(param: unknown): string {
         case "boolean":
             break;
         default:
-            param = String(param);
+            param = JSON.stringify(param);
             break;
     }
     return encodeURIComponent(param as string | number | boolean);

--- a/seed/ts-sdk/mixed-case/no-custom-config/src/core/url/encodePathParam.ts
+++ b/seed/ts-sdk/mixed-case/no-custom-config/src/core/url/encodePathParam.ts
@@ -11,7 +11,7 @@ export function encodePathParam(param: unknown): string {
         case "boolean":
             break;
         default:
-            param = String(param);
+            param = JSON.stringify(param);
             break;
     }
     return encodeURIComponent(param as string | number | boolean);

--- a/seed/ts-sdk/mixed-case/retain-original-casing/src/core/url/encodePathParam.ts
+++ b/seed/ts-sdk/mixed-case/retain-original-casing/src/core/url/encodePathParam.ts
@@ -11,7 +11,7 @@ export function encodePathParam(param: unknown): string {
         case "boolean":
             break;
         default:
-            param = String(param);
+            param = JSON.stringify(param);
             break;
     }
     return encodeURIComponent(param as string | number | boolean);

--- a/seed/ts-sdk/mixed-file-directory/src/core/url/encodePathParam.ts
+++ b/seed/ts-sdk/mixed-file-directory/src/core/url/encodePathParam.ts
@@ -11,7 +11,7 @@ export function encodePathParam(param: unknown): string {
         case "boolean":
             break;
         default:
-            param = String(param);
+            param = JSON.stringify(param);
             break;
     }
     return encodeURIComponent(param as string | number | boolean);

--- a/seed/ts-sdk/multi-line-docs/src/core/url/encodePathParam.ts
+++ b/seed/ts-sdk/multi-line-docs/src/core/url/encodePathParam.ts
@@ -11,7 +11,7 @@ export function encodePathParam(param: unknown): string {
         case "boolean":
             break;
         default:
-            param = String(param);
+            param = JSON.stringify(param);
             break;
     }
     return encodeURIComponent(param as string | number | boolean);

--- a/seed/ts-sdk/multi-url-environment-no-default/src/core/url/encodePathParam.ts
+++ b/seed/ts-sdk/multi-url-environment-no-default/src/core/url/encodePathParam.ts
@@ -11,7 +11,7 @@ export function encodePathParam(param: unknown): string {
         case "boolean":
             break;
         default:
-            param = String(param);
+            param = JSON.stringify(param);
             break;
     }
     return encodeURIComponent(param as string | number | boolean);

--- a/seed/ts-sdk/multi-url-environment/src/core/url/encodePathParam.ts
+++ b/seed/ts-sdk/multi-url-environment/src/core/url/encodePathParam.ts
@@ -11,7 +11,7 @@ export function encodePathParam(param: unknown): string {
         case "boolean":
             break;
         default:
-            param = String(param);
+            param = JSON.stringify(param);
             break;
     }
     return encodeURIComponent(param as string | number | boolean);

--- a/seed/ts-sdk/multiple-request-bodies/src/core/url/encodePathParam.ts
+++ b/seed/ts-sdk/multiple-request-bodies/src/core/url/encodePathParam.ts
@@ -11,7 +11,7 @@ export function encodePathParam(param: unknown): string {
         case "boolean":
             break;
         default:
-            param = String(param);
+            param = JSON.stringify(param);
             break;
     }
     return encodeURIComponent(param as string | number | boolean);

--- a/seed/ts-sdk/no-content-response/src/core/url/encodePathParam.ts
+++ b/seed/ts-sdk/no-content-response/src/core/url/encodePathParam.ts
@@ -11,7 +11,7 @@ export function encodePathParam(param: unknown): string {
         case "boolean":
             break;
         default:
-            param = String(param);
+            param = JSON.stringify(param);
             break;
     }
     return encodeURIComponent(param as string | number | boolean);

--- a/seed/ts-sdk/no-environment/src/core/url/encodePathParam.ts
+++ b/seed/ts-sdk/no-environment/src/core/url/encodePathParam.ts
@@ -11,7 +11,7 @@ export function encodePathParam(param: unknown): string {
         case "boolean":
             break;
         default:
-            param = String(param);
+            param = JSON.stringify(param);
             break;
     }
     return encodeURIComponent(param as string | number | boolean);

--- a/seed/ts-sdk/no-retries/src/core/url/encodePathParam.ts
+++ b/seed/ts-sdk/no-retries/src/core/url/encodePathParam.ts
@@ -11,7 +11,7 @@ export function encodePathParam(param: unknown): string {
         case "boolean":
             break;
         default:
-            param = String(param);
+            param = JSON.stringify(param);
             break;
     }
     return encodeURIComponent(param as string | number | boolean);

--- a/seed/ts-sdk/null-type/src/core/url/encodePathParam.ts
+++ b/seed/ts-sdk/null-type/src/core/url/encodePathParam.ts
@@ -11,7 +11,7 @@ export function encodePathParam(param: unknown): string {
         case "boolean":
             break;
         default:
-            param = String(param);
+            param = JSON.stringify(param);
             break;
     }
     return encodeURIComponent(param as string | number | boolean);

--- a/seed/ts-sdk/nullable-allof-extends/src/core/url/encodePathParam.ts
+++ b/seed/ts-sdk/nullable-allof-extends/src/core/url/encodePathParam.ts
@@ -11,7 +11,7 @@ export function encodePathParam(param: unknown): string {
         case "boolean":
             break;
         default:
-            param = String(param);
+            param = JSON.stringify(param);
             break;
     }
     return encodeURIComponent(param as string | number | boolean);

--- a/seed/ts-sdk/nullable-optional/src/core/url/encodePathParam.ts
+++ b/seed/ts-sdk/nullable-optional/src/core/url/encodePathParam.ts
@@ -11,7 +11,7 @@ export function encodePathParam(param: unknown): string {
         case "boolean":
             break;
         default:
-            param = String(param);
+            param = JSON.stringify(param);
             break;
     }
     return encodeURIComponent(param as string | number | boolean);

--- a/seed/ts-sdk/nullable-request-body/src/core/url/encodePathParam.ts
+++ b/seed/ts-sdk/nullable-request-body/src/core/url/encodePathParam.ts
@@ -11,7 +11,7 @@ export function encodePathParam(param: unknown): string {
         case "boolean":
             break;
         default:
-            param = String(param);
+            param = JSON.stringify(param);
             break;
     }
     return encodeURIComponent(param as string | number | boolean);

--- a/seed/ts-sdk/nullable/src/core/url/encodePathParam.ts
+++ b/seed/ts-sdk/nullable/src/core/url/encodePathParam.ts
@@ -11,7 +11,7 @@ export function encodePathParam(param: unknown): string {
         case "boolean":
             break;
         default:
-            param = String(param);
+            param = JSON.stringify(param);
             break;
     }
     return encodeURIComponent(param as string | number | boolean);

--- a/seed/ts-sdk/oauth-client-credentials-custom/src/core/url/encodePathParam.ts
+++ b/seed/ts-sdk/oauth-client-credentials-custom/src/core/url/encodePathParam.ts
@@ -11,7 +11,7 @@ export function encodePathParam(param: unknown): string {
         case "boolean":
             break;
         default:
-            param = String(param);
+            param = JSON.stringify(param);
             break;
     }
     return encodeURIComponent(param as string | number | boolean);

--- a/seed/ts-sdk/oauth-client-credentials-default/src/core/url/encodePathParam.ts
+++ b/seed/ts-sdk/oauth-client-credentials-default/src/core/url/encodePathParam.ts
@@ -11,7 +11,7 @@ export function encodePathParam(param: unknown): string {
         case "boolean":
             break;
         default:
-            param = String(param);
+            param = JSON.stringify(param);
             break;
     }
     return encodeURIComponent(param as string | number | boolean);

--- a/seed/ts-sdk/oauth-client-credentials-environment-variables/no-custom-config/src/core/url/encodePathParam.ts
+++ b/seed/ts-sdk/oauth-client-credentials-environment-variables/no-custom-config/src/core/url/encodePathParam.ts
@@ -11,7 +11,7 @@ export function encodePathParam(param: unknown): string {
         case "boolean":
             break;
         default:
-            param = String(param);
+            param = JSON.stringify(param);
             break;
     }
     return encodeURIComponent(param as string | number | boolean);

--- a/seed/ts-sdk/oauth-client-credentials-mandatory-auth/no-custom-config/src/core/url/encodePathParam.ts
+++ b/seed/ts-sdk/oauth-client-credentials-mandatory-auth/no-custom-config/src/core/url/encodePathParam.ts
@@ -11,7 +11,7 @@ export function encodePathParam(param: unknown): string {
         case "boolean":
             break;
         default:
-            param = String(param);
+            param = JSON.stringify(param);
             break;
     }
     return encodeURIComponent(param as string | number | boolean);

--- a/seed/ts-sdk/oauth-client-credentials-nested-root/never-throw-errors/src/core/url/encodePathParam.ts
+++ b/seed/ts-sdk/oauth-client-credentials-nested-root/never-throw-errors/src/core/url/encodePathParam.ts
@@ -11,7 +11,7 @@ export function encodePathParam(param: unknown): string {
         case "boolean":
             break;
         default:
-            param = String(param);
+            param = JSON.stringify(param);
             break;
     }
     return encodeURIComponent(param as string | number | boolean);

--- a/seed/ts-sdk/oauth-client-credentials-nested-root/no-custom-config/src/core/url/encodePathParam.ts
+++ b/seed/ts-sdk/oauth-client-credentials-nested-root/no-custom-config/src/core/url/encodePathParam.ts
@@ -11,7 +11,7 @@ export function encodePathParam(param: unknown): string {
         case "boolean":
             break;
         default:
-            param = String(param);
+            param = JSON.stringify(param);
             break;
     }
     return encodeURIComponent(param as string | number | boolean);

--- a/seed/ts-sdk/oauth-client-credentials-openapi/src/core/url/encodePathParam.ts
+++ b/seed/ts-sdk/oauth-client-credentials-openapi/src/core/url/encodePathParam.ts
@@ -11,7 +11,7 @@ export function encodePathParam(param: unknown): string {
         case "boolean":
             break;
         default:
-            param = String(param);
+            param = JSON.stringify(param);
             break;
     }
     return encodeURIComponent(param as string | number | boolean);

--- a/seed/ts-sdk/oauth-client-credentials-reference/src/core/url/encodePathParam.ts
+++ b/seed/ts-sdk/oauth-client-credentials-reference/src/core/url/encodePathParam.ts
@@ -11,7 +11,7 @@ export function encodePathParam(param: unknown): string {
         case "boolean":
             break;
         default:
-            param = String(param);
+            param = JSON.stringify(param);
             break;
     }
     return encodeURIComponent(param as string | number | boolean);

--- a/seed/ts-sdk/oauth-client-credentials-with-variables/src/core/url/encodePathParam.ts
+++ b/seed/ts-sdk/oauth-client-credentials-with-variables/src/core/url/encodePathParam.ts
@@ -11,7 +11,7 @@ export function encodePathParam(param: unknown): string {
         case "boolean":
             break;
         default:
-            param = String(param);
+            param = JSON.stringify(param);
             break;
     }
     return encodeURIComponent(param as string | number | boolean);

--- a/seed/ts-sdk/oauth-client-credentials/no-custom-config/src/core/url/encodePathParam.ts
+++ b/seed/ts-sdk/oauth-client-credentials/no-custom-config/src/core/url/encodePathParam.ts
@@ -11,7 +11,7 @@ export function encodePathParam(param: unknown): string {
         case "boolean":
             break;
         default:
-            param = String(param);
+            param = JSON.stringify(param);
             break;
     }
     return encodeURIComponent(param as string | number | boolean);

--- a/seed/ts-sdk/oauth-client-credentials/serde/src/core/url/encodePathParam.ts
+++ b/seed/ts-sdk/oauth-client-credentials/serde/src/core/url/encodePathParam.ts
@@ -11,7 +11,7 @@ export function encodePathParam(param: unknown): string {
         case "boolean":
             break;
         default:
-            param = String(param);
+            param = JSON.stringify(param);
             break;
     }
     return encodeURIComponent(param as string | number | boolean);

--- a/seed/ts-sdk/object/src/core/url/encodePathParam.ts
+++ b/seed/ts-sdk/object/src/core/url/encodePathParam.ts
@@ -11,7 +11,7 @@ export function encodePathParam(param: unknown): string {
         case "boolean":
             break;
         default:
-            param = String(param);
+            param = JSON.stringify(param);
             break;
     }
     return encodeURIComponent(param as string | number | boolean);

--- a/seed/ts-sdk/objects-with-imports/src/core/url/encodePathParam.ts
+++ b/seed/ts-sdk/objects-with-imports/src/core/url/encodePathParam.ts
@@ -11,7 +11,7 @@ export function encodePathParam(param: unknown): string {
         case "boolean":
             break;
         default:
-            param = String(param);
+            param = JSON.stringify(param);
             break;
     }
     return encodeURIComponent(param as string | number | boolean);

--- a/seed/ts-sdk/optional/src/core/url/encodePathParam.ts
+++ b/seed/ts-sdk/optional/src/core/url/encodePathParam.ts
@@ -11,7 +11,7 @@ export function encodePathParam(param: unknown): string {
         case "boolean":
             break;
         default:
-            param = String(param);
+            param = JSON.stringify(param);
             break;
     }
     return encodeURIComponent(param as string | number | boolean);

--- a/seed/ts-sdk/package-yml/src/core/url/encodePathParam.ts
+++ b/seed/ts-sdk/package-yml/src/core/url/encodePathParam.ts
@@ -11,7 +11,7 @@ export function encodePathParam(param: unknown): string {
         case "boolean":
             break;
         default:
-            param = String(param);
+            param = JSON.stringify(param);
             break;
     }
     return encodeURIComponent(param as string | number | boolean);

--- a/seed/ts-sdk/pagination-custom/src/core/url/encodePathParam.ts
+++ b/seed/ts-sdk/pagination-custom/src/core/url/encodePathParam.ts
@@ -11,7 +11,7 @@ export function encodePathParam(param: unknown): string {
         case "boolean":
             break;
         default:
-            param = String(param);
+            param = JSON.stringify(param);
             break;
     }
     return encodeURIComponent(param as string | number | boolean);

--- a/seed/ts-sdk/pagination-uri-path/src/core/url/encodePathParam.ts
+++ b/seed/ts-sdk/pagination-uri-path/src/core/url/encodePathParam.ts
@@ -11,7 +11,7 @@ export function encodePathParam(param: unknown): string {
         case "boolean":
             break;
         default:
-            param = String(param);
+            param = JSON.stringify(param);
             break;
     }
     return encodeURIComponent(param as string | number | boolean);

--- a/seed/ts-sdk/pagination/no-custom-config/src/core/url/encodePathParam.ts
+++ b/seed/ts-sdk/pagination/no-custom-config/src/core/url/encodePathParam.ts
@@ -11,7 +11,7 @@ export function encodePathParam(param: unknown): string {
         case "boolean":
             break;
         default:
-            param = String(param);
+            param = JSON.stringify(param);
             break;
     }
     return encodeURIComponent(param as string | number | boolean);

--- a/seed/ts-sdk/pagination/page-index-semantics/src/core/url/encodePathParam.ts
+++ b/seed/ts-sdk/pagination/page-index-semantics/src/core/url/encodePathParam.ts
@@ -11,7 +11,7 @@ export function encodePathParam(param: unknown): string {
         case "boolean":
             break;
         default:
-            param = String(param);
+            param = JSON.stringify(param);
             break;
     }
     return encodeURIComponent(param as string | number | boolean);

--- a/seed/ts-sdk/path-parameters/no-custom-config/src/core/url/encodePathParam.ts
+++ b/seed/ts-sdk/path-parameters/no-custom-config/src/core/url/encodePathParam.ts
@@ -11,7 +11,7 @@ export function encodePathParam(param: unknown): string {
         case "boolean":
             break;
         default:
-            param = String(param);
+            param = JSON.stringify(param);
             break;
     }
     return encodeURIComponent(param as string | number | boolean);

--- a/seed/ts-sdk/path-parameters/no-inline-path-parameters-retain-original-casing/src/core/url/encodePathParam.ts
+++ b/seed/ts-sdk/path-parameters/no-inline-path-parameters-retain-original-casing/src/core/url/encodePathParam.ts
@@ -11,7 +11,7 @@ export function encodePathParam(param: unknown): string {
         case "boolean":
             break;
         default:
-            param = String(param);
+            param = JSON.stringify(param);
             break;
     }
     return encodeURIComponent(param as string | number | boolean);

--- a/seed/ts-sdk/path-parameters/no-inline-path-parameters-serde/src/core/url/encodePathParam.ts
+++ b/seed/ts-sdk/path-parameters/no-inline-path-parameters-serde/src/core/url/encodePathParam.ts
@@ -11,7 +11,7 @@ export function encodePathParam(param: unknown): string {
         case "boolean":
             break;
         default:
-            param = String(param);
+            param = JSON.stringify(param);
             break;
     }
     return encodeURIComponent(param as string | number | boolean);

--- a/seed/ts-sdk/path-parameters/no-inline-path-parameters/src/core/url/encodePathParam.ts
+++ b/seed/ts-sdk/path-parameters/no-inline-path-parameters/src/core/url/encodePathParam.ts
@@ -11,7 +11,7 @@ export function encodePathParam(param: unknown): string {
         case "boolean":
             break;
         default:
-            param = String(param);
+            param = JSON.stringify(param);
             break;
     }
     return encodeURIComponent(param as string | number | boolean);

--- a/seed/ts-sdk/path-parameters/parameter-naming-camel-case/src/core/url/encodePathParam.ts
+++ b/seed/ts-sdk/path-parameters/parameter-naming-camel-case/src/core/url/encodePathParam.ts
@@ -11,7 +11,7 @@ export function encodePathParam(param: unknown): string {
         case "boolean":
             break;
         default:
-            param = String(param);
+            param = JSON.stringify(param);
             break;
     }
     return encodeURIComponent(param as string | number | boolean);

--- a/seed/ts-sdk/path-parameters/parameter-naming-original-name/src/core/url/encodePathParam.ts
+++ b/seed/ts-sdk/path-parameters/parameter-naming-original-name/src/core/url/encodePathParam.ts
@@ -11,7 +11,7 @@ export function encodePathParam(param: unknown): string {
         case "boolean":
             break;
         default:
-            param = String(param);
+            param = JSON.stringify(param);
             break;
     }
     return encodeURIComponent(param as string | number | boolean);

--- a/seed/ts-sdk/path-parameters/parameter-naming-snake-case/src/core/url/encodePathParam.ts
+++ b/seed/ts-sdk/path-parameters/parameter-naming-snake-case/src/core/url/encodePathParam.ts
@@ -11,7 +11,7 @@ export function encodePathParam(param: unknown): string {
         case "boolean":
             break;
         default:
-            param = String(param);
+            param = JSON.stringify(param);
             break;
     }
     return encodeURIComponent(param as string | number | boolean);

--- a/seed/ts-sdk/path-parameters/parameter-naming-wire-value/src/core/url/encodePathParam.ts
+++ b/seed/ts-sdk/path-parameters/parameter-naming-wire-value/src/core/url/encodePathParam.ts
@@ -11,7 +11,7 @@ export function encodePathParam(param: unknown): string {
         case "boolean":
             break;
         default:
-            param = String(param);
+            param = JSON.stringify(param);
             break;
     }
     return encodeURIComponent(param as string | number | boolean);

--- a/seed/ts-sdk/path-parameters/retain-original-casing/src/core/url/encodePathParam.ts
+++ b/seed/ts-sdk/path-parameters/retain-original-casing/src/core/url/encodePathParam.ts
@@ -11,7 +11,7 @@ export function encodePathParam(param: unknown): string {
         case "boolean":
             break;
         default:
-            param = String(param);
+            param = JSON.stringify(param);
             break;
     }
     return encodeURIComponent(param as string | number | boolean);

--- a/seed/ts-sdk/plain-text/src/core/url/encodePathParam.ts
+++ b/seed/ts-sdk/plain-text/src/core/url/encodePathParam.ts
@@ -11,7 +11,7 @@ export function encodePathParam(param: unknown): string {
         case "boolean":
             break;
         default:
-            param = String(param);
+            param = JSON.stringify(param);
             break;
     }
     return encodeURIComponent(param as string | number | boolean);

--- a/seed/ts-sdk/property-access/generate-read-write-only-types/src/core/url/encodePathParam.ts
+++ b/seed/ts-sdk/property-access/generate-read-write-only-types/src/core/url/encodePathParam.ts
@@ -11,7 +11,7 @@ export function encodePathParam(param: unknown): string {
         case "boolean":
             break;
         default:
-            param = String(param);
+            param = JSON.stringify(param);
             break;
     }
     return encodeURIComponent(param as string | number | boolean);

--- a/seed/ts-sdk/property-access/no-custom-config/src/core/url/encodePathParam.ts
+++ b/seed/ts-sdk/property-access/no-custom-config/src/core/url/encodePathParam.ts
@@ -11,7 +11,7 @@ export function encodePathParam(param: unknown): string {
         case "boolean":
             break;
         default:
-            param = String(param);
+            param = JSON.stringify(param);
             break;
     }
     return encodeURIComponent(param as string | number | boolean);

--- a/seed/ts-sdk/public-object/src/core/url/encodePathParam.ts
+++ b/seed/ts-sdk/public-object/src/core/url/encodePathParam.ts
@@ -11,7 +11,7 @@ export function encodePathParam(param: unknown): string {
         case "boolean":
             break;
         default:
-            param = String(param);
+            param = JSON.stringify(param);
             break;
     }
     return encodeURIComponent(param as string | number | boolean);

--- a/seed/ts-sdk/query-param-name-conflict/src/core/url/encodePathParam.ts
+++ b/seed/ts-sdk/query-param-name-conflict/src/core/url/encodePathParam.ts
@@ -11,7 +11,7 @@ export function encodePathParam(param: unknown): string {
         case "boolean":
             break;
         default:
-            param = String(param);
+            param = JSON.stringify(param);
             break;
     }
     return encodeURIComponent(param as string | number | boolean);

--- a/seed/ts-sdk/query-parameters-openapi-as-objects/src/core/url/encodePathParam.ts
+++ b/seed/ts-sdk/query-parameters-openapi-as-objects/src/core/url/encodePathParam.ts
@@ -11,7 +11,7 @@ export function encodePathParam(param: unknown): string {
         case "boolean":
             break;
         default:
-            param = String(param);
+            param = JSON.stringify(param);
             break;
     }
     return encodeURIComponent(param as string | number | boolean);

--- a/seed/ts-sdk/query-parameters-openapi/src/core/url/encodePathParam.ts
+++ b/seed/ts-sdk/query-parameters-openapi/src/core/url/encodePathParam.ts
@@ -11,7 +11,7 @@ export function encodePathParam(param: unknown): string {
         case "boolean":
             break;
         default:
-            param = String(param);
+            param = JSON.stringify(param);
             break;
     }
     return encodeURIComponent(param as string | number | boolean);

--- a/seed/ts-sdk/query-parameters/no-custom-config/src/core/url/encodePathParam.ts
+++ b/seed/ts-sdk/query-parameters/no-custom-config/src/core/url/encodePathParam.ts
@@ -11,7 +11,7 @@ export function encodePathParam(param: unknown): string {
         case "boolean":
             break;
         default:
-            param = String(param);
+            param = JSON.stringify(param);
             break;
     }
     return encodeURIComponent(param as string | number | boolean);

--- a/seed/ts-sdk/query-parameters/parameter-naming-camel-case/src/core/url/encodePathParam.ts
+++ b/seed/ts-sdk/query-parameters/parameter-naming-camel-case/src/core/url/encodePathParam.ts
@@ -11,7 +11,7 @@ export function encodePathParam(param: unknown): string {
         case "boolean":
             break;
         default:
-            param = String(param);
+            param = JSON.stringify(param);
             break;
     }
     return encodeURIComponent(param as string | number | boolean);

--- a/seed/ts-sdk/query-parameters/parameter-naming-original-name/src/core/url/encodePathParam.ts
+++ b/seed/ts-sdk/query-parameters/parameter-naming-original-name/src/core/url/encodePathParam.ts
@@ -11,7 +11,7 @@ export function encodePathParam(param: unknown): string {
         case "boolean":
             break;
         default:
-            param = String(param);
+            param = JSON.stringify(param);
             break;
     }
     return encodeURIComponent(param as string | number | boolean);

--- a/seed/ts-sdk/query-parameters/parameter-naming-snake-case/src/core/url/encodePathParam.ts
+++ b/seed/ts-sdk/query-parameters/parameter-naming-snake-case/src/core/url/encodePathParam.ts
@@ -11,7 +11,7 @@ export function encodePathParam(param: unknown): string {
         case "boolean":
             break;
         default:
-            param = String(param);
+            param = JSON.stringify(param);
             break;
     }
     return encodeURIComponent(param as string | number | boolean);

--- a/seed/ts-sdk/query-parameters/parameter-naming-wire-value/src/core/url/encodePathParam.ts
+++ b/seed/ts-sdk/query-parameters/parameter-naming-wire-value/src/core/url/encodePathParam.ts
@@ -11,7 +11,7 @@ export function encodePathParam(param: unknown): string {
         case "boolean":
             break;
         default:
-            param = String(param);
+            param = JSON.stringify(param);
             break;
     }
     return encodeURIComponent(param as string | number | boolean);

--- a/seed/ts-sdk/query-parameters/serde/src/core/url/encodePathParam.ts
+++ b/seed/ts-sdk/query-parameters/serde/src/core/url/encodePathParam.ts
@@ -11,7 +11,7 @@ export function encodePathParam(param: unknown): string {
         case "boolean":
             break;
         default:
-            param = String(param);
+            param = JSON.stringify(param);
             break;
     }
     return encodeURIComponent(param as string | number | boolean);

--- a/seed/ts-sdk/request-parameters/flatten-request-parameters/src/core/url/encodePathParam.ts
+++ b/seed/ts-sdk/request-parameters/flatten-request-parameters/src/core/url/encodePathParam.ts
@@ -11,7 +11,7 @@ export function encodePathParam(param: unknown): string {
         case "boolean":
             break;
         default:
-            param = String(param);
+            param = JSON.stringify(param);
             break;
     }
     return encodeURIComponent(param as string | number | boolean);

--- a/seed/ts-sdk/request-parameters/no-custom-config/src/core/url/encodePathParam.ts
+++ b/seed/ts-sdk/request-parameters/no-custom-config/src/core/url/encodePathParam.ts
@@ -11,7 +11,7 @@ export function encodePathParam(param: unknown): string {
         case "boolean":
             break;
         default:
-            param = String(param);
+            param = JSON.stringify(param);
             break;
     }
     return encodeURIComponent(param as string | number | boolean);

--- a/seed/ts-sdk/request-parameters/use-big-int-and-default-request-parameter-values/src/core/url/encodePathParam.ts
+++ b/seed/ts-sdk/request-parameters/use-big-int-and-default-request-parameter-values/src/core/url/encodePathParam.ts
@@ -11,7 +11,7 @@ export function encodePathParam(param: unknown): string {
         case "boolean":
             break;
         default:
-            param = String(param);
+            param = JSON.stringify(param);
             break;
     }
     return encodeURIComponent(param as string | number | boolean);

--- a/seed/ts-sdk/request-parameters/use-default-request-parameter-values/src/core/url/encodePathParam.ts
+++ b/seed/ts-sdk/request-parameters/use-default-request-parameter-values/src/core/url/encodePathParam.ts
@@ -11,7 +11,7 @@ export function encodePathParam(param: unknown): string {
         case "boolean":
             break;
         default:
-            param = String(param);
+            param = JSON.stringify(param);
             break;
     }
     return encodeURIComponent(param as string | number | boolean);

--- a/seed/ts-sdk/required-nullable/src/core/url/encodePathParam.ts
+++ b/seed/ts-sdk/required-nullable/src/core/url/encodePathParam.ts
@@ -11,7 +11,7 @@ export function encodePathParam(param: unknown): string {
         case "boolean":
             break;
         default:
-            param = String(param);
+            param = JSON.stringify(param);
             break;
     }
     return encodeURIComponent(param as string | number | boolean);

--- a/seed/ts-sdk/reserved-keywords/src/core/url/encodePathParam.ts
+++ b/seed/ts-sdk/reserved-keywords/src/core/url/encodePathParam.ts
@@ -11,7 +11,7 @@ export function encodePathParam(param: unknown): string {
         case "boolean":
             break;
         default:
-            param = String(param);
+            param = JSON.stringify(param);
             break;
     }
     return encodeURIComponent(param as string | number | boolean);

--- a/seed/ts-sdk/response-property/src/core/url/encodePathParam.ts
+++ b/seed/ts-sdk/response-property/src/core/url/encodePathParam.ts
@@ -11,7 +11,7 @@ export function encodePathParam(param: unknown): string {
         case "boolean":
             break;
         default:
-            param = String(param);
+            param = JSON.stringify(param);
             break;
     }
     return encodeURIComponent(param as string | number | boolean);

--- a/seed/ts-sdk/server-sent-event-examples/src/core/url/encodePathParam.ts
+++ b/seed/ts-sdk/server-sent-event-examples/src/core/url/encodePathParam.ts
@@ -11,7 +11,7 @@ export function encodePathParam(param: unknown): string {
         case "boolean":
             break;
         default:
-            param = String(param);
+            param = JSON.stringify(param);
             break;
     }
     return encodeURIComponent(param as string | number | boolean);

--- a/seed/ts-sdk/server-sent-events-openapi/no-custom-config/src/core/url/encodePathParam.ts
+++ b/seed/ts-sdk/server-sent-events-openapi/no-custom-config/src/core/url/encodePathParam.ts
@@ -11,7 +11,7 @@ export function encodePathParam(param: unknown): string {
         case "boolean":
             break;
         default:
-            param = String(param);
+            param = JSON.stringify(param);
             break;
     }
     return encodeURIComponent(param as string | number | boolean);

--- a/seed/ts-sdk/server-sent-events/src/core/url/encodePathParam.ts
+++ b/seed/ts-sdk/server-sent-events/src/core/url/encodePathParam.ts
@@ -11,7 +11,7 @@ export function encodePathParam(param: unknown): string {
         case "boolean":
             break;
         default:
-            param = String(param);
+            param = JSON.stringify(param);
             break;
     }
     return encodeURIComponent(param as string | number | boolean);

--- a/seed/ts-sdk/server-url-templating/src/core/url/encodePathParam.ts
+++ b/seed/ts-sdk/server-url-templating/src/core/url/encodePathParam.ts
@@ -11,7 +11,7 @@ export function encodePathParam(param: unknown): string {
         case "boolean":
             break;
         default:
-            param = String(param);
+            param = JSON.stringify(param);
             break;
     }
     return encodeURIComponent(param as string | number | boolean);

--- a/seed/ts-sdk/simple-api/allow-custom-fetcher/src/core/url/encodePathParam.ts
+++ b/seed/ts-sdk/simple-api/allow-custom-fetcher/src/core/url/encodePathParam.ts
@@ -11,7 +11,7 @@ export function encodePathParam(param: unknown): string {
         case "boolean":
             break;
         default:
-            param = String(param);
+            param = JSON.stringify(param);
             break;
     }
     return encodeURIComponent(param as string | number | boolean);

--- a/seed/ts-sdk/simple-api/allow-extra-fields/src/core/url/encodePathParam.ts
+++ b/seed/ts-sdk/simple-api/allow-extra-fields/src/core/url/encodePathParam.ts
@@ -11,7 +11,7 @@ export function encodePathParam(param: unknown): string {
         case "boolean":
             break;
         default:
-            param = String(param);
+            param = JSON.stringify(param);
             break;
     }
     return encodeURIComponent(param as string | number | boolean);

--- a/seed/ts-sdk/simple-api/bundle/src/core/url/encodePathParam.ts
+++ b/seed/ts-sdk/simple-api/bundle/src/core/url/encodePathParam.ts
@@ -11,7 +11,7 @@ export function encodePathParam(param: unknown): string {
         case "boolean":
             break;
         default:
-            param = String(param);
+            param = JSON.stringify(param);
             break;
     }
     return encodeURIComponent(param as string | number | boolean);

--- a/seed/ts-sdk/simple-api/custom-package-json/src/core/url/encodePathParam.ts
+++ b/seed/ts-sdk/simple-api/custom-package-json/src/core/url/encodePathParam.ts
@@ -11,7 +11,7 @@ export function encodePathParam(param: unknown): string {
         case "boolean":
             break;
         default:
-            param = String(param);
+            param = JSON.stringify(param);
             break;
     }
     return encodeURIComponent(param as string | number | boolean);

--- a/seed/ts-sdk/simple-api/jsr/src/core/url/encodePathParam.ts
+++ b/seed/ts-sdk/simple-api/jsr/src/core/url/encodePathParam.ts
@@ -11,7 +11,7 @@ export function encodePathParam(param: unknown): string {
         case "boolean":
             break;
         default:
-            param = String(param);
+            param = JSON.stringify(param);
             break;
     }
     return encodeURIComponent(param as string | number | boolean);

--- a/seed/ts-sdk/simple-api/legacy-exports/src/core/url/encodePathParam.ts
+++ b/seed/ts-sdk/simple-api/legacy-exports/src/core/url/encodePathParam.ts
@@ -11,7 +11,7 @@ export function encodePathParam(param: unknown): string {
         case "boolean":
             break;
         default:
-            param = String(param);
+            param = JSON.stringify(param);
             break;
     }
     return encodeURIComponent(param as string | number | boolean);

--- a/seed/ts-sdk/simple-api/naming-shorthand/src/core/url/encodePathParam.ts
+++ b/seed/ts-sdk/simple-api/naming-shorthand/src/core/url/encodePathParam.ts
@@ -11,7 +11,7 @@ export function encodePathParam(param: unknown): string {
         case "boolean":
             break;
         default:
-            param = String(param);
+            param = JSON.stringify(param);
             break;
     }
     return encodeURIComponent(param as string | number | boolean);

--- a/seed/ts-sdk/simple-api/naming/src/core/url/encodePathParam.ts
+++ b/seed/ts-sdk/simple-api/naming/src/core/url/encodePathParam.ts
@@ -11,7 +11,7 @@ export function encodePathParam(param: unknown): string {
         case "boolean":
             break;
         default:
-            param = String(param);
+            param = JSON.stringify(param);
             break;
     }
     return encodeURIComponent(param as string | number | boolean);

--- a/seed/ts-sdk/simple-api/no-custom-config/src/core/url/encodePathParam.ts
+++ b/seed/ts-sdk/simple-api/no-custom-config/src/core/url/encodePathParam.ts
@@ -11,7 +11,7 @@ export function encodePathParam(param: unknown): string {
         case "boolean":
             break;
         default:
-            param = String(param);
+            param = JSON.stringify(param);
             break;
     }
     return encodeURIComponent(param as string | number | boolean);

--- a/seed/ts-sdk/simple-api/no-linter-and-formatter/src/core/url/encodePathParam.ts
+++ b/seed/ts-sdk/simple-api/no-linter-and-formatter/src/core/url/encodePathParam.ts
@@ -11,7 +11,7 @@ export function encodePathParam(param: unknown): string {
         case "boolean":
             break;
         default:
-            param = String(param);
+            param = JSON.stringify(param);
             break;
     }
     return encodeURIComponent(param as string | number | boolean);

--- a/seed/ts-sdk/simple-api/no-scripts/src/core/url/encodePathParam.ts
+++ b/seed/ts-sdk/simple-api/no-scripts/src/core/url/encodePathParam.ts
@@ -11,7 +11,7 @@ export function encodePathParam(param: unknown): string {
         case "boolean":
             break;
         default:
-            param = String(param);
+            param = JSON.stringify(param);
             break;
     }
     return encodeURIComponent(param as string | number | boolean);

--- a/seed/ts-sdk/simple-api/oidc-token/src/core/url/encodePathParam.ts
+++ b/seed/ts-sdk/simple-api/oidc-token/src/core/url/encodePathParam.ts
@@ -11,7 +11,7 @@ export function encodePathParam(param: unknown): string {
         case "boolean":
             break;
         default:
-            param = String(param);
+            param = JSON.stringify(param);
             break;
     }
     return encodeURIComponent(param as string | number | boolean);

--- a/seed/ts-sdk/simple-api/omit-fern-headers/src/core/url/encodePathParam.ts
+++ b/seed/ts-sdk/simple-api/omit-fern-headers/src/core/url/encodePathParam.ts
@@ -11,7 +11,7 @@ export function encodePathParam(param: unknown): string {
         case "boolean":
             break;
         default:
-            param = String(param);
+            param = JSON.stringify(param);
             break;
     }
     return encodeURIComponent(param as string | number | boolean);

--- a/seed/ts-sdk/simple-api/use-oxc/src/core/url/encodePathParam.ts
+++ b/seed/ts-sdk/simple-api/use-oxc/src/core/url/encodePathParam.ts
@@ -11,7 +11,7 @@ export function encodePathParam(param: unknown): string {
         case "boolean":
             break;
         default:
-            param = String(param);
+            param = JSON.stringify(param);
             break;
     }
     return encodeURIComponent(param as string | number | boolean);

--- a/seed/ts-sdk/simple-api/use-oxfmt/src/core/url/encodePathParam.ts
+++ b/seed/ts-sdk/simple-api/use-oxfmt/src/core/url/encodePathParam.ts
@@ -11,7 +11,7 @@ export function encodePathParam(param: unknown): string {
         case "boolean":
             break;
         default:
-            param = String(param);
+            param = JSON.stringify(param);
             break;
     }
     return encodeURIComponent(param as string | number | boolean);

--- a/seed/ts-sdk/simple-api/use-oxlint/src/core/url/encodePathParam.ts
+++ b/seed/ts-sdk/simple-api/use-oxlint/src/core/url/encodePathParam.ts
@@ -11,7 +11,7 @@ export function encodePathParam(param: unknown): string {
         case "boolean":
             break;
         default:
-            param = String(param);
+            param = JSON.stringify(param);
             break;
     }
     return encodeURIComponent(param as string | number | boolean);

--- a/seed/ts-sdk/simple-api/use-prettier-no-linter/src/core/url/encodePathParam.ts
+++ b/seed/ts-sdk/simple-api/use-prettier-no-linter/src/core/url/encodePathParam.ts
@@ -11,7 +11,7 @@ export function encodePathParam(param: unknown): string {
         case "boolean":
             break;
         default:
-            param = String(param);
+            param = JSON.stringify(param);
             break;
     }
     return encodeURIComponent(param as string | number | boolean);

--- a/seed/ts-sdk/simple-api/use-prettier/src/core/url/encodePathParam.ts
+++ b/seed/ts-sdk/simple-api/use-prettier/src/core/url/encodePathParam.ts
@@ -11,7 +11,7 @@ export function encodePathParam(param: unknown): string {
         case "boolean":
             break;
         default:
-            param = String(param);
+            param = JSON.stringify(param);
             break;
     }
     return encodeURIComponent(param as string | number | boolean);

--- a/seed/ts-sdk/simple-api/use-yarn/src/core/url/encodePathParam.ts
+++ b/seed/ts-sdk/simple-api/use-yarn/src/core/url/encodePathParam.ts
@@ -11,7 +11,7 @@ export function encodePathParam(param: unknown): string {
         case "boolean":
             break;
         default:
-            param = String(param);
+            param = JSON.stringify(param);
             break;
     }
     return encodeURIComponent(param as string | number | boolean);

--- a/seed/ts-sdk/simple-fhir/src/core/url/encodePathParam.ts
+++ b/seed/ts-sdk/simple-fhir/src/core/url/encodePathParam.ts
@@ -11,7 +11,7 @@ export function encodePathParam(param: unknown): string {
         case "boolean":
             break;
         default:
-            param = String(param);
+            param = JSON.stringify(param);
             break;
     }
     return encodeURIComponent(param as string | number | boolean);

--- a/seed/ts-sdk/single-url-environment-default/src/core/url/encodePathParam.ts
+++ b/seed/ts-sdk/single-url-environment-default/src/core/url/encodePathParam.ts
@@ -11,7 +11,7 @@ export function encodePathParam(param: unknown): string {
         case "boolean":
             break;
         default:
-            param = String(param);
+            param = JSON.stringify(param);
             break;
     }
     return encodeURIComponent(param as string | number | boolean);

--- a/seed/ts-sdk/single-url-environment-no-default/src/core/url/encodePathParam.ts
+++ b/seed/ts-sdk/single-url-environment-no-default/src/core/url/encodePathParam.ts
@@ -11,7 +11,7 @@ export function encodePathParam(param: unknown): string {
         case "boolean":
             break;
         default:
-            param = String(param);
+            param = JSON.stringify(param);
             break;
     }
     return encodeURIComponent(param as string | number | boolean);

--- a/seed/ts-sdk/streaming-parameter/src/core/url/encodePathParam.ts
+++ b/seed/ts-sdk/streaming-parameter/src/core/url/encodePathParam.ts
@@ -11,7 +11,7 @@ export function encodePathParam(param: unknown): string {
         case "boolean":
             break;
         default:
-            param = String(param);
+            param = JSON.stringify(param);
             break;
     }
     return encodeURIComponent(param as string | number | boolean);

--- a/seed/ts-sdk/streaming/no-custom-config/src/core/url/encodePathParam.ts
+++ b/seed/ts-sdk/streaming/no-custom-config/src/core/url/encodePathParam.ts
@@ -11,7 +11,7 @@ export function encodePathParam(param: unknown): string {
         case "boolean":
             break;
         default:
-            param = String(param);
+            param = JSON.stringify(param);
             break;
     }
     return encodeURIComponent(param as string | number | boolean);

--- a/seed/ts-sdk/streaming/serde-layer/src/core/url/encodePathParam.ts
+++ b/seed/ts-sdk/streaming/serde-layer/src/core/url/encodePathParam.ts
@@ -11,7 +11,7 @@ export function encodePathParam(param: unknown): string {
         case "boolean":
             break;
         default:
-            param = String(param);
+            param = JSON.stringify(param);
             break;
     }
     return encodeURIComponent(param as string | number | boolean);

--- a/seed/ts-sdk/streaming/wrapper/src/core/url/encodePathParam.ts
+++ b/seed/ts-sdk/streaming/wrapper/src/core/url/encodePathParam.ts
@@ -11,7 +11,7 @@ export function encodePathParam(param: unknown): string {
         case "boolean":
             break;
         default:
-            param = String(param);
+            param = JSON.stringify(param);
             break;
     }
     return encodeURIComponent(param as string | number | boolean);

--- a/seed/ts-sdk/trace/exhaustive/src/core/url/encodePathParam.ts
+++ b/seed/ts-sdk/trace/exhaustive/src/core/url/encodePathParam.ts
@@ -11,7 +11,7 @@ export function encodePathParam(param: unknown): string {
         case "boolean":
             break;
         default:
-            param = String(param);
+            param = JSON.stringify(param);
             break;
     }
     return encodeURIComponent(param as string | number | boolean);

--- a/seed/ts-sdk/trace/no-custom-config/src/core/url/encodePathParam.ts
+++ b/seed/ts-sdk/trace/no-custom-config/src/core/url/encodePathParam.ts
@@ -11,7 +11,7 @@ export function encodePathParam(param: unknown): string {
         case "boolean":
             break;
         default:
-            param = String(param);
+            param = JSON.stringify(param);
             break;
     }
     return encodeURIComponent(param as string | number | boolean);

--- a/seed/ts-sdk/trace/serde-no-throwing/src/core/url/encodePathParam.ts
+++ b/seed/ts-sdk/trace/serde-no-throwing/src/core/url/encodePathParam.ts
@@ -11,7 +11,7 @@ export function encodePathParam(param: unknown): string {
         case "boolean":
             break;
         default:
-            param = String(param);
+            param = JSON.stringify(param);
             break;
     }
     return encodeURIComponent(param as string | number | boolean);

--- a/seed/ts-sdk/trace/serde/src/core/url/encodePathParam.ts
+++ b/seed/ts-sdk/trace/serde/src/core/url/encodePathParam.ts
@@ -11,7 +11,7 @@ export function encodePathParam(param: unknown): string {
         case "boolean":
             break;
         default:
-            param = String(param);
+            param = JSON.stringify(param);
             break;
     }
     return encodeURIComponent(param as string | number | boolean);

--- a/seed/ts-sdk/ts-express-casing/src/core/url/encodePathParam.ts
+++ b/seed/ts-sdk/ts-express-casing/src/core/url/encodePathParam.ts
@@ -11,7 +11,7 @@ export function encodePathParam(param: unknown): string {
         case "boolean":
             break;
         default:
-            param = String(param);
+            param = JSON.stringify(param);
             break;
     }
     return encodeURIComponent(param as string | number | boolean);

--- a/seed/ts-sdk/ts-extra-properties/src/core/url/encodePathParam.ts
+++ b/seed/ts-sdk/ts-extra-properties/src/core/url/encodePathParam.ts
@@ -11,7 +11,7 @@ export function encodePathParam(param: unknown): string {
         case "boolean":
             break;
         default:
-            param = String(param);
+            param = JSON.stringify(param);
             break;
     }
     return encodeURIComponent(param as string | number | boolean);

--- a/seed/ts-sdk/ts-inline-types/inline/src/core/url/encodePathParam.ts
+++ b/seed/ts-sdk/ts-inline-types/inline/src/core/url/encodePathParam.ts
@@ -11,7 +11,7 @@ export function encodePathParam(param: unknown): string {
         case "boolean":
             break;
         default:
-            param = String(param);
+            param = JSON.stringify(param);
             break;
     }
     return encodeURIComponent(param as string | number | boolean);

--- a/seed/ts-sdk/ts-inline-types/no-inline/src/core/url/encodePathParam.ts
+++ b/seed/ts-sdk/ts-inline-types/no-inline/src/core/url/encodePathParam.ts
@@ -11,7 +11,7 @@ export function encodePathParam(param: unknown): string {
         case "boolean":
             break;
         default:
-            param = String(param);
+            param = JSON.stringify(param);
             break;
     }
     return encodeURIComponent(param as string | number | boolean);

--- a/seed/ts-sdk/undiscriminated-union-with-response-property/src/core/url/encodePathParam.ts
+++ b/seed/ts-sdk/undiscriminated-union-with-response-property/src/core/url/encodePathParam.ts
@@ -11,7 +11,7 @@ export function encodePathParam(param: unknown): string {
         case "boolean":
             break;
         default:
-            param = String(param);
+            param = JSON.stringify(param);
             break;
     }
     return encodeURIComponent(param as string | number | boolean);

--- a/seed/ts-sdk/undiscriminated-unions/no-custom-config/src/core/url/encodePathParam.ts
+++ b/seed/ts-sdk/undiscriminated-unions/no-custom-config/src/core/url/encodePathParam.ts
@@ -11,7 +11,7 @@ export function encodePathParam(param: unknown): string {
         case "boolean":
             break;
         default:
-            param = String(param);
+            param = JSON.stringify(param);
             break;
     }
     return encodeURIComponent(param as string | number | boolean);

--- a/seed/ts-sdk/undiscriminated-unions/skip-response-validation/src/core/url/encodePathParam.ts
+++ b/seed/ts-sdk/undiscriminated-unions/skip-response-validation/src/core/url/encodePathParam.ts
@@ -11,7 +11,7 @@ export function encodePathParam(param: unknown): string {
         case "boolean":
             break;
         default:
-            param = String(param);
+            param = JSON.stringify(param);
             break;
     }
     return encodeURIComponent(param as string | number | boolean);

--- a/seed/ts-sdk/unions-with-local-date/src/core/url/encodePathParam.ts
+++ b/seed/ts-sdk/unions-with-local-date/src/core/url/encodePathParam.ts
@@ -11,7 +11,7 @@ export function encodePathParam(param: unknown): string {
         case "boolean":
             break;
         default:
-            param = String(param);
+            param = JSON.stringify(param);
             break;
     }
     return encodeURIComponent(param as string | number | boolean);

--- a/seed/ts-sdk/unions/no-custom-config/src/core/url/encodePathParam.ts
+++ b/seed/ts-sdk/unions/no-custom-config/src/core/url/encodePathParam.ts
@@ -11,7 +11,7 @@ export function encodePathParam(param: unknown): string {
         case "boolean":
             break;
         default:
-            param = String(param);
+            param = JSON.stringify(param);
             break;
     }
     return encodeURIComponent(param as string | number | boolean);

--- a/seed/ts-sdk/unions/serde-layer/src/core/url/encodePathParam.ts
+++ b/seed/ts-sdk/unions/serde-layer/src/core/url/encodePathParam.ts
@@ -11,7 +11,7 @@ export function encodePathParam(param: unknown): string {
         case "boolean":
             break;
         default:
-            param = String(param);
+            param = JSON.stringify(param);
             break;
     }
     return encodeURIComponent(param as string | number | boolean);

--- a/seed/ts-sdk/unknown/no-custom-config/src/core/url/encodePathParam.ts
+++ b/seed/ts-sdk/unknown/no-custom-config/src/core/url/encodePathParam.ts
@@ -11,7 +11,7 @@ export function encodePathParam(param: unknown): string {
         case "boolean":
             break;
         default:
-            param = String(param);
+            param = JSON.stringify(param);
             break;
     }
     return encodeURIComponent(param as string | number | boolean);

--- a/seed/ts-sdk/unknown/unknown-as-any/src/core/url/encodePathParam.ts
+++ b/seed/ts-sdk/unknown/unknown-as-any/src/core/url/encodePathParam.ts
@@ -11,7 +11,7 @@ export function encodePathParam(param: unknown): string {
         case "boolean":
             break;
         default:
-            param = String(param);
+            param = JSON.stringify(param);
             break;
     }
     return encodeURIComponent(param as string | number | boolean);

--- a/seed/ts-sdk/url-form-encoded/src/core/url/encodePathParam.ts
+++ b/seed/ts-sdk/url-form-encoded/src/core/url/encodePathParam.ts
@@ -11,7 +11,7 @@ export function encodePathParam(param: unknown): string {
         case "boolean":
             break;
         default:
-            param = String(param);
+            param = JSON.stringify(param);
             break;
     }
     return encodeURIComponent(param as string | number | boolean);

--- a/seed/ts-sdk/validation/src/core/url/encodePathParam.ts
+++ b/seed/ts-sdk/validation/src/core/url/encodePathParam.ts
@@ -11,7 +11,7 @@ export function encodePathParam(param: unknown): string {
         case "boolean":
             break;
         default:
-            param = String(param);
+            param = JSON.stringify(param);
             break;
     }
     return encodeURIComponent(param as string | number | boolean);

--- a/seed/ts-sdk/variables/src/core/url/encodePathParam.ts
+++ b/seed/ts-sdk/variables/src/core/url/encodePathParam.ts
@@ -11,7 +11,7 @@ export function encodePathParam(param: unknown): string {
         case "boolean":
             break;
         default:
-            param = String(param);
+            param = JSON.stringify(param);
             break;
     }
     return encodeURIComponent(param as string | number | boolean);

--- a/seed/ts-sdk/version-no-default/src/core/url/encodePathParam.ts
+++ b/seed/ts-sdk/version-no-default/src/core/url/encodePathParam.ts
@@ -11,7 +11,7 @@ export function encodePathParam(param: unknown): string {
         case "boolean":
             break;
         default:
-            param = String(param);
+            param = JSON.stringify(param);
             break;
     }
     return encodeURIComponent(param as string | number | boolean);

--- a/seed/ts-sdk/version/src/core/url/encodePathParam.ts
+++ b/seed/ts-sdk/version/src/core/url/encodePathParam.ts
@@ -11,7 +11,7 @@ export function encodePathParam(param: unknown): string {
         case "boolean":
             break;
         default:
-            param = String(param);
+            param = JSON.stringify(param);
             break;
     }
     return encodeURIComponent(param as string | number | boolean);

--- a/seed/ts-sdk/webhook-audience/src/core/url/encodePathParam.ts
+++ b/seed/ts-sdk/webhook-audience/src/core/url/encodePathParam.ts
@@ -11,7 +11,7 @@ export function encodePathParam(param: unknown): string {
         case "boolean":
             break;
         default:
-            param = String(param);
+            param = JSON.stringify(param);
             break;
     }
     return encodeURIComponent(param as string | number | boolean);

--- a/seed/ts-sdk/webhooks/no-custom-config/src/core/url/encodePathParam.ts
+++ b/seed/ts-sdk/webhooks/no-custom-config/src/core/url/encodePathParam.ts
@@ -11,7 +11,7 @@ export function encodePathParam(param: unknown): string {
         case "boolean":
             break;
         default:
-            param = String(param);
+            param = JSON.stringify(param);
             break;
     }
     return encodeURIComponent(param as string | number | boolean);

--- a/seed/ts-sdk/websocket-bearer-auth/websockets/src/core/url/encodePathParam.ts
+++ b/seed/ts-sdk/websocket-bearer-auth/websockets/src/core/url/encodePathParam.ts
@@ -11,7 +11,7 @@ export function encodePathParam(param: unknown): string {
         case "boolean":
             break;
         default:
-            param = String(param);
+            param = JSON.stringify(param);
             break;
     }
     return encodeURIComponent(param as string | number | boolean);

--- a/seed/ts-sdk/websocket-inferred-auth/websockets/src/core/url/encodePathParam.ts
+++ b/seed/ts-sdk/websocket-inferred-auth/websockets/src/core/url/encodePathParam.ts
@@ -11,7 +11,7 @@ export function encodePathParam(param: unknown): string {
         case "boolean":
             break;
         default:
-            param = String(param);
+            param = JSON.stringify(param);
             break;
     }
     return encodeURIComponent(param as string | number | boolean);

--- a/seed/ts-sdk/websocket-multi-url/src/core/url/encodePathParam.ts
+++ b/seed/ts-sdk/websocket-multi-url/src/core/url/encodePathParam.ts
@@ -11,7 +11,7 @@ export function encodePathParam(param: unknown): string {
         case "boolean":
             break;
         default:
-            param = String(param);
+            param = JSON.stringify(param);
             break;
     }
     return encodeURIComponent(param as string | number | boolean);

--- a/seed/ts-sdk/websocket/no-serde/src/core/url/encodePathParam.ts
+++ b/seed/ts-sdk/websocket/no-serde/src/core/url/encodePathParam.ts
@@ -11,7 +11,7 @@ export function encodePathParam(param: unknown): string {
         case "boolean":
             break;
         default:
-            param = String(param);
+            param = JSON.stringify(param);
             break;
     }
     return encodeURIComponent(param as string | number | boolean);

--- a/seed/ts-sdk/websocket/no-websocket-clients/src/core/url/encodePathParam.ts
+++ b/seed/ts-sdk/websocket/no-websocket-clients/src/core/url/encodePathParam.ts
@@ -11,7 +11,7 @@ export function encodePathParam(param: unknown): string {
         case "boolean":
             break;
         default:
-            param = String(param);
+            param = JSON.stringify(param);
             break;
     }
     return encodeURIComponent(param as string | number | boolean);

--- a/seed/ts-sdk/websocket/serde/src/core/url/encodePathParam.ts
+++ b/seed/ts-sdk/websocket/serde/src/core/url/encodePathParam.ts
@@ -11,7 +11,7 @@ export function encodePathParam(param: unknown): string {
         case "boolean":
             break;
         default:
-            param = String(param);
+            param = JSON.stringify(param);
             break;
     }
     return encodeURIComponent(param as string | number | boolean);


### PR DESCRIPTION
## Description

Refs https://github.com/fern-demo/docusign-typescript-sdk/pull/4

Fixes a mismatch between how the IR generates example URLs and how the runtime `encodePathParam` function serializes non-primitive path parameter values. This caused 10 wire test failures in generated SDKs when auto-generated error examples used object-typed path parameters.

## Changes Made

- Changed `encodePathParam` default case from `String(param)` to `JSON.stringify(param)` for non-primitive types (objects, arrays, etc.)
- Updated `versions.yml` with new version `3.60.4`
- Updated 203 seed snapshot files to reflect the change

## Root Cause

The IR's `getUrlForExample` ([source](https://github.com/fern-api/fern/blob/main/packages/commons/ir-utils/src/examples/v1/generateEndpointExample.ts#L436)) serializes non-string path parameter values with `JSON.stringify`:
```ts
const stringValue = typeof value === "string" ? value : JSON.stringify(value);
```

But the runtime `encodePathParam` used `String(param)`, which converts objects to `[object Object]`. This produced a URL mismatch: the mock server expected `%7B%22key%22%3A%22value%22%7D` (JSON-encoded) but the SDK sent `%5Bobject%20Object%5D`.

## ⚠️ Review Checklist — Important Behavioral Considerations

- [ ] **Arrays**: `String([1,2,3])` → `"1,2,3"` but `JSON.stringify([1,2,3])` → `"[1,2,3]"`. Verify no generated SDK currently relies on comma-separated array path params.
- [ ] **Dates**: `String(new Date())` → `"Mon Mar 30 2026..."` but `JSON.stringify(new Date())` → `"\"2026-03-30T...\""` (note: wrapped in quotes). Verify Date path params aren't affected.
- [ ] **Upstream question**: Should auto-generated examples ever produce object-valued path parameters? If not, an alternative fix could be in the example generator rather than the runtime.
- [ ] **Seed snapshot diff**: 203 files changed mechanically — all should be identical `String(param)` → `JSON.stringify(param)` replacements.

## Testing

- [x] `pnpm run check` (biome lint) passes
- [ ] Unit tests added/updated — **none added**; the existing function has no test file
- [ ] CI seed tests will validate snapshot consistency

Link to Devin session: https://app.devin.ai/sessions/61589e20bb1248ffb9b4a89ad69c9289
Requested by: @iamnamananand996