### PR TITLE
fix(rust): fix dynamic snippet generation for bytes endpoints with query params

### DIFF
--- a/generators/rust/dynamic-snippets/src/EndpointSnippetGenerator.ts
+++ b/generators/rust/dynamic-snippets/src/EndpointSnippetGenerator.ts
@@ -628,20 +628,12 @@ export class EndpointSnippetGenerator {
 
         // SDK generator behavior (from SubClientGenerator.ts):
         // - Referenced body WITHOUT query params → uses inner type directly
-        // - Referenced body WITH query params → creates wrapper type
+        // - Referenced body WITH query params → creates wrapper type (including bytes + query)
         // - Inlined body (properties) → creates wrapper type
-        // - Bytes body WITH query params → individual params for each query param + bytes body
         const body = request.body;
         const isReferencedBodyOnly = body != null && !hasQueryParams && body.type === "referenced";
-        const isBytesWithQueryParams = hasQueryParams && body != null &&
-            body.type === "referenced" && body.bodyType.type === "bytes";
 
-        if (isBytesWithQueryParams) {
-            // Bytes endpoints with query params: SDK generates individual &Option<T> params
-            // for each query parameter, then &Vec<u8> for body (not a struct).
-            // This matches SubClientGenerator's addIndividualQueryParameters behavior.
-            args.push(...this.getBytesEndpointArgs({ request, snippet }));
-        } else if (isReferencedBodyOnly && body.type === "referenced") {
+        if (isReferencedBodyOnly && body.type === "referenced") {
             // Use inner type directly - match SDK generator's behavior for referenced body without query params
             const bodyExpr = this.getReferencedRequestBodyPropertyExpression({
                 body: body.bodyType,
@@ -667,51 +659,6 @@ export class EndpointSnippetGenerator {
         return args;
     }
 
-    private getBytesEndpointArgs({
-        request,
-        snippet
-    }: {
-        request: FernIr.dynamic.InlinedRequest;
-        snippet: FernIr.dynamic.EndpointSnippetRequest;
-    }): rust.Expression[] {
-        const args: rust.Expression[] = [];
-
-        // Build a map of provided query parameter values
-        const queryParameters = this.context.associateQueryParametersByWireValue({
-            parameters: request.queryParameters ?? [],
-            values: snippet.queryParameters ?? {}
-        });
-        const providedValues = new Map<string, rust.Expression>();
-        for (const qp of queryParameters) {
-            const fieldName = this.context.getPropertyName(qp.name.name);
-            providedValues.set(fieldName, this.context.dynamicTypeLiteralMapper.convert(qp));
-        }
-
-        // Generate individual &Option<T> arguments for each query parameter
-        // Order matches the SDK's addIndividualQueryParameters (definition order)
-        const allQueryParams = request.queryParameters ?? [];
-        for (const param of allQueryParams) {
-            const fieldName = this.context.getPropertyName(param.name.name);
-            const value = providedValues.get(fieldName);
-            if (value != null) {
-                args.push(rust.Expression.referenceOf(value));
-            } else {
-                args.push(rust.Expression.referenceOf(rust.Expression.raw("None")));
-            }
-        }
-
-        // Add bytes body argument: &vec![] for empty, or &bytes for provided value
-        if (snippet.requestBody != null && typeof snippet.requestBody === "string" && snippet.requestBody !== "") {
-            args.push(rust.Expression.referenceOf(
-                rust.Expression.raw(`"${snippet.requestBody}".as_bytes().to_vec()`)
-            ));
-        } else {
-            args.push(rust.Expression.referenceOf(rust.Expression.raw("vec![]")));
-        }
-
-        return args;
-    }
-
     private getBodyRequestArg({
         body,
         value
@@ -730,6 +677,9 @@ export class EndpointSnippetGenerator {
     }
 
     private getBytesBodyRequestArg({ value }: { value: unknown }): rust.Expression {
+        if (value == null) {
+            return rust.Expression.raw("vec![]");
+        }
         if (typeof value !== "string") {
             this.context.errors.add({
                 severity: Severity.Critical,

--- a/generators/rust/sdk/versions.yml
+++ b/generators/rust/sdk/versions.yml
@@ -1,5 +1,14 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 
+- version: 0.30.2
+  changelogEntry:
+    - summary: |
+        Fix dynamic snippet generation for bytes endpoints with query parameters
+        to use the request struct instead of positional arguments.
+      type: fix
+  createdAt: "2026-03-31"
+  irVersion: 65
+
 - version: 0.30.1
   changelogEntry:
     - summary: |

--- a/seed/rust-sdk/bytes-upload/reference.md
+++ b/seed/rust-sdk/bytes-upload/reference.md
@@ -60,7 +60,14 @@ async fn main() {
     let client = BytesUploadClient::new(config).expect("Failed to build client");
     client
         .service
-        .upload_with_query_params(&"nova-2".to_string(), &None, &vec![], None)
+        .upload_with_query_params(
+            &UploadWithQueryParamsRequest {
+                model: "nova-2".to_string(),
+                body: todo!("Invalid bytes value"),
+                language: None,
+            },
+            None,
+        )
         .await;
 }
 ```


### PR DESCRIPTION
## Summary

- Removes the special-case `isBytesWithQueryParams` branch in `EndpointSnippetGenerator.ts` that generated positional arguments for bytes endpoints with query parameters
- Bytes+query endpoints now go through the same struct-based code path as all other endpoint types, matching the SDK generator's behavior (introduced in 0.30.1)
- Deletes the now-dead `getBytesEndpointArgs` method

## Context

After 0.30.1 changed the SDK to generate request structs for bytes endpoints with query params (instead of positional args), the dynamic snippets generator was still producing the old positional-arg style. This caused wire test compilation failures (e.g., Deepgram's `transcribe_file` test passing 38 positional args instead of a `&TranscribeFileRequest` struct).

## Test plan

- [x] `pnpm turbo run compile --filter @fern-api/rust-dynamic-snippets` passes
- [x] `pnpm seed test --generator rust-sdk --fixture bytes-upload --skip-scripts` passes
- [x] Deepgram SDK regeneration: `cargo check` and `cargo test` (unit tests) pass
- [x] Generated wire test for `transcribe_file` now uses `&TranscribeFileRequest { .. }` struct

🤖 Generated with [Claude Code](https://claude.com/claude-code)