### PR TITLE
chore(typescript): redirect biome/lint/formatter output to separate log file

### DIFF
--- a/generators/typescript/express/versions.yml
+++ b/generators/typescript/express/versions.yml
@@ -1,4 +1,15 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 0.19.14
+  changelogEntry:
+    - summary: |
+        Redirect biome/lint/formatter output to a separate log file (`/tmp/fern-*.log`)
+        inside the Docker container instead of piping to the main generation log.
+        This reduces noise in the primary output while still preserving the tool
+        output for debugging.
+      type: chore
+  irVersion: 65
+  createdAt: "2026-03-31"
+
 - version: 0.19.13
   changelogEntry:
     - summary: |

--- a/generators/typescript/sdk/versions.yml
+++ b/generators/typescript/sdk/versions.yml
@@ -1,4 +1,15 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 3.60.4
+  changelogEntry:
+    - summary: |
+        Redirect biome/lint/formatter output to a separate log file (`/tmp/fern-*.log`)
+        inside the Docker container instead of piping to the main generation log.
+        This reduces noise in the primary output while still preserving the tool
+        output for debugging.
+      type: chore
+  createdAt: "2026-03-31"
+  irVersion: 65
+
 - version: 3.60.3
   changelogEntry:
     - summary: |

--- a/generators/typescript/utils/commons/src/typescript-project/PersistedTypescriptProject.ts
+++ b/generators/typescript/utils/commons/src/typescript-project/PersistedTypescriptProject.ts
@@ -228,6 +228,13 @@ export class PersistedTypescriptProject {
             });
             logger.debug(`[TIMING] format took ${Date.now() - startTime}ms`);
         } catch (e) {
+            const err = e as { stdout?: string; stderr?: string };
+            await this.writeToolOutputToLogFile({
+                step: "format",
+                stdout: err.stdout ?? "",
+                stderr: err.stderr ?? "",
+                logger
+            });
             logger.error(`Failed to format the generated project: ${e}`);
         }
     }
@@ -254,6 +261,13 @@ export class PersistedTypescriptProject {
             });
             logger.debug(`[TIMING] checkFix took ${Date.now() - startTime}ms`);
         } catch (e) {
+            const err = e as { stdout?: string; stderr?: string };
+            await this.writeToolOutputToLogFile({
+                step: "checkFix",
+                stdout: err.stdout ?? "",
+                stderr: err.stderr ?? "",
+                logger
+            });
             logger.error(`Failed to format the generated project: ${e}`);
         }
     }

--- a/generators/typescript/utils/commons/src/typescript-project/PersistedTypescriptProject.ts
+++ b/generators/typescript/utils/commons/src/typescript-project/PersistedTypescriptProject.ts
@@ -228,11 +228,11 @@ export class PersistedTypescriptProject {
             });
             logger.debug(`[TIMING] format took ${Date.now() - startTime}ms`);
         } catch (e) {
-            const err = e as { stdout?: string; stderr?: string };
+            const error = e as { stdout?: string; stderr?: string };
             await this.writeToolOutputToLogFile({
                 step: "format",
-                stdout: err.stdout ?? "",
-                stderr: err.stderr ?? "",
+                stdout: error.stdout ?? "",
+                stderr: error.stderr ?? "",
                 logger
             });
             logger.error(`Failed to format the generated project: ${e}`);
@@ -261,11 +261,11 @@ export class PersistedTypescriptProject {
             });
             logger.debug(`[TIMING] checkFix took ${Date.now() - startTime}ms`);
         } catch (e) {
-            const err = e as { stdout?: string; stderr?: string };
+            const error = e as { stdout?: string; stderr?: string };
             await this.writeToolOutputToLogFile({
                 step: "checkFix",
-                stdout: err.stdout ?? "",
-                stderr: err.stderr ?? "",
+                stdout: error.stdout ?? "",
+                stderr: error.stderr ?? "",
                 logger
             });
             logger.error(`Failed to format the generated project: ${e}`);

--- a/generators/typescript/utils/commons/src/typescript-project/PersistedTypescriptProject.ts
+++ b/generators/typescript/utils/commons/src/typescript-project/PersistedTypescriptProject.ts
@@ -4,7 +4,7 @@ import { createLoggingExecutable } from "@fern-api/logging-execa";
 import { PublishInfo } from "@fern-api/typescript-base";
 import { execFile } from "child_process";
 import decompress from "decompress";
-import { cp, readdir, rm } from "fs/promises";
+import { cp, readdir, rm, writeFile } from "fs/promises";
 import tmp from "tmp-promise";
 import { promisify } from "util";
 
@@ -214,11 +214,18 @@ export class PersistedTypescriptProject {
 
         const pm = createLoggingExecutable(this.packageManager, {
             cwd: this.directory,
-            logger
+            logger,
+            doNotPipeOutput: true
         });
         try {
             const startTime = Date.now();
-            await pm(this.formatCommand);
+            const result = await pm(this.formatCommand);
+            await this.writeToolOutputToLogFile({
+                step: "format",
+                stdout: result.stdout,
+                stderr: result.stderr,
+                logger
+            });
             logger.debug(`[TIMING] format took ${Date.now() - startTime}ms`);
         } catch (e) {
             logger.error(`Failed to format the generated project: ${e}`);
@@ -233,11 +240,18 @@ export class PersistedTypescriptProject {
         const pm = createLoggingExecutable(this.packageManager, {
             cwd: this.directory,
             logger,
-            reject: false
+            reject: false,
+            doNotPipeOutput: true
         });
         try {
             const startTime = Date.now();
-            await pm(this.checkFixCommand);
+            const result = await pm(this.checkFixCommand);
+            await this.writeToolOutputToLogFile({
+                step: "checkFix",
+                stdout: result.stdout,
+                stderr: result.stderr,
+                logger
+            });
             logger.debug(`[TIMING] checkFix took ${Date.now() - startTime}ms`);
         } catch (e) {
             logger.error(`Failed to format the generated project: ${e}`);
@@ -491,6 +505,29 @@ export class PersistedTypescriptProject {
             maxRetries: 3,
             retryDelay: 100
         });
+    }
+
+    private async writeToolOutputToLogFile({
+        step,
+        stdout,
+        stderr,
+        logger
+    }: {
+        step: string;
+        stdout: string;
+        stderr: string;
+        logger: Logger;
+    }): Promise<void> {
+        const logFilePath = `/tmp/fern-${step}.log`;
+        const content = [stdout, stderr].filter(Boolean).join("\n");
+        if (content.length > 0) {
+            try {
+                await writeFile(logFilePath, content);
+                logger.debug(`${step} output written to ${logFilePath}`);
+            } catch (error) {
+                logger.debug(`Failed to write ${step} output to ${logFilePath}: ${error}`);
+            }
+        }
     }
 
     public async writeArbitraryFiles(run: (pathToProject: AbsoluteFilePath) => Promise<void>): Promise<void> {

--- a/generators/typescript/utils/commons/src/typescript-project/__test__/PersistedTypescriptProject.test.ts
+++ b/generators/typescript/utils/commons/src/typescript-project/__test__/PersistedTypescriptProject.test.ts
@@ -1,7 +1,6 @@
 import { AbsoluteFilePath, RelativeFilePath } from "@fern-api/fs-utils";
 import { createLogger } from "@fern-api/logger";
 import { readFile, rm } from "fs/promises";
-import tmp from "tmp-promise";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { PersistedTypescriptProject } from "../PersistedTypescriptProject.js";
@@ -107,8 +106,12 @@ describe("PersistedTypescriptProject", () => {
             expect(mockExecutable).not.toHaveBeenCalled();
         });
 
-        it("logs error when command throws", async () => {
-            const mockExecutable = vi.fn().mockRejectedValue(new Error("biome crashed"));
+        it("logs error and writes output to log file when command throws", async () => {
+            const error = Object.assign(new Error("biome crashed"), {
+                stdout: "partial format output",
+                stderr: "error: syntax error in file.ts"
+            });
+            const mockExecutable = vi.fn().mockRejectedValue(error);
             mockedCreateLoggingExecutable.mockReturnValue(mockExecutable);
 
             const { logger, lines } = collectLogs();
@@ -117,6 +120,11 @@ describe("PersistedTypescriptProject", () => {
             await project.format(logger);
 
             expect(lines.some((l) => l.includes("Failed to format the generated project"))).toBe(true);
+
+            // Verify tool output is still captured to the log file on failure
+            const logContent = await readFile("/tmp/fern-format.log", "utf-8");
+            expect(logContent).toContain("partial format output");
+            expect(logContent).toContain("error: syntax error in file.ts");
         });
     });
 

--- a/generators/typescript/utils/commons/src/typescript-project/__test__/PersistedTypescriptProject.test.ts
+++ b/generators/typescript/utils/commons/src/typescript-project/__test__/PersistedTypescriptProject.test.ts
@@ -1,0 +1,202 @@
+import { AbsoluteFilePath, RelativeFilePath } from "@fern-api/fs-utils";
+import { createLogger } from "@fern-api/logger";
+import { readFile, rm } from "fs/promises";
+import tmp from "tmp-promise";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { PersistedTypescriptProject } from "../PersistedTypescriptProject.js";
+
+// Mock createLoggingExecutable so we never shell out to a real package manager
+vi.mock("@fern-api/logging-execa", () => ({
+    createLoggingExecutable: vi.fn()
+}));
+
+// eslint-disable-next-line @typescript-eslint/consistent-type-imports -- must be after vi.mock
+const { createLoggingExecutable } = await import("@fern-api/logging-execa");
+const mockedCreateLoggingExecutable = vi.mocked(createLoggingExecutable);
+
+function makeProject(overrides: Partial<PersistedTypescriptProject.Init> = {}): PersistedTypescriptProject {
+    return new PersistedTypescriptProject({
+        directory: AbsoluteFilePath.of("/tmp/fake-project"),
+        srcDirectory: RelativeFilePath.of("src"),
+        distDirectory: RelativeFilePath.of("dist"),
+        testDirectory: RelativeFilePath.of("tests"),
+        buildCommand: ["run", "build"],
+        formatCommand: ["run", "format"],
+        checkFixCommand: ["run", "check:fix"],
+        checkFixPackages: [],
+        checkFixToolBinaries: [],
+        runScripts: true,
+        packageManager: "pnpm",
+        ...overrides
+    });
+}
+
+function collectLogs(): { lines: string[]; logger: ReturnType<typeof createLogger> } {
+    const lines: string[] = [];
+    const logger = createLogger((_level, ...args) => lines.push(args.join(" ")));
+    return { lines, logger };
+}
+
+describe("PersistedTypescriptProject", () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    describe("format", () => {
+        afterEach(async () => {
+            try {
+                await rm("/tmp/fern-format.log");
+            } catch {
+                // ignore if file doesn't exist
+            }
+        });
+
+        it("writes stdout and stderr to /tmp/fern-format.log", async () => {
+            const mockExecutable = vi.fn().mockResolvedValue({
+                stdout: "formatted 42 files",
+                stderr: "warning: trailing whitespace"
+            });
+            mockedCreateLoggingExecutable.mockReturnValue(mockExecutable);
+
+            const { logger, lines } = collectLogs();
+            const project = makeProject();
+
+            await project.format(logger);
+
+            // Verify createLoggingExecutable was called with doNotPipeOutput: true
+            expect(mockedCreateLoggingExecutable).toHaveBeenCalledWith(
+                "pnpm",
+                expect.objectContaining({ doNotPipeOutput: true })
+            );
+
+            // Verify the log file was written with both stdout and stderr
+            const logContent = await readFile("/tmp/fern-format.log", "utf-8");
+            expect(logContent).toContain("formatted 42 files");
+            expect(logContent).toContain("warning: trailing whitespace");
+
+            // Verify debug log about the file being written
+            expect(lines.some((l) => l.includes("format output written to /tmp/fern-format.log"))).toBe(true);
+        });
+
+        it("does not write log file when stdout and stderr are empty", async () => {
+            const mockExecutable = vi.fn().mockResolvedValue({
+                stdout: "",
+                stderr: ""
+            });
+            mockedCreateLoggingExecutable.mockReturnValue(mockExecutable);
+
+            const { logger } = collectLogs();
+            const project = makeProject();
+
+            await project.format(logger);
+
+            // File should not exist since there was no output
+            await expect(readFile("/tmp/fern-format.log", "utf-8")).rejects.toThrow();
+        });
+
+        it("skips when runScripts is false", async () => {
+            const mockExecutable = vi.fn().mockResolvedValue({ stdout: "", stderr: "" });
+            mockedCreateLoggingExecutable.mockReturnValue(mockExecutable);
+
+            const { logger } = collectLogs();
+            const project = makeProject({ runScripts: false });
+
+            await project.format(logger);
+
+            expect(mockExecutable).not.toHaveBeenCalled();
+        });
+
+        it("logs error when command throws", async () => {
+            const mockExecutable = vi.fn().mockRejectedValue(new Error("biome crashed"));
+            mockedCreateLoggingExecutable.mockReturnValue(mockExecutable);
+
+            const { logger, lines } = collectLogs();
+            const project = makeProject();
+
+            await project.format(logger);
+
+            expect(lines.some((l) => l.includes("Failed to format the generated project"))).toBe(true);
+        });
+    });
+
+    describe("checkFix", () => {
+        afterEach(async () => {
+            try {
+                await rm("/tmp/fern-checkFix.log");
+            } catch {
+                // ignore if file doesn't exist
+            }
+        });
+
+        it("writes stdout and stderr to /tmp/fern-checkFix.log", async () => {
+            const mockExecutable = vi.fn().mockResolvedValue({
+                stdout: "checked 100 files",
+                stderr: "fixed 3 issues"
+            });
+            mockedCreateLoggingExecutable.mockReturnValue(mockExecutable);
+
+            const { logger, lines } = collectLogs();
+            const project = makeProject();
+
+            await project.checkFix(logger);
+
+            // Verify createLoggingExecutable was called with doNotPipeOutput: true and reject: false
+            expect(mockedCreateLoggingExecutable).toHaveBeenCalledWith(
+                "pnpm",
+                expect.objectContaining({ doNotPipeOutput: true, reject: false })
+            );
+
+            // Verify the log file was written
+            const logContent = await readFile("/tmp/fern-checkFix.log", "utf-8");
+            expect(logContent).toContain("checked 100 files");
+            expect(logContent).toContain("fixed 3 issues");
+
+            // Verify debug log
+            expect(lines.some((l) => l.includes("checkFix output written to /tmp/fern-checkFix.log"))).toBe(true);
+        });
+
+        it("does not write log file when stdout and stderr are empty", async () => {
+            const mockExecutable = vi.fn().mockResolvedValue({
+                stdout: "",
+                stderr: ""
+            });
+            mockedCreateLoggingExecutable.mockReturnValue(mockExecutable);
+
+            const { logger } = collectLogs();
+            const project = makeProject();
+
+            await project.checkFix(logger);
+
+            await expect(readFile("/tmp/fern-checkFix.log", "utf-8")).rejects.toThrow();
+        });
+
+        it("skips when runScripts is false", async () => {
+            const mockExecutable = vi.fn().mockResolvedValue({ stdout: "", stderr: "" });
+            mockedCreateLoggingExecutable.mockReturnValue(mockExecutable);
+
+            const { logger } = collectLogs();
+            const project = makeProject({ runScripts: false });
+
+            await project.checkFix(logger);
+
+            expect(mockExecutable).not.toHaveBeenCalled();
+        });
+
+        it("writes only stdout when stderr is empty", async () => {
+            const mockExecutable = vi.fn().mockResolvedValue({
+                stdout: "all checks passed",
+                stderr: ""
+            });
+            mockedCreateLoggingExecutable.mockReturnValue(mockExecutable);
+
+            const { logger } = collectLogs();
+            const project = makeProject();
+
+            await project.checkFix(logger);
+
+            const logContent = await readFile("/tmp/fern-checkFix.log", "utf-8");
+            expect(logContent).toBe("all checks passed");
+        });
+    });
+});


### PR DESCRIPTION
## Description

Redirects verbose biome/lint/formatter output from the TS generator's `format()` and `checkFix()` steps to separate log files (`/tmp/fern-format.log`, `/tmp/fern-checkFix.log`) inside the Docker container instead of piping to stdout/stderr (the main generation log).

## Changes Made

- Added `doNotPipeOutput: true` to `format()` and `checkFix()` in `PersistedTypescriptProject.ts`
- Captured command results and write stdout/stderr to `/tmp/fern-{step}.log` via a new `writeToolOutputToLogFile` helper
- Both success and error paths now write tool output to the log file — catch blocks extract `stdout`/`stderr` from the execa error object so diagnostic output is preserved on failure
- Log files live in the ephemeral container and are deleted when the container is removed
- Debug-level messages still log timing info and the file path for discoverability
- Added unit tests for `format()` and `checkFix()` (8 tests) covering: log file writing, empty-output skipping, `runScripts: false` short-circuit, error-with-output capture, and stdout-only output
- Version bumps: SDK → 3.60.4, Express → 0.19.14

## Key review items

- **Type assertion in catch blocks**: `e as { stdout?: string; stderr?: string }` assumes execa-shaped errors. Non-execa errors will have `undefined` stdout/stderr, handled safely via `?? ""` — but worth a glance to confirm this is acceptable.
- **File overwrite**: `writeFile` overwrites (not appends). If the same step somehow runs twice in one container run, the first log is lost. Likely fine in practice.

## Testing
- [x] Unit tests added (8 tests across `format` and `checkFix` — all passing locally)
- [x] Verified compilation passes (`tsc --noEmit` on the affected package)
- [ ] Manual testing in Docker — relies on CI

Link to Devin session: https://app.devin.ai/sessions/aa7b687444f248e39a700ecc16690498
Requested by: @Swimburger
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/14354" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
