### PR TITLE
fix(typescript): add --provenance flag to npm publish for OIDC auth

### DIFF
--- a/generators/typescript/utils/abstract-generator-cli/src/writeGitHubWorkflows.ts
+++ b/generators/typescript/utils/abstract-generator-cli/src/writeGitHubWorkflows.ts
@@ -154,7 +154,7 @@ jobs:
           npm config set //registry.npmjs.org/:_authToken \${NPM_TOKEN}`
         }
           publish() {  # use latest npm to ensure OIDC support
-            npx -y npm@latest publish "$@"
+            npx -y npm@latest publish${useOidc ? " --provenance" : ""} "$@"
           }
           if [[ \${GITHUB_REF} == *alpha* ]]; then
             publish --access ${access} --tag alpha

--- a/seed/ts-sdk/simple-api/oidc-token/.github/workflows/ci.yml
+++ b/seed/ts-sdk/simple-api/oidc-token/.github/workflows/ci.yml
@@ -71,7 +71,7 @@ jobs:
       - name: Publish to npm
         run: |
           publish() {  # use latest npm to ensure OIDC support
-            npx -y npm@latest publish "$@"
+            npx -y npm@latest publish --provenance "$@"
           }
           if [[ ${GITHUB_REF} == *alpha* ]]; then
             publish --access public --tag alpha


### PR DESCRIPTION
## Description

Refs: Reported by customer (afternoon-sdk) — OIDC-based npm publishing fails with `ENEEDAUTH` because the generated CI workflow never passes `--provenance` to `npm publish`.

When `tokenEnvironmentVariable` is set to `<USE_OIDC>`, the generator correctly emits `id-token: write` permissions and omits `NPM_TOKEN`, but the `npm publish` command is missing `--provenance`. Without that flag, npm never requests the GitHub Actions OIDC token and falls back to token-based auth, which doesn't exist.

## Changes Made

- Added `--provenance` flag to the `npm publish` command in `writeGitHubWorkflows.ts` when OIDC mode is active
- Updated the `oidc-token` seed test fixture to match the new expected output
- Fixed missing trailing newline in the seed fixture

## Testing

- [ ] Lint passes (`pnpm run check`)
- [ ] Manually verified the fix on a customer repo ([fern-demo/afternoon-ts-sdk#1](https://github.com/fern-demo/afternoon-ts-sdk/pull/1), merged)
- [ ] Cannot fully E2E test OIDC publishing (requires npm trusted publisher config + GitHub Actions tag push)

## Human Review Checklist

- [ ] Verify non-OIDC publish paths are unaffected (the ternary defaults to `""` when `useOidc` is false)
- [ ] Confirm no other seed fixtures use the OIDC token path (only `simple-api/oidc-token` does)

Link to Devin session: https://app.devin.ai/sessions/eeefaf1e00634ccba9a8aedc5d5058c9
Requested by: @jon-fern
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/14351" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
