### PR TITLE
feat(cli): add docs.yml config for Context7 verification files

### DIFF
--- a/docs-yml.schema.json
+++ b/docs-yml.schema.json
@@ -5714,6 +5714,16 @@
               "type": "null"
             }
           ]
+        },
+        "context7": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
         }
       },
       "additionalProperties": false

--- a/fern/apis/docs-yml/definition/docs.yml
+++ b/fern/apis/docs-yml/definition/docs.yml
@@ -1952,6 +1952,13 @@ types:
   IntegrationsConfig:
     properties:
       intercom: optional<string>
+      context7:
+        type: optional<string>
+        docs: |
+          Relative filepath to a `context7.json` file that Fern should host at `/context7.json`.
+
+          Fern only validates that the file exists and contains valid JSON. The contents are passed through
+          without enforcing a specific schema so customers can keep up with Context7's evolving format.
 
   ExperimentalConfig:
     properties:

--- a/fern/apis/docs-yml/definition/docs.yml
+++ b/fern/apis/docs-yml/definition/docs.yml
@@ -1956,9 +1956,7 @@ types:
         type: optional<string>
         docs: |
           Relative filepath to a `context7.json` file that Fern should host at `/context7.json`.
-
-          Fern only validates that the file exists and contains valid JSON. The contents are passed through
-          without enforcing a specific schema so customers can keep up with Context7's evolving format.
+          Fern only checks that the file exists and is valid JSON, then passes it through as-is.
 
   ExperimentalConfig:
     properties:

--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -1,4 +1,14 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+
+- version: 4.52.0
+  changelogEntry:
+    - summary: |
+        Add `integrations.context7` to `docs.yml` so Fern can upload and publish a customer-provided
+        `context7.json` verification file for docs sites.
+      type: feat
+  createdAt: "2026-03-31"
+  irVersion: 65
+
 - version: 4.51.0
   changelogEntry:
     - summary: |

--- a/packages/cli/configuration-loader/src/docs-yml/__test__/collapsibleNavigationConfig.test.ts
+++ b/packages/cli/configuration-loader/src/docs-yml/__test__/collapsibleNavigationConfig.test.ts
@@ -3,6 +3,7 @@ import { validateAgainstJsonSchema } from "@fern-api/core-utils";
 import { AbsoluteFilePath } from "@fern-api/fs-utils";
 import { createMockTaskContext, FernCliError } from "@fern-api/task-context";
 import fs from "fs";
+import os from "os";
 import path from "path";
 import { describe, expect, it } from "vitest";
 
@@ -194,6 +195,58 @@ describe("docs.yml navigation collapsible config", () => {
                 }
             ]
         });
+    });
+
+    it("should accept a Context7 file that contains valid JSON", async () => {
+        const context = createMockTaskContext();
+        const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "fern-context7-valid-"));
+        const docsConfigPath = path.join(tempDir, "docs.yml");
+        const context7Path = path.join(tempDir, "context7.json");
+        fs.writeFileSync(context7Path, '{"public_key":"pk_test"}');
+
+        const rawDocsConfiguration: docsYml.RawSchemas.DocsConfiguration = {
+            instances: [],
+            title: "Test",
+            navigation: [],
+            integrations: {
+                context7: "./context7.json"
+            }
+        };
+
+        const parsed = await parseDocsConfiguration({
+            rawDocsConfiguration,
+            absolutePathToFernFolder: AbsoluteFilePath.of(tempDir),
+            absoluteFilepathToDocsConfig: AbsoluteFilePath.of(docsConfigPath),
+            context
+        });
+
+        expect(parsed.context7File).toBe(AbsoluteFilePath.of(context7Path));
+    });
+
+    it("should reject a Context7 file with invalid JSON", async () => {
+        const context = createMockTaskContext();
+        const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "fern-context7-invalid-"));
+        const docsConfigPath = path.join(tempDir, "docs.yml");
+        const context7Path = path.join(tempDir, "context7.json");
+        fs.writeFileSync(context7Path, "{not-valid-json}");
+
+        const rawDocsConfiguration: docsYml.RawSchemas.DocsConfiguration = {
+            instances: [],
+            title: "Test",
+            navigation: [],
+            integrations: {
+                context7: "./context7.json"
+            }
+        };
+
+        await expect(
+            parseDocsConfiguration({
+                rawDocsConfiguration,
+                absolutePathToFernFolder: AbsoluteFilePath.of(tempDir),
+                absoluteFilepathToDocsConfig: AbsoluteFilePath.of(docsConfigPath),
+                context
+            })
+        ).rejects.toBeInstanceOf(FernCliError);
     });
 });
 

--- a/packages/cli/configuration-loader/src/docs-yml/parseDocsConfiguration.ts
+++ b/packages/cli/configuration-loader/src/docs-yml/parseDocsConfiguration.ts
@@ -129,6 +129,12 @@ export async function parseDocsConfiguration({
 
     const metadataPromise = convertMetadata(rawMetadata, absoluteFilepathToDocsConfig);
 
+    const context7FilePromise = parseContext7File({
+        rawPath: rawDocsConfiguration.integrations?.context7,
+        absoluteFilepathToDocsConfig,
+        context
+    });
+
     const [navigation, pages, typography, css, js, metadata, context7File] = await Promise.all([
         convertedNavigationPromise,
         pagesPromise,
@@ -136,11 +142,7 @@ export async function parseDocsConfiguration({
         cssPromise,
         jsPromise,
         metadataPromise,
-        parseContext7File({
-            rawPath: rawDocsConfiguration.integrations?.context7,
-            absoluteFilepathToDocsConfig,
-            context
-        })
+        context7FilePromise
     ]);
 
     // Validate incompatible tabs configuration: sidebar placement + center alignment

--- a/packages/cli/configuration-loader/src/docs-yml/parseDocsConfiguration.ts
+++ b/packages/cli/configuration-loader/src/docs-yml/parseDocsConfiguration.ts
@@ -129,13 +129,18 @@ export async function parseDocsConfiguration({
 
     const metadataPromise = convertMetadata(rawMetadata, absoluteFilepathToDocsConfig);
 
-    const [navigation, pages, typography, css, js, metadata] = await Promise.all([
+    const [navigation, pages, typography, css, js, metadata, context7File] = await Promise.all([
         convertedNavigationPromise,
         pagesPromise,
         typographyPromise,
         cssPromise,
         jsPromise,
-        metadataPromise
+        metadataPromise,
+        parseContext7File({
+            rawPath: rawDocsConfiguration.integrations?.context7,
+            absoluteFilepathToDocsConfig,
+            context
+        })
     ]);
 
     // Validate incompatible tabs configuration: sidebar placement + center alignment
@@ -186,6 +191,7 @@ export async function parseDocsConfiguration({
         typography,
         layout: convertLayoutConfig(layout, tabsObj?.alignment, tabsObj?.placement),
         settings: convertSettingsConfig(rawDocsConfiguration.settings),
+        context7File,
         theme: resolvedTheme,
         analyticsConfig: {
             ...rawDocsConfiguration.analytics,
@@ -450,6 +456,34 @@ function convertSettingsConfig(
         disableExplorerProxy: settings.disableExplorerProxy ?? false,
         disableAnalytics: settings.disableAnalytics ?? false
     };
+}
+
+async function parseContext7File({
+    rawPath,
+    absoluteFilepathToDocsConfig,
+    context
+}: {
+    rawPath: string | undefined;
+    absoluteFilepathToDocsConfig: AbsoluteFilePath;
+    context: TaskContext;
+}): Promise<AbsoluteFilePath | undefined> {
+    if (rawPath == null) {
+        return undefined;
+    }
+
+    const absolutePath = resolveFilepath(rawPath, absoluteFilepathToDocsConfig);
+    const contents = await readFile(absolutePath, "utf8");
+
+    try {
+        JSON.parse(contents);
+    } catch (error) {
+        context.failAndThrow(
+            `Invalid JSON in Context7 config file: ${rawPath}`,
+            error instanceof Error ? error.message : String(error)
+        );
+    }
+
+    return absolutePath;
 }
 
 function convertLayoutConfig(

--- a/packages/cli/configuration/src/docs-yml/DocsYmlSchemas.ts
+++ b/packages/cli/configuration/src/docs-yml/DocsYmlSchemas.ts
@@ -580,7 +580,8 @@ export const CheckConfig = z.object({
 // ===== Integrations =====
 
 export const IntegrationsConfig = z.object({
-    intercom: z.string().optional()
+    intercom: z.string().optional(),
+    context7: z.string().optional()
 });
 
 // ===== Experimental =====

--- a/packages/cli/configuration/src/docs-yml/ParsedDocsConfiguration.ts
+++ b/packages/cli/configuration/src/docs-yml/ParsedDocsConfiguration.ts
@@ -69,6 +69,7 @@ export interface ParsedDocsConfiguration {
     typography: TypographyConfig | undefined;
     layout: CjsFdrSdk.docs.v1.commons.DocsLayoutConfig | undefined;
     settings: CjsFdrSdk.docs.v1.commons.DocsSettingsConfig | undefined;
+    context7File: AbsoluteFilePath | undefined;
     languages: Language[] | undefined;
     defaultLanguage: CjsFdrSdk.docs.v1.commons.ProgrammingLanguage | undefined;
     analyticsConfig: CjsFdrSdk.docs.v1.commons.AnalyticsConfig | undefined;

--- a/packages/cli/configuration/src/docs-yml/schemas/sdk/api/resources/docs/types/IntegrationsConfig.ts
+++ b/packages/cli/configuration/src/docs-yml/schemas/sdk/api/resources/docs/types/IntegrationsConfig.ts
@@ -4,9 +4,7 @@ export interface IntegrationsConfig {
     intercom?: string;
     /**
      * Relative filepath to a `context7.json` file that Fern should host at `/context7.json`.
-     *
-     * Fern only validates that the file exists and contains valid JSON. The contents are passed through
-     * without enforcing a specific schema so customers can keep up with Context7's evolving format.
+     * Fern only checks that the file exists and is valid JSON, then passes it through as-is.
      */
     context7?: string;
 }

--- a/packages/cli/configuration/src/docs-yml/schemas/sdk/api/resources/docs/types/IntegrationsConfig.ts
+++ b/packages/cli/configuration/src/docs-yml/schemas/sdk/api/resources/docs/types/IntegrationsConfig.ts
@@ -2,4 +2,11 @@
 
 export interface IntegrationsConfig {
     intercom?: string;
+    /**
+     * Relative filepath to a `context7.json` file that Fern should host at `/context7.json`.
+     *
+     * Fern only validates that the file exists and contains valid JSON. The contents are passed through
+     * without enforcing a specific schema so customers can keep up with Context7's evolving format.
+     */
+    context7?: string;
 }

--- a/packages/cli/configuration/src/docs-yml/schemas/sdk/serialization/resources/docs/types/IntegrationsConfig.ts
+++ b/packages/cli/configuration/src/docs-yml/schemas/sdk/serialization/resources/docs/types/IntegrationsConfig.ts
@@ -9,10 +9,12 @@ export const IntegrationsConfig: core.serialization.ObjectSchema<
     FernDocsConfig.IntegrationsConfig
 > = core.serialization.object({
     intercom: core.serialization.string().optional(),
+    context7: core.serialization.string().optional(),
 });
 
 export declare namespace IntegrationsConfig {
     export interface Raw {
         intercom?: string | null;
+        context7?: string | null;
     }
 }

--- a/packages/cli/docs-resolver/src/DocsDefinitionResolver.ts
+++ b/packages/cli/docs-resolver/src/DocsDefinitionResolver.ts
@@ -805,7 +805,13 @@ export class DocsDefinitionResolver {
             js: this.convertJavascriptConfiguration(),
             metadata: this.convertMetadata(),
             redirects: this.parsedDocsConfig.redirects,
-            integrations: this.parsedDocsConfig.integrations,
+            integrations:
+                this.parsedDocsConfig.integrations != null || this.parsedDocsConfig.context7File != null
+                    ? ({
+                          ...this.parsedDocsConfig.integrations,
+                          context7: this.getFileId(this.parsedDocsConfig.context7File)
+                      } as DocsV1Write.DocsConfig["integrations"])
+                    : undefined,
             footerLinks: this.parsedDocsConfig.footerLinks?.map((footerLink) => ({
                 ...footerLink,
                 value: DocsV1Write.Url(footerLink.value)

--- a/packages/cli/docs-resolver/src/DocsDefinitionResolver.ts
+++ b/packages/cli/docs-resolver/src/DocsDefinitionResolver.ts
@@ -747,6 +747,13 @@ export class DocsDefinitionResolver {
     }
 
     private async convertDocsConfiguration(root: FernNavigation.V1.RootNode): Promise<DocsV1Write.DocsConfig> {
+        const integrations =
+            this.parsedDocsConfig.integrations != null || this.parsedDocsConfig.context7File != null
+                ? ({
+                      ...this.parsedDocsConfig.integrations,
+                      context7: this.getFileId(this.parsedDocsConfig.context7File)
+                  } as DocsV1Write.DocsConfig["integrations"])
+                : undefined;
         const config: DocsV1Write.DocsConfig = {
             aiChatConfig:
                 this.parsedDocsConfig.aiChatConfig != null
@@ -805,13 +812,7 @@ export class DocsDefinitionResolver {
             js: this.convertJavascriptConfiguration(),
             metadata: this.convertMetadata(),
             redirects: this.parsedDocsConfig.redirects,
-            integrations:
-                this.parsedDocsConfig.integrations != null || this.parsedDocsConfig.context7File != null
-                    ? ({
-                          ...this.parsedDocsConfig.integrations,
-                          context7: this.getFileId(this.parsedDocsConfig.context7File)
-                      } as DocsV1Write.DocsConfig["integrations"])
-                    : undefined,
+            integrations,
             footerLinks: this.parsedDocsConfig.footerLinks?.map((footerLink) => ({
                 ...footerLink,
                 value: DocsV1Write.Url(footerLink.value)

--- a/packages/cli/docs-resolver/src/utils/getImageFilepathsToUpload.ts
+++ b/packages/cli/docs-resolver/src/utils/getImageFilepathsToUpload.ts
@@ -153,7 +153,6 @@ export async function collectFilesFromDocsConfig({
         });
     }
 
-    /* context7 verification file */
     if (parsedDocsConfig.context7File != null) {
         filepaths.add(parsedDocsConfig.context7File);
     }

--- a/packages/cli/docs-resolver/src/utils/getImageFilepathsToUpload.ts
+++ b/packages/cli/docs-resolver/src/utils/getImageFilepathsToUpload.ts
@@ -153,6 +153,11 @@ export async function collectFilesFromDocsConfig({
         });
     }
 
+    /* context7 verification file */
+    if (parsedDocsConfig.context7File != null) {
+        filepaths.add(parsedDocsConfig.context7File);
+    }
+
     /* custom page action icons */
     if (parsedDocsConfig.pageActions?.options?.custom != null) {
         await Promise.all(

--- a/packages/cli/workspace/loader/src/docs-yml.schema.json
+++ b/packages/cli/workspace/loader/src/docs-yml.schema.json
@@ -5714,6 +5714,16 @@
               "type": "null"
             }
           ]
+        },
+        "context7": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
         }
       },
       "additionalProperties": false

--- a/packages/cli/yaml/docs-validator/src/docsAst/visitDocsConfigFileYamlAst.ts
+++ b/packages/cli/yaml/docs-validator/src/docsAst/visitDocsConfigFileYamlAst.ts
@@ -150,7 +150,19 @@ export async function visitDocsConfigFileYamlAst({
                 willBeUploaded: false
             });
         },
-        integrations: noop,
+        integrations: async (integrations) => {
+            if (integrations?.context7 == null) {
+                return;
+            }
+
+            await visitFilepath({
+                absoluteFilepathToConfiguration,
+                rawUnresolvedFilepath: integrations.context7,
+                visitor,
+                nodePath: ["integrations", "context7"],
+                willBeUploaded: true
+            });
+        },
         js: async (js) => {
             if (js == null) {
                 return;


### PR DESCRIPTION
## Description
Linear ticket: Closes [FER-9301](https://linear.app/buildwithfern/issue/FER-9302/add-support-for-specifying-context7json-in-docsyml)

Adds `integrations.context7` to `docs.yml` so customers can point Fern at a local `context7.json` file. The CLI validates that the file exists and contains valid JSON, uploads it as part of docs publish, and includes it in the published docs config so the docs app can serve it from `/context7.json`.

## Changes Made
- Added `integrations.context7` to the `docs.yml` schema and regenerated the related generated schema artifacts
- Validated and resolved the configured Context7 JSON file during docs config parsing
- Included the Context7 file in docs asset upload and published its uploaded file ID in the docs config

## Testing
- [x] Unit tests added/updated
- [x] Manual testing completed