### PR TITLE
fix(ci): reduce flaky e2e test failures from resource contention

### DIFF
--- a/packages/cli/ete-tests/src/tests/generate/generate.test.ts
+++ b/packages/cli/ete-tests/src/tests/generate/generate.test.ts
@@ -9,7 +9,7 @@ const fixturesDir = join(AbsoluteFilePath.of(__dirname), RelativeFilePath.of("fi
 
 describe("fern generate", () => {
     it.concurrent("default api (fern init)", async ({ signal }) => {
-        const pathOfDirectory = await init();
+        const pathOfDirectory = await init({ signal });
 
         await runFernCli(["generate", "--local", "--keepDocker"], {
             cwd: pathOfDirectory,

--- a/packages/cli/ete-tests/src/tests/upgrade-generator/fixtures/fern/generators.yml
+++ b/packages/cli/ete-tests/src/tests/upgrade-generator/fixtures/fern/generators.yml
@@ -15,7 +15,7 @@ groups:
   python-sdk:
     generators:
       - name: fernapi/fern-python-sdk
-        version: 3.0.0
+        version: 2.0.0
         smart-casing: true
         config:
           inline_request_params: false
@@ -39,7 +39,7 @@ groups:
     generators:
       - name: fernapi/fern-python-sdk
         autorelease: false
-        version: 3.0.0
+        version: 2.0.0
         config: {}
       - name: fernapi/fern-java-sdk
         version: 0.0.1

--- a/packages/cli/ete-tests/src/tests/upgrade-generator/upgrade-generator.test.ts
+++ b/packages/cli/ete-tests/src/tests/upgrade-generator/upgrade-generator.test.ts
@@ -35,7 +35,7 @@ describe("fern generator upgrade", () => {
             { cwd: directory, signal }
         );
 
-        expect(JSON.parse((await readFile(outputFile)).toString()).version).not.toEqual("3.0.0");
+        expect(JSON.parse((await readFile(outputFile)).toString()).version).not.toEqual("2.0.0");
     }, 60_000);
 
     it.concurrent("fern generator upgrade with filters", async ({ signal }) => {
@@ -74,7 +74,7 @@ describe("fern generator upgrade", () => {
             { cwd: directory, signal }
         );
 
-        expect(JSON.parse((await readFile(outputFile)).toString()).version).not.toEqual("3.0.0");
+        expect(JSON.parse((await readFile(outputFile)).toString()).version).not.toEqual("2.0.0");
     }, 60_000);
 
     it("fern generator help commands", async ({ signal }) => {
@@ -223,7 +223,7 @@ describe("fern generator upgrade", () => {
             { cwd: directory, signal }
         );
 
-        expect(JSON.parse((await readFile(outputFile)).toString()).version).toEqual("3.0.0");
+        expect(JSON.parse((await readFile(outputFile)).toString()).version).toEqual("2.0.0");
 
         const outputFileJava = join(directory, RelativeFilePath.of("version-autorelease-java.txt"));
         await runFernCli(
@@ -273,7 +273,7 @@ describe("fern generator upgrade", () => {
             { cwd: directory, signal }
         );
 
-        expect(JSON.parse((await readFile(outputFile)).toString()).version).not.toEqual("3.0.0");
+        expect(JSON.parse((await readFile(outputFile)).toString()).version).not.toEqual("2.0.0");
     }, 60_000);
 
     it.concurrent("fern generator upgrade shows major version message", async ({ signal }) => {

--- a/packages/cli/ete-tests/vitest.config.ts
+++ b/packages/cli/ete-tests/vitest.config.ts
@@ -1,4 +1,4 @@
-import { defineConfig, mergeConfig, defaultConfig } from "@fern-api/configs/vitest/base.mjs";
+import { defaultConfig, defineConfig, mergeConfig } from "@fern-api/configs/vitest/base.mjs";
 
 export default defineConfig(
     mergeConfig(defaultConfig, {

--- a/packages/cli/ete-tests/vitest.config.ts
+++ b/packages/cli/ete-tests/vitest.config.ts
@@ -1,1 +1,19 @@
-export { default } from "@fern-api/configs/vitest/base.mjs";
+import { defineConfig, mergeConfig, defaultConfig } from "@fern-api/configs/vitest/base.mjs";
+
+export default defineConfig(
+    mergeConfig(defaultConfig, {
+        test: {
+            // ETE tests spawn heavy child processes (Node CLI, Docker containers).
+            // Running too many test files in parallel causes resource contention
+            // and widespread timeouts on CI runners.
+            poolOptions: {
+                threads: {
+                    maxThreads: 4
+                },
+                forks: {
+                    maxForks: 4
+                }
+            }
+        }
+    })
+);


### PR DESCRIPTION
## Description

Refs [CI run with 26/168 test failures](https://github.com/fern-api/fern/actions/runs/23806622036/job/69381766905?pr=14353)

The `test-ete` CI job fails frequently due to widespread test timeouts. Root cause analysis of the linked run identified three independent issues.

## Changes Made

### 1. Limit file-level parallelism for e2e tests (`vitest.config.ts`)
The e2e tests spawn heavy child processes (Node CLI instances, Docker containers). With vitest's default parallelism (one worker per CPU core), 34 test files run simultaneously, each spawning multiple CLI processes. This causes resource contention that makes individual tests exceed their 60s/180s timeouts.

Added a custom vitest config that caps `maxThreads`/`maxForks` at 4 (the base config's `maxConcurrency: 10` only limits *in-file* concurrent tests, not *file-level* parallelism).

### 2. Fix leaked CLI process in `generate.test.ts`
The `init()` call was missing the `signal` parameter, so when the test timed out, the spawned CLI process was never killed — it continued consuming CPU/memory and starving other concurrent tests.

### 3. Pin upgrade-generator fixture to older version (`3.0.0` → `2.0.0`)
The fixture pinned `fernapi/fern-python-sdk` at `3.0.0`, which is the current latest version. The upgrade tests assert the version changes after running `fern generator upgrade`, so they deterministically fail when there's nothing to upgrade to. Pinning to `2.0.0` ensures upgrades are always available (2.16.0 exists in the 2.x line). Updated both the `python-sdk` and `autorelease-disabled` groups, plus the four corresponding assertions.

## Testing

- [x] CI `test-ete` job passed on both pushes (0 failures vs. 26 in the linked run)
- The "Obsolete snapshots" errors in the failing run are a **consequence** of timeouts (tests time out before reaching `toMatchSnapshot()`), not a separate issue

## Human Review Checklist

- **`maxThreads: 4`** — is this the right cap for the CI runner size? A lower value (e.g., 2) would be safer but slower; a higher value might still cause contention on smaller runners
- **Version `2.0.0` pin** — this works because `2.16.0` exists. The same fragility exists for `shouldnt-upgrade` at `2.16.0` (assumes it's the latest 2.x). If a new 2.x version is ever released, that separate test would break — but that's pre-existing, not introduced here
- **`mergeConfig` usage** — verify the deep merge doesn't unintentionally override base config fields (e.g., `tags`, `reporters`, `maxConcurrency`)

Link to Devin session: https://app.devin.ai/sessions/521e91fb2dd6444383bbfc453ccf501c
Requested by: @Swimburger
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/14356" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
