### PR TITLE
fix(go): apply major version suffix to module path before appending packagePath

### DIFF
--- a/generators/go-v2/ast/src/utils/resolveRootImportPath.ts
+++ b/generators/go-v2/ast/src/utils/resolveRootImportPath.ts
@@ -13,8 +13,11 @@ export function resolveRootImportPath({
     customConfig: BaseGoCustomConfigSchema | undefined;
 }): string {
     const suffix = getMajorVersionSuffix({ config });
-    const importPath = getImportPath({ config, customConfig });
-    return suffix != null ? maybeAppendMajorVersionSuffix({ importPath, majorVersion: suffix }) : importPath;
+    const modulePath = getImportPath({ config, customConfig, isModulePath: true });
+    const modulePathWithSuffix =
+        suffix != null ? maybeAppendMajorVersionSuffix({ importPath: modulePath, majorVersion: suffix }) : modulePath;
+    const packagePath = customConfig?.packagePath ?? "";
+    return packagePath ? path.join(modulePathWithSuffix, packagePath) : modulePathWithSuffix;
 }
 
 export function resolveRootModulePath({

--- a/generators/go/sdk/versions.yml
+++ b/generators/go/sdk/versions.yml
@@ -1,4 +1,15 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 1.32.2
+  changelogEntry:
+    - summary: |
+        Fix doubled major version suffix in import paths when module.path
+        already contains a /vN suffix and packagePath is configured. The
+        /vN suffix is now applied to the module path before appending the
+        packagePath, preventing paths like github.com/owner/repo/v2/pkg/v2.
+      type: fix
+  createdAt: "2026-04-01"
+  irVersion: 61
+
 - version: 1.32.1
   changelogEntry:
     - summary: |


### PR DESCRIPTION
## Description

`resolveRootImportPath` was applying the `/vN` major version suffix to the full import path (module + packagePath) instead of just the module path. When the module path already contained `/vN` and a `packagePath` was configured, `maybeAppendMajorVersionSuffix` checked the basename of the combined path (e.g. `"management"`) which didn't match `"v2"`, causing a second `/vN` to be appended and producing doubled version suffixes in all generated import paths.

This was a latent bug exposed by the 4.46.2 CLI fix (PR #14125), which improved Go proxy version resolution to correctly find v2+ module versions. Before that, the CLI returned v1.x versions, so the suffix logic never triggered.

## Changes Made

- Apply the `/vN` suffix to the module path first (where the dedup check works correctly), then append the packagePath afterward
- Added new version entry `1.32.2` in `generators/go/sdk/versions.yml`

## Testing

- [x] Reproduced the doubled `/vN` error locally with reverted fix
- [x] Verified fix generates correct import paths with `pnpm seed run --generator go-sdk`
- [x] Verified fix with `fern generate --preview --local --version 2.7.1` against affected config
- [x] Verified `go mod tidy` passes on generated output overlaid on cloned target repo
- [x] Confirmed existing seed fixtures with `packagePath` are unaffected