### PR TITLE
feat(rust): multi-environment support

### DIFF
--- a/generators/rust/base/src/AsIs.ts
+++ b/generators/rust/base/src/AsIs.ts
@@ -23,10 +23,6 @@ interface AsIsFileSpec {
  */
 const AsIsFileSpecs = {
     // Core infrastructure templates
-    ApiClientBuilder: {
-        relativePathToDir: "src",
-        filename: "client.rs"
-    },
     Prelude: {
         relativePathToDir: "src",
         filename: "prelude.rs"

--- a/generators/rust/base/src/asIs/http_client.rs
+++ b/generators/rust/base/src/asIs/http_client.rs
@@ -144,6 +144,16 @@ impl HttpClient {
         })
     }
 
+    /// Returns the configured base URL.
+    pub fn base_url(&self) -> &str {
+        &self.config.base_url
+    }
+
+    /// Returns a reference to the client configuration.
+    pub fn config(&self) -> &ClientConfig {
+        &self.config
+    }
+
     /// Execute a request with the given method, path, and options
     pub async fn execute_request<T>(
         &self,
@@ -184,6 +194,48 @@ impl HttpClient {
         self.apply_custom_headers(&mut req, &options)?;
 
         // Execute with retries
+        let response = self.execute_with_retries(req, &options).await?;
+        self.parse_response(response).await
+    }
+
+    /// Execute a request with an explicit base URL override.
+    ///
+    /// Used for multi-URL environments where different endpoints
+    /// resolve to different base URLs.
+    pub async fn execute_request_with_base_url<T>(
+        &self,
+        base_url: &str,
+        method: Method,
+        path: &str,
+        body: Option<serde_json::Value>,
+        query_params: Option<Vec<(String, String)>>,
+        options: Option<RequestOptions>,
+    ) -> Result<T, ApiError>
+    where
+        T: DeserializeOwned,
+    {
+        let url = join_url(base_url, path);
+        let mut request = self.client.request(method, &url);
+
+        if let Some(params) = query_params {
+            request = request.query(&params);
+        }
+
+        if let Some(opts) = &options {
+            if !opts.additional_query_params.is_empty() {
+                request = request.query(&opts.additional_query_params);
+            }
+        }
+
+        if let Some(body) = body {
+            request = request.json(&body);
+        }
+
+        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
+
+        self.apply_auth_headers(&mut req, &options).await?;
+        self.apply_custom_headers(&mut req, &options)?;
+
         let response = self.execute_with_retries(req, &options).await?;
         self.parse_response(response).await
     }
@@ -475,6 +527,43 @@ impl HttpClient {
         let response = self.execute_with_retries(req, &options).await?;
 
         // Return streaming response
+        Ok(ByteStream::new(response))
+    }
+
+    /// Execute a streaming request with an explicit base URL override.
+    pub async fn execute_stream_request_with_base_url(
+        &self,
+        base_url: &str,
+        method: Method,
+        path: &str,
+        body: Option<serde_json::Value>,
+        query_params: Option<Vec<(String, String)>>,
+        options: Option<RequestOptions>,
+    ) -> Result<ByteStream, ApiError> {
+        let url = join_url(base_url, path);
+        let mut request = self.client.request(method, &url);
+
+        if let Some(params) = query_params {
+            request = request.query(&params);
+        }
+
+        if let Some(opts) = &options {
+            if !opts.additional_query_params.is_empty() {
+                request = request.query(&opts.additional_query_params);
+            }
+        }
+
+        if let Some(body) = body {
+            request = request.json(&body);
+        }
+
+        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
+
+        self.apply_auth_headers(&mut req, &options).await?;
+        self.apply_custom_headers(&mut req, &options)?;
+
+        let response = self.execute_with_retries(req, &options).await?;
+
         Ok(ByteStream::new(response))
     }
 

--- a/generators/rust/sdk/src/SdkGeneratorCli.ts
+++ b/generators/rust/sdk/src/SdkGeneratorCli.ts
@@ -21,6 +21,7 @@ import { exec } from "child_process";
 import { promisify } from "util";
 import { EnvironmentGenerator } from "./environment/EnvironmentGenerator.js";
 import { ErrorGenerator } from "./error/ErrorGenerator.js";
+import { ApiClientBuilderGenerator } from "./generators/ApiClientBuilderGenerator.js";
 import { ClientConfigGenerator } from "./generators/ClientConfigGenerator.js";
 import { RootClientGenerator } from "./generators/RootClientGenerator.js";
 import { SubClientGenerator } from "./generators/SubClientGenerator.js";
@@ -251,6 +252,8 @@ export class SdkGeneratorCli extends AbstractRustGeneratorCli<SdkCustomConfigSch
         context.logger.debug("Generating client configuration files...");
         const clientConfigGenerator = new ClientConfigGenerator(context);
         files.push(clientConfigGenerator.generate());
+        const apiClientBuilderGenerator = new ApiClientBuilderGenerator(context);
+        files.push(apiClientBuilderGenerator.generate());
 
         // Client.rs and nested mod.rs files
         context.logger.debug(`Generating root client: ${context.getClientName()}...`);

--- a/generators/rust/sdk/src/SdkGeneratorContext.ts
+++ b/generators/rust/sdk/src/SdkGeneratorContext.ts
@@ -40,12 +40,25 @@ export class SdkGeneratorContext extends AbstractRustGeneratorContext<SdkCustomC
         }
     }
 
+    public hasEnvironments(): boolean {
+        return this.ir.environments?.environments != null;
+    }
+
+    public hasMultipleBaseUrls(): boolean {
+        return this.ir.environments?.environments?.type === "multipleBaseUrls";
+    }
+
+    public getEnvironmentEnumName(): string {
+        return this.customConfig.environmentEnumName || "Environment";
+    }
+
     public getCoreAsIsFiles(): AsIsFileDefinition[] {
         let files = Object.values(AsIsFiles);
         // Exclude core/mod.rs — it's generated dynamically to only declare modules for files that exist.
         // The static asIs mod.rs always declares mod sse_stream and mod websocket, which breaks
         // cargo fmt when those files are conditionally excluded (cargo fmt doesn't evaluate #[cfg]).
         files = files.filter((file) => file !== AsIsFiles.CoreMod);
+        files = files.filter((file) => file.filename !== "client.rs");
         // Only include sse_stream.rs when there are streaming endpoints
         if (!this.hasStreamingEndpoints()) {
             files = files.filter((file) => file.filename !== "sse_stream.rs");
@@ -61,6 +74,10 @@ export class SdkGeneratorContext extends AbstractRustGeneratorContext<SdkCustomC
         // Only include base64_bytes.rs when base64 types are used
         if (!this.usesBase64()) {
             files = files.filter((file) => file.filename !== "base64_bytes.rs");
+        }
+        // Only include number_serializers.rs when floating point types are used
+        if (!this.usesFloatingPoint()) {
+            files = files.filter((file) => file.filename !== "number_serializers.rs");
         }
         // Only include flexible_datetime.rs when datetime/date types are used
         if (!this.usesDateTime()) {

--- a/generators/rust/sdk/src/SdkGeneratorContext.ts
+++ b/generators/rust/sdk/src/SdkGeneratorContext.ts
@@ -83,10 +83,6 @@ export class SdkGeneratorContext extends AbstractRustGeneratorContext<SdkCustomC
         if (!this.usesDateTime()) {
             files = files.filter((file) => file.filename !== "flexible_datetime.rs");
         }
-        // Only include number_serializers.rs when floating point types are used
-        if (!this.usesFloatingPoint()) {
-            files = files.filter((file) => file.filename !== "number_serializers.rs");
-        }
         return files;
     }
 

--- a/generators/rust/sdk/src/__test__/ClientConfigAuth.test.ts
+++ b/generators/rust/sdk/src/__test__/ClientConfigAuth.test.ts
@@ -1,6 +1,7 @@
 import * as fs from "fs";
 import * as path from "path";
 import { describe, expect, it } from "vitest";
+import { ApiClientBuilderGenerator } from "../generators/ApiClientBuilderGenerator.js";
 import { ClientConfigGenerator } from "../generators/ClientConfigGenerator.js";
 import { createSampleGeneratorContext } from "./util/createSampleGeneratorContext.js";
 
@@ -15,8 +16,10 @@ const context = createSampleGeneratorContext();
 const clientConfigGenerator = new ClientConfigGenerator(context);
 const CLIENT_CONFIG = clientConfigGenerator.generate().fileContents;
 
-// Read AsIs files for testing
-const API_CLIENT_BUILDER = readAsIsFile("client.rs");
+// Generate ApiClientBuilder for testing using the generator
+const apiClientBuilderGenerator = new ApiClientBuilderGenerator(context);
+const API_CLIENT_BUILDER = apiClientBuilderGenerator.generate().fileContents;
+
 const HTTP_CLIENT = readAsIsFile("http_client.rs");
 const REQUEST_OPTIONS = readAsIsFile("request_options.rs");
 

--- a/generators/rust/sdk/src/__test__/EnvironmentGenerator.test.ts
+++ b/generators/rust/sdk/src/__test__/EnvironmentGenerator.test.ts
@@ -130,7 +130,10 @@ function createMockContext(ir: FernIr.IntermediateRepresentation): SdkGeneratorC
     return {
         ir,
         getClientName: () => "TestClient",
-        customConfig: {}
+        customConfig: {},
+        hasEnvironments: () => ir.environments?.environments != null,
+        hasMultipleBaseUrls: () => ir.environments?.environments?.type === "multipleBaseUrls",
+        getEnvironmentEnumName: () => "Environment"
     } as SdkGeneratorContext;
 }
 

--- a/generators/rust/sdk/src/__test__/QueryParameterGenerator.test.ts
+++ b/generators/rust/sdk/src/__test__/QueryParameterGenerator.test.ts
@@ -154,6 +154,7 @@ function createMockContext(ir: FernIr.IntermediateRepresentation): SdkGeneratorC
                 .toLowerCase()
                 .replace(/^_/, "");
         },
+        hasMultipleBaseUrls: () => false,
         escapeRustKeyword: (name: string) => {
             // Simple implementation for testing - just returns the name as-is
             // In production, this would escape Rust keywords with r# prefix

--- a/generators/rust/sdk/src/__test__/snapshots/api-client-builder-api-key.rs
+++ b/generators/rust/sdk/src/__test__/snapshots/api-client-builder-api-key.rs
@@ -1,28 +1,11 @@
-use crate::api::resources::{{CLIENT_NAME}};
+use crate::api::resources::TestClient;
 use crate::{ApiError, ClientConfig};
 use std::collections::HashMap;
 use std::time::Duration;
-
-/*
-Things to know:
-
-`impl Into<String>` is a generic parameter constraint in Rust that means "accept any type that can be converted into a String."
-It's essentially Rust's way of saying "I'll take a string in any form you give it to me."
-
-Types that implement Into<String>:
-
-// All of these work:
-builder.api_key("hello")           // &str
-builder.api_key("hello".to_string()) // String
-builder.api_key(format!("key_{}", id)) // String from format!
-builder.api_key(my_string_variable)    // String variable
-*/
-
 /// Builder for creating API clients with custom configuration
 pub struct ApiClientBuilder {
     config: ClientConfig,
 }
-
 impl Default for ApiClientBuilder {
     fn default() -> Self {
         Self {
@@ -30,7 +13,6 @@ impl Default for ApiClientBuilder {
         }
     }
 }
-
 impl ApiClientBuilder {
     /// Create a new builder with the specified base URL
     pub fn new(base_url: impl Into<String>) -> Self {
@@ -117,11 +99,10 @@ impl ApiClientBuilder {
     }
 
     /// Build the client with validation
-    pub fn build(self) -> Result<{{CLIENT_NAME}}, ApiError> {
-        {{CLIENT_NAME}}::new(self.config)
+    pub fn build(self) -> Result<TestClient, ApiError> {
+        TestClient::new(self.config)
     }
 }
-
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/generators/rust/sdk/src/__test__/snapshots/http-client-api-key.rs
+++ b/generators/rust/sdk/src/__test__/snapshots/http-client-api-key.rs
@@ -144,6 +144,16 @@ impl HttpClient {
         })
     }
 
+    /// Returns the configured base URL.
+    pub fn base_url(&self) -> &str {
+        &self.config.base_url
+    }
+
+    /// Returns a reference to the client configuration.
+    pub fn config(&self) -> &ClientConfig {
+        &self.config
+    }
+
     /// Execute a request with the given method, path, and options
     pub async fn execute_request<T>(
         &self,
@@ -184,6 +194,48 @@ impl HttpClient {
         self.apply_custom_headers(&mut req, &options)?;
 
         // Execute with retries
+        let response = self.execute_with_retries(req, &options).await?;
+        self.parse_response(response).await
+    }
+
+    /// Execute a request with an explicit base URL override.
+    ///
+    /// Used for multi-URL environments where different endpoints
+    /// resolve to different base URLs.
+    pub async fn execute_request_with_base_url<T>(
+        &self,
+        base_url: &str,
+        method: Method,
+        path: &str,
+        body: Option<serde_json::Value>,
+        query_params: Option<Vec<(String, String)>>,
+        options: Option<RequestOptions>,
+    ) -> Result<T, ApiError>
+    where
+        T: DeserializeOwned,
+    {
+        let url = join_url(base_url, path);
+        let mut request = self.client.request(method, &url);
+
+        if let Some(params) = query_params {
+            request = request.query(&params);
+        }
+
+        if let Some(opts) = &options {
+            if !opts.additional_query_params.is_empty() {
+                request = request.query(&opts.additional_query_params);
+            }
+        }
+
+        if let Some(body) = body {
+            request = request.json(&body);
+        }
+
+        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
+
+        self.apply_auth_headers(&mut req, &options).await?;
+        self.apply_custom_headers(&mut req, &options)?;
+
         let response = self.execute_with_retries(req, &options).await?;
         self.parse_response(response).await
     }
@@ -475,6 +527,43 @@ impl HttpClient {
         let response = self.execute_with_retries(req, &options).await?;
 
         // Return streaming response
+        Ok(ByteStream::new(response))
+    }
+
+    /// Execute a streaming request with an explicit base URL override.
+    pub async fn execute_stream_request_with_base_url(
+        &self,
+        base_url: &str,
+        method: Method,
+        path: &str,
+        body: Option<serde_json::Value>,
+        query_params: Option<Vec<(String, String)>>,
+        options: Option<RequestOptions>,
+    ) -> Result<ByteStream, ApiError> {
+        let url = join_url(base_url, path);
+        let mut request = self.client.request(method, &url);
+
+        if let Some(params) = query_params {
+            request = request.query(&params);
+        }
+
+        if let Some(opts) = &options {
+            if !opts.additional_query_params.is_empty() {
+                request = request.query(&opts.additional_query_params);
+            }
+        }
+
+        if let Some(body) = body {
+            request = request.json(&body);
+        }
+
+        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
+
+        self.apply_auth_headers(&mut req, &options).await?;
+        self.apply_custom_headers(&mut req, &options)?;
+
+        let response = self.execute_with_retries(req, &options).await?;
+
         Ok(ByteStream::new(response))
     }
 

--- a/generators/rust/sdk/src/__test__/snapshots/multi-url-basic.rs
+++ b/generators/rust/sdk/src/__test__/snapshots/multi-url-basic.rs
@@ -22,6 +22,20 @@ impl Environment {
         Self::Staging(urls) => &urls.api,
     }
 }
+
+    pub fn api_url(&self) -> &str {
+    match self {
+        Self::Production(urls) => &urls.api,
+        Self::Staging(urls) => &urls.api,
+    }
+}
+
+    pub fn auth_url(&self) -> &str {
+    match self {
+        Self::Production(urls) => &urls.auth,
+        Self::Staging(urls) => &urls.auth,
+    }
+}
 }
 impl Default for Environment {
     fn default() -> Self {

--- a/generators/rust/sdk/src/__test__/snapshots/multi-url-many-services.rs
+++ b/generators/rust/sdk/src/__test__/snapshots/multi-url-many-services.rs
@@ -35,6 +35,38 @@ impl Environment {
         Self::Development(urls) => &urls.api,
     }
 }
+
+    pub fn api_url(&self) -> &str {
+    match self {
+        Self::Production(urls) => &urls.api,
+        Self::Staging(urls) => &urls.api,
+        Self::Development(urls) => &urls.api,
+    }
+}
+
+    pub fn auth_url(&self) -> &str {
+    match self {
+        Self::Production(urls) => &urls.auth,
+        Self::Staging(urls) => &urls.auth,
+        Self::Development(urls) => &urls.auth,
+    }
+}
+
+    pub fn storage_url(&self) -> &str {
+    match self {
+        Self::Production(urls) => &urls.storage,
+        Self::Staging(urls) => &urls.storage,
+        Self::Development(urls) => &urls.storage,
+    }
+}
+
+    pub fn analytics_url(&self) -> &str {
+    match self {
+        Self::Production(urls) => &urls.analytics,
+        Self::Staging(urls) => &urls.analytics,
+        Self::Development(urls) => &urls.analytics,
+    }
+}
 }
 impl Default for Environment {
     fn default() -> Self {

--- a/generators/rust/sdk/src/__test__/snapshots/multi-url-mixed-protocols.rs
+++ b/generators/rust/sdk/src/__test__/snapshots/multi-url-mixed-protocols.rs
@@ -22,6 +22,20 @@ impl Environment {
         Self::Local(urls) => &urls.api,
     }
 }
+
+    pub fn api_url(&self) -> &str {
+    match self {
+        Self::Production(urls) => &urls.api,
+        Self::Local(urls) => &urls.api,
+    }
+}
+
+    pub fn websocket_url(&self) -> &str {
+    match self {
+        Self::Production(urls) => &urls.websocket,
+        Self::Local(urls) => &urls.websocket,
+    }
+}
 }
 impl Default for Environment {
     fn default() -> Self {

--- a/generators/rust/sdk/src/__test__/util/createSampleGeneratorContext.ts
+++ b/generators/rust/sdk/src/__test__/util/createSampleGeneratorContext.ts
@@ -39,6 +39,9 @@ export function createSampleGeneratorContext(args: CreateSampleGeneratorContextA
         getApiClientBuilderClientName: () => "TestClient",
         getCrateName: () => "test_api",
         getCrateVersion: () => "0.1.0",
-        customConfig: {}
+        customConfig: {},
+        hasEnvironments: () => mockIR.environments?.environments != null,
+        hasMultipleBaseUrls: () => mockIR.environments?.environments?.type === "multipleBaseUrls",
+        getEnvironmentEnumName: () => "Environment"
     } as SdkGeneratorContext;
 }

--- a/generators/rust/sdk/src/environment/EnvironmentGenerator.ts
+++ b/generators/rust/sdk/src/environment/EnvironmentGenerator.ts
@@ -21,6 +21,9 @@ import {
 } from "@fern-api/rust-codegen";
 import { SdkGeneratorContext } from "../SdkGeneratorContext.js";
 
+/** The default URL getter method name, used for single-URL environments or the primary URL */
+export const DEFAULT_URL_METHOD = "url";
+
 export declare namespace EnvironmentGenerator {
     interface Args {
         context: SdkGeneratorContext;
@@ -32,6 +35,30 @@ export class EnvironmentGenerator {
 
     constructor({ context }: EnvironmentGenerator.Args) {
         this.context = context;
+    }
+
+    /**
+     * Returns the name of the URL getter method for a specific base URL ID in a multi-URL
+     * environment. For example, if the base URL ID maps to "wss", returns "wss_url".
+     * Returns "url" as fallback for single-URL environments or if the ID is not found.
+     */
+    public getUrlMethodNameForBaseUrlId(baseUrlId: string | undefined): string {
+        const environmentsConfig = this.context.ir.environments;
+        if (!environmentsConfig?.environments || !baseUrlId) {
+            return DEFAULT_URL_METHOD;
+        }
+
+        return environmentsConfig.environments._visit({
+            singleBaseUrl: () => DEFAULT_URL_METHOD,
+            multipleBaseUrls: (config) => {
+                const baseUrl = config.baseUrls.find((b) => b.id === baseUrlId);
+                if (baseUrl) {
+                    return `${baseUrl.name.snakeCase.safeName}_url`;
+                }
+                return DEFAULT_URL_METHOD;
+            },
+            _other: () => DEFAULT_URL_METHOD
+        });
     }
 
     public generate(): RustFile | null {
@@ -220,11 +247,45 @@ export class EnvironmentGenerator {
 
     private createMultiUrlImplBlock(config: FernIr.MultipleBaseUrlsEnvironments): ImplBlock {
         const getUrlMethod = this.createMultiUrlGetUrlMethod(config);
+        const perUrlMethods = this.createPerBaseUrlGetterMethods(config);
         const environmentEnumName = this.getEnvironmentEnumName();
 
         return rust.implBlock({
             targetType: Type.reference(new Reference({ name: environmentEnumName })),
-            methods: [getUrlMethod]
+            methods: [getUrlMethod, ...perUrlMethods]
+        });
+    }
+
+    /**
+     * Creates a getter method for each base URL in a multi-URL environment.
+     * For example, if there are "rest" and "wss" base URLs, this generates
+     * `rest_url(&self) -> &str` and `wss_url(&self) -> &str`.
+     */
+    private createPerBaseUrlGetterMethods(config: FernIr.MultipleBaseUrlsEnvironments): Method[] {
+        return config.baseUrls.map((baseUrl) => {
+            const fieldName = baseUrl.name.snakeCase.safeName;
+            const matchArms = config.environments.map((env) => {
+                const pattern = Pattern.raw(`Self::${env.name.pascalCase.safeName}(urls)`);
+                const expression = Expression.reference(`&urls.${fieldName}`);
+                return MatchArm.withExpression(pattern, expression);
+            });
+
+            const matchStatement = Statement.matchEnhanced(Expression.self(), matchArms);
+
+            return rust.method({
+                name: `${fieldName}_url`,
+                visibility: PUBLIC,
+                parameters: [
+                    {
+                        name: "self",
+                        parameterType: Type.str(),
+                        isSelf: true,
+                        isRef: true
+                    }
+                ],
+                returnType: Type.reference(new Reference({ name: "&str" })),
+                body: CodeBlock.fromStatements([matchStatement])
+            });
         });
     }
 
@@ -292,7 +353,6 @@ export class EnvironmentGenerator {
     }
 
     private getEnvironmentEnumName(): string {
-        const customConfig = this.context.customConfig;
-        return customConfig.environmentEnumName || "Environment";
+        return this.context.getEnvironmentEnumName();
     }
 }

--- a/generators/rust/sdk/src/generators/ApiClientBuilderGenerator.ts
+++ b/generators/rust/sdk/src/generators/ApiClientBuilderGenerator.ts
@@ -1,42 +1,101 @@
-use crate::api::resources::WebsocketMultiUrlClient;
-use crate::Environment;
-use crate::{ApiError, ClientConfig};
-use std::collections::HashMap;
-use std::time::Duration;
-/// Builder for creating API clients with custom configuration
+import { RelativeFilePath } from "@fern-api/fs-utils";
+import { RustFile } from "@fern-api/rust-base";
+import { rust } from "@fern-api/rust-codegen";
+
+import { SdkGeneratorContext } from "../SdkGeneratorContext.js";
+
+export class ApiClientBuilderGenerator {
+    private readonly context: SdkGeneratorContext;
+    private readonly clientName: string;
+    private readonly environmentEnumName: string;
+
+    constructor(context: SdkGeneratorContext) {
+        this.context = context;
+        this.clientName = context.getApiClientBuilderClientName();
+        this.environmentEnumName = context.getEnvironmentEnumName();
+    }
+
+    public generate(): RustFile {
+        const lines: string[] = [];
+
+        lines.push(this.generateImports());
+        lines.push(this.generateStruct());
+        lines.push(this.generateDefaultImpl());
+        lines.push(this.generateImplBlock());
+        lines.push(this.generateTests());
+
+        const module = rust.module({
+            rawDeclarations: lines
+        });
+
+        return new RustFile({
+            filename: "client.rs",
+            directory: RelativeFilePath.of("src"),
+            fileContents: module.toString()
+        });
+    }
+
+    private generateImports(): string {
+        const imports = [
+            `use crate::api::resources::${this.clientName};`,
+            "use crate::{ApiError, ClientConfig};",
+            "use std::collections::HashMap;",
+            "use std::time::Duration;"
+        ];
+        if (this.context.hasEnvironments()) {
+            imports.push(`use crate::${this.environmentEnumName};`);
+        }
+        return imports.join("\n");
+    }
+
+    private generateStruct(): string {
+        return `/// Builder for creating API clients with custom configuration
 pub struct ApiClientBuilder {
     config: ClientConfig,
-}
-impl Default for ApiClientBuilder {
+}`;
+    }
+
+    private generateDefaultImpl(): string {
+        return `impl Default for ApiClientBuilder {
     fn default() -> Self {
         Self {
             config: ClientConfig::default(),
         }
     }
-}
-impl ApiClientBuilder {
-    /// Create a new builder with the specified base URL
-    ///
-    /// This disables environment-based URL resolution. Use `environment()` instead
-    /// to configure per-service URL resolution for multi-URL environments.
+}`;
+    }
+
+    private generateImplBlock(): string {
+        const methods: string[] = [];
+        const isMultiUrl = this.context.hasMultipleBaseUrls();
+
+        // new(base_url) — for multi-URL, clears environment to None
+        const newDocExtra = isMultiUrl
+            ? `\n    ///\n    /// This disables environment-based URL resolution. Use \`environment()\` instead\n    /// to configure per-service URL resolution for multi-URL environments.`
+            : "";
+        const clearEnvironment = isMultiUrl ? "\n        config.environment = None;" : "";
+        methods.push(`    /// Create a new builder with the specified base URL${newDocExtra}
     pub fn new(base_url: impl Into<String>) -> Self {
         let mut config = ClientConfig::default();
-        config.base_url = base_url.into();
-        config.environment = None;
+        config.base_url = base_url.into();${clearEnvironment}
         Self { config }
-    }
+    }`);
 
-    /// Set the environment, updating the base URL
-    ///
-    /// In multi-URL environments, this enables per-service URL resolution.
-    /// Each service will use its designated URL from the environment.
-    pub fn environment(mut self, environment: Environment) -> Self {
-        self.config.base_url = environment.url().to_string();
-        self.config.environment = Some(environment);
+        // environment() setter — only when environments exist
+        if (this.context.hasEnvironments()) {
+            const envDocExtra = isMultiUrl
+                ? `\n    ///\n    /// In multi-URL environments, this enables per-service URL resolution.\n    /// Each service will use its designated URL from the environment.`
+                : "";
+            const setEnvironment = isMultiUrl ? "\n        self.config.environment = Some(environment);" : "";
+            methods.push(`    /// Set the environment, updating the base URL${envDocExtra}
+    pub fn environment(mut self, environment: ${this.environmentEnumName}) -> Self {
+        self.config.base_url = environment.url().to_string();${setEnvironment}
         self
-    }
+    }`);
+        }
 
-    /// Set the API key for authentication
+        // Standard setter methods
+        methods.push(`    /// Set the API key for authentication
     pub fn api_key(mut self, key: impl Into<String>) -> Self {
         self.config.api_key = Some(key.into());
         self
@@ -114,23 +173,28 @@ impl ApiClientBuilder {
     }
 
     /// Build the client with validation
-    pub fn build(self) -> Result<WebsocketMultiUrlClient, ApiError> {
-        WebsocketMultiUrlClient::new(self.config)
-    }
-}
-#[cfg(test)]
-mod tests {
-    use super::*;
+    pub fn build(self) -> Result<${this.clientName}, ApiError> {
+        ${this.clientName}::new(self.config)
+    }`);
 
+        return `impl ApiClientBuilder {\n${methods.join("\n\n")}\n}`;
+    }
+
+    private generateTests(): string {
+        const environmentTest = this.context.hasEnvironments()
+            ? `
     #[test]
     fn test_environment() {
-        let builder = ApiClientBuilder::default().environment(Environment::default());
-        assert_eq!(
-            builder.config.base_url,
-            Environment::default().url().to_string()
-        );
+        let builder = ApiClientBuilder::default().environment(${this.environmentEnumName}::default());
+        assert_eq!(builder.config.base_url, ${this.environmentEnumName}::default().url().to_string());
     }
+`
+            : "";
 
+        return `#[cfg(test)]
+mod tests {
+    use super::*;
+${environmentTest}
     #[test]
     fn test_new_sets_base_url() {
         let builder = ApiClientBuilder::new("https://api.example.com");
@@ -175,16 +239,16 @@ mod tests {
 
     #[test]
     fn test_oauth_credentials() {
-        let builder =
-            ApiClientBuilder::new("https://api.example.com").oauth_credentials("cid", "secret");
+        let builder = ApiClientBuilder::new("https://api.example.com")
+            .oauth_credentials("cid", "secret");
         assert_eq!(builder.config.client_id, Some("cid".to_string()));
         assert_eq!(builder.config.client_secret, Some("secret".to_string()));
     }
 
     #[test]
     fn test_timeout() {
-        let builder =
-            ApiClientBuilder::new("https://api.example.com").timeout(Duration::from_secs(120));
+        let builder = ApiClientBuilder::new("https://api.example.com")
+            .timeout(Duration::from_secs(120));
         assert_eq!(builder.config.timeout, Duration::from_secs(120));
     }
 
@@ -196,8 +260,8 @@ mod tests {
 
     #[test]
     fn test_custom_header() {
-        let builder =
-            ApiClientBuilder::new("https://api.example.com").custom_header("X-Custom", "value");
+        let builder = ApiClientBuilder::new("https://api.example.com")
+            .custom_header("X-Custom", "value");
         assert_eq!(
             builder.config.custom_headers.get("X-Custom"),
             Some(&"value".to_string())
@@ -209,7 +273,8 @@ mod tests {
         let mut headers = HashMap::new();
         headers.insert("X-One".to_string(), "1".to_string());
         headers.insert("X-Two".to_string(), "2".to_string());
-        let builder = ApiClientBuilder::new("https://api.example.com").custom_headers(headers);
+        let builder = ApiClientBuilder::new("https://api.example.com")
+            .custom_headers(headers);
         assert_eq!(
             builder.config.custom_headers.get("X-One"),
             Some(&"1".to_string())
@@ -222,7 +287,8 @@ mod tests {
 
     #[test]
     fn test_user_agent() {
-        let builder = ApiClientBuilder::new("https://api.example.com").user_agent("my-sdk/1.0");
+        let builder = ApiClientBuilder::new("https://api.example.com")
+            .user_agent("my-sdk/1.0");
         assert_eq!(builder.config.user_agent, "my-sdk/1.0");
     }
 
@@ -251,5 +317,7 @@ mod tests {
     fn test_build_succeeds() {
         let result = ApiClientBuilder::new("https://api.example.com").build();
         assert!(result.is_ok());
+    }
+}`;
     }
 }

--- a/generators/rust/sdk/src/generators/ClientConfigGenerator.ts
+++ b/generators/rust/sdk/src/generators/ClientConfigGenerator.ts
@@ -32,8 +32,8 @@ export class ClientConfigGenerator {
             new UseStatement({ path: "std::time", items: ["Duration"] })
         ];
 
-        if (this.hasEnvironments()) {
-            const environmentEnumName = this.getEnvironmentEnumName();
+        if (this.context.hasEnvironments()) {
+            const environmentEnumName = this.context.getEnvironmentEnumName();
             imports.push(new UseStatement({ path: "crate", items: [environmentEnumName] }));
         }
 
@@ -99,6 +99,17 @@ export class ClientConfigGenerator {
             })
         ];
 
+        if (this.context.hasMultipleBaseUrls()) {
+            const environmentEnumName = this.context.getEnvironmentEnumName();
+            fields.push(
+                rust.field({
+                    name: "environment",
+                    type: rust.Type.option(rust.Type.reference(rust.reference({ name: environmentEnumName }))),
+                    visibility: PUBLIC
+                })
+            );
+        }
+
         return rust.struct({
             name: "ClientConfig",
             visibility: PUBLIC,
@@ -109,7 +120,7 @@ export class ClientConfigGenerator {
 
     private generateDefaultImpl() {
         const userAgent = `${this.context.ir.apiName.pascalCase.safeName} Rust SDK`;
-        const environmentEnumName = this.getEnvironmentEnumName();
+        const environmentEnumName = this.context.getEnvironmentEnumName();
         const hasDefaultEnvironment = this.context.ir.environments?.defaultEnvironment !== undefined;
 
         // Platform headers for Fern SDK identification
@@ -125,7 +136,7 @@ export class ClientConfigGenerator {
                     {
                         name: "base_url",
                         value:
-                            this.hasEnvironments() && hasDefaultEnvironment
+                            this.context.hasEnvironments() && hasDefaultEnvironment
                                 ? Expression.methodCall({
                                       target: Expression.methodCall({
                                           target: Expression.functionCall(`${environmentEnumName}::default`, []),
@@ -182,7 +193,19 @@ export class ClientConfigGenerator {
                     {
                         name: "user_agent",
                         value: Expression.toString(Expression.stringLiteral(userAgent))
-                    }
+                    },
+                    ...(this.context.hasMultipleBaseUrls()
+                        ? [
+                              {
+                                  name: "environment",
+                                  value: Expression.raw(
+                                      hasDefaultEnvironment
+                                          ? `Some(${environmentEnumName}::default())`
+                                          : "None"
+                                  )
+                              }
+                          ]
+                        : [])
                 ])
             )
         });
@@ -194,12 +217,4 @@ export class ClientConfigGenerator {
         });
     }
 
-    private hasEnvironments(): boolean {
-        return this.context.ir.environments?.environments != null;
-    }
-
-    private getEnvironmentEnumName(): string {
-        const customConfig = this.context.customConfig;
-        return customConfig.environmentEnumName || "Environment";
-    }
 }

--- a/generators/rust/sdk/src/generators/ClientGeneratorContext.ts
+++ b/generators/rust/sdk/src/generators/ClientGeneratorContext.ts
@@ -12,7 +12,7 @@ export class ClientGeneratorContext {
     private readonly packageOrSubpackage: FernIr.Package | FernIr.Subpackage;
     private readonly sdkGeneratorContext: SdkGeneratorContext;
 
-    public readonly subClients: { fieldName: string; clientName: string }[];
+    public readonly subClients: { fieldName: string; clientName: string; serviceId: string | undefined }[];
     public readonly httpClient: { fieldName: string; clientName: string };
 
     public constructor({ packageOrSubpackage, sdkGeneratorContext }: ClientGeneratorContext.Args) {
@@ -22,7 +22,7 @@ export class ClientGeneratorContext {
         this.httpClient = this.getHttpClient();
     }
 
-    private getSubClients(): { fieldName: string; clientName: string }[] {
+    private getSubClients(): { fieldName: string; clientName: string; serviceId: string | undefined }[] {
         return this.sdkGeneratorContext
             .getSubpackagesOrThrow(this.packageOrSubpackage)
             .filter(([, subpackage]) => subpackage.service != null || subpackage.hasEndpointsInTree)
@@ -31,7 +31,8 @@ export class ClientGeneratorContext {
                 const fieldName = subpackage.name.snakeCase.safeName;
                 return {
                     fieldName,
-                    clientName
+                    clientName,
+                    serviceId: subpackage.service ?? undefined
                 };
             });
     }

--- a/generators/rust/sdk/src/generators/ClientGeneratorContext.ts
+++ b/generators/rust/sdk/src/generators/ClientGeneratorContext.ts
@@ -12,7 +12,7 @@ export class ClientGeneratorContext {
     private readonly packageOrSubpackage: FernIr.Package | FernIr.Subpackage;
     private readonly sdkGeneratorContext: SdkGeneratorContext;
 
-    public readonly subClients: { fieldName: string; clientName: string; serviceId: string | undefined }[];
+    public readonly subClients: { fieldName: string; clientName: string }[];
     public readonly httpClient: { fieldName: string; clientName: string };
 
     public constructor({ packageOrSubpackage, sdkGeneratorContext }: ClientGeneratorContext.Args) {
@@ -22,7 +22,7 @@ export class ClientGeneratorContext {
         this.httpClient = this.getHttpClient();
     }
 
-    private getSubClients(): { fieldName: string; clientName: string; serviceId: string | undefined }[] {
+    private getSubClients(): { fieldName: string; clientName: string }[] {
         return this.sdkGeneratorContext
             .getSubpackagesOrThrow(this.packageOrSubpackage)
             .filter(([, subpackage]) => subpackage.service != null || subpackage.hasEndpointsInTree)
@@ -31,8 +31,7 @@ export class ClientGeneratorContext {
                 const fieldName = subpackage.name.snakeCase.safeName;
                 return {
                     fieldName,
-                    clientName,
-                    serviceId: subpackage.service ?? undefined
+                    clientName
                 };
             });
     }

--- a/generators/rust/sdk/src/generators/RootClientGenerator.ts
+++ b/generators/rust/sdk/src/generators/RootClientGenerator.ts
@@ -3,7 +3,6 @@ import { RelativeFilePath } from "@fern-api/fs-utils";
 import { RustFile } from "@fern-api/rust-base";
 import { rust, UseStatement } from "@fern-api/rust-codegen";
 
-import { DEFAULT_URL_METHOD, EnvironmentGenerator } from "../environment/EnvironmentGenerator.js";
 import { SdkGeneratorContext } from "../SdkGeneratorContext.js";
 import { ClientGeneratorContext } from "./ClientGeneratorContext.js";
 import { SubClientGenerator } from "./SubClientGenerator.js";
@@ -14,7 +13,6 @@ export class RootClientGenerator {
     private readonly package: FernIr.Package;
     private readonly projectName: string;
     private readonly clientGeneratorContext: ClientGeneratorContext;
-    private readonly environmentGenerator: EnvironmentGenerator;
     private readonly wsConnectors: Array<{
         connectorName: string;
         fieldName: string;
@@ -28,7 +26,6 @@ export class RootClientGenerator {
         this.context = context;
         this.package = context.ir.rootPackage;
         this.projectName = context.ir.apiName.pascalCase.safeName;
-        this.environmentGenerator = new EnvironmentGenerator({ context });
         this.clientGeneratorContext = new ClientGeneratorContext({
             packageOrSubpackage: this.package,
             sdkGeneratorContext: context
@@ -290,31 +287,10 @@ export class RootClientGenerator {
     }
 
     /**
-     * Looks up the EnvironmentBaseUrlId for a service by checking its first endpoint's baseUrl.
-     * Returns undefined if the service has no endpoints or no baseUrl.
-     */
-    private getServiceBaseUrlId(serviceId: string): string | undefined {
-        const service = this.context.getHttpServiceOrThrow(serviceId);
-        const firstEndpoint = service.endpoints[0];
-        return firstEndpoint?.baseUrl ?? undefined;
-    }
-
-    /**
      * Returns WebSocket connectors that don't collide with existing HTTP sub-client field names.
      */
     private getUniqueWsConnectors(httpFieldNames: Set<string>): typeof this.wsConnectors {
         return this.wsConnectors.filter((c) => !httpFieldNames.has(c.fieldName));
-    }
-
-    /**
-     * Generates the Rust expression to resolve a URL from the environment,
-     * falling back to config.base_url when environment is None.
-     */
-    private resolveUrlExpression(urlMethod: string, configVar: string): string {
-        return (
-            `${configVar}.environment.as_ref()\n` +
-            `                    .map_or_else(|| ${configVar}.base_url.clone(), |env| env.${urlMethod}().to_string())`
-        );
     }
 
     private generateConstructor(subpackages: FernIr.Subpackage[]): rust.Client.SimpleMethod {
@@ -327,24 +303,7 @@ export class RootClientGenerator {
         }
 
         // HTTP sub-client initializations
-        const isMultiUrl = this.context.hasMultipleBaseUrls();
-        for (const { fieldName, clientName, serviceId } of this.clientGeneratorContext.subClients) {
-            if (isMultiUrl && serviceId != null) {
-                const baseUrlId = this.getServiceBaseUrlId(serviceId);
-                if (baseUrlId != null) {
-                    const urlMethod = this.environmentGenerator.getUrlMethodNameForBaseUrlId(baseUrlId);
-                    if (urlMethod !== DEFAULT_URL_METHOD) {
-                        allInits.push(
-                            `${fieldName}: {\n` +
-                                `                let mut cfg = config.clone();\n` +
-                                `                cfg.base_url = ${this.resolveUrlExpression(urlMethod, "cfg")};\n` +
-                                `                ${clientName}::new(cfg)?\n` +
-                                `            }`
-                        );
-                        continue;
-                    }
-                }
-            }
+        for (const { fieldName, clientName } of this.clientGeneratorContext.subClients) {
             allInits.push(`${fieldName}: ${clientName}::new(config.clone())?`);
         }
 

--- a/generators/rust/sdk/src/generators/RootClientGenerator.ts
+++ b/generators/rust/sdk/src/generators/RootClientGenerator.ts
@@ -3,6 +3,7 @@ import { RelativeFilePath } from "@fern-api/fs-utils";
 import { RustFile } from "@fern-api/rust-base";
 import { rust, UseStatement } from "@fern-api/rust-codegen";
 
+import { DEFAULT_URL_METHOD, EnvironmentGenerator } from "../environment/EnvironmentGenerator.js";
 import { SdkGeneratorContext } from "../SdkGeneratorContext.js";
 import { ClientGeneratorContext } from "./ClientGeneratorContext.js";
 import { SubClientGenerator } from "./SubClientGenerator.js";
@@ -13,6 +14,7 @@ export class RootClientGenerator {
     private readonly package: FernIr.Package;
     private readonly projectName: string;
     private readonly clientGeneratorContext: ClientGeneratorContext;
+    private readonly environmentGenerator: EnvironmentGenerator;
     private readonly wsConnectors: Array<{
         connectorName: string;
         fieldName: string;
@@ -26,6 +28,7 @@ export class RootClientGenerator {
         this.context = context;
         this.package = context.ir.rootPackage;
         this.projectName = context.ir.apiName.pascalCase.safeName;
+        this.environmentGenerator = new EnvironmentGenerator({ context });
         this.clientGeneratorContext = new ClientGeneratorContext({
             packageOrSubpackage: this.package,
             sdkGeneratorContext: context
@@ -287,10 +290,31 @@ export class RootClientGenerator {
     }
 
     /**
+     * Looks up the EnvironmentBaseUrlId for a service by checking its first endpoint's baseUrl.
+     * Returns undefined if the service has no endpoints or no baseUrl.
+     */
+    private getServiceBaseUrlId(serviceId: string): string | undefined {
+        const service = this.context.getHttpServiceOrThrow(serviceId);
+        const firstEndpoint = service.endpoints[0];
+        return firstEndpoint?.baseUrl ?? undefined;
+    }
+
+    /**
      * Returns WebSocket connectors that don't collide with existing HTTP sub-client field names.
      */
     private getUniqueWsConnectors(httpFieldNames: Set<string>): typeof this.wsConnectors {
         return this.wsConnectors.filter((c) => !httpFieldNames.has(c.fieldName));
+    }
+
+    /**
+     * Generates the Rust expression to resolve a URL from the environment,
+     * falling back to config.base_url when environment is None.
+     */
+    private resolveUrlExpression(urlMethod: string, configVar: string): string {
+        return (
+            `${configVar}.environment.as_ref()\n` +
+            `                    .map_or_else(|| ${configVar}.base_url.clone(), |env| env.${urlMethod}().to_string())`
+        );
     }
 
     private generateConstructor(subpackages: FernIr.Subpackage[]): rust.Client.SimpleMethod {
@@ -303,7 +327,24 @@ export class RootClientGenerator {
         }
 
         // HTTP sub-client initializations
-        for (const { fieldName, clientName } of this.clientGeneratorContext.subClients) {
+        const isMultiUrl = this.context.hasMultipleBaseUrls();
+        for (const { fieldName, clientName, serviceId } of this.clientGeneratorContext.subClients) {
+            if (isMultiUrl && serviceId != null) {
+                const baseUrlId = this.getServiceBaseUrlId(serviceId);
+                if (baseUrlId != null) {
+                    const urlMethod = this.environmentGenerator.getUrlMethodNameForBaseUrlId(baseUrlId);
+                    if (urlMethod !== DEFAULT_URL_METHOD) {
+                        allInits.push(
+                            `${fieldName}: {\n` +
+                                `                let mut cfg = config.clone();\n` +
+                                `                cfg.base_url = ${this.resolveUrlExpression(urlMethod, "cfg")};\n` +
+                                `                ${clientName}::new(cfg)?\n` +
+                                `            }`
+                        );
+                        continue;
+                    }
+                }
+            }
             allInits.push(`${fieldName}: ${clientName}::new(config.clone())?`);
         }
 
@@ -507,8 +548,9 @@ export class RootClientGenerator {
             return null;
         }
 
-        // Check if this subpackage has subclients (nested structure)
-        const subClientSubpackages = this.context.getSubpackagesOrThrow(targetSubpackage);
+        // Check if this subpackage has subclients (nested structure), excluding websocket-only ones
+        const subClientSubpackages = this.context.getSubpackagesOrThrow(targetSubpackage)
+            .filter(([, sp]) => !this.context.isWebSocketOnlySubpackage(sp));
         const hasSubClients = subClientSubpackages.length > 0;
 
         if (!hasSubClients) {
@@ -544,7 +586,7 @@ export class RootClientGenerator {
         currentPath: string,
         subpackage: FernIr.Subpackage
     ): RustFile {
-        // Generate submodule declarations and re-exports
+        // Generate submodule declarations and re-exports (websocket-only subpackages already excluded)
         const subModuleDeclarations: string[] = [];
         subClientSubpackages.forEach(([, subClientSubpackage]) => {
             // Use the actual directory name, not the full filename

--- a/generators/rust/sdk/src/generators/SubClientGenerator.ts
+++ b/generators/rust/sdk/src/generators/SubClientGenerator.ts
@@ -5,6 +5,7 @@ import { rust, UseStatement } from "@fern-api/rust-codegen";
 import { generateRustTypeForTypeReference } from "@fern-api/rust-model";
 
 import { SdkGeneratorContext } from "../SdkGeneratorContext.js";
+import { EnvironmentGenerator } from "../environment/EnvironmentGenerator.js";
 import { ClientGeneratorContext } from "./ClientGeneratorContext.js";
 
 interface EndpointParameter {
@@ -28,9 +29,11 @@ export class SubClientGenerator {
     private readonly subpackage: FernIr.Subpackage;
     private readonly service?: FernIr.HttpService;
     private readonly clientGeneratorContext: ClientGeneratorContext;
+    private readonly environmentGenerator: EnvironmentGenerator;
 
     constructor(context: SdkGeneratorContext, subpackage: FernIr.Subpackage) {
         this.context = context;
+        this.environmentGenerator = new EnvironmentGenerator({ context: this.context });
         this.subpackage = subpackage;
         this.service = subpackage.service ? this.context.getHttpServiceOrThrow(subpackage.service) : undefined;
         this.clientGeneratorContext = new ClientGeneratorContext({
@@ -852,6 +855,21 @@ export class SubClientGenerator {
         return methods;
     }
 
+    /**
+     * Returns the URL method name for an endpoint's base URL, or undefined
+     * if no multi-URL resolution is needed (single-URL env or no baseUrl on endpoint).
+     */
+    private getEndpointUrlMethodName(endpoint: FernIr.HttpEndpoint): string | undefined {
+        if (!this.context.hasMultipleBaseUrls()) {
+            return undefined;
+        }
+        const baseUrlId = endpoint.baseUrl ?? undefined;
+        if (!baseUrlId) {
+            return undefined;
+        }
+        return this.environmentGenerator.getUrlMethodNameForBaseUrlId(baseUrlId);
+    }
+
     private generateHttpMethod(endpoint: FernIr.HttpEndpoint): rust.Client.SimpleMethod {
         const params = this.extractParametersFromEndpoint(endpoint);
         const parameters = this.buildMethodParameters(params, endpoint);
@@ -918,13 +936,31 @@ export class SubClientGenerator {
             }
         }
 
+        // Determine if this endpoint needs multi-URL resolution.
+        // Only apply to execute_request and execute_stream_request (we have _with_base_url variants for these).
+        const urlMethodName = this.getEndpointUrlMethodName(endpoint);
+        const supportsBaseUrlOverride = executeMethod === "execute_request" || executeMethod === "execute_stream_request";
+        let body: string;
+
+        if (urlMethodName && supportsBaseUrlOverride) {
+            // Multi-URL: resolve base URL at call time from environment
+            const baseUrlResolution =
+                `let base_url = self.http_client.config().environment.as_ref()\n` +
+                `            .map_or(self.http_client.base_url(), |env| env.${urlMethodName}());\n`;
+            body = `${baseUrlResolution}        self.http_client.${executeMethod}_with_base_url${typeParameter}(
+            base_url,${executeArgs}
+        ).await`;
+        } else {
+            body = `self.http_client.${executeMethod}${typeParameter}(${executeArgs}
+        ).await`;
+        }
+
         return {
             name: endpoint.name.snakeCase.safeName,
             parameters,
             returnType: returnType.toString(),
             isAsync: true,
-            body: `self.http_client.${executeMethod}${typeParameter}(${executeArgs}
-        ).await`,
+            body,
             docs: endpoint.docs
                 ? rust.docComment({
                       summary: endpoint.docs,

--- a/generators/rust/sdk/src/generators/index.ts
+++ b/generators/rust/sdk/src/generators/index.ts
@@ -1,3 +1,4 @@
+export * from "./ApiClientBuilderGenerator.js";
 export * from "./ClientConfigGenerator.js";
 export * from "./ClientGeneratorContext.js";
 export * from "./RootClientGenerator.js";

--- a/generators/rust/sdk/versions.yml
+++ b/generators/rust/sdk/versions.yml
@@ -1,5 +1,36 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 
+- version: 0.29.0
+  changelogEntry:
+    - summary: |
+        Add per-endpoint URL resolution for multi-URL environments. Each endpoint
+        now resolves its base URL at call time from the environment object, matching
+        the Python and Java SDK approach.
+      type: feat
+    - summary: |
+        Generate `ApiClientBuilder` from code instead of a static template, enabling
+        environment-aware builder methods for multi-URL APIs.
+      type: feat
+    - summary: |
+        Add per-base-URL getter methods on the `Environment` enum (e.g.,
+        `api_url()`, `agent_url()`) for multi-URL environments.
+      type: feat
+    - summary: |
+        Add `Option<Environment>` field to `ClientConfig` for multi-URL environments
+        to support per-endpoint URL resolution.
+      type: feat
+    - summary: |
+        Add `base_url()`, `config()`, `execute_request_with_base_url()`, and
+        `execute_stream_request_with_base_url()` accessors to `HttpClient` for
+        multi-URL endpoint resolution.
+      type: feat
+    - summary: |
+        Remove construction-time URL override from `RootClientGenerator`; all
+        sub-clients now receive `config.clone()` uniformly.
+      type: chore
+  createdAt: "2026-03-31"
+  irVersion: 65
+
 - version: 0.28.0
   changelogEntry:
     - summary: |

--- a/seed/rust-sdk/multi-url-environment/src/api/resources/ec_2/ec_2.rs
+++ b/seed/rust-sdk/multi-url-environment/src/api/resources/ec_2/ec_2.rs
@@ -18,8 +18,15 @@ impl Ec2Client {
         request: &BootInstanceRequest,
         options: Option<RequestOptions>,
     ) -> Result<(), ApiError> {
+        let base_url = self
+            .http_client
+            .config()
+            .environment
+            .as_ref()
+            .map_or(self.http_client.base_url(), |env| env.ec_2_url());
         self.http_client
-            .execute_request(
+            .execute_request_with_base_url(
+                base_url,
                 Method::POST,
                 "/ec2/boot",
                 Some(serde_json::to_value(request).map_err(ApiError::Serialization)?),

--- a/seed/rust-sdk/multi-url-environment/src/api/resources/s_3/s_3.rs
+++ b/seed/rust-sdk/multi-url-environment/src/api/resources/s_3/s_3.rs
@@ -18,8 +18,15 @@ impl S3Client {
         request: &GetPresignedUrlRequest,
         options: Option<RequestOptions>,
     ) -> Result<String, ApiError> {
+        let base_url = self
+            .http_client
+            .config()
+            .environment
+            .as_ref()
+            .map_or(self.http_client.base_url(), |env| env.s_3_url());
         self.http_client
-            .execute_request(
+            .execute_request_with_base_url(
+                base_url,
                 Method::POST,
                 "/s3/presigned-url",
                 Some(serde_json::to_value(request).map_err(ApiError::Serialization)?),

--- a/seed/rust-sdk/multi-url-environment/src/client.rs
+++ b/seed/rust-sdk/multi-url-environment/src/client.rs
@@ -1,28 +1,12 @@
 use crate::api::resources::MultiUrlEnvironmentClient;
+use crate::Environment;
 use crate::{ApiError, ClientConfig};
 use std::collections::HashMap;
 use std::time::Duration;
-
-/*
-Things to know:
-
-`impl Into<String>` is a generic parameter constraint in Rust that means "accept any type that can be converted into a String."
-It's essentially Rust's way of saying "I'll take a string in any form you give it to me."
-
-Types that implement Into<String>:
-
-// All of these work:
-builder.api_key("hello")           // &str
-builder.api_key("hello".to_string()) // String
-builder.api_key(format!("key_{}", id)) // String from format!
-builder.api_key(my_string_variable)    // String variable
-*/
-
 /// Builder for creating API clients with custom configuration
 pub struct ApiClientBuilder {
     config: ClientConfig,
 }
-
 impl Default for ApiClientBuilder {
     fn default() -> Self {
         Self {
@@ -30,13 +14,26 @@ impl Default for ApiClientBuilder {
         }
     }
 }
-
 impl ApiClientBuilder {
     /// Create a new builder with the specified base URL
+    ///
+    /// This disables environment-based URL resolution. Use `environment()` instead
+    /// to configure per-service URL resolution for multi-URL environments.
     pub fn new(base_url: impl Into<String>) -> Self {
         let mut config = ClientConfig::default();
         config.base_url = base_url.into();
+        config.environment = None;
         Self { config }
+    }
+
+    /// Set the environment, updating the base URL
+    ///
+    /// In multi-URL environments, this enables per-service URL resolution.
+    /// Each service will use its designated URL from the environment.
+    pub fn environment(mut self, environment: Environment) -> Self {
+        self.config.base_url = environment.url().to_string();
+        self.config.environment = Some(environment);
+        self
     }
 
     /// Set the API key for authentication
@@ -121,10 +118,18 @@ impl ApiClientBuilder {
         MultiUrlEnvironmentClient::new(self.config)
     }
 }
-
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_environment() {
+        let builder = ApiClientBuilder::default().environment(Environment::default());
+        assert_eq!(
+            builder.config.base_url,
+            Environment::default().url().to_string()
+        );
+    }
 
     #[test]
     fn test_new_sets_base_url() {

--- a/seed/rust-sdk/multi-url-environment/src/config.rs
+++ b/seed/rust-sdk/multi-url-environment/src/config.rs
@@ -15,6 +15,7 @@ pub struct ClientConfig {
     pub max_retries: u32,
     pub custom_headers: HashMap<String, String>,
     pub user_agent: String,
+    pub environment: Option<Environment>,
 }
 impl Default for ClientConfig {
     fn default() -> Self {
@@ -37,6 +38,7 @@ impl Default for ClientConfig {
                 ("X-Fern-SDK-Version".to_string(), "0.0.1".to_string()),
             ]),
             user_agent: "MultiUrlEnvironment Rust SDK".to_string(),
+            environment: Some(Environment::default()),
         }
     }
 }

--- a/seed/rust-sdk/multi-url-environment/src/core/http_client.rs
+++ b/seed/rust-sdk/multi-url-environment/src/core/http_client.rs
@@ -144,6 +144,16 @@ impl HttpClient {
         })
     }
 
+    /// Returns the configured base URL.
+    pub fn base_url(&self) -> &str {
+        &self.config.base_url
+    }
+
+    /// Returns a reference to the client configuration.
+    pub fn config(&self) -> &ClientConfig {
+        &self.config
+    }
+
     /// Execute a request with the given method, path, and options
     pub async fn execute_request<T>(
         &self,
@@ -184,6 +194,48 @@ impl HttpClient {
         self.apply_custom_headers(&mut req, &options)?;
 
         // Execute with retries
+        let response = self.execute_with_retries(req, &options).await?;
+        self.parse_response(response).await
+    }
+
+    /// Execute a request with an explicit base URL override.
+    ///
+    /// Used for multi-URL environments where different endpoints
+    /// resolve to different base URLs.
+    pub async fn execute_request_with_base_url<T>(
+        &self,
+        base_url: &str,
+        method: Method,
+        path: &str,
+        body: Option<serde_json::Value>,
+        query_params: Option<Vec<(String, String)>>,
+        options: Option<RequestOptions>,
+    ) -> Result<T, ApiError>
+    where
+        T: DeserializeOwned,
+    {
+        let url = join_url(base_url, path);
+        let mut request = self.client.request(method, &url);
+
+        if let Some(params) = query_params {
+            request = request.query(&params);
+        }
+
+        if let Some(opts) = &options {
+            if !opts.additional_query_params.is_empty() {
+                request = request.query(&opts.additional_query_params);
+            }
+        }
+
+        if let Some(body) = body {
+            request = request.json(&body);
+        }
+
+        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
+
+        self.apply_auth_headers(&mut req, &options).await?;
+        self.apply_custom_headers(&mut req, &options)?;
+
         let response = self.execute_with_retries(req, &options).await?;
         self.parse_response(response).await
     }
@@ -475,6 +527,43 @@ impl HttpClient {
         let response = self.execute_with_retries(req, &options).await?;
 
         // Return streaming response
+        Ok(ByteStream::new(response))
+    }
+
+    /// Execute a streaming request with an explicit base URL override.
+    pub async fn execute_stream_request_with_base_url(
+        &self,
+        base_url: &str,
+        method: Method,
+        path: &str,
+        body: Option<serde_json::Value>,
+        query_params: Option<Vec<(String, String)>>,
+        options: Option<RequestOptions>,
+    ) -> Result<ByteStream, ApiError> {
+        let url = join_url(base_url, path);
+        let mut request = self.client.request(method, &url);
+
+        if let Some(params) = query_params {
+            request = request.query(&params);
+        }
+
+        if let Some(opts) = &options {
+            if !opts.additional_query_params.is_empty() {
+                request = request.query(&opts.additional_query_params);
+            }
+        }
+
+        if let Some(body) = body {
+            request = request.json(&body);
+        }
+
+        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
+
+        self.apply_auth_headers(&mut req, &options).await?;
+        self.apply_custom_headers(&mut req, &options)?;
+
+        let response = self.execute_with_retries(req, &options).await?;
+
         Ok(ByteStream::new(response))
     }
 }

--- a/seed/rust-sdk/multi-url-environment/src/environment.rs
+++ b/seed/rust-sdk/multi-url-environment/src/environment.rs
@@ -22,6 +22,20 @@ impl Environment {
             Self::Staging(urls) => &urls.ec_2,
         }
     }
+
+    pub fn ec_2_url(&self) -> &str {
+        match self {
+            Self::Production(urls) => &urls.ec_2,
+            Self::Staging(urls) => &urls.ec_2,
+        }
+    }
+
+    pub fn s_3_url(&self) -> &str {
+        match self {
+            Self::Production(urls) => &urls.s_3,
+            Self::Staging(urls) => &urls.s_3,
+        }
+    }
 }
 impl Default for Environment {
     fn default() -> Self {

--- a/seed/rust-sdk/websocket-multi-url/src/config.rs
+++ b/seed/rust-sdk/websocket-multi-url/src/config.rs
@@ -15,6 +15,7 @@ pub struct ClientConfig {
     pub max_retries: u32,
     pub custom_headers: HashMap<String, String>,
     pub user_agent: String,
+    pub environment: Option<Environment>,
 }
 impl Default for ClientConfig {
     fn default() -> Self {
@@ -37,6 +38,7 @@ impl Default for ClientConfig {
                 ("X-Fern-SDK-Version".to_string(), "0.0.1".to_string()),
             ]),
             user_agent: "WebsocketMultiUrl Rust SDK".to_string(),
+            environment: Some(Environment::default()),
         }
     }
 }

--- a/seed/rust-sdk/websocket-multi-url/src/core/http_client.rs
+++ b/seed/rust-sdk/websocket-multi-url/src/core/http_client.rs
@@ -144,6 +144,16 @@ impl HttpClient {
         })
     }
 
+    /// Returns the configured base URL.
+    pub fn base_url(&self) -> &str {
+        &self.config.base_url
+    }
+
+    /// Returns a reference to the client configuration.
+    pub fn config(&self) -> &ClientConfig {
+        &self.config
+    }
+
     /// Execute a request with the given method, path, and options
     pub async fn execute_request<T>(
         &self,
@@ -184,6 +194,48 @@ impl HttpClient {
         self.apply_custom_headers(&mut req, &options)?;
 
         // Execute with retries
+        let response = self.execute_with_retries(req, &options).await?;
+        self.parse_response(response).await
+    }
+
+    /// Execute a request with an explicit base URL override.
+    ///
+    /// Used for multi-URL environments where different endpoints
+    /// resolve to different base URLs.
+    pub async fn execute_request_with_base_url<T>(
+        &self,
+        base_url: &str,
+        method: Method,
+        path: &str,
+        body: Option<serde_json::Value>,
+        query_params: Option<Vec<(String, String)>>,
+        options: Option<RequestOptions>,
+    ) -> Result<T, ApiError>
+    where
+        T: DeserializeOwned,
+    {
+        let url = join_url(base_url, path);
+        let mut request = self.client.request(method, &url);
+
+        if let Some(params) = query_params {
+            request = request.query(&params);
+        }
+
+        if let Some(opts) = &options {
+            if !opts.additional_query_params.is_empty() {
+                request = request.query(&opts.additional_query_params);
+            }
+        }
+
+        if let Some(body) = body {
+            request = request.json(&body);
+        }
+
+        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
+
+        self.apply_auth_headers(&mut req, &options).await?;
+        self.apply_custom_headers(&mut req, &options)?;
+
         let response = self.execute_with_retries(req, &options).await?;
         self.parse_response(response).await
     }
@@ -475,6 +527,43 @@ impl HttpClient {
         let response = self.execute_with_retries(req, &options).await?;
 
         // Return streaming response
+        Ok(ByteStream::new(response))
+    }
+
+    /// Execute a streaming request with an explicit base URL override.
+    pub async fn execute_stream_request_with_base_url(
+        &self,
+        base_url: &str,
+        method: Method,
+        path: &str,
+        body: Option<serde_json::Value>,
+        query_params: Option<Vec<(String, String)>>,
+        options: Option<RequestOptions>,
+    ) -> Result<ByteStream, ApiError> {
+        let url = join_url(base_url, path);
+        let mut request = self.client.request(method, &url);
+
+        if let Some(params) = query_params {
+            request = request.query(&params);
+        }
+
+        if let Some(opts) = &options {
+            if !opts.additional_query_params.is_empty() {
+                request = request.query(&opts.additional_query_params);
+            }
+        }
+
+        if let Some(body) = body {
+            request = request.json(&body);
+        }
+
+        let mut req = request.build().map_err(|e| ApiError::Network(e))?;
+
+        self.apply_auth_headers(&mut req, &options).await?;
+        self.apply_custom_headers(&mut req, &options)?;
+
+        let response = self.execute_with_retries(req, &options).await?;
+
         Ok(ByteStream::new(response))
     }
 }

--- a/seed/rust-sdk/websocket-multi-url/src/environment.rs
+++ b/seed/rust-sdk/websocket-multi-url/src/environment.rs
@@ -22,6 +22,20 @@ impl Environment {
             Self::Staging(urls) => &urls.rest,
         }
     }
+
+    pub fn rest_url(&self) -> &str {
+        match self {
+            Self::Production(urls) => &urls.rest,
+            Self::Staging(urls) => &urls.rest,
+        }
+    }
+
+    pub fn wss_url(&self) -> &str {
+        match self {
+            Self::Production(urls) => &urls.wss,
+            Self::Staging(urls) => &urls.wss,
+        }
+    }
 }
 impl Default for Environment {
     fn default() -> Self {


### PR DESCRIPTION
## Description
Building off of https://github.com/fern-api/fern/pull/14344, this PR adds multi-environment support for Rust:
- `ApiClientBuilder` is now generated instead of produced by template. This allows for its methods to adapt based on the API's possible environment or environments.
- Multi-URL environments now generate a getter method for each URL (`api_url()`, `wss_url()`, etc.)
- Each endpoint now resolves its own base URL at call time: SubClientGenerator looks up the endpoint's baseUrl from the IR, maps it to the corresponding environment getter (e.g., env.agent_url()), and falls back to config.base_url when no environment is set. This matches the Python/Java approach.
- `ClientConfig` now has an `Option<Environment>` to facilitate this; internal breaking change. `ApiClientBuilder::new(base_url)` clears this to None (disabling environment-based resolution), while `ApiClientBuilder::environment(env)` sets both the base URL and environment.

## Testing
The `websocket-multi-url` fixture and the Deepgram API.
- [X] Unit tests added/updated
- [X] Manual testing completed
