### PR TITLE
fix(typescript): skip hasNextPage().toBe(true) assertion when example has_more is false

### DIFF
--- a/generators/typescript/sdk/generator/src/test-generator/TestGenerator.ts
+++ b/generators/typescript/sdk/generator/src/test-generator/TestGenerator.ts
@@ -2332,7 +2332,18 @@ function isPaginationCursorMissingInExample({
     }
 
     // If the leaf is explicitly undefined or null, treat it as "missing"
-    return cursor === undefined || cursor === null;
+    if (cursor === undefined || cursor === null) {
+        return true;
+    }
+
+    // For offset pagination, if the hasNextPage property is explicitly false,
+    // treat it as "missing" so we don't generate hasNextPage().toBe(true) assertions
+    // that would contradict the mock data
+    if (pagination.type === "offset" && cursor === false) {
+        return true;
+    }
+
+    return false;
 }
 
 /**

--- a/generators/typescript/sdk/versions.yml
+++ b/generators/typescript/sdk/versions.yml
@@ -1,4 +1,17 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 3.60.6
+  changelogEntry:
+    - summary: |
+        Fix wire test generator asserting `hasNextPage().toBe(true)` for offset-paginated
+        endpoints when the example response has `has_more: false` (or equivalent
+        `hasNextPage` property set to `false`). The generator now checks the actual value
+        of the has-next-page property in the mock response and skips the `hasNextPage()`
+        and `getNextPage()` assertions when the example indicates there is no next page,
+        matching the SDK's runtime behavior.
+      type: fix
+  createdAt: "2026-03-31"
+  irVersion: 65
+
 - version: 3.60.5
   changelogEntry:
     - summary: |

--- a/seed/ts-sdk/pagination/no-custom-config/reference.md
+++ b/seed/ts-sdk/pagination/no-custom-config/reference.md
@@ -1488,7 +1488,7 @@ const response = page.response;
 ```typescript
 const pageableResponse = await client.users.listWithOffsetPaginationHasNextPage({
     page: 1,
-    limit: 1,
+    limit: 3,
     order: "asc"
 });
 for await (const item of pageableResponse) {
@@ -1498,7 +1498,7 @@ for await (const item of pageableResponse) {
 // Or you can manually iterate page-by-page
 let page = await client.users.listWithOffsetPaginationHasNextPage({
     page: 1,
-    limit: 1,
+    limit: 3,
     order: "asc"
 });
 while (page.hasNextPage()) {

--- a/seed/ts-sdk/pagination/no-custom-config/snippet.json
+++ b/seed/ts-sdk/pagination/no-custom-config/snippet.json
@@ -240,8 +240,21 @@
             },
             "snippet": {
                 "type": "typescript",
-                "client": "import { SeedPaginationClient } from \"@fern/pagination\";\n\nconst client = new SeedPaginationClient({ environment: \"YOUR_BASE_URL\", token: \"YOUR_TOKEN\" });\nconst pageableResponse = await client.users.listWithOffsetPaginationHasNextPage({\n    page: 1,\n    limit: 1,\n    order: \"asc\"\n});\nfor await (const item of pageableResponse) {\n    console.log(item);\n}\n\n// Or you can manually iterate page-by-page\nlet page = await client.users.listWithOffsetPaginationHasNextPage({\n    page: 1,\n    limit: 1,\n    order: \"asc\"\n});\nwhile (page.hasNextPage()) {\n    page = page.getNextPage();\n}\n\n// You can also access the underlying response\nconst response = page.response;\n"
-            }
+                "client": "import { SeedPaginationClient } from \"@fern/pagination\";\n\nconst client = new SeedPaginationClient({ environment: \"YOUR_BASE_URL\", token: \"YOUR_TOKEN\" });\nconst pageableResponse = await client.users.listWithOffsetPaginationHasNextPage({\n    page: 1,\n    limit: 3,\n    order: \"asc\"\n});\nfor await (const item of pageableResponse) {\n    console.log(item);\n}\n\n// Or you can manually iterate page-by-page\nlet page = await client.users.listWithOffsetPaginationHasNextPage({\n    page: 1,\n    limit: 3,\n    order: \"asc\"\n});\nwhile (page.hasNextPage()) {\n    page = page.getNextPage();\n}\n\n// You can also access the underlying response\nconst response = page.response;\n"
+            },
+            "example_identifier": "HasNextPage"
+        },
+        {
+            "id": {
+                "path": "/users",
+                "method": "GET",
+                "identifier_override": "endpoint_users.listWithOffsetPaginationHasNextPage"
+            },
+            "snippet": {
+                "type": "typescript",
+                "client": "import { SeedPaginationClient } from \"@fern/pagination\";\n\nconst client = new SeedPaginationClient({ environment: \"YOUR_BASE_URL\", token: \"YOUR_TOKEN\" });\nconst pageableResponse = await client.users.listWithOffsetPaginationHasNextPage({\n    page: 1,\n    limit: 10,\n    order: \"asc\"\n});\nfor await (const item of pageableResponse) {\n    console.log(item);\n}\n\n// Or you can manually iterate page-by-page\nlet page = await client.users.listWithOffsetPaginationHasNextPage({\n    page: 1,\n    limit: 10,\n    order: \"asc\"\n});\nwhile (page.hasNextPage()) {\n    page = page.getNextPage();\n}\n\n// You can also access the underlying response\nconst response = page.response;\n"
+            },
+            "example_identifier": "NoNextPage"
         },
         {
             "id": {

--- a/seed/ts-sdk/pagination/no-custom-config/src/api/resources/users/client/Client.ts
+++ b/seed/ts-sdk/pagination/no-custom-config/src/api/resources/users/client/Client.ts
@@ -626,7 +626,14 @@ export class UsersClient {
      * @example
      *     await client.users.listWithOffsetPaginationHasNextPage({
      *         page: 1,
-     *         limit: 1,
+     *         limit: 3,
+     *         order: "asc"
+     *     })
+     *
+     * @example
+     *     await client.users.listWithOffsetPaginationHasNextPage({
+     *         page: 1,
+     *         limit: 10,
      *         order: "asc"
      *     })
      */

--- a/seed/ts-sdk/pagination/no-custom-config/src/api/resources/users/client/requests/ListWithOffsetPaginationHasNextPageRequest.ts
+++ b/seed/ts-sdk/pagination/no-custom-config/src/api/resources/users/client/requests/ListWithOffsetPaginationHasNextPageRequest.ts
@@ -6,7 +6,14 @@ import type * as SeedPagination from "../../../../index.js";
  * @example
  *     {
  *         page: 1,
- *         limit: 1,
+ *         limit: 3,
+ *         order: "asc"
+ *     }
+ *
+ * @example
+ *     {
+ *         page: 1,
+ *         limit: 10,
  *         order: "asc"
  *     }
  */

--- a/seed/ts-sdk/pagination/no-custom-config/tests/wire/users.test.ts
+++ b/seed/ts-sdk/pagination/no-custom-config/tests/wire/users.test.ts
@@ -439,17 +439,17 @@ describe("UsersClient", () => {
         expect(expected.data).toEqual(nextPage.data);
     });
 
-    test("listWithOffsetPaginationHasNextPage", async () => {
+    test("listWithOffsetPaginationHasNextPage (1)", async () => {
         const server = mockServerPool.createServer();
         const client = new SeedPaginationClient({ maxRetries: 0, token: "test", environment: server.baseUrl });
 
         const rawResponseBody = {
             hasNextPage: true,
-            page: { page: 1, next: { page: 1, starting_after: "starting_after" }, per_page: 1, total_page: 1 },
-            total_count: 1,
+            page: { page: 1, next: { page: 2, starting_after: "next_cursor" }, per_page: 3, total_page: 5 },
+            total_count: 15,
             data: [
-                { name: "name", id: 1 },
-                { name: "name", id: 1 },
+                { name: "Alice", id: 1 },
+                { name: "Bob", id: 2 },
             ],
         };
 
@@ -466,27 +466,27 @@ describe("UsersClient", () => {
             page: {
                 page: 1,
                 next: {
-                    page: 1,
-                    starting_after: "starting_after",
+                    page: 2,
+                    starting_after: "next_cursor",
                 },
-                per_page: 1,
-                total_page: 1,
+                per_page: 3,
+                total_page: 5,
             },
-            total_count: 1,
+            total_count: 15,
             data: [
                 {
-                    name: "name",
+                    name: "Alice",
                     id: 1,
                 },
                 {
-                    name: "name",
-                    id: 1,
+                    name: "Bob",
+                    id: 2,
                 },
             ],
         };
         const page = await client.users.listWithOffsetPaginationHasNextPage({
             page: 1,
-            limit: 1,
+            limit: 3,
             order: "asc",
         });
 
@@ -494,6 +494,54 @@ describe("UsersClient", () => {
         expect(page.hasNextPage()).toBe(true);
         const nextPage = await page.getNextPage();
         expect(expected.data).toEqual(nextPage.data);
+    });
+
+    test("listWithOffsetPaginationHasNextPage (2)", async () => {
+        const server = mockServerPool.createServer();
+        const client = new SeedPaginationClient({ maxRetries: 0, token: "test", environment: server.baseUrl });
+
+        const rawResponseBody = {
+            hasNextPage: false,
+            page: { page: 1, next: { page: 2, starting_after: "next_cursor" }, per_page: 10, total_page: 1 },
+            total_count: 2,
+            data: [
+                { name: "Alice", id: 1 },
+                { name: "Bob", id: 2 },
+            ],
+        };
+
+        server.mockEndpoint().get("/users").respondWith().statusCode(200).jsonBody(rawResponseBody).build();
+
+        const expected = {
+            hasNextPage: false,
+            page: {
+                page: 1,
+                next: {
+                    page: 2,
+                    starting_after: "next_cursor",
+                },
+                per_page: 10,
+                total_page: 1,
+            },
+            total_count: 2,
+            data: [
+                {
+                    name: "Alice",
+                    id: 1,
+                },
+                {
+                    name: "Bob",
+                    id: 2,
+                },
+            ],
+        };
+        const page = await client.users.listWithOffsetPaginationHasNextPage({
+            page: 1,
+            limit: 10,
+            order: "asc",
+        });
+
+        expect(expected.data).toEqual(page.data);
     });
 
     test("listWithExtendedResults", async () => {

--- a/seed/ts-sdk/pagination/page-index-semantics/reference.md
+++ b/seed/ts-sdk/pagination/page-index-semantics/reference.md
@@ -1488,7 +1488,7 @@ const response = page.response;
 ```typescript
 const pageableResponse = await client.users.listWithOffsetPaginationHasNextPage({
     page: 1,
-    limit: 1,
+    limit: 3,
     order: "asc"
 });
 for await (const item of pageableResponse) {
@@ -1498,7 +1498,7 @@ for await (const item of pageableResponse) {
 // Or you can manually iterate page-by-page
 let page = await client.users.listWithOffsetPaginationHasNextPage({
     page: 1,
-    limit: 1,
+    limit: 3,
     order: "asc"
 });
 while (page.hasNextPage()) {

--- a/seed/ts-sdk/pagination/page-index-semantics/snippet.json
+++ b/seed/ts-sdk/pagination/page-index-semantics/snippet.json
@@ -240,8 +240,21 @@
             },
             "snippet": {
                 "type": "typescript",
-                "client": "import { SeedPaginationClient } from \"@fern/pagination\";\n\nconst client = new SeedPaginationClient({ environment: \"YOUR_BASE_URL\", token: \"YOUR_TOKEN\" });\nconst pageableResponse = await client.users.listWithOffsetPaginationHasNextPage({\n    page: 1,\n    limit: 1,\n    order: \"asc\"\n});\nfor await (const item of pageableResponse) {\n    console.log(item);\n}\n\n// Or you can manually iterate page-by-page\nlet page = await client.users.listWithOffsetPaginationHasNextPage({\n    page: 1,\n    limit: 1,\n    order: \"asc\"\n});\nwhile (page.hasNextPage()) {\n    page = page.getNextPage();\n}\n\n// You can also access the underlying response\nconst response = page.response;\n"
-            }
+                "client": "import { SeedPaginationClient } from \"@fern/pagination\";\n\nconst client = new SeedPaginationClient({ environment: \"YOUR_BASE_URL\", token: \"YOUR_TOKEN\" });\nconst pageableResponse = await client.users.listWithOffsetPaginationHasNextPage({\n    page: 1,\n    limit: 3,\n    order: \"asc\"\n});\nfor await (const item of pageableResponse) {\n    console.log(item);\n}\n\n// Or you can manually iterate page-by-page\nlet page = await client.users.listWithOffsetPaginationHasNextPage({\n    page: 1,\n    limit: 3,\n    order: \"asc\"\n});\nwhile (page.hasNextPage()) {\n    page = page.getNextPage();\n}\n\n// You can also access the underlying response\nconst response = page.response;\n"
+            },
+            "example_identifier": "HasNextPage"
+        },
+        {
+            "id": {
+                "path": "/users",
+                "method": "GET",
+                "identifier_override": "endpoint_users.listWithOffsetPaginationHasNextPage"
+            },
+            "snippet": {
+                "type": "typescript",
+                "client": "import { SeedPaginationClient } from \"@fern/pagination\";\n\nconst client = new SeedPaginationClient({ environment: \"YOUR_BASE_URL\", token: \"YOUR_TOKEN\" });\nconst pageableResponse = await client.users.listWithOffsetPaginationHasNextPage({\n    page: 1,\n    limit: 10,\n    order: \"asc\"\n});\nfor await (const item of pageableResponse) {\n    console.log(item);\n}\n\n// Or you can manually iterate page-by-page\nlet page = await client.users.listWithOffsetPaginationHasNextPage({\n    page: 1,\n    limit: 10,\n    order: \"asc\"\n});\nwhile (page.hasNextPage()) {\n    page = page.getNextPage();\n}\n\n// You can also access the underlying response\nconst response = page.response;\n"
+            },
+            "example_identifier": "NoNextPage"
         },
         {
             "id": {

--- a/seed/ts-sdk/pagination/page-index-semantics/src/api/resources/users/client/Client.ts
+++ b/seed/ts-sdk/pagination/page-index-semantics/src/api/resources/users/client/Client.ts
@@ -626,7 +626,14 @@ export class UsersClient {
      * @example
      *     await client.users.listWithOffsetPaginationHasNextPage({
      *         page: 1,
-     *         limit: 1,
+     *         limit: 3,
+     *         order: "asc"
+     *     })
+     *
+     * @example
+     *     await client.users.listWithOffsetPaginationHasNextPage({
+     *         page: 1,
+     *         limit: 10,
      *         order: "asc"
      *     })
      */

--- a/seed/ts-sdk/pagination/page-index-semantics/src/api/resources/users/client/requests/ListWithOffsetPaginationHasNextPageRequest.ts
+++ b/seed/ts-sdk/pagination/page-index-semantics/src/api/resources/users/client/requests/ListWithOffsetPaginationHasNextPageRequest.ts
@@ -6,7 +6,14 @@ import type * as SeedPagination from "../../../../index.js";
  * @example
  *     {
  *         page: 1,
- *         limit: 1,
+ *         limit: 3,
+ *         order: "asc"
+ *     }
+ *
+ * @example
+ *     {
+ *         page: 1,
+ *         limit: 10,
  *         order: "asc"
  *     }
  */

--- a/seed/ts-sdk/pagination/page-index-semantics/tests/wire/users.test.ts
+++ b/seed/ts-sdk/pagination/page-index-semantics/tests/wire/users.test.ts
@@ -439,17 +439,17 @@ describe("UsersClient", () => {
         expect(expected.data).toEqual(nextPage.data);
     });
 
-    test("listWithOffsetPaginationHasNextPage", async () => {
+    test("listWithOffsetPaginationHasNextPage (1)", async () => {
         const server = mockServerPool.createServer();
         const client = new SeedPaginationClient({ maxRetries: 0, token: "test", environment: server.baseUrl });
 
         const rawResponseBody = {
             hasNextPage: true,
-            page: { page: 1, next: { page: 1, starting_after: "starting_after" }, per_page: 1, total_page: 1 },
-            total_count: 1,
+            page: { page: 1, next: { page: 2, starting_after: "next_cursor" }, per_page: 3, total_page: 5 },
+            total_count: 15,
             data: [
-                { name: "name", id: 1 },
-                { name: "name", id: 1 },
+                { name: "Alice", id: 1 },
+                { name: "Bob", id: 2 },
             ],
         };
 
@@ -466,27 +466,27 @@ describe("UsersClient", () => {
             page: {
                 page: 1,
                 next: {
-                    page: 1,
-                    starting_after: "starting_after",
+                    page: 2,
+                    starting_after: "next_cursor",
                 },
-                per_page: 1,
-                total_page: 1,
+                per_page: 3,
+                total_page: 5,
             },
-            total_count: 1,
+            total_count: 15,
             data: [
                 {
-                    name: "name",
+                    name: "Alice",
                     id: 1,
                 },
                 {
-                    name: "name",
-                    id: 1,
+                    name: "Bob",
+                    id: 2,
                 },
             ],
         };
         const page = await client.users.listWithOffsetPaginationHasNextPage({
             page: 1,
-            limit: 1,
+            limit: 3,
             order: "asc",
         });
 
@@ -494,6 +494,54 @@ describe("UsersClient", () => {
         expect(page.hasNextPage()).toBe(true);
         const nextPage = await page.getNextPage();
         expect(expected.data).toEqual(nextPage.data);
+    });
+
+    test("listWithOffsetPaginationHasNextPage (2)", async () => {
+        const server = mockServerPool.createServer();
+        const client = new SeedPaginationClient({ maxRetries: 0, token: "test", environment: server.baseUrl });
+
+        const rawResponseBody = {
+            hasNextPage: false,
+            page: { page: 1, next: { page: 2, starting_after: "next_cursor" }, per_page: 10, total_page: 1 },
+            total_count: 2,
+            data: [
+                { name: "Alice", id: 1 },
+                { name: "Bob", id: 2 },
+            ],
+        };
+
+        server.mockEndpoint().get("/users").respondWith().statusCode(200).jsonBody(rawResponseBody).build();
+
+        const expected = {
+            hasNextPage: false,
+            page: {
+                page: 1,
+                next: {
+                    page: 2,
+                    starting_after: "next_cursor",
+                },
+                per_page: 10,
+                total_page: 1,
+            },
+            total_count: 2,
+            data: [
+                {
+                    name: "Alice",
+                    id: 1,
+                },
+                {
+                    name: "Bob",
+                    id: 2,
+                },
+            ],
+        };
+        const page = await client.users.listWithOffsetPaginationHasNextPage({
+            page: 1,
+            limit: 10,
+            order: "asc",
+        });
+
+        expect(expected.data).toEqual(page.data);
     });
 
     test("listWithExtendedResults", async () => {

--- a/test-definitions/fern/apis/pagination/definition/users.yml
+++ b/test-definitions/fern/apis/pagination/definition/users.yml
@@ -312,6 +312,49 @@ service:
           order:
             type: optional<Order>
       response: ListUsersPaginationResponse
+      examples:
+        - name: HasNextPage
+          query-parameters:
+            page: 1
+            limit: 3
+            order: asc
+          response:
+            body:
+              hasNextPage: true
+              page:
+                page: 1
+                next:
+                  page: 2
+                  starting_after: "next_cursor"
+                per_page: 3
+                total_page: 5
+              total_count: 15
+              data:
+                - name: "Alice"
+                  id: 1
+                - name: "Bob"
+                  id: 2
+        - name: NoNextPage
+          query-parameters:
+            page: 1
+            limit: 10
+            order: asc
+          response:
+            body:
+              hasNextPage: false
+              page:
+                page: 1
+                next:
+                  page: 2
+                  starting_after: "next_cursor"
+                per_page: 10
+                total_page: 1
+              total_count: 2
+              data:
+                - name: "Alice"
+                  id: 1
+                - name: "Bob"
+                  id: 2
 
     listWithExtendedResults:
       pagination:


### PR DESCRIPTION
## Description

Fixes a bug where the wire test generator unconditionally asserted `expect(page.hasNextPage()).toBe(true)` for all offset-paginated endpoints, regardless of the actual `has_more` value in the example response. This caused all pagination wire tests to fail for APIs like Close where every example has `has_more: false`.

## Changes Made

- Extended `isPaginationCursorMissingInExample` in `TestGenerator.ts` to treat an explicitly `false` `hasNextPage` property (for offset pagination) the same as a missing cursor — skipping the `hasNextPage()` / `getNextPage()` assertions while still generating the rest of the test (mock setup, SDK call, response data validation)
- Added `HasNextPage` and `NoNextPage` examples to the `listWithOffsetPaginationHasNextPage` endpoint in the pagination test fixture to cover both branches
- Updated IR snapshot (`pagination.json`) to reflect the new user-specified examples
- Added version `3.60.6` changelog entry in `versions.yml`

## Testing

- [x] `pnpm run check` (biome lint) passes
- [x] `pnpm turbo run compile --filter @fern-typescript/sdk-generator` passes
- [x] Seed tests for `pagination` fixture regenerated — `NoNextPage` example correctly generates a test that validates response data without `hasNextPage().toBe(true)` or `getNextPage()` assertions
- [x] Both `no-custom-config` and `page-index-semantics` seed configs pass
- [x] IR generator tests pass with updated snapshot

## Human Review Checklist

- [ ] **Assertion strategy**: When `has_more: false`, the generator skips the `hasNextPage()` assertion entirely (consistent with cursor-missing behavior). An alternative would be to assert `hasNextPage().toBe(false)`. Is skipping preferred over asserting the negative?
- [ ] **Scope**: Fix only targets `pagination.type === "offset"`. Cursor pagination with falsy-but-present values (e.g., `cursor_next: ""`) is not affected. Is this sufficient?
- [ ] **Function naming**: `isPaginationCursorMissingInExample` now returns `true` for "present but false" — the name may be slightly misleading. Worth renaming?

Link to Devin session: https://app.devin.ai/sessions/cc5dc6d0609d4922a984deb5358db540
Requested by: @jon-fern
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/14376" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
