### PR TITLE
fix(typescript): coerce non-primitive path parameter examples to strings

### DIFF
--- a/generators/typescript/sdk/generator/src/test-generator/TestGenerator.ts
+++ b/generators/typescript/sdk/generator/src/test-generator/TestGenerator.ts
@@ -462,7 +462,7 @@ export function ${functionName}(server: MockServer): void {
     ${rawResponseBody ? code`const rawResponseBody = ${rawResponseBody};` : ""}
     server
         .mockEndpoint()
-        .${endpoint.method.toLowerCase()}("${getMockUrlForExample(endpoint, example)}")${example.serviceHeaders
+        .${endpoint.method.toLowerCase()}("${example.url}")${example.serviceHeaders
             .filter((h) => h.value.jsonExample != null)
             .map((h) => {
                 return code`.header("${h.name.wireValue}", "${h.value.jsonExample}")
@@ -528,7 +528,7 @@ export function ${functionName}(server: MockServer): void {
     ${rawResponseBody ? code`const rawResponseBody = ${rawResponseBody};` : ""}
     server
         .mockEndpoint()
-        .${endpoint.method.toLowerCase()}("${getMockUrlForExample(endpoint, example)}")${example.serviceHeaders
+        .${endpoint.method.toLowerCase()}("${example.url}")${example.serviceHeaders
             .filter((h) => h.value.jsonExample != null)
             .map((h) => {
                 return code`.header("${h.name.wireValue}", "${h.value.jsonExample}")
@@ -1148,7 +1148,7 @@ describe("${serviceName}", () => {
                 // If nested, isCursorMissing is forced to true below to skip getNextPage().
                 if (nextProperty.propertyPath == null || nextProperty.propertyPath.length === 0) {
                     const wireKey = nextProperty.property.name.wireValue;
-                    const paginationMockUrl = getMockUrlForExample(endpoint, example);
+                    const paginationMockUrl = example.url;
                     const nextValueCode =
                         pagination.type === "uri"
                             ? code`\`\${server.baseUrl}${paginationMockUrl}\``
@@ -1410,11 +1410,7 @@ describe("${serviceName}", () => {
             testName += ` (${exampleIndex + 1})`;
         }
 
-        // Reconstruct the mock URL from the endpoint path template using the same encoding
-        // as the SDK's encodePathParam to ensure the mock handler URL matches the actual request URL.
-        // The IR's example.url uses JSON.stringify for non-primitive path params while the SDK's
-        // encodePathParam uses String(), causing a mismatch (e.g., "%7B%22key%22..." vs "%5Bobject%20Object%5D").
-        const mockUrl = getMockUrlForExample(endpoint, example);
+        const mockUrl = example.url;
 
         return code`
     test("${testName}", async () => {
@@ -2333,39 +2329,4 @@ function isPaginationCursorMissingInExample({
 
     // If the leaf is explicitly undefined or null, treat it as "missing"
     return cursor === undefined || cursor === null;
-}
-
-/**
- * Reconstructs the mock URL for a test example using encoding that matches the SDK's
- * `encodePathParam` behavior. The IR's `example.url` uses `JSON.stringify` for non-primitive
- * path parameter values, but the SDK's `encodePathParam` uses `String()` for objects,
- * which produces different encoding (e.g., `[object Object]` vs `{"key":"value"}`).
- * This ensures the mock server URL matches the actual request URL sent by the SDK.
- */
-function getMockUrlForExample(endpoint: FernIr.HttpEndpoint, example: FernIr.ExampleEndpointCall): string {
-    const pathParameters: Record<string, string> = {};
-    [...example.rootPathParameters, ...example.servicePathParameters, ...example.endpointPathParameters].forEach(
-        (examplePathParameter) => {
-            const value = examplePathParameter.value.jsonExample;
-            // Match the SDK's encodePathParam behavior: use String() for non-primitive values
-            // instead of JSON.stringify, so the mock URL matches the actual request URL.
-            let stringValue: string;
-            if (value === null) {
-                stringValue = "null";
-            } else if (value === undefined) {
-                stringValue = "undefined";
-            } else if (typeof value === "string" || typeof value === "number" || typeof value === "boolean") {
-                stringValue = String(value);
-            } else {
-                stringValue = String(value);
-            }
-            pathParameters[examplePathParameter.name.originalName] = stringValue;
-        }
-    );
-    const url =
-        endpoint.fullPath.head +
-        endpoint.fullPath.parts
-            .map((pathPart) => encodeURIComponent(`${pathParameters[pathPart.pathParameter]}`) + pathPart.tail)
-            .join("");
-    return url.startsWith("/") || url === "" ? url : `/${url}`;
 }

--- a/generators/typescript/sdk/versions.yml
+++ b/generators/typescript/sdk/versions.yml
@@ -1,4 +1,17 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 3.60.6
+  changelogEntry:
+    - summary: |
+        Fix auto-generated error test examples producing object path parameter values
+        (e.g. `{ key: "value" }`) instead of strings. Path parameters are always scalar
+        URL segments, so `generatePathParameterExamples` now coerces non-primitive values
+        to a string fallback derived from the parameter name. This prevents `[object Object]`
+        from appearing in generated wire test URLs and removes the `getMockUrlForExample`
+        workaround added in 3.60.5.
+      type: fix
+  createdAt: "2026-03-31"
+  irVersion: 65
+
 - version: 3.60.5
   changelogEntry:
     - summary: |

--- a/packages/commons/ir-utils/src/examples/v1/generateParameterExamples.ts
+++ b/packages/commons/ir-utils/src/examples/v1/generateParameterExamples.ts
@@ -1,8 +1,10 @@
 import {
     ExampleHeader,
     ExamplePathParameter,
+    ExamplePrimitive,
     ExampleQueryParameter,
     ExampleQueryParameterShape,
+    ExampleTypeReferenceShape,
     HttpHeader,
     PathParameter,
     QueryParameter,
@@ -22,6 +24,11 @@ export interface GenerateParamsOptions {
 
 /**
  * Generates path-parameter examples.
+ *
+ * Path parameters are always scalar URL segments, so the generated example
+ * must be a primitive value (string, number, or boolean).  When the
+ * underlying type resolves to an object or array (e.g. `unknown` -> `{ key: "value" }`),
+ * we fall back to a descriptive string derived from the parameter name.
  */
 export function generatePathParameterExamples(
     pathParameters: PathParameter[],
@@ -41,10 +48,26 @@ export function generatePathParameterExamples(
         if (generatedExample.type === "failure") {
             return generatedExample; // short-circuit failure
         }
-        result.push({
-            name: p.name,
-            value: generatedExample.example
-        });
+
+        // Path parameters must be scalar URL segments.  If the generated
+        // example is a non-primitive (object / array), replace it with a
+        // string value so the URL is well-formed.
+        const json = generatedExample.example.jsonExample;
+        if (typeof json !== "string" && typeof json !== "number" && typeof json !== "boolean") {
+            const fallback = p.name.originalName;
+            result.push({
+                name: p.name,
+                value: {
+                    jsonExample: fallback,
+                    shape: ExampleTypeReferenceShape.primitive(ExamplePrimitive.string({ original: fallback }))
+                }
+            });
+        } else {
+            result.push({
+                name: p.name,
+                value: generatedExample.example
+            });
+        }
     }
 
     // On success, return the array and no JSON example needed


### PR DESCRIPTION
## Description

Refs: Follow-up to #14346

Fixes the root cause of `[object Object]` appearing in generated wire test URLs for SDKs like `@fern-demo/docusign-typescript-sdk`. The previous fix (#14346 / v3.60.5) added a `getMockUrlForExample` workaround in `TestGenerator.ts` that masked the symptom; this PR fixes the actual bug upstream in example generation and removes that workaround.

## Changes Made

- **`generateParameterExamples.ts`**: After generating a path parameter example, check whether the `jsonExample` is a primitive (string/number/boolean). If not (e.g. an object from an `unknown`-typed path param), replace it with a string fallback using the parameter's `originalName`. This ensures `example.url` is always well-formed.
- **`TestGenerator.ts`**: Remove the `getMockUrlForExample()` helper function and revert all 4 call sites back to using `example.url` directly.
- **`versions.yml`**: Bump to 3.60.7 with changelog entry.

## Testing

- [x] TS SDK generator compiles cleanly
- [x] Seed tests pass (22/22 exhaustive fixture configurations)
- [x] Lint (`biome check`) passes
- [ ] **Note**: The seed `exhaustive` fixture uses `string`-typed path params, so the coercion branch is not directly exercised by seed tests. The bug only manifests with non-primitive path param types (e.g. `unknown` in DocuSign).

## Review Checklist

- [ ] Verify `typeof json` check covers all non-primitive cases correctly (`null` is `typeof "object"` and will also get the fallback — is this acceptable for path params?)
- [ ] Verify `p.name.originalName` produces sensible fallback URL segments for real-world APIs like DocuSign
- [ ] Confirm no other consumers of `ExamplePathParameter` values are broken by receiving a coerced string instead of the original object shape
- [ ] Consider whether a seed fixture with a non-primitive path param type should be added for regression coverage

## Updates since last revision

- Resolved merge conflict in `versions.yml`: main already had a 3.60.6 entry (offset pagination fix), so bumped this fix to **3.60.7**.

Link to Devin session: https://app.devin.ai/sessions/899fd02193ee4aba973ebe0a66cc7c4b
Requested by: @iamnamananand996