### PR TITLE
fix: propagate audiences from generator group in seed run custom fixture

### DIFF
--- a/packages/seed/src/commands/run/runWithCustomFixture.ts
+++ b/packages/seed/src/commands/run/runWithCustomFixture.ts
@@ -118,12 +118,14 @@ export async function runWithCustomFixture({
             return;
         }
 
+        const groupAudiences = generatorGroup.group.audiences;
         const runFixtureConfig: FixtureConfigurations = {
             ...customFixtureConfig,
             customConfig: {
                 ...(customFixtureConfig?.customConfig as Record<string, unknown>),
                 ...(generatorGroup.invocation.config as Record<string, unknown>)
             },
+            audiences: groupAudiences.type === "select" ? groupAudiences.audiences : undefined,
             readmeConfig: apiWorkspace.generatorsConfiguration?.rawConfiguration.readme,
             outputFolder: ""
         };


### PR DESCRIPTION
## Description

When running `seed run` against a customer fixture that has audience filtering configured in `generators.yml`, the audiences were silently ignored. This caused the seed run path to generate IR with **all** audiences, while the CLI (`fern generate`) correctly applied audience filtering — producing different generated SDK code and wire tests between the two paths.

## Changes Made

- Propagate `audiences` from the generator group (read from the fixture's `generators.yml`) into the `runFixtureConfig` passed to the test runner
- When the group has `type: "select"` audiences, the specific audience list is forwarded; when `type: "all"`, `undefined` is passed (preserving the existing `ALL_AUDIENCES` default)

## Root Cause

In `runWithCustomFixture.ts`, `getGeneratorGroup()` correctly reads the generator group (including its `audiences` field) from the fixture's `generators.yml`. However, when constructing `runFixtureConfig`, the audiences were never included — so `TestRunner.run` always saw `configuration?.audiences` as `undefined`, causing `LocalTestRunner` to default to `ALL_AUDIENCES` regardless of what was configured.

## Human Review Checklist

- [ ] Verify the `audiences` field type compatibility: `GeneratorGroup.audiences` is `Audiences` (`{ type: "all" } | { type: "select", audiences: string[] }`), while `FixtureConfigurations.audiences` is `string[] | undefined`. The conversion logic (`type === "select" ? .audiences : undefined`) bridges these correctly.
- [ ] Confirm this doesn't break the separate `seed test` path, which has its own audience handling via `seed.yml` fixture configs.

## Testing

- [x] Reproduced the issue by running both CLI (`fern generate --group typescript --api sdks --local`) and seed run against the Cohere fixture
- [x] Verified the fix produces audience-filtered output in seed run (confirmed via diff of `datasets.test.ts` before/after)
- [x] `pnpm run check` passes cleanly

Link to Devin session: https://app.devin.ai/sessions/f4c651c7afc24dadbdb6a15dd78df56d
Requested by: @jsklan
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/14405" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
