### PR TITLE
fix(openapi): wire up x-fern-discriminator-context extension in both importers

### DIFF
--- a/packages/cli/api-importers/openapi/openapi-ir-parser/src/schema/convertDiscriminatedOneOf.ts
+++ b/packages/cli/api-importers/openapi/openapi-ir-parser/src/schema/convertDiscriminatedOneOf.ts
@@ -12,7 +12,7 @@ import { OpenAPIV3 } from "openapi-types";
 import { getExtension } from "../getExtension.js";
 import { FernOpenAPIExtension } from "../openapi/v3/extensions/fernExtensions.js";
 import { convertReferenceObject, convertSchema, convertSchemaObject } from "./convertSchemas.js";
-import { inferDiscriminatorContext, inferDiscriminatorContextFromVariants } from "./inferDiscriminatorContext.js";
+import { inferDiscriminatorContextFromVariants, resolveDiscriminatorContext } from "./inferDiscriminatorContext.js";
 import { SchemaParserContext } from "./SchemaParserContext.js";
 import { isReferenceObject } from "./utils/isReferenceObject.js";
 
@@ -53,9 +53,7 @@ export function convertDiscriminatedOneOf({
 }): SchemaWithExample {
     const discriminant = discriminator.propertyName;
     const discriminantNameOverride = getExtension<string>(discriminator, FernOpenAPIExtension.FERN_PROPERTY_NAME);
-    const discriminatorContext =
-        getExtension<"data" | "protocol">(discriminator, FernOpenAPIExtension.DISCRIMINATOR_CONTEXT) ??
-        inferDiscriminatorContext({ discriminator, context });
+    const discriminatorContext = resolveDiscriminatorContext({ discriminator, context });
     const unionSubTypes = Object.fromEntries(
         Object.entries(discriminator.mapping ?? {}).map(([discriminantValue, schema]) => {
             const subtypeReference = convertReferenceObject(

--- a/packages/cli/api-importers/openapi/openapi-ir-parser/src/schema/convertSchemas.ts
+++ b/packages/cli/api-importers/openapi/openapi-ir-parser/src/schema/convertSchemas.ts
@@ -45,6 +45,7 @@ import {
     getExampleAsNumber,
     getExamplesString
 } from "./examples/getExample.js";
+import { inferDiscriminatorContext } from "./inferDiscriminatorContext.js";
 import type { SchemaParserContext } from "./SchemaParserContext.js";
 import { getBreadcrumbsFromReference } from "./utils/getBreadcrumbsFromReference.js";
 import { getGeneratedTypeName } from "./utils/getSchemaName.js";
@@ -937,7 +938,16 @@ export function convertSchemaObject(
         }
 
         if (schema.type === "object" && schema.discriminator != null && schema.discriminator.mapping != null) {
-            if (!context.options.discriminatedUnionV2) {
+            const objectDiscriminatorContext =
+                getExtension<"data" | "protocol">(
+                    schema.discriminator,
+                    FernOpenAPIExtension.DISCRIMINATOR_CONTEXT
+                ) ??
+                inferDiscriminatorContext({
+                    discriminator: schema.discriminator,
+                    context
+                });
+            if (!context.options.discriminatedUnionV2 || objectDiscriminatorContext === "protocol") {
                 return convertDiscriminatedOneOf({
                     nameOverride,
                     generatedName,
@@ -983,7 +993,19 @@ export function convertSchemaObject(
                 schema.discriminator.mapping != null &&
                 Object.keys(schema.discriminator.mapping).length > 0
             ) {
-                if (context.options.discriminatedUnionV2 || isUndiscriminated) {
+                const discriminatorContext =
+                    getExtension<"data" | "protocol">(
+                        schema.discriminator,
+                        FernOpenAPIExtension.DISCRIMINATOR_CONTEXT
+                    ) ??
+                    inferDiscriminatorContext({
+                        discriminator: schema.discriminator,
+                        context
+                    });
+                if (
+                    (context.options.discriminatedUnionV2 || isUndiscriminated) &&
+                    discriminatorContext !== "protocol"
+                ) {
                     return convertUndiscriminatedOneOfWithDiscriminant({
                         nameOverride,
                         generatedName,

--- a/packages/cli/api-importers/openapi/openapi-ir-parser/src/schema/convertSchemas.ts
+++ b/packages/cli/api-importers/openapi/openapi-ir-parser/src/schema/convertSchemas.ts
@@ -45,7 +45,7 @@ import {
     getExampleAsNumber,
     getExamplesString
 } from "./examples/getExample.js";
-import { inferDiscriminatorContext } from "./inferDiscriminatorContext.js";
+import { resolveDiscriminatorContext } from "./inferDiscriminatorContext.js";
 import type { SchemaParserContext } from "./SchemaParserContext.js";
 import { getBreadcrumbsFromReference } from "./utils/getBreadcrumbsFromReference.js";
 import { getGeneratedTypeName } from "./utils/getSchemaName.js";
@@ -938,17 +938,10 @@ export function convertSchemaObject(
         }
 
         if (schema.type === "object" && schema.discriminator != null && schema.discriminator.mapping != null) {
-            const rawDiscriminatorContext = getExtension<string>(
-                schema.discriminator,
-                FernOpenAPIExtension.DISCRIMINATOR_CONTEXT
-            );
-            const objectDiscriminatorContext =
-                rawDiscriminatorContext === "data" || rawDiscriminatorContext === "protocol"
-                    ? rawDiscriminatorContext
-                    : inferDiscriminatorContext({
-                          discriminator: schema.discriminator,
-                          context
-                      });
+            const objectDiscriminatorContext = resolveDiscriminatorContext({
+                discriminator: schema.discriminator,
+                context
+            });
             if (!context.options.discriminatedUnionV2 || objectDiscriminatorContext === "protocol") {
                 return convertDiscriminatedOneOf({
                     nameOverride,
@@ -995,17 +988,10 @@ export function convertSchemaObject(
                 schema.discriminator.mapping != null &&
                 Object.keys(schema.discriminator.mapping).length > 0
             ) {
-                const rawContext = getExtension<string>(
-                    schema.discriminator,
-                    FernOpenAPIExtension.DISCRIMINATOR_CONTEXT
-                );
-                const discriminatorContext =
-                    rawContext === "data" || rawContext === "protocol"
-                        ? rawContext
-                        : inferDiscriminatorContext({
-                              discriminator: schema.discriminator,
-                              context
-                          });
+                const discriminatorContext = resolveDiscriminatorContext({
+                    discriminator: schema.discriminator,
+                    context
+                });
                 if (
                     (context.options.discriminatedUnionV2 || isUndiscriminated) &&
                     discriminatorContext !== "protocol"

--- a/packages/cli/api-importers/openapi/openapi-ir-parser/src/schema/convertSchemas.ts
+++ b/packages/cli/api-importers/openapi/openapi-ir-parser/src/schema/convertSchemas.ts
@@ -938,15 +938,17 @@ export function convertSchemaObject(
         }
 
         if (schema.type === "object" && schema.discriminator != null && schema.discriminator.mapping != null) {
+            const rawDiscriminatorContext = getExtension<string>(
+                schema.discriminator,
+                FernOpenAPIExtension.DISCRIMINATOR_CONTEXT
+            );
             const objectDiscriminatorContext =
-                getExtension<"data" | "protocol">(
-                    schema.discriminator,
-                    FernOpenAPIExtension.DISCRIMINATOR_CONTEXT
-                ) ??
-                inferDiscriminatorContext({
-                    discriminator: schema.discriminator,
-                    context
-                });
+                rawDiscriminatorContext === "data" || rawDiscriminatorContext === "protocol"
+                    ? rawDiscriminatorContext
+                    : inferDiscriminatorContext({
+                          discriminator: schema.discriminator,
+                          context
+                      });
             if (!context.options.discriminatedUnionV2 || objectDiscriminatorContext === "protocol") {
                 return convertDiscriminatedOneOf({
                     nameOverride,
@@ -993,15 +995,17 @@ export function convertSchemaObject(
                 schema.discriminator.mapping != null &&
                 Object.keys(schema.discriminator.mapping).length > 0
             ) {
+                const rawContext = getExtension<string>(
+                    schema.discriminator,
+                    FernOpenAPIExtension.DISCRIMINATOR_CONTEXT
+                );
                 const discriminatorContext =
-                    getExtension<"data" | "protocol">(
-                        schema.discriminator,
-                        FernOpenAPIExtension.DISCRIMINATOR_CONTEXT
-                    ) ??
-                    inferDiscriminatorContext({
-                        discriminator: schema.discriminator,
-                        context
-                    });
+                    rawContext === "data" || rawContext === "protocol"
+                        ? rawContext
+                        : inferDiscriminatorContext({
+                              discriminator: schema.discriminator,
+                              context
+                          });
                 if (
                     (context.options.discriminatedUnionV2 || isUndiscriminated) &&
                     discriminatorContext !== "protocol"

--- a/packages/cli/api-importers/openapi/openapi-ir-parser/src/schema/inferDiscriminatorContext.ts
+++ b/packages/cli/api-importers/openapi/openapi-ir-parser/src/schema/inferDiscriminatorContext.ts
@@ -1,5 +1,7 @@
 import { OpenAPIV3 } from "openapi-types";
 
+import { getExtension } from "../getExtension.js";
+import { FernOpenAPIExtension } from "../openapi/v3/extensions/fernExtensions.js";
 import { SchemaParserContext } from "./SchemaParserContext.js";
 import { isReferenceObject } from "./utils/isReferenceObject.js";
 
@@ -88,6 +90,23 @@ function variantMatchesSseSpec(schema: OpenAPIV3.SchemaObject, context: SchemaPa
     }
 
     return hasEvent;
+}
+
+/**
+ * Resolves the discriminator context from an explicit extension value, falling
+ * back to inference from variant shapes when no extension is set.
+ */
+export function resolveDiscriminatorContext({
+    discriminator,
+    context
+}: {
+    discriminator: OpenAPIV3.DiscriminatorObject;
+    context: SchemaParserContext;
+}): "data" | "protocol" {
+    return (
+        getExtension<"data" | "protocol">(discriminator, FernOpenAPIExtension.DISCRIMINATOR_CONTEXT) ??
+        inferDiscriminatorContext({ discriminator, context })
+    );
 }
 
 /**

--- a/packages/cli/api-importers/v3-importer-commons/src/converters/schema/OneOfSchemaConverter.ts
+++ b/packages/cli/api-importers/v3-importer-commons/src/converters/schema/OneOfSchemaConverter.ts
@@ -10,6 +10,7 @@ import {
 } from "@fern-api/ir-sdk";
 import { OpenAPIV3_1 } from "openapi-types";
 import { FernDiscriminatedExtension } from "../../extensions/x-fern-discriminated.js";
+import { FernDiscriminatorContextExtension } from "../../extensions/x-fern-discriminator-context.js";
 import { FernEnumExtension } from "../../extensions/x-fern-enum.js";
 import { AbstractConverter, AbstractConverterContext } from "../../index.js";
 import { convertProperties } from "../../utils/ConvertProperties.js";
@@ -315,6 +316,12 @@ export class OneOfSchemaConverter extends AbstractConverter<
             referencedTypes.add(typeId);
         }
 
+        const discriminatorContextExtension = new FernDiscriminatorContextExtension({
+            context: this.context,
+            breadcrumbs: [...this.breadcrumbs, "discriminator"],
+            node: this.schema.discriminator
+        });
+
         return {
             type: Type.union({
                 baseProperties,
@@ -325,7 +332,7 @@ export class OneOfSchemaConverter extends AbstractConverter<
                 extends: extends_,
                 types: unionTypes,
                 default: undefined,
-                discriminatorContext: undefined
+                discriminatorContext: discriminatorContextExtension.convert()
             }),
             referencedTypes,
             inlinedTypes: {

--- a/packages/cli/api-importers/v3-importer-commons/src/extensions/index.ts
+++ b/packages/cli/api-importers/v3-importer-commons/src/extensions/index.ts
@@ -1,5 +1,6 @@
 export { AudienceExtension } from "./x-fern-audiences.js";
 export { FernAvailabilityExtension } from "./x-fern-availability.js";
+export { FernDiscriminatorContextExtension } from "./x-fern-discriminator-context.js";
 export { FernEnumExtension } from "./x-fern-enum.js";
 export { FernIgnoreExtension } from "./x-fern-ignore.js";
 export { FernOptionalExtension } from "./x-fern-optional.js";

--- a/packages/cli/api-importers/v3-importer-commons/src/extensions/x-fern-discriminator-context.ts
+++ b/packages/cli/api-importers/v3-importer-commons/src/extensions/x-fern-discriminator-context.ts
@@ -1,0 +1,37 @@
+import { AbstractExtension } from "../AbstractExtension.js";
+
+export declare namespace FernDiscriminatorContextExtension {
+    export interface Args extends AbstractExtension.Args {
+        node: unknown;
+    }
+}
+
+export class FernDiscriminatorContextExtension extends AbstractExtension<"data" | "protocol"> {
+    private readonly node: unknown;
+    public readonly key = "x-fern-discriminator-context";
+
+    constructor({ breadcrumbs, node, context }: FernDiscriminatorContextExtension.Args) {
+        super({ breadcrumbs, context });
+        this.node = node;
+    }
+
+    public convert(): "data" | "protocol" | undefined {
+        const extensionValue = this.getExtensionValue(this.node);
+        if (extensionValue == null) {
+            return undefined;
+        }
+
+        if (typeof extensionValue !== "string") {
+            return undefined;
+        }
+
+        if (extensionValue === "protocol") {
+            return "protocol";
+        }
+        if (extensionValue === "data") {
+            return "data";
+        }
+
+        return undefined;
+    }
+}

--- a/packages/cli/api-importers/v3-importer-commons/src/extensions/x-fern-discriminator-context.ts
+++ b/packages/cli/api-importers/v3-importer-commons/src/extensions/x-fern-discriminator-context.ts
@@ -17,21 +17,9 @@ export class FernDiscriminatorContextExtension extends AbstractExtension<"data" 
 
     public convert(): "data" | "protocol" | undefined {
         const extensionValue = this.getExtensionValue(this.node);
-        if (extensionValue == null) {
-            return undefined;
+        if (extensionValue === "data" || extensionValue === "protocol") {
+            return extensionValue;
         }
-
-        if (typeof extensionValue !== "string") {
-            return undefined;
-        }
-
-        if (extensionValue === "protocol") {
-            return "protocol";
-        }
-        if (extensionValue === "data") {
-            return "data";
-        }
-
         return undefined;
     }
 }

--- a/packages/cli/cli/changes/unreleased/fix-sse-discriminator-context.yml
+++ b/packages/cli/cli/changes/unreleased/fix-sse-discriminator-context.yml
@@ -1,0 +1,4 @@
+- summary: |
+    Support `x-fern-discriminator-context` extension on OpenAPI discriminator objects and auto-infer
+    `protocol` context for SSE-shaped discriminated unions.
+  type: fix


### PR DESCRIPTION
## Description

The `x-fern-discriminator-context: protocol` extension on OpenAPI discriminator objects was not being read by either importer, causing SSE event discriminators to lose their protocol context in the Fern IR. This meant Go and TypeScript generators could not emit `WithEventDiscriminator` for SSE streaming endpoints.

## Changes Made

- Added `FernDiscriminatorContextExtension` in v3-importer-commons following the existing extension pattern (`x-fern-availability`, `x-fern-discriminated`, etc.)
- Updated `OneOfSchemaConverter` to read `x-fern-discriminator-context` from the discriminator object and pass it through to `Type.union()` (was hardcoded to `undefined`)
- Updated legacy `convertSchemas.ts` to check discriminator context before converting discriminated unions to undiscriminated when `discriminatedUnionV2` is enabled, preserving protocol-level discriminators in both the `type: "object"` and `oneOf` code paths

## Testing

- [x] Unit tests pass (openapi-ir-parser: 56/56)
- [x] Verified Fern IR output shows `discriminatorContext: "protocol"` on the union type declaration