### PR TITLE
feat(cli): log default group name when --group is not specified

### DIFF
--- a/packages/cli/cli/src/commands/generate/generateAPIWorkspace.ts
+++ b/packages/cli/cli/src/commands/generate/generateAPIWorkspace.ts
@@ -75,6 +75,11 @@ export async function generateWorkspace({
     }
 
     const groupNameOrDefault = groupName ?? workspace.generatorsConfiguration.defaultGroup;
+    if (groupName == null && groupNameOrDefault != null) {
+        context.logger.info(
+            chalk.dim(`Using default group '${groupNameOrDefault}' from ${GENERATORS_CONFIGURATION_FILENAME}`)
+        );
+    }
     if (groupNameOrDefault == null) {
         const groupNames = workspace.generatorsConfiguration.groups.map((g) => g.groupName);
         const longestGroupName = Math.max(...groupNames.map((name) => name.length));

--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -1,4 +1,14 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 4.52.2
+  changelogEntry:
+    - summary: |
+        Log which group is being used when `fern generate` falls back to the
+        `default-group` configured in `generators.yml`, so it is clear which
+        group is running even when `--group` is not explicitly passed.
+      type: feat
+  createdAt: "2026-03-31"
+  irVersion: 65
+
 - version: 4.52.1
   changelogEntry:
     - summary: |

--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -1,5 +1,5 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
-- version: 4.52.2
+- version: 4.53.0
   changelogEntry:
     - summary: |
         Log which group is being used when `fern generate` falls back to the


### PR DESCRIPTION
## Description

When running `fern generate` without `--group`, the CLI silently uses the `default-group` from `generators.yml`. This makes it unclear which group is actually being generated. This PR adds an info log so users can see which group was resolved.

## Changes Made

- Added an info-level log message in `generateAPIWorkspace.ts` that prints the resolved default group name when `--group` is not explicitly passed (e.g. `Using default group 'local' from generators.yml`)
- The message uses `chalk.dim` to keep it visually subtle
- Added `versions.yml` entry (v4.53.0, minor bump for `feat`)

## Human Review Checklist

- [ ] Log level (`info`) and styling (`chalk.dim`) are appropriate for this use case
- [ ] Condition `groupName == null && groupNameOrDefault != null` correctly identifies the default-group fallback path (i.e. not triggered when `--group` is explicitly passed, nor when no default is configured)

## Testing

- [x] Manual testing completed — built CLI locally and ran `fern generate` against a fixture with `default-group: local`. Output confirmed:
  ```
  [api]: Using default group 'local' from generators.yml
  ```
- [x] CI passing (all 36 checks green)

Link to Devin session: https://app.devin.ai/sessions/6c43947090514337b909d95f635485e5
Requested by: @Swimburger
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/14396" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
