### PR TITLE
chore(ci): fix issue template labels to avoid duplicate headers

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -6,7 +6,7 @@ body:
   - type: dropdown
     id: product
     attributes:
-      label: "Which Fern component?"
+      label: "Component"
       options:
         - "CLI"
         - "SDKs"
@@ -19,7 +19,7 @@ body:
   - type: dropdown
     id: priority
     attributes:
-      label: "How urgent is this?"
+      label: "Priority"
       options:
         - "P0 - Critical (Blocking work)"
         - "P1 - High (Strongly needed)"
@@ -31,7 +31,7 @@ body:
   - type: dropdown
     id: sdk-language
     attributes:
-      label: "Which SDK language(s)?"
+      label: "SDK Language(s)"
       description: "Only if you selected 'SDKs' above. Skip this field otherwise."
       multiple: true
       options:
@@ -50,8 +50,8 @@ body:
   - type: textarea
     id: issue-description
     attributes:
-      label: "What's the issue?"
-      description: "Please provide: \n1. Steps to reproduce\n2. Expected behavior\n3. Actual behavior\n4. Environment details (OS, versions, etc.)"
+      label: "Bug Description"
+      description: "Please describe only the issue here. Component, priority, and language are captured by the fields above — no need to repeat them.\n1. Steps to reproduce\n2. Expected behavior\n3. Actual behavior\n4. Environment details (OS, versions, etc.)"
       placeholder: |
         Steps to reproduce:
         1. First step (e.g., "Initialize Fern project")
@@ -72,8 +72,8 @@ body:
   - type: textarea
     id: versions
     attributes:
-      label: "Fern CLI & Generator Versions"
-      description: "Report your Fern CLI version (from `fern.config.json`) and, if applicable, your SDK Generator versions (from `generators.yml`)."
+      label: "Versions"
+      description: "Report your Fern CLI version (from `fern.config.json`) and, if applicable, your SDK generator versions (from `generators.yml`)."
       placeholder: |
         Fern CLI version: [e.g., v0.55.1]
         SDK Generator versions: 

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -6,7 +6,7 @@ body:
   - type: dropdown
     id: product
     attributes:
-      label: "Which Fern component?"
+      label: "Component"
       options:
         - "CLI"
         - "SDKs"
@@ -19,7 +19,7 @@ body:
   - type: dropdown
     id: priority
     attributes:
-      label: "How important is this?"
+      label: "Priority"
       options:
         - "P0 - Critical (Blocking work)"
         - "P1 - High (Strongly needed)"
@@ -31,7 +31,7 @@ body:
   - type: dropdown
     id: sdk-language
     attributes:
-      label: "Which SDK language(s)?"
+      label: "SDK Language(s)"
       description: "Only if you selected 'SDKs' above. Skip this field otherwise."
       multiple: true
       options:
@@ -50,8 +50,8 @@ body:
   - type: textarea
     id: proposed-feature
     attributes:
-      label: "What's the feature?"
-      description: "Clearly describe the functionality and how it is useful."
+      label: "Feature Description"
+      description: "Clearly describe the functionality and how it is useful. Component, priority, and language are captured by the fields above — no need to repeat them."
       placeholder: |
         Example:
         - **Feature**: Auto-retry for failed SDK requests.

--- a/.github/workflows/backfill-issue-labels.yml
+++ b/.github/workflows/backfill-issue-labels.yml
@@ -124,7 +124,7 @@ jobs:
                 const currentLabels = issue.labels.map(l => typeof l === "string" ? l : l.name);
 
                 // Component
-                const componentSection = body.match(/### Which Fern component\?\s*\n\n(.+)/);
+                const componentSection = body.match(/### (?:Component|Which Fern component\?)\s*\n\n(.+)/);
                 if (componentSection) {
                   const component = componentSection[1].trim();
                   if (componentMap[component]) {
@@ -136,7 +136,7 @@ jobs:
                 }
 
                 // Priority
-                const prioritySection = body.match(/### How (?:urgent|important) is this\?\s*\n\n(.+)/);
+                const prioritySection = body.match(/### (?:Priority|How (?:urgent|important) is this\?)\s*\n\n(.+)/);
                 if (prioritySection) {
                   const priority = prioritySection[1].trim();
                   if (priorityMap[priority]) {
@@ -148,7 +148,7 @@ jobs:
                 }
 
                 // SDK languages
-                const langSection = body.match(/### Which SDK language\(s\)\?\s*\n\n([\s\S]*?)(?=\n###|\n*$)/);
+                const langSection = body.match(/### (?:SDK Language\(s\)|Which SDK language\(s\)\?)\s*\n\n([\s\S]*?)(?=\n###|\n*$)/);
                 if (langSection) {
                   const langText = langSection[1].trim();
                   if (langText && langText !== "_No response_") {

--- a/.github/workflows/issue-labeler.yml
+++ b/.github/workflows/issue-labeler.yml
@@ -37,14 +37,18 @@ jobs:
             ];
 
             // --- Component labels ---
-            const componentSection = body.match(/### Which Fern component\?\s*\n\n(.+)/);
+            const componentSection = body.match(/### (?:Component|Which Fern component\?)\s*\n\n(.+)/);
             if (componentSection) {
               const component = componentSection[1].trim();
               const componentMap = {
                 "CLI": "component:cli",
+                "Fern CLI": "component:cli",
                 "SDKs": "component:sdks",
+                "SDK Generator": "component:sdks",
                 "Docs": "component:docs",
+                "Fern Docs": "component:docs",
                 "Dashboard": "component:dashboard",
+                "Fern Editor": "component:dashboard",
                 "Other": "component:other",
               };
               if (componentMap[component]) {
@@ -53,7 +57,7 @@ jobs:
             }
 
             // --- Priority labels ---
-            const prioritySection = body.match(/### How (?:urgent|important) is this\?\s*\n\n(.+)/);
+            const prioritySection = body.match(/### (?:Priority|How (?:urgent|important) is this\?)\s*\n\n(.+)/);
             if (prioritySection) {
               const priority = prioritySection[1].trim();
               const priorityMap = {
@@ -69,7 +73,7 @@ jobs:
 
             // --- SDK language labels ---
             const selectedLangs = [];
-            const langSection = body.match(/### Which SDK language\(s\)\?\s*\n\n([\s\S]*?)(?=\n###|\n*$)/);
+            const langSection = body.match(/### (?:SDK Language\(s\)|Which SDK language\(s\)\?)\s*\n\n([\s\S]*?)(?=\n###|\n*$)/);
             if (langSection) {
               const langText = langSection[1].trim();
               if (langText && langText !== "_No response_") {


### PR DESCRIPTION
## Description

Refs https://github.com/fern-api/fern/issues/14258

Fixes duplicate `### Header` sections in GitHub issues. When users paste old-format markdown (e.g. `### Which Fern component?`) into the description textarea, these headers collide with the form-generated headers, producing confusing duplicate sections (as seen in #14258 before it was manually edited).

## Changes Made

- **Shortened form field labels** in `bug_report.yml` and `feature_request.yml` to concise names that won't collide with pasted content:
  - `"Which Fern component?"` → `"Component"`
  - `"How urgent/important is this?"` → `"Priority"`
  - `"Which SDK language(s)?"` → `"SDK Language(s)"`
  - `"What's the issue?"` → `"Bug Description"`
  - `"What's the feature?"` → `"Feature Description"`
  - `"Fern CLI & Generator Versions"` → `"Versions"`
- **Added guidance** in description textarea: _"Component, priority, and language are captured by the fields above — no need to repeat them."_
- **Updated labeler regex** in `issue-labeler.yml` and `backfill-issue-labels.yml` to match both old and new label formats via non-capturing alternation (e.g. `### (?:Component|Which Fern component\?)`)
- **Added old dropdown values** (`SDK Generator`, `Fern CLI`, `Fern Docs`, `Fern Editor`) to the issue-labeler component map so older issues still get labeled correctly on edit

## Testing

- [ ] Manual testing completed — verify by creating a test issue with the new template to confirm labels render correctly and auto-labeling still works
- [ ] Verify regex backward compatibility by editing an existing issue that uses the old header format

## Human Review Checklist

- [ ] Confirm the shortened labels still read clearly in the GitHub issue form UI
- [ ] Verify the regex alternation patterns correctly match both old (`### Which Fern component?`) and new (`### Component`) header formats
- [ ] Check that the expanded component map values (`Fern CLI` → `component:cli`, `SDK Generator` → `component:sdks`, etc.) are correct

Link to Devin session: https://app.devin.ai/sessions/af6396287cf547b4ae850c1bf579e70e
Requested by: @dannysheridan