### PR TITLE
fix(internal): disable gpgsign in replay test git repos

### DIFF
--- a/packages/generator-cli/src/__test__/replay-advanced.test.ts
+++ b/packages/generator-cli/src/__test__/replay-advanced.test.ts
@@ -44,6 +44,7 @@ async function setupRepoWithGeneration(): Promise<SetupResult> {
     gitExec(["init"], repoPath);
     gitExec(["config", "user.name", "Test User"], repoPath);
     gitExec(["config", "user.email", "test@example.com"], repoPath);
+    gitExec(["config", "commit.gpgsign", "false"], repoPath);
 
     // Initial commit
     writeFileSync(join(repoPath, "README.md"), "# SDK\n");
@@ -147,6 +148,7 @@ describe("error resilience", { tags: ["slow", "flaky"] }, () => {
             gitExec(["init"], repoPath);
             gitExec(["config", "user.name", "Test User"], repoPath);
             gitExec(["config", "user.email", "test@example.com"], repoPath);
+            gitExec(["config", "commit.gpgsign", "false"], repoPath);
 
             writeFileSync(join(repoPath, "README.md"), "# SDK\n");
             gitExec(["add", "."], repoPath);
@@ -177,6 +179,7 @@ describe("error resilience", { tags: ["slow", "flaky"] }, () => {
             gitExec(["init"], repoPath);
             gitExec(["config", "user.name", "Test User"], repoPath);
             gitExec(["config", "user.email", "test@example.com"], repoPath);
+            gitExec(["config", "commit.gpgsign", "false"], repoPath);
 
             writeFileSync(join(repoPath, "README.md"), "# SDK\n");
             gitExec(["add", "."], repoPath);
@@ -271,6 +274,7 @@ describe("ReplayStep integration", { tags: ["slow", "flaky"] }, () => {
             gitExec(["init"], freshRepo);
             gitExec(["config", "user.name", "Test User"], freshRepo);
             gitExec(["config", "user.email", "test@example.com"], freshRepo);
+            gitExec(["config", "commit.gpgsign", "false"], freshRepo);
             writeFileSync(join(freshRepo, "README.md"), "# Fresh\n");
             gitExec(["add", "."], freshRepo);
             gitExec(["commit", "-m", "initial commit"], freshRepo);

--- a/packages/generator-cli/src/__test__/replay-core.test.ts
+++ b/packages/generator-cli/src/__test__/replay-core.test.ts
@@ -17,6 +17,7 @@ function initRepo(repoPath: string): void {
     gitExec(["init"], repoPath);
     gitExec(["config", "user.name", "Test User"], repoPath);
     gitExec(["config", "user.email", "test@example.com"], repoPath);
+    gitExec(["config", "commit.gpgsign", "false"], repoPath);
 }
 
 function commitAsUser(repoPath: string, message: string): string {


### PR DESCRIPTION
## Description

Running `pnpm test:update` prompts for fingerprint/GPG signing when the developer has commit signing configured globally (e.g., via 1Password SSH agent). The replay test files create temporary git repos and make commits, but don't disable GPG signing — unlike `AutoVersioningService.test.ts` which already sets `commit.gpgsign=false`.

## Changes Made

- Added `gitExec(["config", "commit.gpgsign", "false"], ...)` to all temporary git repo initializations in:
  - `replay-core.test.ts` — the shared `initRepo()` helper (covers all tests in this file)
  - `replay-advanced.test.ts` — `setupRepoWithGeneration()` + 3 inline init blocks

## Testing

- [ ] Verified the pattern matches existing usage in `AutoVersioningService.test.ts`
- [ ] No production code changed — test-only fix

## Human Review Checklist

- Confirm all 5 git-init sites across both files are covered (1 in `replay-core.test.ts`, 4 in `replay-advanced.test.ts`)

Link to Devin session: https://app.devin.ai/sessions/fe6ca80392b947c8a3606f6ed4cb5bdd
Requested by: @Swimburger
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/14387" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
