### PR TITLE
chore(ruby): change default Rubocop variable number style

### DIFF
--- a/generators/ruby-v2/base/src/project/RubocopFile.ts
+++ b/generators/ruby-v2/base/src/project/RubocopFile.ts
@@ -16,7 +16,7 @@ export class RubocopFile {
     }
 
     private getVariableNumberConfig(): string {
-        const style = this.context.customConfig.rubocopVariableNumberStyle ?? "snake_case";
+        const style = this.context.customConfig.rubocopVariableNumberStyle ?? "normalcase";
 
         if (style === "disabled") {
             return `Naming/VariableNumber:

--- a/generators/ruby-v2/sdk/versions.yml
+++ b/generators/ruby-v2/sdk/versions.yml
@@ -1,5 +1,15 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 
+- version: 1.1.11
+  changelogEntry:
+    - summary: |
+        Change default `rubocopVariableNumberStyle` from `snake_case` to `normalcase`,
+        so field names with embedded digits (e.g., `recaptcha_v2`, `office365`) no longer
+        trigger RuboCop warnings by default.
+      type: chore
+  createdAt: "2026-03-31"
+  irVersion: 61
+
 - version: 1.1.10
   changelogEntry:
     - summary: |


### PR DESCRIPTION
Update generators/ruby-v2/base/src/project/RubocopFile.ts to use 'normalcase' as the fallback for context.customConfig.rubocopVariableNumberStyle instead of 'snake_case'. This alters the default naming style applied when no custom setting is provided.