### PR TITLE
fix(rust): properly wrap bytes requests

### DIFF
--- a/generators/rust/base/src/context/AbstractRustGeneratorContext.ts
+++ b/generators/rust/base/src/context/AbstractRustGeneratorContext.ts
@@ -754,6 +754,39 @@ export abstract class AbstractRustGeneratorContext<
             `Registered ${referencedRequestWithQueryCount} referenced request with query filenames and type names`
         );
 
+        // Priority 3.6: Bytes request body with query parameters
+        let bytesRequestCount = 0;
+        for (const service of Object.values(ir.services)) {
+            for (const endpoint of service.endpoints) {
+                // Only bytes endpoints with query parameters
+                if (endpoint.requestBody?.type === "bytes" && endpoint.queryParameters.length > 0) {
+                    const requestName = `${endpoint.name.pascalCase.safeName}Request`;
+                    const baseFilename = convertPascalToSnakeCase(requestName);
+
+                    // Register both filename and type name
+                    const registeredFilename = this.project.filenameRegistry.registerBytesRequestFilename(
+                        endpoint.id,
+                        baseFilename
+                    );
+                    const registeredTypeName = this.project.filenameRegistry.registerBytesRequestTypeName(
+                        endpoint.id,
+                        requestName
+                    );
+
+                    // Log if collision was resolved
+                    if (registeredFilename !== baseFilename || registeredTypeName !== requestName) {
+                        this.logger.debug(
+                            `Bytes request collision resolved: ` +
+                                `${requestName} → ${registeredTypeName}, ` +
+                                `${baseFilename}.rs → ${registeredFilename}.rs`
+                        );
+                    }
+                    bytesRequestCount++;
+                }
+            }
+        }
+        this.logger.debug(`Registered ${bytesRequestCount} bytes request filenames and type names`);
+
         // Priority 4: Client names (root client + all subpackage clients)
         let clientNameCount = 0;
 
@@ -1210,6 +1243,30 @@ export abstract class AbstractRustGeneratorContext<
      */
     public getReferencedRequestWithQueryTypeName(endpointId: string): string {
         return this.project.filenameRegistry.getReferencedRequestWithQueryTypeNameOrThrow(endpointId);
+    }
+
+    /**
+     * Get filename for bytes request body using endpoint ID.
+     * @param endpointId - The unique endpoint ID from IR
+     */
+    public getFilenameForBytesRequestBody(endpointId: string): string {
+        return this.project.filenameRegistry.getBytesRequestFilenameOrThrow(endpointId);
+    }
+
+    /**
+     * Get module name for bytes request body from filename.
+     */
+    public getModuleNameForBytesRequestBody(endpointId: string): string {
+        const filename = this.getFilenameForBytesRequestBody(endpointId);
+        return filename.replace(".rs", "");
+    }
+
+    /**
+     * Get unique type name for bytes request body using endpoint ID.
+     * @param endpointId - The unique endpoint ID from IR
+     */
+    public getBytesRequestTypeName(endpointId: string): string {
+        return this.project.filenameRegistry.getBytesRequestTypeNameOrThrow(endpointId);
     }
 
     /**

--- a/generators/rust/base/src/project/RustFilenameRegistry.ts
+++ b/generators/rust/base/src/project/RustFilenameRegistry.ts
@@ -179,6 +179,30 @@ export class RustFilenameRegistry {
     }
 
     /**
+     * Register filename for bytes request body types
+     * @param endpointId - Unique endpoint ID from IR
+     * @param baseFilename - Base filename in snake_case (without .rs extension)
+     * @returns The registered unique filename (without .rs extension)
+     */
+    public registerBytesRequestFilename(endpointId: string, baseFilename: string): string {
+        return this.filenameRegistry.registerSymbol(this.getBytesRequestFilenameId(endpointId), [
+            baseFilename,
+            `${baseFilename}_request`,
+            `${baseFilename}_bytes`
+        ]);
+    }
+
+    /**
+     * Register type name for bytes request body
+     * @param endpointId - Unique endpoint ID from IR
+     * @param baseTypeName - Base type name in PascalCase
+     * @returns The registered unique type name
+     */
+    public registerBytesRequestTypeName(endpointId: string, baseTypeName: string): string {
+        return this.typenameRegistry.registerSymbol(this.getBytesRequestTypeNameId(endpointId), [baseTypeName]);
+    }
+
+    /**
      * Register client name for a subpackage or root client
      * @param clientId - Unique identifier for the client (subpackage ID or "root")
      * @param baseClientName - Base client name in PascalCase
@@ -337,6 +361,30 @@ export class RustFilenameRegistry {
         return typename;
     }
 
+    /**
+     * Get registered filename for bytes request body
+     * @param endpointId - Unique endpoint ID from IR
+     * @returns Filename with .rs extension
+     * @throws Error if filename not registered
+     */
+    public getBytesRequestFilenameOrThrow(endpointId: string): string {
+        const filename = this.filenameRegistry.getSymbolNameById(this.getBytesRequestFilenameId(endpointId));
+        assertDefined(filename, `Filename not found for bytes request ${endpointId}`);
+        return `${filename}.rs`;
+    }
+
+    /**
+     * Get registered type name for bytes request body
+     * @param endpointId - Unique endpoint ID from IR
+     * @returns The unique type name
+     * @throws Error if type name not registered
+     */
+    public getBytesRequestTypeNameOrThrow(endpointId: string): string {
+        const typename = this.typenameRegistry.getSymbolNameById(this.getBytesRequestTypeNameId(endpointId));
+        assertDefined(typename, `Type name not found for bytes request ${endpointId}`);
+        return typename;
+    }
+
     // =====================================
     // Private Helper Methods
     // =====================================
@@ -383,5 +431,13 @@ export class RustFilenameRegistry {
 
     private getReferencedRequestWithQueryTypeNameId(endpointId: string): string {
         return `${TYPENAME_ID_PREFIX}referenced_request_with_query_${endpointId}`;
+    }
+
+    private getBytesRequestFilenameId(endpointId: string): string {
+        return `${FILENAME_ID_PREFIX}bytes_request_${endpointId}`;
+    }
+
+    private getBytesRequestTypeNameId(endpointId: string): string {
+        return `${TYPENAME_ID_PREFIX}bytes_request_${endpointId}`;
     }
 }

--- a/generators/rust/model/src/ModelGeneratorCli.ts
+++ b/generators/rust/model/src/ModelGeneratorCli.ts
@@ -211,6 +211,24 @@ export class ModelGeneratorCli extends AbstractRustGeneratorCli<ModelCustomConfi
             }
         }
 
+        // Add bytes request body types
+        for (const service of Object.values(context.ir.services)) {
+            for (const endpoint of service.endpoints) {
+                if (endpoint.requestBody?.type === "bytes" && endpoint.queryParameters.length > 0) {
+                    const filename = context.getFilenameForBytesRequestBody(endpoint.id);
+                    const rawModuleName = filename.replace(".rs", "");
+                    const escapedModuleName = context.escapeRustKeyword(rawModuleName);
+                    const typeName = context.getBytesRequestTypeName(endpoint.id);
+
+                    if (!uniqueModuleNames.has(escapedModuleName)) {
+                        uniqueModuleNames.add(escapedModuleName);
+                        moduleExports.push({ moduleName: escapedModuleName, typeName });
+                        requestTypeCount++;
+                    }
+                }
+            }
+        }
+
         // Add documentation summary if we have types
         if (moduleExports.length > 0) {
             writer.writeLine("//!");

--- a/generators/rust/model/src/bytes-request-body/BytesRequestBodyGenerator.ts
+++ b/generators/rust/model/src/bytes-request-body/BytesRequestBodyGenerator.ts
@@ -1,0 +1,102 @@
+import { FernIr } from "@fern-fern/ir-sdk";
+import { RelativeFilePath } from "@fern-api/fs-utils";
+import { RustFile } from "@fern-api/rust-base";
+
+import { ModelGeneratorContext } from "../ModelGeneratorContext.js";
+import { convertQueryParametersToProperties } from "../utils/structUtils.js";
+import { RequestGenerator } from "../inlined-request-body/RequestGenerator.js";
+
+export class BytesRequestBodyGenerator {
+    private readonly ir: FernIr.IntermediateRepresentation;
+    private readonly context: ModelGeneratorContext;
+
+    public constructor(context: ModelGeneratorContext) {
+        this.ir = context.ir;
+        this.context = context;
+    }
+
+    public generateFiles(): RustFile[] {
+        const files: RustFile[] = [];
+
+        for (const service of Object.values(this.ir.services)) {
+            for (const endpoint of service.endpoints) {
+                if (this.isBytesEndpointWithQuery(endpoint)) {
+                    const file = this.generateBytesRequestBodyFile(endpoint);
+                    if (file) {
+                        files.push(file);
+                    }
+                }
+            }
+        }
+
+        return files;
+    }
+
+    private isBytesEndpointWithQuery(endpoint: FernIr.HttpEndpoint): boolean {
+        return endpoint.requestBody?.type === "bytes" && endpoint.queryParameters.length > 0;
+    }
+
+    private generateBytesRequestBodyFile(endpoint: FernIr.HttpEndpoint): RustFile | null {
+        try {
+            const filename = this.context.getFilenameForBytesRequestBody(endpoint.id);
+            const uniqueRequestName = this.context.getBytesRequestTypeName(endpoint.id);
+
+            const allProperties: FernIr.InlinedRequestBodyProperty[] = [];
+            const allSkipFields = new Set<string>();
+
+            // Add body field as Vec<u8> (using Base64 primitive, same as FileUploadRequestBodyGenerator)
+            const primitiveType: FernIr.PrimitiveType = {
+                v1: FernIr.PrimitiveTypeV1.Base64,
+                v2: undefined
+            };
+            const bodyType = FernIr.TypeReference.primitive(primitiveType);
+            const bodyProp: FernIr.InlinedRequestBodyProperty = {
+                name: {
+                    name: {
+                        originalName: "body",
+                        camelCase: { unsafeName: "body", safeName: "body" },
+                        snakeCase: { unsafeName: "body", safeName: "body" },
+                        screamingSnakeCase: { unsafeName: "BODY", safeName: "BODY" },
+                        pascalCase: { unsafeName: "Body", safeName: "Body" }
+                    },
+                    wireValue: "body"
+                },
+                valueType: bodyType,
+                docs: undefined,
+                availability: undefined,
+                propertyAccess: undefined,
+                v2Examples: undefined
+            };
+            allProperties.push(bodyProp);
+            allSkipFields.add("body");
+
+            // Add query parameters
+            const { properties: queryProperties, fieldNames: queryParamFieldNames } =
+                convertQueryParametersToProperties(endpoint.queryParameters, this.context);
+            allProperties.push(...queryProperties);
+
+            // Both body and query param fields skip serialization
+            const skipFields = new Set([...allSkipFields, ...queryParamFieldNames]);
+
+            const objectGenerator = new RequestGenerator({
+                name: uniqueRequestName,
+                properties: allProperties,
+                extendedProperties: [],
+                docsContent: undefined,
+                context: this.context,
+                queryParamFieldNames: skipFields
+            });
+
+            const fileContents = objectGenerator.generateFileContents();
+
+            return new RustFile({
+                filename,
+                directory: RelativeFilePath.of("src"),
+                fileContents
+            });
+        } catch (error) {
+            this.context.logger?.warn(`Failed to generate bytes request body file: ${error}`);
+            return null;
+        }
+    }
+}

--- a/generators/rust/model/src/bytes-request-body/BytesRequestBodyGenerator.ts
+++ b/generators/rust/model/src/bytes-request-body/BytesRequestBodyGenerator.ts
@@ -7,18 +7,16 @@ import { convertQueryParametersToProperties } from "../utils/structUtils.js";
 import { RequestGenerator } from "../inlined-request-body/RequestGenerator.js";
 
 export class BytesRequestBodyGenerator {
-    private readonly ir: FernIr.IntermediateRepresentation;
     private readonly context: ModelGeneratorContext;
 
     public constructor(context: ModelGeneratorContext) {
-        this.ir = context.ir;
         this.context = context;
     }
 
     public generateFiles(): RustFile[] {
         const files: RustFile[] = [];
 
-        for (const service of Object.values(this.ir.services)) {
+        for (const service of Object.values(this.context.ir.services)) {
             for (const endpoint of service.endpoints) {
                 if (this.isBytesEndpointWithQuery(endpoint)) {
                     const file = this.generateBytesRequestBodyFile(endpoint);

--- a/generators/rust/model/src/bytes-request-body/index.ts
+++ b/generators/rust/model/src/bytes-request-body/index.ts
@@ -1,0 +1,1 @@
+export { BytesRequestBodyGenerator } from "./BytesRequestBodyGenerator.js";

--- a/generators/rust/model/src/generateModels.ts
+++ b/generators/rust/model/src/generateModels.ts
@@ -2,6 +2,7 @@ import { FernIr } from "@fern-fern/ir-sdk";
 import { RelativeFilePath } from "@fern-api/fs-utils";
 import { BUILD_ERROR_RS, RustFile } from "@fern-api/rust-base";
 import { AliasGenerator } from "./alias/index.js";
+import { BytesRequestBodyGenerator } from "./bytes-request-body/index.js";
 import { EnumGenerator } from "./enum/index.js";
 import { FileUploadRequestBodyGenerator } from "./file-upload-request-body/index.js";
 import { InlinedRequestBodyGenerator } from "./inlined-request-body/index.js";
@@ -96,6 +97,10 @@ export function generateModels({ context }: { context: ModelGeneratorContext }):
     // Generate request types for endpoints with referenced body + query parameters
     const referencedRequestWithQueryGenerator = new ReferencedRequestWithQueryGenerator(context);
     files.push(...referencedRequestWithQueryGenerator.generateFiles());
+
+    // Generate bytes request body types for bytes endpoints with query parameters
+    const bytesRequestBodyGenerator = new BytesRequestBodyGenerator(context);
+    files.push(...bytesRequestBodyGenerator.generateFiles());
 
     // Deduplicate files by filename to prevent file collisions
     // This is a safety net for tracing logs - ideally generators shouldn't create duplicates

--- a/generators/rust/model/src/utils/structUtils.ts
+++ b/generators/rust/model/src/utils/structUtils.ts
@@ -245,10 +245,10 @@ export function generateFieldAttributes(
         attributes.push(Attribute.serde.default());
     }
 
-    // Add flexible datetime serde attribute - both "offset" (default) and "utc" use flexible parsing
-    // "offset" uses flexible_datetime::offset module (DateTime<FixedOffset>)
-    // "utc" uses flexible_datetime::utc module (DateTime<Utc>)
-    if (context) {
+    // Add custom serde with/format attributes for special types.
+    // Skip when the field is entirely excluded from serialization (e.g. query params or bytes body)
+    // since the with modules may not exist and aren't needed.
+    if (context && !options?.skipSerialization) {
         const dateTimeType = context.getDateTimeType();
         const typeRef = isOptional ? getInnerTypeFromOptional(property.valueType) : property.valueType;
         if (isDateTimeOnlyType(typeRef)) {

--- a/generators/rust/sdk/src/SdkGeneratorCli.ts
+++ b/generators/rust/sdk/src/SdkGeneratorCli.ts
@@ -752,6 +752,29 @@ export class SdkGeneratorCli extends AbstractRustGeneratorCli<SdkCustomConfigSch
             }
         }
 
+        // Add bytes request body types for bytes endpoints with query parameters
+        for (const service of Object.values(context.ir.services)) {
+            for (const endpoint of service.endpoints) {
+                if (endpoint.requestBody?.type === "bytes" && endpoint.queryParameters.length > 0) {
+                    const uniqueRequestName = context.getBytesRequestTypeName(endpoint.id);
+                    const rawModuleName = context.getModuleNameForBytesRequestBody(endpoint.id);
+                    const escapedModuleName = context.escapeRustKeyword(rawModuleName);
+
+                    if (!uniqueModuleNames.has(escapedModuleName)) {
+                        uniqueModuleNames.add(escapedModuleName);
+                        moduleDeclarations.push(new ModuleDeclaration({ name: escapedModuleName, isPublic: true }));
+                        useStatements.push(
+                            new UseStatement({
+                                path: escapedModuleName,
+                                items: [uniqueRequestName],
+                                isPublic: true
+                            })
+                        );
+                    }
+                }
+            }
+        }
+
         return new Module({
             moduleDeclarations,
             useStatements,

--- a/generators/rust/sdk/src/SdkGeneratorCli.ts
+++ b/generators/rust/sdk/src/SdkGeneratorCli.ts
@@ -996,27 +996,15 @@ export class SdkGeneratorCli extends AbstractRustGeneratorCli<SdkCustomConfigSch
             return true;
         }
 
-        // Check for inline request bodies
+        // Check for endpoints that generate request types
         for (const service of Object.values(context.ir.services)) {
             for (const endpoint of service.endpoints) {
                 if (endpoint.requestBody?.type === "inlinedRequestBody") {
                     return true;
                 }
-            }
-        }
-
-        // Check for query-only endpoints that generate request types
-        for (const service of Object.values(context.ir.services)) {
-            for (const endpoint of service.endpoints) {
                 if (endpoint.queryParameters?.length > 0 && !endpoint.requestBody) {
                     return true;
                 }
-            }
-        }
-
-        // Check for bytes endpoints with query parameters that generate request types
-        for (const service of Object.values(context.ir.services)) {
-            for (const endpoint of service.endpoints) {
                 if (endpoint.requestBody?.type === "bytes" && endpoint.queryParameters.length > 0) {
                     return true;
                 }

--- a/generators/rust/sdk/src/SdkGeneratorCli.ts
+++ b/generators/rust/sdk/src/SdkGeneratorCli.ts
@@ -1014,6 +1014,15 @@ export class SdkGeneratorCli extends AbstractRustGeneratorCli<SdkCustomConfigSch
             }
         }
 
+        // Check for bytes endpoints with query parameters that generate request types
+        for (const service of Object.values(context.ir.services)) {
+            for (const endpoint of service.endpoints) {
+                if (endpoint.requestBody?.type === "bytes" && endpoint.queryParameters.length > 0) {
+                    return true;
+                }
+            }
+        }
+
         return false;
     }
 

--- a/generators/rust/sdk/src/generators/SubClientGenerator.ts
+++ b/generators/rust/sdk/src/generators/SubClientGenerator.ts
@@ -906,10 +906,13 @@ export class SubClientGenerator {
         } else if (isBytesRequest) {
             // Use bytes request for octet-stream endpoints
             executeMethod = "execute_bytes_request";
+            const bytesBody = endpoint.queryParameters.length > 0
+                ? "Some(request.body.to_vec())"
+                : "Some(request.to_vec())";
             executeArgs = `
             Method::${httpMethod},
             ${pathExpression},
-            Some(request.to_vec()),
+            ${bytesBody},
             ${this.buildQueryParameters(endpoint)},
             options,`;
         } else {
@@ -1023,9 +1026,9 @@ export class SubClientGenerator {
         // Handle all three scenarios properly
         if (endpoint.requestBody && endpoint.queryParameters.length > 0) {
             if (this.isBytesEndpoint(endpoint)) {
-                // BYTES + QUERY: bytes body can't hold query fields, add them separately
+                // BYTES + QUERY: use request struct (like all other endpoint types)
                 this.addRequestBodyParameter(endpoint, params);
-                this.addIndividualQueryParameters(endpoint, params);
+                // Query params are now included in the request body struct
             } else {
                 // MIXED: Request body contains both body + query fields
                 this.addRequestBodyParameter(endpoint, params);
@@ -1106,7 +1109,15 @@ export class SubClientGenerator {
                     const requestTypeName = this.getRequestTypeName(endpoint);
                     return rust.Type.reference(rust.reference({ name: requestTypeName }));
                 },
-                bytes: () => rust.Type.vec(rust.Type.primitive(rust.PrimitiveType.U8)),
+                bytes: () => {
+                    // If there are query parameters, use the generated request struct
+                    if (endpoint.queryParameters.length > 0) {
+                        const requestTypeName = this.context.getBytesRequestTypeName(endpoint.id);
+                        return rust.Type.reference(rust.reference({ name: requestTypeName }));
+                    }
+                    // No query params — use raw Vec<u8>
+                    return rust.Type.vec(rust.Type.primitive(rust.PrimitiveType.U8));
+                },
                 _other: () => {
                     // Generate proper request type for unknown cases too
                     const requestTypeName = this.getRequestTypeName(endpoint);
@@ -1395,14 +1406,7 @@ export class SubClientGenerator {
     private getQueryParameterSource(queryParam: FernIr.QueryParameter, endpoint?: FernIr.HttpEndpoint): string {
         const fieldName = this.context.escapeRustKeyword(queryParam.name.name.snakeCase.unsafeName);
 
-        if (endpoint && this.isBytesEndpoint(endpoint)) {
-            // BYTES body: query params are individual method parameters
-            // For required string params (&str), use .to_string() since &str doesn't impl Into<Option<String>>
-            if (!this.isOptionalType(queryParam.valueType)) {
-                return `${fieldName}.to_string()`;
-            }
-            return `${fieldName}.clone()`;
-        } else if (endpoint?.requestBody) {
+        if (endpoint?.requestBody) {
             // MIXED or BODY-ONLY: Query params are in request struct
             return `request.${fieldName}.clone()`;
         } else if (endpoint && endpoint.queryParameters.length > 0 && !endpoint.requestBody) {

--- a/generators/rust/sdk/src/generators/SubClientGenerator.ts
+++ b/generators/rust/sdk/src/generators/SubClientGenerator.ts
@@ -1025,15 +1025,8 @@ export class SubClientGenerator {
 
         // Handle all three scenarios properly
         if (endpoint.requestBody && endpoint.queryParameters.length > 0) {
-            if (this.isBytesEndpoint(endpoint)) {
-                // BYTES + QUERY: use request struct (like all other endpoint types)
-                this.addRequestBodyParameter(endpoint, params);
-                // Query params are now included in the request body struct
-            } else {
-                // MIXED: Request body contains both body + query fields
-                this.addRequestBodyParameter(endpoint, params);
-                // Query params are now included in the request body struct
-            }
+            // Request body struct contains both body fields and query params
+            this.addRequestBodyParameter(endpoint, params);
         } else if (endpoint.requestBody) {
             // BODY-ONLY: Traditional request body
             this.addRequestBodyParameter(endpoint, params);

--- a/generators/rust/sdk/versions.yml
+++ b/generators/rust/sdk/versions.yml
@@ -1,5 +1,15 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 
+- version: 0.30.1
+  changelogEntry:
+    - summary: |
+        Generate request structs for bytes (octet-stream) endpoints that have query
+        parameters, replacing positional arguments with a single struct that bundles
+        the raw body and all query params. Includes a builder pattern for ergonomic
+        construction. This aligns bytes endpoints with the existing behavior of
+        JSON, file-upload, and other endpoint types.
+      type: feat
+
 - version: 0.30.0
   changelogEntry:
     - summary: |

--- a/generators/rust/sdk/versions.yml
+++ b/generators/rust/sdk/versions.yml
@@ -3,12 +3,12 @@
 - version: 0.30.1
   changelogEntry:
     - summary: |
-        Generate request structs for bytes (octet-stream) endpoints that have query
-        parameters, replacing positional arguments with a single struct that bundles
-        the raw body and all query params. Includes a builder pattern for ergonomic
-        construction. This aligns bytes endpoints with the existing behavior of
-        JSON, file-upload, and other endpoint types.
-      type: feat
+        Generate request structs for bytes (octet-stream) endpoints with query
+        parameters, replacing positional arguments with a single struct that
+        bundles the raw body and all query params with a builder pattern.
+      type: fix
+  createdAt: "2026-03-31"
+  irVersion: 65
 
 - version: 0.30.0
   changelogEntry:

--- a/seed/rust-sdk/bytes-upload/src/api/mod.rs
+++ b/seed/rust-sdk/bytes-upload/src/api/mod.rs
@@ -6,7 +6,10 @@
 //! ## Modules
 //!
 //! - [`resources`] - Service clients and endpoints
+//! - [`types`] - Request, response, and model types
 
 pub mod resources;
+pub mod types;
 
 pub use resources::{BytesUploadClient, ServiceClient};
+pub use types::*;

--- a/seed/rust-sdk/bytes-upload/src/api/resources/service/service.rs
+++ b/seed/rust-sdk/bytes-upload/src/api/resources/service/service.rs
@@ -31,19 +31,17 @@ impl ServiceClient {
 
     pub async fn upload_with_query_params(
         &self,
-        model: &str,
-        language: &Option<String>,
-        request: &Vec<u8>,
+        request: &UploadWithQueryParamsRequest,
         options: Option<RequestOptions>,
     ) -> Result<(), ApiError> {
         self.http_client
             .execute_bytes_request(
                 Method::POST,
                 "upload-content-with-query-params",
-                Some(request.to_vec()),
+                Some(request.body.to_vec()),
                 QueryBuilder::new()
-                    .string("model", model.to_string())
-                    .string("language", language.clone())
+                    .string("model", request.model.clone())
+                    .string("language", request.language.clone())
                     .build(),
                 options,
             )

--- a/seed/rust-sdk/bytes-upload/src/api/types/mod.rs
+++ b/seed/rust-sdk/bytes-upload/src/api/types/mod.rs
@@ -1,0 +1,3 @@
+pub mod upload_with_query_params_request;
+
+pub use upload_with_query_params_request::UploadWithQueryParamsRequest;

--- a/seed/rust-sdk/bytes-upload/src/api/types/upload_with_query_params_request.rs
+++ b/seed/rust-sdk/bytes-upload/src/api/types/upload_with_query_params_request.rs
@@ -1,0 +1,60 @@
+pub use crate::prelude::*;
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq, Hash)]
+pub struct UploadWithQueryParamsRequest {
+    #[serde(skip_serializing)]
+    #[serde(default)]
+    pub body: Vec<u8>,
+    /// The model to use for processing
+    #[serde(skip_serializing)]
+    #[serde(default)]
+    pub model: String,
+    /// The language of the content
+    #[serde(skip_serializing)]
+    pub language: Option<String>,
+}
+
+impl UploadWithQueryParamsRequest {
+    pub fn builder() -> UploadWithQueryParamsRequestBuilder {
+        <UploadWithQueryParamsRequestBuilder as Default>::default()
+    }
+}
+
+#[derive(Clone, PartialEq, Default, Debug)]
+#[non_exhaustive]
+pub struct UploadWithQueryParamsRequestBuilder {
+    body: Option<Vec<u8>>,
+    model: Option<String>,
+    language: Option<String>,
+}
+
+impl UploadWithQueryParamsRequestBuilder {
+    pub fn body(mut self, value: Vec<u8>) -> Self {
+        self.body = Some(value);
+        self
+    }
+
+    pub fn model(mut self, value: impl Into<String>) -> Self {
+        self.model = Some(value.into());
+        self
+    }
+
+    pub fn language(mut self, value: impl Into<String>) -> Self {
+        self.language = Some(value.into());
+        self
+    }
+
+    /// Consumes the builder and constructs a [`UploadWithQueryParamsRequest`].
+    /// This method will fail if any of the following fields are not set:
+    /// - [`body`](UploadWithQueryParamsRequestBuilder::body)
+    /// - [`model`](UploadWithQueryParamsRequestBuilder::model)
+    pub fn build(self) -> Result<UploadWithQueryParamsRequest, BuildError> {
+        Ok(UploadWithQueryParamsRequest {
+            body: self.body.ok_or_else(|| BuildError::missing_field("body"))?,
+            model: self
+                .model
+                .ok_or_else(|| BuildError::missing_field("model"))?,
+            language: self.language,
+        })
+    }
+}

--- a/seed/rust-sdk/bytes-upload/src/lib.rs
+++ b/seed/rust-sdk/bytes-upload/src/lib.rs
@@ -36,6 +36,7 @@ pub mod core;
 pub mod error;
 pub mod prelude;
 
+pub use api::*;
 pub use client::*;
 pub use config::*;
 pub use core::*;


### PR DESCRIPTION
## Description
Properly wrap bytes requests HTTP endpoints, so their properties can be configured via a builder instead of by positional arguments.

## Changes Made
Rust generator; adds a `BytesRequestBodyGenerator`.

## Testing
`bytes-upload`.
- [X] Unit tests added/updated
- [X] Manual testing completed
