### PR TITLE
fix(deps): add pnpm supply chain security hardening

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -11,6 +11,32 @@ packages:
   - "!packages/cli/cli-v2/dist/dev"
   - "!packages/cli/cli-v2/dist/prod"
 
+# Supply chain security settings
+# See: https://pnpm.io/settings
+onlyBuiltDependencies:
+  - "@sentry/cli"
+  - esbuild
+  - puppeteer
+
+# Require packages to be published for at least 1 day before they can be installed.
+# This mitigates supply chain attacks like the axios compromise (March 2026) where
+# malicious versions were published and removed within hours.
+minimumReleaseAge: 1440
+
+# Exempt internal Fern packages from the release age requirement since they are
+# published and consumed frequently within the monorepo ecosystem.
+minimumReleaseAgeExclude:
+  - "@fern-api/*"
+  - "@fern-fern/*"
+
+# Prevent trust level downgrades (e.g. a previously trusted-publisher package
+# losing its attestation). Catches compromised maintainer accounts.
+trustPolicy: no-downgrade
+
+# Block transitive dependencies from using exotic sources (git repos, tarball URLs).
+# Only direct dependencies may use non-registry sources.
+blockExoticSubdeps: true
+
 catalog:
   "@babel/core": ^7.29.0
   "@babel/preset-env": ^7.29.2

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -33,6 +33,11 @@ minimumReleaseAgeExclude:
 # losing its attestation). Catches compromised maintainer accounts.
 trustPolicy: no-downgrade
 
+# Only enforce trust checks on versions published within the last day.
+# Older versions that lost attestation are unlikely to be supply chain attacks;
+# attacks target the install window immediately after compromise.
+trustPolicyIgnoreAfter: 1440
+
 # Block transitive dependencies from using exotic sources (git repos, tarball URLs).
 # Only direct dependencies may use non-registry sources.
 blockExoticSubdeps: true


### PR DESCRIPTION
## Description

Adds pnpm supply chain security settings to `pnpm-workspace.yaml` in response to the [axios supply chain attack](https://snyk.io/blog/axios-npm-package-compromised-supply-chain-attack-delivers-cross-platform/) (March 31, 2026), where a compromised maintainer account published malicious versions containing a RAT via `postinstall` scripts.

## Changes Made

All settings added to `pnpm-workspace.yaml`:

- **`onlyBuiltDependencies`**: Explicit allowlist of packages permitted to run install scripts (`@sentry/cli`, `esbuild`, `puppeteer`). All other postinstall scripts are blocked.
- **`minimumReleaseAge: 1440`**: Requires packages to be published for at least 1 day before installation. The malicious axios versions were live for only ~2 hours.
- **`minimumReleaseAgeExclude`**: Exempts `@fern-api/*` and `@fern-fern/*` internal packages from the release age gate.
- **`trustPolicy: no-downgrade`**: Prevents installing packages whose trust level (e.g., npm provenance/trusted publisher) has decreased compared to prior versions.
- **`trustPolicyIgnoreAfter: 1440`**: Only enforces trust checks on versions published within the last day. Older versions that lost attestation (e.g. `@redocly/openapi-core`) are allowed through, since attacks target the install window immediately after compromise — not years-old releases.
- **`blockExoticSubdeps: true`**: Blocks transitive dependencies from resolving via git repos or direct tarball URLs.

- [ ] Updated README.md generator (if applicable)

## Testing

- [x] `pnpm install` completes successfully with new settings
- [x] `pnpm run check` (biome lint) passes
- [x] `pnpm dedupe --check` passes without trust downgrade errors
- [ ] Unit tests added/updated — N/A, config-only change

## Human Review Checklist

- [ ] Verify `onlyBuiltDependencies` list is complete — CI may surface additional packages that need postinstall scripts (check for `Ignored build scripts:` warnings in install output)
- [ ] Confirm `minimumReleaseAge` exclusions cover all internally-published packages that may be consumed same-day
- [ ] Confirm `blockExoticSubdeps` doesn't break any transitive deps using git/tarball sources
- [ ] Verify the `trustPolicy` + `trustPolicyIgnoreAfter` combination behaves as expected: only recently-published versions (< 1 day) are subject to the no-downgrade check

Link to Devin session: https://app.devin.ai/sessions/206da4c8832040d3aa6c33104ff98b1f
Requested by: @Swimburger