### PR TITLE
fix(ci): reduce ETE test concurrency to prevent timeout failures

### DIFF
--- a/packages/cli/ete-tests/src/tests/jsonschema/jsonschema.test.ts
+++ b/packages/cli/ete-tests/src/tests/jsonschema/jsonschema.test.ts
@@ -17,5 +17,5 @@ describe("jsonschema", () => {
             await readFile(join(pathOfDirectory, RelativeFilePath.of("schema.json")), "utf-8")
         );
         expect(jsonSchema).toMatchSnapshot();
-    }, 20_000);
+    }, 60_000);
 });

--- a/packages/cli/ete-tests/vitest.config.ts
+++ b/packages/cli/ete-tests/vitest.config.ts
@@ -6,12 +6,16 @@ export default defineConfig(
             // ETE tests spawn heavy child processes (Node CLI, Docker containers).
             // Running too many test files in parallel causes resource contention
             // and widespread timeouts on CI runners.
+            //
+            // Effective cap: 3 file-workers × 5 in-file concurrent tests = 15
+            // concurrent CLI processes (down from 4 × 10 = 40).
+            maxConcurrency: 5,
             poolOptions: {
                 threads: {
-                    maxThreads: 4
+                    maxThreads: 3
                 },
                 forks: {
-                    maxForks: 4
+                    maxForks: 3
                 }
             }
         }


### PR DESCRIPTION
## Description

ETE tests are frequently timing out on CI, blocking PRs from merging. The root cause is excessive concurrency: the previous config allowed up to **4 file-workers × 10 in-file concurrent tests = 40 simultaneous CLI processes**, each spawning a full Node.js CLI (and some additionally launching Docker containers). This causes resource starvation on CI runners, where lighter tests (init, add, generators-get, etc.) can't complete within their timeouts while heavy Docker-based tests (fernignore, generate-with-settings) consume CPU/memory.

Evidence from [this CI run](https://github.com/fern-api/fern/actions/runs/23855035411/job/69545534749?pr=14423): 128 tests passed but 32 timed out across 12 test files. The fernignore test alone took ~262s while lighter tests that normally take seconds couldn't finish within 60s.

## Changes Made

- **Reduced file-level parallelism**: `maxThreads`/`maxForks` 4 → 3
- **Capped in-file concurrency**: Added `maxConcurrency: 5` (was inheriting 10 from base config)
- Net effect: max concurrent CLI processes drops from **40 → 15**
- **Bumped jsonschema test timeout**: 20s → 60s to match other lightweight ETE tests (was an outlier)

## Testing

- [ ] CI ETE test job passes without timeouts (this is the test — can only be validated in CI)

## Review Checklist

- [ ] **Is the concurrency reduction sufficient?** 15 concurrent processes is a ~62% reduction. If timeouts persist, may need to go lower (e.g., 2 threads).
- [ ] **Will tests still finish within the 20-minute CI step timeout?** Based on analysis of test durations, estimated wall-clock time is ~6-7 min with the new settings.
- [ ] **Should any other test timeouts be bumped?** Only `jsonschema` had an unusually tight 20s timeout; all other lightweight tests already use 60s.

Link to Devin session: https://app.devin.ai/sessions/6fa69f14dfea46ffaf07262f9a6f4e38
Requested by: @jsklan
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/14426" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
