### PR TITLE
fix(go): fix SSE discriminator injection logic

### DIFF
--- a/generators/go-v2/base/src/asIs/core/stream.go_
+++ b/generators/go-v2/base/src/asIs/core/stream.go_
@@ -568,8 +568,8 @@ func (s *SseStreamReader) injectDiscriminator(data []byte, value string) []byte 
 	if openIdx < 0 {
 		return data
 	}
-	// Skip injection if the key already exists in the data.
-	if bytes.Contains(data, s.discriminatorKeyCheck) || bytes.Contains(data, s.discriminatorKeyCheckSp) {
+	// Skip injection if the key already exists at the top level of the JSON object.
+	if jsonContainsTopLevelKey(data[openIdx:], s.discriminatorKeyCheck, s.discriminatorKeyCheckSp) {
 		return data
 	}
 	// Build the injected key-value: "field":"value"
@@ -591,6 +591,53 @@ func (s *SseStreamReader) injectDiscriminator(data []byte, value string) []byte 
 		result = append(result, after...)
 	}
 	return result
+}
+
+// jsonContainsTopLevelKey reports whether the JSON object in data contains the
+// given key at the top level (depth 1). It avoids false positives from keys
+// with the same name nested inside child objects or arrays.
+//
+// data must start at the opening '{' of the JSON object.
+// keyCheck and keyCheckSp are the precomputed patterns "key": and "key" :
+func jsonContainsTopLevelKey(data []byte, keyCheck []byte, keyCheckSp []byte) bool {
+	depth := 0
+	inString := false
+	escaped := false
+	for i := 0; i < len(data); i++ {
+		b := data[i]
+		if escaped {
+			escaped = false
+			continue
+		}
+		if b == '\\' && inString {
+			escaped = true
+			continue
+		}
+		if b == '"' {
+			if !inString && depth == 1 {
+				// At top-level depth, starting a new string — check for key match.
+				remaining := data[i:]
+				if bytes.HasPrefix(remaining, keyCheck) || bytes.HasPrefix(remaining, keyCheckSp) {
+					return true
+				}
+			}
+			inString = !inString
+			continue
+		}
+		if inString {
+			continue
+		}
+		switch b {
+		case '{', '[':
+			depth++
+		case '}', ']':
+			depth--
+			if depth <= 0 {
+				return false
+			}
+		}
+	}
+	return false
 }
 
 type SseEvent struct {

--- a/generators/go-v2/base/src/asIs/core/stream_test.go_
+++ b/generators/go-v2/base/src/asIs/core/stream_test.go_
@@ -815,6 +815,92 @@ func TestStream_RecvEventWithTerminator(t *testing.T) {
 	assert.Equal(t, io.EOF, err)
 }
 
+func TestSseStreamReader_InjectDiscriminator(t *testing.T) {
+	makeReader := func(field string) *SseStreamReader {
+		opts := &streamOptions{eventDiscriminator: field}
+		quoted := `"` + field + `"`
+		return &SseStreamReader{
+			options:                 opts,
+			discriminatorQuotedField: []byte(quoted),
+			discriminatorKeyCheck:    []byte(quoted + ":"),
+			discriminatorKeyCheckSp:  []byte(quoted + " :"),
+		}
+	}
+
+	tests := []struct {
+		desc     string
+		field    string
+		data     string
+		event    string
+		expected string
+	}{
+		{
+			desc:     "injects into simple object",
+			field:    "type",
+			data:     `{"content":"hello"}`,
+			event:    "completion",
+			expected: `{"type":"completion","content":"hello"}`,
+		},
+		{
+			desc:     "injects into empty object",
+			field:    "type",
+			data:     `{}`,
+			event:    "completion",
+			expected: `{"type":"completion"}`,
+		},
+		{
+			desc:     "skips when top-level key exists",
+			field:    "type",
+			data:     `{"type":"already","content":"hello"}`,
+			event:    "completion",
+			expected: `{"type":"already","content":"hello"}`,
+		},
+		{
+			desc:     "does NOT skip when key only exists in nested object",
+			field:    "type",
+			data:     `{"offset":"abc","event":{"type":"user.created","source":"auth0"}}`,
+			event:    "user.created",
+			expected: `{"type":"user.created","offset":"abc","event":{"type":"user.created","source":"auth0"}}`,
+		},
+		{
+			desc:     "does NOT skip when key only exists in nested array element",
+			field:    "type",
+			data:     `{"items":[{"type":"inner"}]}`,
+			event:    "outer",
+			expected: `{"type":"outer","items":[{"type":"inner"}]}`,
+		},
+		{
+			desc:     "skips when top-level key exists alongside nested key",
+			field:    "type",
+			data:     `{"type":"top","nested":{"type":"inner"}}`,
+			event:    "completion",
+			expected: `{"type":"top","nested":{"type":"inner"}}`,
+		},
+		{
+			desc:     "handles key with spaces before colon",
+			field:    "type",
+			data:     `{"type" :"already","content":"hello"}`,
+			event:    "completion",
+			expected: `{"type" :"already","content":"hello"}`,
+		},
+		{
+			desc:     "does not match key substring in string value",
+			field:    "type",
+			data:     `{"message":"the \"type\": field is important"}`,
+			event:    "completion",
+			expected: `{"type":"completion","message":"the \"type\": field is important"}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			reader := makeReader(tt.field)
+			result := reader.injectDiscriminator([]byte(tt.data), tt.event)
+			assert.Equal(t, tt.expected, string(result))
+		})
+	}
+}
+
 // Helper function to create int pointer
 func intPtr(i int) *int {
 	return &i

--- a/generators/go/sdk/versions.yml
+++ b/generators/go/sdk/versions.yml
@@ -1,4 +1,17 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 1.32.0-rc1
+  changelogEntry:
+    - summary: |
+        Fix SSE event discriminator injection skipping when the discriminator key
+        exists in a nested object. Previously, `injectDiscriminator` used a naive
+        substring check that matched the key at any nesting depth, causing
+        deserialization failures for payloads like
+        `{"event":{"type":"user.created"}}` where `"type"` only appears nested.
+        The check now only considers top-level JSON keys.
+      type: fix
+  createdAt: "2026-03-31"
+  irVersion: 61
+
 - version: 1.32.0-rc0
   changelogEntry:
     - summary: |

--- a/seed/go-sdk/server-sent-event-examples/with-wire-tests/core/stream.go
+++ b/seed/go-sdk/server-sent-event-examples/with-wire-tests/core/stream.go
@@ -568,8 +568,8 @@ func (s *SseStreamReader) injectDiscriminator(data []byte, value string) []byte 
 	if openIdx < 0 {
 		return data
 	}
-	// Skip injection if the key already exists in the data.
-	if bytes.Contains(data, s.discriminatorKeyCheck) || bytes.Contains(data, s.discriminatorKeyCheckSp) {
+	// Skip injection if the key already exists at the top level of the JSON object.
+	if jsonContainsTopLevelKey(data[openIdx:], s.discriminatorKeyCheck, s.discriminatorKeyCheckSp) {
 		return data
 	}
 	// Build the injected key-value: "field":"value"
@@ -591,6 +591,53 @@ func (s *SseStreamReader) injectDiscriminator(data []byte, value string) []byte 
 		result = append(result, after...)
 	}
 	return result
+}
+
+// jsonContainsTopLevelKey reports whether the JSON object in data contains the
+// given key at the top level (depth 1). It avoids false positives from keys
+// with the same name nested inside child objects or arrays.
+//
+// data must start at the opening '{' of the JSON object.
+// keyCheck and keyCheckSp are the precomputed patterns "key": and "key" :
+func jsonContainsTopLevelKey(data []byte, keyCheck []byte, keyCheckSp []byte) bool {
+	depth := 0
+	inString := false
+	escaped := false
+	for i := 0; i < len(data); i++ {
+		b := data[i]
+		if escaped {
+			escaped = false
+			continue
+		}
+		if b == '\\' && inString {
+			escaped = true
+			continue
+		}
+		if b == '"' {
+			if !inString && depth == 1 {
+				// At top-level depth, starting a new string — check for key match.
+				remaining := data[i:]
+				if bytes.HasPrefix(remaining, keyCheck) || bytes.HasPrefix(remaining, keyCheckSp) {
+					return true
+				}
+			}
+			inString = !inString
+			continue
+		}
+		if inString {
+			continue
+		}
+		switch b {
+		case '{', '[':
+			depth++
+		case '}', ']':
+			depth--
+			if depth <= 0 {
+				return false
+			}
+		}
+	}
+	return false
 }
 
 type SseEvent struct {

--- a/seed/go-sdk/server-sent-event-examples/with-wire-tests/core/stream_test.go
+++ b/seed/go-sdk/server-sent-event-examples/with-wire-tests/core/stream_test.go
@@ -815,6 +815,92 @@ func TestStream_RecvEventWithTerminator(t *testing.T) {
 	assert.Equal(t, io.EOF, err)
 }
 
+func TestSseStreamReader_InjectDiscriminator(t *testing.T) {
+	makeReader := func(field string) *SseStreamReader {
+		opts := &streamOptions{eventDiscriminator: field}
+		quoted := `"` + field + `"`
+		return &SseStreamReader{
+			options:                  opts,
+			discriminatorQuotedField: []byte(quoted),
+			discriminatorKeyCheck:    []byte(quoted + ":"),
+			discriminatorKeyCheckSp:  []byte(quoted + " :"),
+		}
+	}
+
+	tests := []struct {
+		desc     string
+		field    string
+		data     string
+		event    string
+		expected string
+	}{
+		{
+			desc:     "injects into simple object",
+			field:    "type",
+			data:     `{"content":"hello"}`,
+			event:    "completion",
+			expected: `{"type":"completion","content":"hello"}`,
+		},
+		{
+			desc:     "injects into empty object",
+			field:    "type",
+			data:     `{}`,
+			event:    "completion",
+			expected: `{"type":"completion"}`,
+		},
+		{
+			desc:     "skips when top-level key exists",
+			field:    "type",
+			data:     `{"type":"already","content":"hello"}`,
+			event:    "completion",
+			expected: `{"type":"already","content":"hello"}`,
+		},
+		{
+			desc:     "does NOT skip when key only exists in nested object",
+			field:    "type",
+			data:     `{"offset":"abc","event":{"type":"user.created","source":"auth0"}}`,
+			event:    "user.created",
+			expected: `{"type":"user.created","offset":"abc","event":{"type":"user.created","source":"auth0"}}`,
+		},
+		{
+			desc:     "does NOT skip when key only exists in nested array element",
+			field:    "type",
+			data:     `{"items":[{"type":"inner"}]}`,
+			event:    "outer",
+			expected: `{"type":"outer","items":[{"type":"inner"}]}`,
+		},
+		{
+			desc:     "skips when top-level key exists alongside nested key",
+			field:    "type",
+			data:     `{"type":"top","nested":{"type":"inner"}}`,
+			event:    "completion",
+			expected: `{"type":"top","nested":{"type":"inner"}}`,
+		},
+		{
+			desc:     "handles key with spaces before colon",
+			field:    "type",
+			data:     `{"type" :"already","content":"hello"}`,
+			event:    "completion",
+			expected: `{"type" :"already","content":"hello"}`,
+		},
+		{
+			desc:     "does not match key substring in string value",
+			field:    "type",
+			data:     `{"message":"the \"type\": field is important"}`,
+			event:    "completion",
+			expected: `{"type":"completion","message":"the \"type\": field is important"}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			reader := makeReader(tt.field)
+			result := reader.injectDiscriminator([]byte(tt.data), tt.event)
+			assert.Equal(t, tt.expected, string(result))
+		})
+	}
+}
+
 // Helper function to create int pointer
 func intPtr(i int) *int {
 	return &i

--- a/seed/go-sdk/server-sent-events-openapi/with-wire-tests/core/stream.go
+++ b/seed/go-sdk/server-sent-events-openapi/with-wire-tests/core/stream.go
@@ -568,8 +568,8 @@ func (s *SseStreamReader) injectDiscriminator(data []byte, value string) []byte 
 	if openIdx < 0 {
 		return data
 	}
-	// Skip injection if the key already exists in the data.
-	if bytes.Contains(data, s.discriminatorKeyCheck) || bytes.Contains(data, s.discriminatorKeyCheckSp) {
+	// Skip injection if the key already exists at the top level of the JSON object.
+	if jsonContainsTopLevelKey(data[openIdx:], s.discriminatorKeyCheck, s.discriminatorKeyCheckSp) {
 		return data
 	}
 	// Build the injected key-value: "field":"value"
@@ -591,6 +591,53 @@ func (s *SseStreamReader) injectDiscriminator(data []byte, value string) []byte 
 		result = append(result, after...)
 	}
 	return result
+}
+
+// jsonContainsTopLevelKey reports whether the JSON object in data contains the
+// given key at the top level (depth 1). It avoids false positives from keys
+// with the same name nested inside child objects or arrays.
+//
+// data must start at the opening '{' of the JSON object.
+// keyCheck and keyCheckSp are the precomputed patterns "key": and "key" :
+func jsonContainsTopLevelKey(data []byte, keyCheck []byte, keyCheckSp []byte) bool {
+	depth := 0
+	inString := false
+	escaped := false
+	for i := 0; i < len(data); i++ {
+		b := data[i]
+		if escaped {
+			escaped = false
+			continue
+		}
+		if b == '\\' && inString {
+			escaped = true
+			continue
+		}
+		if b == '"' {
+			if !inString && depth == 1 {
+				// At top-level depth, starting a new string — check for key match.
+				remaining := data[i:]
+				if bytes.HasPrefix(remaining, keyCheck) || bytes.HasPrefix(remaining, keyCheckSp) {
+					return true
+				}
+			}
+			inString = !inString
+			continue
+		}
+		if inString {
+			continue
+		}
+		switch b {
+		case '{', '[':
+			depth++
+		case '}', ']':
+			depth--
+			if depth <= 0 {
+				return false
+			}
+		}
+	}
+	return false
 }
 
 type SseEvent struct {

--- a/seed/go-sdk/server-sent-events-openapi/with-wire-tests/core/stream_test.go
+++ b/seed/go-sdk/server-sent-events-openapi/with-wire-tests/core/stream_test.go
@@ -815,6 +815,92 @@ func TestStream_RecvEventWithTerminator(t *testing.T) {
 	assert.Equal(t, io.EOF, err)
 }
 
+func TestSseStreamReader_InjectDiscriminator(t *testing.T) {
+	makeReader := func(field string) *SseStreamReader {
+		opts := &streamOptions{eventDiscriminator: field}
+		quoted := `"` + field + `"`
+		return &SseStreamReader{
+			options:                  opts,
+			discriminatorQuotedField: []byte(quoted),
+			discriminatorKeyCheck:    []byte(quoted + ":"),
+			discriminatorKeyCheckSp:  []byte(quoted + " :"),
+		}
+	}
+
+	tests := []struct {
+		desc     string
+		field    string
+		data     string
+		event    string
+		expected string
+	}{
+		{
+			desc:     "injects into simple object",
+			field:    "type",
+			data:     `{"content":"hello"}`,
+			event:    "completion",
+			expected: `{"type":"completion","content":"hello"}`,
+		},
+		{
+			desc:     "injects into empty object",
+			field:    "type",
+			data:     `{}`,
+			event:    "completion",
+			expected: `{"type":"completion"}`,
+		},
+		{
+			desc:     "skips when top-level key exists",
+			field:    "type",
+			data:     `{"type":"already","content":"hello"}`,
+			event:    "completion",
+			expected: `{"type":"already","content":"hello"}`,
+		},
+		{
+			desc:     "does NOT skip when key only exists in nested object",
+			field:    "type",
+			data:     `{"offset":"abc","event":{"type":"user.created","source":"auth0"}}`,
+			event:    "user.created",
+			expected: `{"type":"user.created","offset":"abc","event":{"type":"user.created","source":"auth0"}}`,
+		},
+		{
+			desc:     "does NOT skip when key only exists in nested array element",
+			field:    "type",
+			data:     `{"items":[{"type":"inner"}]}`,
+			event:    "outer",
+			expected: `{"type":"outer","items":[{"type":"inner"}]}`,
+		},
+		{
+			desc:     "skips when top-level key exists alongside nested key",
+			field:    "type",
+			data:     `{"type":"top","nested":{"type":"inner"}}`,
+			event:    "completion",
+			expected: `{"type":"top","nested":{"type":"inner"}}`,
+		},
+		{
+			desc:     "handles key with spaces before colon",
+			field:    "type",
+			data:     `{"type" :"already","content":"hello"}`,
+			event:    "completion",
+			expected: `{"type" :"already","content":"hello"}`,
+		},
+		{
+			desc:     "does not match key substring in string value",
+			field:    "type",
+			data:     `{"message":"the \"type\": field is important"}`,
+			event:    "completion",
+			expected: `{"type":"completion","message":"the \"type\": field is important"}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			reader := makeReader(tt.field)
+			result := reader.injectDiscriminator([]byte(tt.data), tt.event)
+			assert.Equal(t, tt.expected, string(result))
+		})
+	}
+}
+
 // Helper function to create int pointer
 func intPtr(i int) *int {
 	return &i

--- a/seed/go-sdk/server-sent-events/with-wire-tests/core/stream.go
+++ b/seed/go-sdk/server-sent-events/with-wire-tests/core/stream.go
@@ -568,8 +568,8 @@ func (s *SseStreamReader) injectDiscriminator(data []byte, value string) []byte 
 	if openIdx < 0 {
 		return data
 	}
-	// Skip injection if the key already exists in the data.
-	if bytes.Contains(data, s.discriminatorKeyCheck) || bytes.Contains(data, s.discriminatorKeyCheckSp) {
+	// Skip injection if the key already exists at the top level of the JSON object.
+	if jsonContainsTopLevelKey(data[openIdx:], s.discriminatorKeyCheck, s.discriminatorKeyCheckSp) {
 		return data
 	}
 	// Build the injected key-value: "field":"value"
@@ -591,6 +591,53 @@ func (s *SseStreamReader) injectDiscriminator(data []byte, value string) []byte 
 		result = append(result, after...)
 	}
 	return result
+}
+
+// jsonContainsTopLevelKey reports whether the JSON object in data contains the
+// given key at the top level (depth 1). It avoids false positives from keys
+// with the same name nested inside child objects or arrays.
+//
+// data must start at the opening '{' of the JSON object.
+// keyCheck and keyCheckSp are the precomputed patterns "key": and "key" :
+func jsonContainsTopLevelKey(data []byte, keyCheck []byte, keyCheckSp []byte) bool {
+	depth := 0
+	inString := false
+	escaped := false
+	for i := 0; i < len(data); i++ {
+		b := data[i]
+		if escaped {
+			escaped = false
+			continue
+		}
+		if b == '\\' && inString {
+			escaped = true
+			continue
+		}
+		if b == '"' {
+			if !inString && depth == 1 {
+				// At top-level depth, starting a new string — check for key match.
+				remaining := data[i:]
+				if bytes.HasPrefix(remaining, keyCheck) || bytes.HasPrefix(remaining, keyCheckSp) {
+					return true
+				}
+			}
+			inString = !inString
+			continue
+		}
+		if inString {
+			continue
+		}
+		switch b {
+		case '{', '[':
+			depth++
+		case '}', ']':
+			depth--
+			if depth <= 0 {
+				return false
+			}
+		}
+	}
+	return false
 }
 
 type SseEvent struct {

--- a/seed/go-sdk/server-sent-events/with-wire-tests/core/stream_test.go
+++ b/seed/go-sdk/server-sent-events/with-wire-tests/core/stream_test.go
@@ -815,6 +815,92 @@ func TestStream_RecvEventWithTerminator(t *testing.T) {
 	assert.Equal(t, io.EOF, err)
 }
 
+func TestSseStreamReader_InjectDiscriminator(t *testing.T) {
+	makeReader := func(field string) *SseStreamReader {
+		opts := &streamOptions{eventDiscriminator: field}
+		quoted := `"` + field + `"`
+		return &SseStreamReader{
+			options:                  opts,
+			discriminatorQuotedField: []byte(quoted),
+			discriminatorKeyCheck:    []byte(quoted + ":"),
+			discriminatorKeyCheckSp:  []byte(quoted + " :"),
+		}
+	}
+
+	tests := []struct {
+		desc     string
+		field    string
+		data     string
+		event    string
+		expected string
+	}{
+		{
+			desc:     "injects into simple object",
+			field:    "type",
+			data:     `{"content":"hello"}`,
+			event:    "completion",
+			expected: `{"type":"completion","content":"hello"}`,
+		},
+		{
+			desc:     "injects into empty object",
+			field:    "type",
+			data:     `{}`,
+			event:    "completion",
+			expected: `{"type":"completion"}`,
+		},
+		{
+			desc:     "skips when top-level key exists",
+			field:    "type",
+			data:     `{"type":"already","content":"hello"}`,
+			event:    "completion",
+			expected: `{"type":"already","content":"hello"}`,
+		},
+		{
+			desc:     "does NOT skip when key only exists in nested object",
+			field:    "type",
+			data:     `{"offset":"abc","event":{"type":"user.created","source":"auth0"}}`,
+			event:    "user.created",
+			expected: `{"type":"user.created","offset":"abc","event":{"type":"user.created","source":"auth0"}}`,
+		},
+		{
+			desc:     "does NOT skip when key only exists in nested array element",
+			field:    "type",
+			data:     `{"items":[{"type":"inner"}]}`,
+			event:    "outer",
+			expected: `{"type":"outer","items":[{"type":"inner"}]}`,
+		},
+		{
+			desc:     "skips when top-level key exists alongside nested key",
+			field:    "type",
+			data:     `{"type":"top","nested":{"type":"inner"}}`,
+			event:    "completion",
+			expected: `{"type":"top","nested":{"type":"inner"}}`,
+		},
+		{
+			desc:     "handles key with spaces before colon",
+			field:    "type",
+			data:     `{"type" :"already","content":"hello"}`,
+			event:    "completion",
+			expected: `{"type" :"already","content":"hello"}`,
+		},
+		{
+			desc:     "does not match key substring in string value",
+			field:    "type",
+			data:     `{"message":"the \"type\": field is important"}`,
+			event:    "completion",
+			expected: `{"type":"completion","message":"the \"type\": field is important"}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			reader := makeReader(tt.field)
+			result := reader.injectDiscriminator([]byte(tt.data), tt.event)
+			assert.Equal(t, tt.expected, string(result))
+		})
+	}
+}
+
 // Helper function to create int pointer
 func intPtr(i int) *int {
 	return &i

--- a/seed/go-sdk/streaming/core/stream.go
+++ b/seed/go-sdk/streaming/core/stream.go
@@ -568,8 +568,8 @@ func (s *SseStreamReader) injectDiscriminator(data []byte, value string) []byte 
 	if openIdx < 0 {
 		return data
 	}
-	// Skip injection if the key already exists in the data.
-	if bytes.Contains(data, s.discriminatorKeyCheck) || bytes.Contains(data, s.discriminatorKeyCheckSp) {
+	// Skip injection if the key already exists at the top level of the JSON object.
+	if jsonContainsTopLevelKey(data[openIdx:], s.discriminatorKeyCheck, s.discriminatorKeyCheckSp) {
 		return data
 	}
 	// Build the injected key-value: "field":"value"
@@ -591,6 +591,53 @@ func (s *SseStreamReader) injectDiscriminator(data []byte, value string) []byte 
 		result = append(result, after...)
 	}
 	return result
+}
+
+// jsonContainsTopLevelKey reports whether the JSON object in data contains the
+// given key at the top level (depth 1). It avoids false positives from keys
+// with the same name nested inside child objects or arrays.
+//
+// data must start at the opening '{' of the JSON object.
+// keyCheck and keyCheckSp are the precomputed patterns "key": and "key" :
+func jsonContainsTopLevelKey(data []byte, keyCheck []byte, keyCheckSp []byte) bool {
+	depth := 0
+	inString := false
+	escaped := false
+	for i := 0; i < len(data); i++ {
+		b := data[i]
+		if escaped {
+			escaped = false
+			continue
+		}
+		if b == '\\' && inString {
+			escaped = true
+			continue
+		}
+		if b == '"' {
+			if !inString && depth == 1 {
+				// At top-level depth, starting a new string — check for key match.
+				remaining := data[i:]
+				if bytes.HasPrefix(remaining, keyCheck) || bytes.HasPrefix(remaining, keyCheckSp) {
+					return true
+				}
+			}
+			inString = !inString
+			continue
+		}
+		if inString {
+			continue
+		}
+		switch b {
+		case '{', '[':
+			depth++
+		case '}', ']':
+			depth--
+			if depth <= 0 {
+				return false
+			}
+		}
+	}
+	return false
 }
 
 type SseEvent struct {

--- a/seed/go-sdk/streaming/core/stream_test.go
+++ b/seed/go-sdk/streaming/core/stream_test.go
@@ -815,6 +815,92 @@ func TestStream_RecvEventWithTerminator(t *testing.T) {
 	assert.Equal(t, io.EOF, err)
 }
 
+func TestSseStreamReader_InjectDiscriminator(t *testing.T) {
+	makeReader := func(field string) *SseStreamReader {
+		opts := &streamOptions{eventDiscriminator: field}
+		quoted := `"` + field + `"`
+		return &SseStreamReader{
+			options:                  opts,
+			discriminatorQuotedField: []byte(quoted),
+			discriminatorKeyCheck:    []byte(quoted + ":"),
+			discriminatorKeyCheckSp:  []byte(quoted + " :"),
+		}
+	}
+
+	tests := []struct {
+		desc     string
+		field    string
+		data     string
+		event    string
+		expected string
+	}{
+		{
+			desc:     "injects into simple object",
+			field:    "type",
+			data:     `{"content":"hello"}`,
+			event:    "completion",
+			expected: `{"type":"completion","content":"hello"}`,
+		},
+		{
+			desc:     "injects into empty object",
+			field:    "type",
+			data:     `{}`,
+			event:    "completion",
+			expected: `{"type":"completion"}`,
+		},
+		{
+			desc:     "skips when top-level key exists",
+			field:    "type",
+			data:     `{"type":"already","content":"hello"}`,
+			event:    "completion",
+			expected: `{"type":"already","content":"hello"}`,
+		},
+		{
+			desc:     "does NOT skip when key only exists in nested object",
+			field:    "type",
+			data:     `{"offset":"abc","event":{"type":"user.created","source":"auth0"}}`,
+			event:    "user.created",
+			expected: `{"type":"user.created","offset":"abc","event":{"type":"user.created","source":"auth0"}}`,
+		},
+		{
+			desc:     "does NOT skip when key only exists in nested array element",
+			field:    "type",
+			data:     `{"items":[{"type":"inner"}]}`,
+			event:    "outer",
+			expected: `{"type":"outer","items":[{"type":"inner"}]}`,
+		},
+		{
+			desc:     "skips when top-level key exists alongside nested key",
+			field:    "type",
+			data:     `{"type":"top","nested":{"type":"inner"}}`,
+			event:    "completion",
+			expected: `{"type":"top","nested":{"type":"inner"}}`,
+		},
+		{
+			desc:     "handles key with spaces before colon",
+			field:    "type",
+			data:     `{"type" :"already","content":"hello"}`,
+			event:    "completion",
+			expected: `{"type" :"already","content":"hello"}`,
+		},
+		{
+			desc:     "does not match key substring in string value",
+			field:    "type",
+			data:     `{"message":"the \"type\": field is important"}`,
+			event:    "completion",
+			expected: `{"type":"completion","message":"the \"type\": field is important"}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			reader := makeReader(tt.field)
+			result := reader.injectDiscriminator([]byte(tt.data), tt.event)
+			assert.Equal(t, tt.expected, string(result))
+		})
+	}
+}
+
 // Helper function to create int pointer
 func intPtr(i int) *int {
 	return &i


### PR DESCRIPTION
## Description
`injectDiscriminator` would skip injection if it found the discriminator key anywhere in the JSON payload; it should only skip injection if the discriminator key is at top-level.

SSE payloads like `{"offset":"abc","event":{"type":"user.created","source":"auth0"}}` with `EventDiscriminator: "type"` would fail deserialization because `"type":` inside the nested event object caused the duplicate-key check to skip injection entirely. The top-level discriminator was never added, so the union variant couldn't be identified.

## Testing
Websocket fixtures, Auth0.
- [X] Unit tests added/updated
- [X] Manual testing completed
