### PR TITLE
chore(csharp): upgrade WireMock.Net from 1.25.0 to 2.2.0

### DIFF
--- a/docker/seed/Dockerfile.csharp
+++ b/docker/seed/Dockerfile.csharp
@@ -41,11 +41,11 @@ RUN dotnet tool install -g csharpier --version "1.2.6" && \
       <PackageReference Include="Grpc.Net.Client" Version="2.63.0" /> \
       <PackageReference Include="Grpc.Net.ClientFactory" Version="2.63.0" /> \
       <PackageReference Include="Grpc.Tools" Version="2.64.0" /> \
-      <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0"/> \
-      <PackageReference Include="NUnit" Version="4.3.2"/> \
-      <PackageReference Include="NUnit3TestAdapter" Version="5.0.0"/> \
-      <PackageReference Include="NUnit.Analyzers" Version="4.6.0" /> \
-      <PackageReference Include="coverlet.collector" Version="6.0.4" /> \
+      <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0"/> \
+      <PackageReference Include="NUnit" Version="4.5.1"/> \
+      <PackageReference Include="NUnit3TestAdapter" Version="6.2.0"/> \
+      <PackageReference Include="NUnit.Analyzers" Version="4.12.0" /> \
+      <PackageReference Include="coverlet.collector" Version="8.0.1" /> \
       <PackageReference Include="WireMock.Net" Version="2.2.0" /> \
       <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.2" /> \
       <PackageReference Include="Microsoft.IO.RecyclableMemoryStream" Version="3.0.1" /> \

--- a/docker/seed/Dockerfile.csharp
+++ b/docker/seed/Dockerfile.csharp
@@ -46,7 +46,7 @@ RUN dotnet tool install -g csharpier --version "1.2.6" && \
       <PackageReference Include="NUnit3TestAdapter" Version="5.0.0"/> \
       <PackageReference Include="NUnit.Analyzers" Version="4.6.0" /> \
       <PackageReference Include="coverlet.collector" Version="6.0.4" /> \
-      <PackageReference Include="WireMock.Net" Version="2.1.0" /> \
+      <PackageReference Include="WireMock.Net" Version="2.2.0" /> \
       <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.2" /> \
       <PackageReference Include="Microsoft.IO.RecyclableMemoryStream" Version="3.0.1" /> \
       <PackageReference Include="System.Net.ServerSentEvents" Version="9.0.9" /> \

--- a/docker/seed/Dockerfile.csharp
+++ b/docker/seed/Dockerfile.csharp
@@ -46,7 +46,7 @@ RUN dotnet tool install -g csharpier --version "1.2.6" && \
       <PackageReference Include="NUnit3TestAdapter" Version="5.0.0"/> \
       <PackageReference Include="NUnit.Analyzers" Version="4.6.0" /> \
       <PackageReference Include="coverlet.collector" Version="6.0.4" /> \
-      <PackageReference Include="WireMock.Net" Version="1.7.4" /> \
+      <PackageReference Include="WireMock.Net" Version="2.1.0" /> \
       <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.2" /> \
       <PackageReference Include="Microsoft.IO.RecyclableMemoryStream" Version="3.0.1" /> \
       <PackageReference Include="System.Net.ServerSentEvents" Version="9.0.9" /> \

--- a/generators/csharp/base/src/asIs/test/Template.Test.csproj
+++ b/generators/csharp/base/src/asIs/test/Template.Test.csproj
@@ -26,7 +26,7 @@
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="WireMock.Net" Version="2.1.0" />
+        <PackageReference Include="WireMock.Net" Version="2.2.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/generators/csharp/base/src/asIs/test/Template.Test.csproj
+++ b/generators/csharp/base/src/asIs/test/Template.Test.csproj
@@ -26,7 +26,7 @@
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="WireMock.Net" Version="1.25.0" />
+        <PackageReference Include="WireMock.Net" Version="2.1.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/generators/csharp/model/versions.yml
+++ b/generators/csharp/model/versions.yml
@@ -1,4 +1,13 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 0.8.5
+  changelogEntry:
+    - summary: |
+        Upgrade WireMock.Net from 1.25.0 to 2.1.0 in generated test projects.
+        This is a test-only dependency and does not affect the shipped SDK.
+      type: chore
+  createdAt: "2026-04-01"
+  irVersion: 65
+
 - version: 0.8.4
   changelogEntry:
     - summary: |

--- a/generators/csharp/model/versions.yml
+++ b/generators/csharp/model/versions.yml
@@ -2,7 +2,7 @@
 - version: 0.8.5
   changelogEntry:
     - summary: |
-        Upgrade WireMock.Net from 1.25.0 to 2.1.0 in generated test projects.
+        Upgrade WireMock.Net from 1.25.0 to 2.2.0 in generated test projects.
         This is a test-only dependency and does not affect the shipped SDK.
       type: chore
   createdAt: "2026-04-01"

--- a/generators/csharp/sdk/versions.yml
+++ b/generators/csharp/sdk/versions.yml
@@ -1,4 +1,13 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 2.55.3
+  changelogEntry:
+    - summary: |
+        Upgrade WireMock.Net from 1.25.0 to 2.1.0 in generated test projects.
+        This is a test-only dependency and does not affect the shipped SDK.
+      type: chore
+  createdAt: "2026-04-01"
+  irVersion: 65
+
 - version: 2.55.2
   changelogEntry:
     - summary: |

--- a/generators/csharp/sdk/versions.yml
+++ b/generators/csharp/sdk/versions.yml
@@ -2,7 +2,7 @@
 - version: 2.55.3
   changelogEntry:
     - summary: |
-        Upgrade WireMock.Net from 1.25.0 to 2.1.0 in generated test projects.
+        Upgrade WireMock.Net from 1.25.0 to 2.2.0 in generated test projects.
         This is a test-only dependency and does not affect the shipped SDK.
       type: chore
   createdAt: "2026-04-01"

--- a/seed/csharp-model/accept-header/src/SeedAccept.Test/SeedAccept.Test.csproj
+++ b/seed/csharp-model/accept-header/src/SeedAccept.Test/SeedAccept.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.1.0" />
+    <PackageReference Include="WireMock.Net" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/accept-header/src/SeedAccept.Test/SeedAccept.Test.csproj
+++ b/seed/csharp-model/accept-header/src/SeedAccept.Test/SeedAccept.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="1.25.0" />
+    <PackageReference Include="WireMock.Net" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/alias-extends/src/SeedAliasExtends.Test/SeedAliasExtends.Test.csproj
+++ b/seed/csharp-model/alias-extends/src/SeedAliasExtends.Test/SeedAliasExtends.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.1.0" />
+    <PackageReference Include="WireMock.Net" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/alias-extends/src/SeedAliasExtends.Test/SeedAliasExtends.Test.csproj
+++ b/seed/csharp-model/alias-extends/src/SeedAliasExtends.Test/SeedAliasExtends.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="1.25.0" />
+    <PackageReference Include="WireMock.Net" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/alias/src/SeedAlias.Test/SeedAlias.Test.csproj
+++ b/seed/csharp-model/alias/src/SeedAlias.Test/SeedAlias.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.1.0" />
+    <PackageReference Include="WireMock.Net" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/alias/src/SeedAlias.Test/SeedAlias.Test.csproj
+++ b/seed/csharp-model/alias/src/SeedAlias.Test/SeedAlias.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="1.25.0" />
+    <PackageReference Include="WireMock.Net" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/any-auth/src/SeedAnyAuth.Test/SeedAnyAuth.Test.csproj
+++ b/seed/csharp-model/any-auth/src/SeedAnyAuth.Test/SeedAnyAuth.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.1.0" />
+    <PackageReference Include="WireMock.Net" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/any-auth/src/SeedAnyAuth.Test/SeedAnyAuth.Test.csproj
+++ b/seed/csharp-model/any-auth/src/SeedAnyAuth.Test/SeedAnyAuth.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="1.25.0" />
+    <PackageReference Include="WireMock.Net" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/api-wide-base-path/src/SeedApiWideBasePath.Test/SeedApiWideBasePath.Test.csproj
+++ b/seed/csharp-model/api-wide-base-path/src/SeedApiWideBasePath.Test/SeedApiWideBasePath.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.1.0" />
+    <PackageReference Include="WireMock.Net" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/api-wide-base-path/src/SeedApiWideBasePath.Test/SeedApiWideBasePath.Test.csproj
+++ b/seed/csharp-model/api-wide-base-path/src/SeedApiWideBasePath.Test/SeedApiWideBasePath.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="1.25.0" />
+    <PackageReference Include="WireMock.Net" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/audiences/src/SeedAudiences.Test/SeedAudiences.Test.csproj
+++ b/seed/csharp-model/audiences/src/SeedAudiences.Test/SeedAudiences.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.1.0" />
+    <PackageReference Include="WireMock.Net" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/audiences/src/SeedAudiences.Test/SeedAudiences.Test.csproj
+++ b/seed/csharp-model/audiences/src/SeedAudiences.Test/SeedAudiences.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="1.25.0" />
+    <PackageReference Include="WireMock.Net" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/basic-auth-environment-variables/src/SeedBasicAuthEnvironmentVariables.Test/SeedBasicAuthEnvironmentVariables.Test.csproj
+++ b/seed/csharp-model/basic-auth-environment-variables/src/SeedBasicAuthEnvironmentVariables.Test/SeedBasicAuthEnvironmentVariables.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.1.0" />
+    <PackageReference Include="WireMock.Net" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/basic-auth-environment-variables/src/SeedBasicAuthEnvironmentVariables.Test/SeedBasicAuthEnvironmentVariables.Test.csproj
+++ b/seed/csharp-model/basic-auth-environment-variables/src/SeedBasicAuthEnvironmentVariables.Test/SeedBasicAuthEnvironmentVariables.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="1.25.0" />
+    <PackageReference Include="WireMock.Net" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/basic-auth/src/SeedBasicAuth.Test/SeedBasicAuth.Test.csproj
+++ b/seed/csharp-model/basic-auth/src/SeedBasicAuth.Test/SeedBasicAuth.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.1.0" />
+    <PackageReference Include="WireMock.Net" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/basic-auth/src/SeedBasicAuth.Test/SeedBasicAuth.Test.csproj
+++ b/seed/csharp-model/basic-auth/src/SeedBasicAuth.Test/SeedBasicAuth.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="1.25.0" />
+    <PackageReference Include="WireMock.Net" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/bearer-token-environment-variable/src/SeedBearerTokenEnvironmentVariable.Test/SeedBearerTokenEnvironmentVariable.Test.csproj
+++ b/seed/csharp-model/bearer-token-environment-variable/src/SeedBearerTokenEnvironmentVariable.Test/SeedBearerTokenEnvironmentVariable.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.1.0" />
+    <PackageReference Include="WireMock.Net" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/bearer-token-environment-variable/src/SeedBearerTokenEnvironmentVariable.Test/SeedBearerTokenEnvironmentVariable.Test.csproj
+++ b/seed/csharp-model/bearer-token-environment-variable/src/SeedBearerTokenEnvironmentVariable.Test/SeedBearerTokenEnvironmentVariable.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="1.25.0" />
+    <PackageReference Include="WireMock.Net" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/bytes-download/src/SeedBytesDownload.Test/SeedBytesDownload.Test.csproj
+++ b/seed/csharp-model/bytes-download/src/SeedBytesDownload.Test/SeedBytesDownload.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.1.0" />
+    <PackageReference Include="WireMock.Net" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/bytes-download/src/SeedBytesDownload.Test/SeedBytesDownload.Test.csproj
+++ b/seed/csharp-model/bytes-download/src/SeedBytesDownload.Test/SeedBytesDownload.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="1.25.0" />
+    <PackageReference Include="WireMock.Net" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/bytes-upload/src/SeedBytesUpload.Test/SeedBytesUpload.Test.csproj
+++ b/seed/csharp-model/bytes-upload/src/SeedBytesUpload.Test/SeedBytesUpload.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.1.0" />
+    <PackageReference Include="WireMock.Net" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/bytes-upload/src/SeedBytesUpload.Test/SeedBytesUpload.Test.csproj
+++ b/seed/csharp-model/bytes-upload/src/SeedBytesUpload.Test/SeedBytesUpload.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="1.25.0" />
+    <PackageReference Include="WireMock.Net" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/circular-references-advanced/src/SeedApi.Test/SeedApi.Test.csproj
+++ b/seed/csharp-model/circular-references-advanced/src/SeedApi.Test/SeedApi.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.1.0" />
+    <PackageReference Include="WireMock.Net" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/circular-references-advanced/src/SeedApi.Test/SeedApi.Test.csproj
+++ b/seed/csharp-model/circular-references-advanced/src/SeedApi.Test/SeedApi.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="1.25.0" />
+    <PackageReference Include="WireMock.Net" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/circular-references/src/SeedApi.Test/SeedApi.Test.csproj
+++ b/seed/csharp-model/circular-references/src/SeedApi.Test/SeedApi.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.1.0" />
+    <PackageReference Include="WireMock.Net" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/circular-references/src/SeedApi.Test/SeedApi.Test.csproj
+++ b/seed/csharp-model/circular-references/src/SeedApi.Test/SeedApi.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="1.25.0" />
+    <PackageReference Include="WireMock.Net" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/client-side-params/src/SeedClientSideParams.Test/SeedClientSideParams.Test.csproj
+++ b/seed/csharp-model/client-side-params/src/SeedClientSideParams.Test/SeedClientSideParams.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.1.0" />
+    <PackageReference Include="WireMock.Net" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/client-side-params/src/SeedClientSideParams.Test/SeedClientSideParams.Test.csproj
+++ b/seed/csharp-model/client-side-params/src/SeedClientSideParams.Test/SeedClientSideParams.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="1.25.0" />
+    <PackageReference Include="WireMock.Net" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/content-type/src/SeedContentTypes.Test/SeedContentTypes.Test.csproj
+++ b/seed/csharp-model/content-type/src/SeedContentTypes.Test/SeedContentTypes.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.1.0" />
+    <PackageReference Include="WireMock.Net" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/content-type/src/SeedContentTypes.Test/SeedContentTypes.Test.csproj
+++ b/seed/csharp-model/content-type/src/SeedContentTypes.Test/SeedContentTypes.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="1.25.0" />
+    <PackageReference Include="WireMock.Net" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/cross-package-type-names/src/SeedCrossPackageTypeNames.Test/SeedCrossPackageTypeNames.Test.csproj
+++ b/seed/csharp-model/cross-package-type-names/src/SeedCrossPackageTypeNames.Test/SeedCrossPackageTypeNames.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.1.0" />
+    <PackageReference Include="WireMock.Net" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/cross-package-type-names/src/SeedCrossPackageTypeNames.Test/SeedCrossPackageTypeNames.Test.csproj
+++ b/seed/csharp-model/cross-package-type-names/src/SeedCrossPackageTypeNames.Test/SeedCrossPackageTypeNames.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="1.25.0" />
+    <PackageReference Include="WireMock.Net" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/csharp-grpc-proto-exhaustive/src/SeedApi.Test/SeedApi.Test.csproj
+++ b/seed/csharp-model/csharp-grpc-proto-exhaustive/src/SeedApi.Test/SeedApi.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.1.0" />
+    <PackageReference Include="WireMock.Net" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/csharp-grpc-proto-exhaustive/src/SeedApi.Test/SeedApi.Test.csproj
+++ b/seed/csharp-model/csharp-grpc-proto-exhaustive/src/SeedApi.Test/SeedApi.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="1.25.0" />
+    <PackageReference Include="WireMock.Net" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/csharp-grpc-proto/src/SeedApi.Test/SeedApi.Test.csproj
+++ b/seed/csharp-model/csharp-grpc-proto/src/SeedApi.Test/SeedApi.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.1.0" />
+    <PackageReference Include="WireMock.Net" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/csharp-grpc-proto/src/SeedApi.Test/SeedApi.Test.csproj
+++ b/seed/csharp-model/csharp-grpc-proto/src/SeedApi.Test/SeedApi.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="1.25.0" />
+    <PackageReference Include="WireMock.Net" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/csharp-namespace-collision/src/SeedCsharpNamespaceCollision.Test/SeedCsharpNamespaceCollision.Test.csproj
+++ b/seed/csharp-model/csharp-namespace-collision/src/SeedCsharpNamespaceCollision.Test/SeedCsharpNamespaceCollision.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.1.0" />
+    <PackageReference Include="WireMock.Net" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/csharp-namespace-collision/src/SeedCsharpNamespaceCollision.Test/SeedCsharpNamespaceCollision.Test.csproj
+++ b/seed/csharp-model/csharp-namespace-collision/src/SeedCsharpNamespaceCollision.Test/SeedCsharpNamespaceCollision.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="1.25.0" />
+    <PackageReference Include="WireMock.Net" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/csharp-namespace-conflict/src/SeedCsharpNamespaceConflict.Test/SeedCsharpNamespaceConflict.Test.csproj
+++ b/seed/csharp-model/csharp-namespace-conflict/src/SeedCsharpNamespaceConflict.Test/SeedCsharpNamespaceConflict.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.1.0" />
+    <PackageReference Include="WireMock.Net" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/csharp-namespace-conflict/src/SeedCsharpNamespaceConflict.Test/SeedCsharpNamespaceConflict.Test.csproj
+++ b/seed/csharp-model/csharp-namespace-conflict/src/SeedCsharpNamespaceConflict.Test/SeedCsharpNamespaceConflict.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="1.25.0" />
+    <PackageReference Include="WireMock.Net" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/csharp-readonly-request/src/SeedCsharpReadonlyRequest.Test/SeedCsharpReadonlyRequest.Test.csproj
+++ b/seed/csharp-model/csharp-readonly-request/src/SeedCsharpReadonlyRequest.Test/SeedCsharpReadonlyRequest.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.1.0" />
+    <PackageReference Include="WireMock.Net" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/csharp-readonly-request/src/SeedCsharpReadonlyRequest.Test/SeedCsharpReadonlyRequest.Test.csproj
+++ b/seed/csharp-model/csharp-readonly-request/src/SeedCsharpReadonlyRequest.Test/SeedCsharpReadonlyRequest.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="1.25.0" />
+    <PackageReference Include="WireMock.Net" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/csharp-system-collision/src/SeedCsharpSystemCollision.Test/SeedCsharpSystemCollision.Test.csproj
+++ b/seed/csharp-model/csharp-system-collision/src/SeedCsharpSystemCollision.Test/SeedCsharpSystemCollision.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.1.0" />
+    <PackageReference Include="WireMock.Net" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/csharp-system-collision/src/SeedCsharpSystemCollision.Test/SeedCsharpSystemCollision.Test.csproj
+++ b/seed/csharp-model/csharp-system-collision/src/SeedCsharpSystemCollision.Test/SeedCsharpSystemCollision.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="1.25.0" />
+    <PackageReference Include="WireMock.Net" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/csharp-xml-entities/src/SeedCsharpXmlEntities.Test/SeedCsharpXmlEntities.Test.csproj
+++ b/seed/csharp-model/csharp-xml-entities/src/SeedCsharpXmlEntities.Test/SeedCsharpXmlEntities.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.1.0" />
+    <PackageReference Include="WireMock.Net" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/csharp-xml-entities/src/SeedCsharpXmlEntities.Test/SeedCsharpXmlEntities.Test.csproj
+++ b/seed/csharp-model/csharp-xml-entities/src/SeedCsharpXmlEntities.Test/SeedCsharpXmlEntities.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="1.25.0" />
+    <PackageReference Include="WireMock.Net" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/dollar-string-examples/src/SeedDollarStringExamples.Test/SeedDollarStringExamples.Test.csproj
+++ b/seed/csharp-model/dollar-string-examples/src/SeedDollarStringExamples.Test/SeedDollarStringExamples.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.1.0" />
+    <PackageReference Include="WireMock.Net" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/dollar-string-examples/src/SeedDollarStringExamples.Test/SeedDollarStringExamples.Test.csproj
+++ b/seed/csharp-model/dollar-string-examples/src/SeedDollarStringExamples.Test/SeedDollarStringExamples.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="1.25.0" />
+    <PackageReference Include="WireMock.Net" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/empty-clients/src/SeedEmptyClients.Test/SeedEmptyClients.Test.csproj
+++ b/seed/csharp-model/empty-clients/src/SeedEmptyClients.Test/SeedEmptyClients.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.1.0" />
+    <PackageReference Include="WireMock.Net" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/empty-clients/src/SeedEmptyClients.Test/SeedEmptyClients.Test.csproj
+++ b/seed/csharp-model/empty-clients/src/SeedEmptyClients.Test/SeedEmptyClients.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="1.25.0" />
+    <PackageReference Include="WireMock.Net" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/endpoint-security-auth/src/SeedEndpointSecurityAuth.Test/SeedEndpointSecurityAuth.Test.csproj
+++ b/seed/csharp-model/endpoint-security-auth/src/SeedEndpointSecurityAuth.Test/SeedEndpointSecurityAuth.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.1.0" />
+    <PackageReference Include="WireMock.Net" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/endpoint-security-auth/src/SeedEndpointSecurityAuth.Test/SeedEndpointSecurityAuth.Test.csproj
+++ b/seed/csharp-model/endpoint-security-auth/src/SeedEndpointSecurityAuth.Test/SeedEndpointSecurityAuth.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="1.25.0" />
+    <PackageReference Include="WireMock.Net" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/enum/forward-compatible-enums/src/SeedEnum.Test/SeedEnum.Test.csproj
+++ b/seed/csharp-model/enum/forward-compatible-enums/src/SeedEnum.Test/SeedEnum.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.1.0" />
+    <PackageReference Include="WireMock.Net" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/enum/forward-compatible-enums/src/SeedEnum.Test/SeedEnum.Test.csproj
+++ b/seed/csharp-model/enum/forward-compatible-enums/src/SeedEnum.Test/SeedEnum.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="1.25.0" />
+    <PackageReference Include="WireMock.Net" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/enum/plain-enums/src/SeedEnum.Test/SeedEnum.Test.csproj
+++ b/seed/csharp-model/enum/plain-enums/src/SeedEnum.Test/SeedEnum.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.1.0" />
+    <PackageReference Include="WireMock.Net" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/enum/plain-enums/src/SeedEnum.Test/SeedEnum.Test.csproj
+++ b/seed/csharp-model/enum/plain-enums/src/SeedEnum.Test/SeedEnum.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="1.25.0" />
+    <PackageReference Include="WireMock.Net" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/error-property/src/SeedErrorProperty.Test/SeedErrorProperty.Test.csproj
+++ b/seed/csharp-model/error-property/src/SeedErrorProperty.Test/SeedErrorProperty.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.1.0" />
+    <PackageReference Include="WireMock.Net" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/error-property/src/SeedErrorProperty.Test/SeedErrorProperty.Test.csproj
+++ b/seed/csharp-model/error-property/src/SeedErrorProperty.Test/SeedErrorProperty.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="1.25.0" />
+    <PackageReference Include="WireMock.Net" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/errors/src/SeedErrors.Test/SeedErrors.Test.csproj
+++ b/seed/csharp-model/errors/src/SeedErrors.Test/SeedErrors.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.1.0" />
+    <PackageReference Include="WireMock.Net" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/errors/src/SeedErrors.Test/SeedErrors.Test.csproj
+++ b/seed/csharp-model/errors/src/SeedErrors.Test/SeedErrors.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="1.25.0" />
+    <PackageReference Include="WireMock.Net" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/examples/src/SeedExamples.Test/SeedExamples.Test.csproj
+++ b/seed/csharp-model/examples/src/SeedExamples.Test/SeedExamples.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.1.0" />
+    <PackageReference Include="WireMock.Net" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/examples/src/SeedExamples.Test/SeedExamples.Test.csproj
+++ b/seed/csharp-model/examples/src/SeedExamples.Test/SeedExamples.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="1.25.0" />
+    <PackageReference Include="WireMock.Net" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/exhaustive/src/SeedExhaustive.Test/SeedExhaustive.Test.csproj
+++ b/seed/csharp-model/exhaustive/src/SeedExhaustive.Test/SeedExhaustive.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.1.0" />
+    <PackageReference Include="WireMock.Net" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/exhaustive/src/SeedExhaustive.Test/SeedExhaustive.Test.csproj
+++ b/seed/csharp-model/exhaustive/src/SeedExhaustive.Test/SeedExhaustive.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="1.25.0" />
+    <PackageReference Include="WireMock.Net" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/extends/src/SeedExtends.Test/SeedExtends.Test.csproj
+++ b/seed/csharp-model/extends/src/SeedExtends.Test/SeedExtends.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.1.0" />
+    <PackageReference Include="WireMock.Net" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/extends/src/SeedExtends.Test/SeedExtends.Test.csproj
+++ b/seed/csharp-model/extends/src/SeedExtends.Test/SeedExtends.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="1.25.0" />
+    <PackageReference Include="WireMock.Net" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/extra-properties/src/SeedExtraProperties.Test/SeedExtraProperties.Test.csproj
+++ b/seed/csharp-model/extra-properties/src/SeedExtraProperties.Test/SeedExtraProperties.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.1.0" />
+    <PackageReference Include="WireMock.Net" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/extra-properties/src/SeedExtraProperties.Test/SeedExtraProperties.Test.csproj
+++ b/seed/csharp-model/extra-properties/src/SeedExtraProperties.Test/SeedExtraProperties.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="1.25.0" />
+    <PackageReference Include="WireMock.Net" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/file-download/src/SeedFileDownload.Test/SeedFileDownload.Test.csproj
+++ b/seed/csharp-model/file-download/src/SeedFileDownload.Test/SeedFileDownload.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.1.0" />
+    <PackageReference Include="WireMock.Net" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/file-download/src/SeedFileDownload.Test/SeedFileDownload.Test.csproj
+++ b/seed/csharp-model/file-download/src/SeedFileDownload.Test/SeedFileDownload.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="1.25.0" />
+    <PackageReference Include="WireMock.Net" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/file-upload-openapi/src/SeedApi.Test/SeedApi.Test.csproj
+++ b/seed/csharp-model/file-upload-openapi/src/SeedApi.Test/SeedApi.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.1.0" />
+    <PackageReference Include="WireMock.Net" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/file-upload-openapi/src/SeedApi.Test/SeedApi.Test.csproj
+++ b/seed/csharp-model/file-upload-openapi/src/SeedApi.Test/SeedApi.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="1.25.0" />
+    <PackageReference Include="WireMock.Net" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/file-upload/src/SeedFileUpload.Test/SeedFileUpload.Test.csproj
+++ b/seed/csharp-model/file-upload/src/SeedFileUpload.Test/SeedFileUpload.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.1.0" />
+    <PackageReference Include="WireMock.Net" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/file-upload/src/SeedFileUpload.Test/SeedFileUpload.Test.csproj
+++ b/seed/csharp-model/file-upload/src/SeedFileUpload.Test/SeedFileUpload.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="1.25.0" />
+    <PackageReference Include="WireMock.Net" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/folders/src/SeedApi.Test/SeedApi.Test.csproj
+++ b/seed/csharp-model/folders/src/SeedApi.Test/SeedApi.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.1.0" />
+    <PackageReference Include="WireMock.Net" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/folders/src/SeedApi.Test/SeedApi.Test.csproj
+++ b/seed/csharp-model/folders/src/SeedApi.Test/SeedApi.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="1.25.0" />
+    <PackageReference Include="WireMock.Net" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/header-auth-environment-variable/src/SeedHeaderTokenEnvironmentVariable.Test/SeedHeaderTokenEnvironmentVariable.Test.csproj
+++ b/seed/csharp-model/header-auth-environment-variable/src/SeedHeaderTokenEnvironmentVariable.Test/SeedHeaderTokenEnvironmentVariable.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.1.0" />
+    <PackageReference Include="WireMock.Net" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/header-auth-environment-variable/src/SeedHeaderTokenEnvironmentVariable.Test/SeedHeaderTokenEnvironmentVariable.Test.csproj
+++ b/seed/csharp-model/header-auth-environment-variable/src/SeedHeaderTokenEnvironmentVariable.Test/SeedHeaderTokenEnvironmentVariable.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="1.25.0" />
+    <PackageReference Include="WireMock.Net" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/header-auth/src/SeedHeaderToken.Test/SeedHeaderToken.Test.csproj
+++ b/seed/csharp-model/header-auth/src/SeedHeaderToken.Test/SeedHeaderToken.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.1.0" />
+    <PackageReference Include="WireMock.Net" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/header-auth/src/SeedHeaderToken.Test/SeedHeaderToken.Test.csproj
+++ b/seed/csharp-model/header-auth/src/SeedHeaderToken.Test/SeedHeaderToken.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="1.25.0" />
+    <PackageReference Include="WireMock.Net" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/http-head/src/SeedHttpHead.Test/SeedHttpHead.Test.csproj
+++ b/seed/csharp-model/http-head/src/SeedHttpHead.Test/SeedHttpHead.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.1.0" />
+    <PackageReference Include="WireMock.Net" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/http-head/src/SeedHttpHead.Test/SeedHttpHead.Test.csproj
+++ b/seed/csharp-model/http-head/src/SeedHttpHead.Test/SeedHttpHead.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="1.25.0" />
+    <PackageReference Include="WireMock.Net" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/idempotency-headers/src/SeedIdempotencyHeaders.Test/SeedIdempotencyHeaders.Test.csproj
+++ b/seed/csharp-model/idempotency-headers/src/SeedIdempotencyHeaders.Test/SeedIdempotencyHeaders.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.1.0" />
+    <PackageReference Include="WireMock.Net" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/idempotency-headers/src/SeedIdempotencyHeaders.Test/SeedIdempotencyHeaders.Test.csproj
+++ b/seed/csharp-model/idempotency-headers/src/SeedIdempotencyHeaders.Test/SeedIdempotencyHeaders.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="1.25.0" />
+    <PackageReference Include="WireMock.Net" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/imdb/src/SeedApi.Test/SeedApi.Test.csproj
+++ b/seed/csharp-model/imdb/src/SeedApi.Test/SeedApi.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.1.0" />
+    <PackageReference Include="WireMock.Net" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/imdb/src/SeedApi.Test/SeedApi.Test.csproj
+++ b/seed/csharp-model/imdb/src/SeedApi.Test/SeedApi.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="1.25.0" />
+    <PackageReference Include="WireMock.Net" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/inferred-auth-explicit/src/SeedInferredAuthExplicit.Test/SeedInferredAuthExplicit.Test.csproj
+++ b/seed/csharp-model/inferred-auth-explicit/src/SeedInferredAuthExplicit.Test/SeedInferredAuthExplicit.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.1.0" />
+    <PackageReference Include="WireMock.Net" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/inferred-auth-explicit/src/SeedInferredAuthExplicit.Test/SeedInferredAuthExplicit.Test.csproj
+++ b/seed/csharp-model/inferred-auth-explicit/src/SeedInferredAuthExplicit.Test/SeedInferredAuthExplicit.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="1.25.0" />
+    <PackageReference Include="WireMock.Net" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/inferred-auth-implicit-api-key/src/SeedInferredAuthImplicitApiKey.Test/SeedInferredAuthImplicitApiKey.Test.csproj
+++ b/seed/csharp-model/inferred-auth-implicit-api-key/src/SeedInferredAuthImplicitApiKey.Test/SeedInferredAuthImplicitApiKey.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.1.0" />
+    <PackageReference Include="WireMock.Net" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/inferred-auth-implicit-api-key/src/SeedInferredAuthImplicitApiKey.Test/SeedInferredAuthImplicitApiKey.Test.csproj
+++ b/seed/csharp-model/inferred-auth-implicit-api-key/src/SeedInferredAuthImplicitApiKey.Test/SeedInferredAuthImplicitApiKey.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="1.25.0" />
+    <PackageReference Include="WireMock.Net" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/inferred-auth-implicit-no-expiry/src/SeedInferredAuthImplicitNoExpiry.Test/SeedInferredAuthImplicitNoExpiry.Test.csproj
+++ b/seed/csharp-model/inferred-auth-implicit-no-expiry/src/SeedInferredAuthImplicitNoExpiry.Test/SeedInferredAuthImplicitNoExpiry.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.1.0" />
+    <PackageReference Include="WireMock.Net" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/inferred-auth-implicit-no-expiry/src/SeedInferredAuthImplicitNoExpiry.Test/SeedInferredAuthImplicitNoExpiry.Test.csproj
+++ b/seed/csharp-model/inferred-auth-implicit-no-expiry/src/SeedInferredAuthImplicitNoExpiry.Test/SeedInferredAuthImplicitNoExpiry.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="1.25.0" />
+    <PackageReference Include="WireMock.Net" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/inferred-auth-implicit-reference/src/SeedInferredAuthImplicit.Test/SeedInferredAuthImplicit.Test.csproj
+++ b/seed/csharp-model/inferred-auth-implicit-reference/src/SeedInferredAuthImplicit.Test/SeedInferredAuthImplicit.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.1.0" />
+    <PackageReference Include="WireMock.Net" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/inferred-auth-implicit-reference/src/SeedInferredAuthImplicit.Test/SeedInferredAuthImplicit.Test.csproj
+++ b/seed/csharp-model/inferred-auth-implicit-reference/src/SeedInferredAuthImplicit.Test/SeedInferredAuthImplicit.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="1.25.0" />
+    <PackageReference Include="WireMock.Net" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/inferred-auth-implicit/src/SeedInferredAuthImplicit.Test/SeedInferredAuthImplicit.Test.csproj
+++ b/seed/csharp-model/inferred-auth-implicit/src/SeedInferredAuthImplicit.Test/SeedInferredAuthImplicit.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.1.0" />
+    <PackageReference Include="WireMock.Net" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/inferred-auth-implicit/src/SeedInferredAuthImplicit.Test/SeedInferredAuthImplicit.Test.csproj
+++ b/seed/csharp-model/inferred-auth-implicit/src/SeedInferredAuthImplicit.Test/SeedInferredAuthImplicit.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="1.25.0" />
+    <PackageReference Include="WireMock.Net" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/license/src/SeedLicense.Test/SeedLicense.Test.csproj
+++ b/seed/csharp-model/license/src/SeedLicense.Test/SeedLicense.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.1.0" />
+    <PackageReference Include="WireMock.Net" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/license/src/SeedLicense.Test/SeedLicense.Test.csproj
+++ b/seed/csharp-model/license/src/SeedLicense.Test/SeedLicense.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="1.25.0" />
+    <PackageReference Include="WireMock.Net" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/literal/src/SeedLiteral.Test/SeedLiteral.Test.csproj
+++ b/seed/csharp-model/literal/src/SeedLiteral.Test/SeedLiteral.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.1.0" />
+    <PackageReference Include="WireMock.Net" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/literal/src/SeedLiteral.Test/SeedLiteral.Test.csproj
+++ b/seed/csharp-model/literal/src/SeedLiteral.Test/SeedLiteral.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="1.25.0" />
+    <PackageReference Include="WireMock.Net" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/literals-unions/src/SeedLiteralsUnions.Test/SeedLiteralsUnions.Test.csproj
+++ b/seed/csharp-model/literals-unions/src/SeedLiteralsUnions.Test/SeedLiteralsUnions.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.1.0" />
+    <PackageReference Include="WireMock.Net" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/literals-unions/src/SeedLiteralsUnions.Test/SeedLiteralsUnions.Test.csproj
+++ b/seed/csharp-model/literals-unions/src/SeedLiteralsUnions.Test/SeedLiteralsUnions.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="1.25.0" />
+    <PackageReference Include="WireMock.Net" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/mixed-case/src/SeedMixedCase.Test/SeedMixedCase.Test.csproj
+++ b/seed/csharp-model/mixed-case/src/SeedMixedCase.Test/SeedMixedCase.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.1.0" />
+    <PackageReference Include="WireMock.Net" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/mixed-case/src/SeedMixedCase.Test/SeedMixedCase.Test.csproj
+++ b/seed/csharp-model/mixed-case/src/SeedMixedCase.Test/SeedMixedCase.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="1.25.0" />
+    <PackageReference Include="WireMock.Net" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/mixed-file-directory/src/SeedMixedFileDirectory.Test/SeedMixedFileDirectory.Test.csproj
+++ b/seed/csharp-model/mixed-file-directory/src/SeedMixedFileDirectory.Test/SeedMixedFileDirectory.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.1.0" />
+    <PackageReference Include="WireMock.Net" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/mixed-file-directory/src/SeedMixedFileDirectory.Test/SeedMixedFileDirectory.Test.csproj
+++ b/seed/csharp-model/mixed-file-directory/src/SeedMixedFileDirectory.Test/SeedMixedFileDirectory.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="1.25.0" />
+    <PackageReference Include="WireMock.Net" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/multi-line-docs/src/SeedMultiLineDocs.Test/SeedMultiLineDocs.Test.csproj
+++ b/seed/csharp-model/multi-line-docs/src/SeedMultiLineDocs.Test/SeedMultiLineDocs.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.1.0" />
+    <PackageReference Include="WireMock.Net" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/multi-line-docs/src/SeedMultiLineDocs.Test/SeedMultiLineDocs.Test.csproj
+++ b/seed/csharp-model/multi-line-docs/src/SeedMultiLineDocs.Test/SeedMultiLineDocs.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="1.25.0" />
+    <PackageReference Include="WireMock.Net" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/multi-url-environment-no-default/src/SeedMultiUrlEnvironmentNoDefault.Test/SeedMultiUrlEnvironmentNoDefault.Test.csproj
+++ b/seed/csharp-model/multi-url-environment-no-default/src/SeedMultiUrlEnvironmentNoDefault.Test/SeedMultiUrlEnvironmentNoDefault.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.1.0" />
+    <PackageReference Include="WireMock.Net" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/multi-url-environment-no-default/src/SeedMultiUrlEnvironmentNoDefault.Test/SeedMultiUrlEnvironmentNoDefault.Test.csproj
+++ b/seed/csharp-model/multi-url-environment-no-default/src/SeedMultiUrlEnvironmentNoDefault.Test/SeedMultiUrlEnvironmentNoDefault.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="1.25.0" />
+    <PackageReference Include="WireMock.Net" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/multi-url-environment/src/SeedMultiUrlEnvironment.Test/SeedMultiUrlEnvironment.Test.csproj
+++ b/seed/csharp-model/multi-url-environment/src/SeedMultiUrlEnvironment.Test/SeedMultiUrlEnvironment.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.1.0" />
+    <PackageReference Include="WireMock.Net" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/multi-url-environment/src/SeedMultiUrlEnvironment.Test/SeedMultiUrlEnvironment.Test.csproj
+++ b/seed/csharp-model/multi-url-environment/src/SeedMultiUrlEnvironment.Test/SeedMultiUrlEnvironment.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="1.25.0" />
+    <PackageReference Include="WireMock.Net" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/multiple-request-bodies/src/SeedApi.Test/SeedApi.Test.csproj
+++ b/seed/csharp-model/multiple-request-bodies/src/SeedApi.Test/SeedApi.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.1.0" />
+    <PackageReference Include="WireMock.Net" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/multiple-request-bodies/src/SeedApi.Test/SeedApi.Test.csproj
+++ b/seed/csharp-model/multiple-request-bodies/src/SeedApi.Test/SeedApi.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="1.25.0" />
+    <PackageReference Include="WireMock.Net" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/no-content-response/src/SeedApi.Test/SeedApi.Test.csproj
+++ b/seed/csharp-model/no-content-response/src/SeedApi.Test/SeedApi.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.1.0" />
+    <PackageReference Include="WireMock.Net" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/no-content-response/src/SeedApi.Test/SeedApi.Test.csproj
+++ b/seed/csharp-model/no-content-response/src/SeedApi.Test/SeedApi.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="1.25.0" />
+    <PackageReference Include="WireMock.Net" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/no-environment/src/SeedNoEnvironment.Test/SeedNoEnvironment.Test.csproj
+++ b/seed/csharp-model/no-environment/src/SeedNoEnvironment.Test/SeedNoEnvironment.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.1.0" />
+    <PackageReference Include="WireMock.Net" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/no-environment/src/SeedNoEnvironment.Test/SeedNoEnvironment.Test.csproj
+++ b/seed/csharp-model/no-environment/src/SeedNoEnvironment.Test/SeedNoEnvironment.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="1.25.0" />
+    <PackageReference Include="WireMock.Net" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/no-retries/src/SeedNoRetries.Test/SeedNoRetries.Test.csproj
+++ b/seed/csharp-model/no-retries/src/SeedNoRetries.Test/SeedNoRetries.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.1.0" />
+    <PackageReference Include="WireMock.Net" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/no-retries/src/SeedNoRetries.Test/SeedNoRetries.Test.csproj
+++ b/seed/csharp-model/no-retries/src/SeedNoRetries.Test/SeedNoRetries.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="1.25.0" />
+    <PackageReference Include="WireMock.Net" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/null-type/src/SeedApi.Test/SeedApi.Test.csproj
+++ b/seed/csharp-model/null-type/src/SeedApi.Test/SeedApi.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.1.0" />
+    <PackageReference Include="WireMock.Net" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/null-type/src/SeedApi.Test/SeedApi.Test.csproj
+++ b/seed/csharp-model/null-type/src/SeedApi.Test/SeedApi.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="1.25.0" />
+    <PackageReference Include="WireMock.Net" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/nullable-allof-extends/src/SeedApi.Test/SeedApi.Test.csproj
+++ b/seed/csharp-model/nullable-allof-extends/src/SeedApi.Test/SeedApi.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.1.0" />
+    <PackageReference Include="WireMock.Net" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/nullable-allof-extends/src/SeedApi.Test/SeedApi.Test.csproj
+++ b/seed/csharp-model/nullable-allof-extends/src/SeedApi.Test/SeedApi.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="1.25.0" />
+    <PackageReference Include="WireMock.Net" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/nullable-optional/src/SeedNullableOptional.Test/SeedNullableOptional.Test.csproj
+++ b/seed/csharp-model/nullable-optional/src/SeedNullableOptional.Test/SeedNullableOptional.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.1.0" />
+    <PackageReference Include="WireMock.Net" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/nullable-optional/src/SeedNullableOptional.Test/SeedNullableOptional.Test.csproj
+++ b/seed/csharp-model/nullable-optional/src/SeedNullableOptional.Test/SeedNullableOptional.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="1.25.0" />
+    <PackageReference Include="WireMock.Net" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/nullable-request-body/src/SeedApi.Test/SeedApi.Test.csproj
+++ b/seed/csharp-model/nullable-request-body/src/SeedApi.Test/SeedApi.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.1.0" />
+    <PackageReference Include="WireMock.Net" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/nullable-request-body/src/SeedApi.Test/SeedApi.Test.csproj
+++ b/seed/csharp-model/nullable-request-body/src/SeedApi.Test/SeedApi.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="1.25.0" />
+    <PackageReference Include="WireMock.Net" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/nullable/src/SeedNullable.Test/SeedNullable.Test.csproj
+++ b/seed/csharp-model/nullable/src/SeedNullable.Test/SeedNullable.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.1.0" />
+    <PackageReference Include="WireMock.Net" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/nullable/src/SeedNullable.Test/SeedNullable.Test.csproj
+++ b/seed/csharp-model/nullable/src/SeedNullable.Test/SeedNullable.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="1.25.0" />
+    <PackageReference Include="WireMock.Net" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/oauth-client-credentials-custom/src/SeedOauthClientCredentials.Test/SeedOauthClientCredentials.Test.csproj
+++ b/seed/csharp-model/oauth-client-credentials-custom/src/SeedOauthClientCredentials.Test/SeedOauthClientCredentials.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.1.0" />
+    <PackageReference Include="WireMock.Net" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/oauth-client-credentials-custom/src/SeedOauthClientCredentials.Test/SeedOauthClientCredentials.Test.csproj
+++ b/seed/csharp-model/oauth-client-credentials-custom/src/SeedOauthClientCredentials.Test/SeedOauthClientCredentials.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="1.25.0" />
+    <PackageReference Include="WireMock.Net" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/oauth-client-credentials-default/src/SeedOauthClientCredentialsDefault.Test/SeedOauthClientCredentialsDefault.Test.csproj
+++ b/seed/csharp-model/oauth-client-credentials-default/src/SeedOauthClientCredentialsDefault.Test/SeedOauthClientCredentialsDefault.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.1.0" />
+    <PackageReference Include="WireMock.Net" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/oauth-client-credentials-default/src/SeedOauthClientCredentialsDefault.Test/SeedOauthClientCredentialsDefault.Test.csproj
+++ b/seed/csharp-model/oauth-client-credentials-default/src/SeedOauthClientCredentialsDefault.Test/SeedOauthClientCredentialsDefault.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="1.25.0" />
+    <PackageReference Include="WireMock.Net" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/oauth-client-credentials-environment-variables/src/SeedOauthClientCredentialsEnvironmentVariables.Test/SeedOauthClientCredentialsEnvironmentVariables.Test.csproj
+++ b/seed/csharp-model/oauth-client-credentials-environment-variables/src/SeedOauthClientCredentialsEnvironmentVariables.Test/SeedOauthClientCredentialsEnvironmentVariables.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.1.0" />
+    <PackageReference Include="WireMock.Net" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/oauth-client-credentials-environment-variables/src/SeedOauthClientCredentialsEnvironmentVariables.Test/SeedOauthClientCredentialsEnvironmentVariables.Test.csproj
+++ b/seed/csharp-model/oauth-client-credentials-environment-variables/src/SeedOauthClientCredentialsEnvironmentVariables.Test/SeedOauthClientCredentialsEnvironmentVariables.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="1.25.0" />
+    <PackageReference Include="WireMock.Net" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/oauth-client-credentials-mandatory-auth/src/SeedOauthClientCredentialsMandatoryAuth.Test/SeedOauthClientCredentialsMandatoryAuth.Test.csproj
+++ b/seed/csharp-model/oauth-client-credentials-mandatory-auth/src/SeedOauthClientCredentialsMandatoryAuth.Test/SeedOauthClientCredentialsMandatoryAuth.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.1.0" />
+    <PackageReference Include="WireMock.Net" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/oauth-client-credentials-mandatory-auth/src/SeedOauthClientCredentialsMandatoryAuth.Test/SeedOauthClientCredentialsMandatoryAuth.Test.csproj
+++ b/seed/csharp-model/oauth-client-credentials-mandatory-auth/src/SeedOauthClientCredentialsMandatoryAuth.Test/SeedOauthClientCredentialsMandatoryAuth.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="1.25.0" />
+    <PackageReference Include="WireMock.Net" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/oauth-client-credentials-nested-root/src/SeedOauthClientCredentials.Test/SeedOauthClientCredentials.Test.csproj
+++ b/seed/csharp-model/oauth-client-credentials-nested-root/src/SeedOauthClientCredentials.Test/SeedOauthClientCredentials.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.1.0" />
+    <PackageReference Include="WireMock.Net" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/oauth-client-credentials-nested-root/src/SeedOauthClientCredentials.Test/SeedOauthClientCredentials.Test.csproj
+++ b/seed/csharp-model/oauth-client-credentials-nested-root/src/SeedOauthClientCredentials.Test/SeedOauthClientCredentials.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="1.25.0" />
+    <PackageReference Include="WireMock.Net" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/oauth-client-credentials-openapi/src/SeedApi.Test/SeedApi.Test.csproj
+++ b/seed/csharp-model/oauth-client-credentials-openapi/src/SeedApi.Test/SeedApi.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.1.0" />
+    <PackageReference Include="WireMock.Net" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/oauth-client-credentials-openapi/src/SeedApi.Test/SeedApi.Test.csproj
+++ b/seed/csharp-model/oauth-client-credentials-openapi/src/SeedApi.Test/SeedApi.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="1.25.0" />
+    <PackageReference Include="WireMock.Net" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/oauth-client-credentials-reference/src/SeedOauthClientCredentialsReference.Test/SeedOauthClientCredentialsReference.Test.csproj
+++ b/seed/csharp-model/oauth-client-credentials-reference/src/SeedOauthClientCredentialsReference.Test/SeedOauthClientCredentialsReference.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.1.0" />
+    <PackageReference Include="WireMock.Net" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/oauth-client-credentials-reference/src/SeedOauthClientCredentialsReference.Test/SeedOauthClientCredentialsReference.Test.csproj
+++ b/seed/csharp-model/oauth-client-credentials-reference/src/SeedOauthClientCredentialsReference.Test/SeedOauthClientCredentialsReference.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="1.25.0" />
+    <PackageReference Include="WireMock.Net" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/oauth-client-credentials-with-variables/src/SeedOauthClientCredentialsWithVariables.Test/SeedOauthClientCredentialsWithVariables.Test.csproj
+++ b/seed/csharp-model/oauth-client-credentials-with-variables/src/SeedOauthClientCredentialsWithVariables.Test/SeedOauthClientCredentialsWithVariables.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.1.0" />
+    <PackageReference Include="WireMock.Net" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/oauth-client-credentials-with-variables/src/SeedOauthClientCredentialsWithVariables.Test/SeedOauthClientCredentialsWithVariables.Test.csproj
+++ b/seed/csharp-model/oauth-client-credentials-with-variables/src/SeedOauthClientCredentialsWithVariables.Test/SeedOauthClientCredentialsWithVariables.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="1.25.0" />
+    <PackageReference Include="WireMock.Net" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/oauth-client-credentials/src/SeedOauthClientCredentials.Test/SeedOauthClientCredentials.Test.csproj
+++ b/seed/csharp-model/oauth-client-credentials/src/SeedOauthClientCredentials.Test/SeedOauthClientCredentials.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.1.0" />
+    <PackageReference Include="WireMock.Net" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/oauth-client-credentials/src/SeedOauthClientCredentials.Test/SeedOauthClientCredentials.Test.csproj
+++ b/seed/csharp-model/oauth-client-credentials/src/SeedOauthClientCredentials.Test/SeedOauthClientCredentials.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="1.25.0" />
+    <PackageReference Include="WireMock.Net" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/object/src/SeedObject.Test/SeedObject.Test.csproj
+++ b/seed/csharp-model/object/src/SeedObject.Test/SeedObject.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.1.0" />
+    <PackageReference Include="WireMock.Net" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/object/src/SeedObject.Test/SeedObject.Test.csproj
+++ b/seed/csharp-model/object/src/SeedObject.Test/SeedObject.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="1.25.0" />
+    <PackageReference Include="WireMock.Net" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/objects-with-imports/src/SeedObjectsWithImports.Test/SeedObjectsWithImports.Test.csproj
+++ b/seed/csharp-model/objects-with-imports/src/SeedObjectsWithImports.Test/SeedObjectsWithImports.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.1.0" />
+    <PackageReference Include="WireMock.Net" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/objects-with-imports/src/SeedObjectsWithImports.Test/SeedObjectsWithImports.Test.csproj
+++ b/seed/csharp-model/objects-with-imports/src/SeedObjectsWithImports.Test/SeedObjectsWithImports.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="1.25.0" />
+    <PackageReference Include="WireMock.Net" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/optional/src/SeedObjectsWithImports.Test/SeedObjectsWithImports.Test.csproj
+++ b/seed/csharp-model/optional/src/SeedObjectsWithImports.Test/SeedObjectsWithImports.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.1.0" />
+    <PackageReference Include="WireMock.Net" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/optional/src/SeedObjectsWithImports.Test/SeedObjectsWithImports.Test.csproj
+++ b/seed/csharp-model/optional/src/SeedObjectsWithImports.Test/SeedObjectsWithImports.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="1.25.0" />
+    <PackageReference Include="WireMock.Net" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/package-yml/src/SeedPackageYml.Test/SeedPackageYml.Test.csproj
+++ b/seed/csharp-model/package-yml/src/SeedPackageYml.Test/SeedPackageYml.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.1.0" />
+    <PackageReference Include="WireMock.Net" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/package-yml/src/SeedPackageYml.Test/SeedPackageYml.Test.csproj
+++ b/seed/csharp-model/package-yml/src/SeedPackageYml.Test/SeedPackageYml.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="1.25.0" />
+    <PackageReference Include="WireMock.Net" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/pagination-custom/src/SeedPagination.Test/SeedPagination.Test.csproj
+++ b/seed/csharp-model/pagination-custom/src/SeedPagination.Test/SeedPagination.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.1.0" />
+    <PackageReference Include="WireMock.Net" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/pagination-custom/src/SeedPagination.Test/SeedPagination.Test.csproj
+++ b/seed/csharp-model/pagination-custom/src/SeedPagination.Test/SeedPagination.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="1.25.0" />
+    <PackageReference Include="WireMock.Net" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/pagination-uri-path/src/SeedPaginationUriPath.Test/SeedPaginationUriPath.Test.csproj
+++ b/seed/csharp-model/pagination-uri-path/src/SeedPaginationUriPath.Test/SeedPaginationUriPath.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.1.0" />
+    <PackageReference Include="WireMock.Net" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/pagination-uri-path/src/SeedPaginationUriPath.Test/SeedPaginationUriPath.Test.csproj
+++ b/seed/csharp-model/pagination-uri-path/src/SeedPaginationUriPath.Test/SeedPaginationUriPath.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="1.25.0" />
+    <PackageReference Include="WireMock.Net" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/pagination/src/SeedPagination.Test/SeedPagination.Test.csproj
+++ b/seed/csharp-model/pagination/src/SeedPagination.Test/SeedPagination.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.1.0" />
+    <PackageReference Include="WireMock.Net" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/pagination/src/SeedPagination.Test/SeedPagination.Test.csproj
+++ b/seed/csharp-model/pagination/src/SeedPagination.Test/SeedPagination.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="1.25.0" />
+    <PackageReference Include="WireMock.Net" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/path-parameters/src/SeedPathParameters.Test/SeedPathParameters.Test.csproj
+++ b/seed/csharp-model/path-parameters/src/SeedPathParameters.Test/SeedPathParameters.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.1.0" />
+    <PackageReference Include="WireMock.Net" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/path-parameters/src/SeedPathParameters.Test/SeedPathParameters.Test.csproj
+++ b/seed/csharp-model/path-parameters/src/SeedPathParameters.Test/SeedPathParameters.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="1.25.0" />
+    <PackageReference Include="WireMock.Net" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/plain-text/src/SeedPlainText.Test/SeedPlainText.Test.csproj
+++ b/seed/csharp-model/plain-text/src/SeedPlainText.Test/SeedPlainText.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.1.0" />
+    <PackageReference Include="WireMock.Net" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/plain-text/src/SeedPlainText.Test/SeedPlainText.Test.csproj
+++ b/seed/csharp-model/plain-text/src/SeedPlainText.Test/SeedPlainText.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="1.25.0" />
+    <PackageReference Include="WireMock.Net" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/property-access/src/SeedPropertyAccess.Test/SeedPropertyAccess.Test.csproj
+++ b/seed/csharp-model/property-access/src/SeedPropertyAccess.Test/SeedPropertyAccess.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.1.0" />
+    <PackageReference Include="WireMock.Net" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/property-access/src/SeedPropertyAccess.Test/SeedPropertyAccess.Test.csproj
+++ b/seed/csharp-model/property-access/src/SeedPropertyAccess.Test/SeedPropertyAccess.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="1.25.0" />
+    <PackageReference Include="WireMock.Net" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/public-object/src/SeedPublicObject.Test/SeedPublicObject.Test.csproj
+++ b/seed/csharp-model/public-object/src/SeedPublicObject.Test/SeedPublicObject.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.1.0" />
+    <PackageReference Include="WireMock.Net" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/public-object/src/SeedPublicObject.Test/SeedPublicObject.Test.csproj
+++ b/seed/csharp-model/public-object/src/SeedPublicObject.Test/SeedPublicObject.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="1.25.0" />
+    <PackageReference Include="WireMock.Net" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/query-param-name-conflict/src/SeedApi.Test/SeedApi.Test.csproj
+++ b/seed/csharp-model/query-param-name-conflict/src/SeedApi.Test/SeedApi.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.1.0" />
+    <PackageReference Include="WireMock.Net" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/query-param-name-conflict/src/SeedApi.Test/SeedApi.Test.csproj
+++ b/seed/csharp-model/query-param-name-conflict/src/SeedApi.Test/SeedApi.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="1.25.0" />
+    <PackageReference Include="WireMock.Net" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/query-parameters-openapi-as-objects/src/SeedApi.Test/SeedApi.Test.csproj
+++ b/seed/csharp-model/query-parameters-openapi-as-objects/src/SeedApi.Test/SeedApi.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.1.0" />
+    <PackageReference Include="WireMock.Net" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/query-parameters-openapi-as-objects/src/SeedApi.Test/SeedApi.Test.csproj
+++ b/seed/csharp-model/query-parameters-openapi-as-objects/src/SeedApi.Test/SeedApi.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="1.25.0" />
+    <PackageReference Include="WireMock.Net" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/query-parameters-openapi/src/SeedApi.Test/SeedApi.Test.csproj
+++ b/seed/csharp-model/query-parameters-openapi/src/SeedApi.Test/SeedApi.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.1.0" />
+    <PackageReference Include="WireMock.Net" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/query-parameters-openapi/src/SeedApi.Test/SeedApi.Test.csproj
+++ b/seed/csharp-model/query-parameters-openapi/src/SeedApi.Test/SeedApi.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="1.25.0" />
+    <PackageReference Include="WireMock.Net" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/query-parameters/src/SeedQueryParameters.Test/SeedQueryParameters.Test.csproj
+++ b/seed/csharp-model/query-parameters/src/SeedQueryParameters.Test/SeedQueryParameters.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.1.0" />
+    <PackageReference Include="WireMock.Net" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/query-parameters/src/SeedQueryParameters.Test/SeedQueryParameters.Test.csproj
+++ b/seed/csharp-model/query-parameters/src/SeedQueryParameters.Test/SeedQueryParameters.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="1.25.0" />
+    <PackageReference Include="WireMock.Net" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/request-parameters/src/SeedRequestParameters.Test/SeedRequestParameters.Test.csproj
+++ b/seed/csharp-model/request-parameters/src/SeedRequestParameters.Test/SeedRequestParameters.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.1.0" />
+    <PackageReference Include="WireMock.Net" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/request-parameters/src/SeedRequestParameters.Test/SeedRequestParameters.Test.csproj
+++ b/seed/csharp-model/request-parameters/src/SeedRequestParameters.Test/SeedRequestParameters.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="1.25.0" />
+    <PackageReference Include="WireMock.Net" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/required-nullable/src/SeedApi.Test/SeedApi.Test.csproj
+++ b/seed/csharp-model/required-nullable/src/SeedApi.Test/SeedApi.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.1.0" />
+    <PackageReference Include="WireMock.Net" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/required-nullable/src/SeedApi.Test/SeedApi.Test.csproj
+++ b/seed/csharp-model/required-nullable/src/SeedApi.Test/SeedApi.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="1.25.0" />
+    <PackageReference Include="WireMock.Net" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/reserved-keywords/src/SeedNurseryApi.Test/SeedNurseryApi.Test.csproj
+++ b/seed/csharp-model/reserved-keywords/src/SeedNurseryApi.Test/SeedNurseryApi.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.1.0" />
+    <PackageReference Include="WireMock.Net" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/reserved-keywords/src/SeedNurseryApi.Test/SeedNurseryApi.Test.csproj
+++ b/seed/csharp-model/reserved-keywords/src/SeedNurseryApi.Test/SeedNurseryApi.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="1.25.0" />
+    <PackageReference Include="WireMock.Net" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/response-property/src/SeedResponseProperty.Test/SeedResponseProperty.Test.csproj
+++ b/seed/csharp-model/response-property/src/SeedResponseProperty.Test/SeedResponseProperty.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.1.0" />
+    <PackageReference Include="WireMock.Net" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/response-property/src/SeedResponseProperty.Test/SeedResponseProperty.Test.csproj
+++ b/seed/csharp-model/response-property/src/SeedResponseProperty.Test/SeedResponseProperty.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="1.25.0" />
+    <PackageReference Include="WireMock.Net" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/server-sent-event-examples/src/SeedServerSentEvents.Test/SeedServerSentEvents.Test.csproj
+++ b/seed/csharp-model/server-sent-event-examples/src/SeedServerSentEvents.Test/SeedServerSentEvents.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.1.0" />
+    <PackageReference Include="WireMock.Net" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/server-sent-event-examples/src/SeedServerSentEvents.Test/SeedServerSentEvents.Test.csproj
+++ b/seed/csharp-model/server-sent-event-examples/src/SeedServerSentEvents.Test/SeedServerSentEvents.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="1.25.0" />
+    <PackageReference Include="WireMock.Net" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/server-sent-events-openapi/src/SeedApi.Test/SeedApi.Test.csproj
+++ b/seed/csharp-model/server-sent-events-openapi/src/SeedApi.Test/SeedApi.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.1.0" />
+    <PackageReference Include="WireMock.Net" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/server-sent-events-openapi/src/SeedApi.Test/SeedApi.Test.csproj
+++ b/seed/csharp-model/server-sent-events-openapi/src/SeedApi.Test/SeedApi.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="1.25.0" />
+    <PackageReference Include="WireMock.Net" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/server-sent-events/src/SeedServerSentEvents.Test/SeedServerSentEvents.Test.csproj
+++ b/seed/csharp-model/server-sent-events/src/SeedServerSentEvents.Test/SeedServerSentEvents.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.1.0" />
+    <PackageReference Include="WireMock.Net" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/server-sent-events/src/SeedServerSentEvents.Test/SeedServerSentEvents.Test.csproj
+++ b/seed/csharp-model/server-sent-events/src/SeedServerSentEvents.Test/SeedServerSentEvents.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="1.25.0" />
+    <PackageReference Include="WireMock.Net" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/server-url-templating/src/SeedApi.Test/SeedApi.Test.csproj
+++ b/seed/csharp-model/server-url-templating/src/SeedApi.Test/SeedApi.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.1.0" />
+    <PackageReference Include="WireMock.Net" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/server-url-templating/src/SeedApi.Test/SeedApi.Test.csproj
+++ b/seed/csharp-model/server-url-templating/src/SeedApi.Test/SeedApi.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="1.25.0" />
+    <PackageReference Include="WireMock.Net" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/simple-api/src/SeedSimpleApi.Test/SeedSimpleApi.Test.csproj
+++ b/seed/csharp-model/simple-api/src/SeedSimpleApi.Test/SeedSimpleApi.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.1.0" />
+    <PackageReference Include="WireMock.Net" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/simple-api/src/SeedSimpleApi.Test/SeedSimpleApi.Test.csproj
+++ b/seed/csharp-model/simple-api/src/SeedSimpleApi.Test/SeedSimpleApi.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="1.25.0" />
+    <PackageReference Include="WireMock.Net" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/simple-fhir/src/SeedApi.Test/SeedApi.Test.csproj
+++ b/seed/csharp-model/simple-fhir/src/SeedApi.Test/SeedApi.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.1.0" />
+    <PackageReference Include="WireMock.Net" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/simple-fhir/src/SeedApi.Test/SeedApi.Test.csproj
+++ b/seed/csharp-model/simple-fhir/src/SeedApi.Test/SeedApi.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="1.25.0" />
+    <PackageReference Include="WireMock.Net" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/single-url-environment-default/src/SeedSingleUrlEnvironmentDefault.Test/SeedSingleUrlEnvironmentDefault.Test.csproj
+++ b/seed/csharp-model/single-url-environment-default/src/SeedSingleUrlEnvironmentDefault.Test/SeedSingleUrlEnvironmentDefault.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.1.0" />
+    <PackageReference Include="WireMock.Net" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/single-url-environment-default/src/SeedSingleUrlEnvironmentDefault.Test/SeedSingleUrlEnvironmentDefault.Test.csproj
+++ b/seed/csharp-model/single-url-environment-default/src/SeedSingleUrlEnvironmentDefault.Test/SeedSingleUrlEnvironmentDefault.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="1.25.0" />
+    <PackageReference Include="WireMock.Net" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/single-url-environment-no-default/src/SeedSingleUrlEnvironmentNoDefault.Test/SeedSingleUrlEnvironmentNoDefault.Test.csproj
+++ b/seed/csharp-model/single-url-environment-no-default/src/SeedSingleUrlEnvironmentNoDefault.Test/SeedSingleUrlEnvironmentNoDefault.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.1.0" />
+    <PackageReference Include="WireMock.Net" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/single-url-environment-no-default/src/SeedSingleUrlEnvironmentNoDefault.Test/SeedSingleUrlEnvironmentNoDefault.Test.csproj
+++ b/seed/csharp-model/single-url-environment-no-default/src/SeedSingleUrlEnvironmentNoDefault.Test/SeedSingleUrlEnvironmentNoDefault.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="1.25.0" />
+    <PackageReference Include="WireMock.Net" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/streaming-parameter/src/SeedStreaming.Test/SeedStreaming.Test.csproj
+++ b/seed/csharp-model/streaming-parameter/src/SeedStreaming.Test/SeedStreaming.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.1.0" />
+    <PackageReference Include="WireMock.Net" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/streaming-parameter/src/SeedStreaming.Test/SeedStreaming.Test.csproj
+++ b/seed/csharp-model/streaming-parameter/src/SeedStreaming.Test/SeedStreaming.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="1.25.0" />
+    <PackageReference Include="WireMock.Net" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/streaming/src/SeedStreaming.Test/SeedStreaming.Test.csproj
+++ b/seed/csharp-model/streaming/src/SeedStreaming.Test/SeedStreaming.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.1.0" />
+    <PackageReference Include="WireMock.Net" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/streaming/src/SeedStreaming.Test/SeedStreaming.Test.csproj
+++ b/seed/csharp-model/streaming/src/SeedStreaming.Test/SeedStreaming.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="1.25.0" />
+    <PackageReference Include="WireMock.Net" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/trace/src/SeedTrace.Test/SeedTrace.Test.csproj
+++ b/seed/csharp-model/trace/src/SeedTrace.Test/SeedTrace.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.1.0" />
+    <PackageReference Include="WireMock.Net" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/trace/src/SeedTrace.Test/SeedTrace.Test.csproj
+++ b/seed/csharp-model/trace/src/SeedTrace.Test/SeedTrace.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="1.25.0" />
+    <PackageReference Include="WireMock.Net" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/undiscriminated-union-with-response-property/src/SeedUndiscriminatedUnionWithResponseProperty.Test/SeedUndiscriminatedUnionWithResponseProperty.Test.csproj
+++ b/seed/csharp-model/undiscriminated-union-with-response-property/src/SeedUndiscriminatedUnionWithResponseProperty.Test/SeedUndiscriminatedUnionWithResponseProperty.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.1.0" />
+    <PackageReference Include="WireMock.Net" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/undiscriminated-union-with-response-property/src/SeedUndiscriminatedUnionWithResponseProperty.Test/SeedUndiscriminatedUnionWithResponseProperty.Test.csproj
+++ b/seed/csharp-model/undiscriminated-union-with-response-property/src/SeedUndiscriminatedUnionWithResponseProperty.Test/SeedUndiscriminatedUnionWithResponseProperty.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="1.25.0" />
+    <PackageReference Include="WireMock.Net" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/undiscriminated-unions/src/SeedUndiscriminatedUnions.Test/SeedUndiscriminatedUnions.Test.csproj
+++ b/seed/csharp-model/undiscriminated-unions/src/SeedUndiscriminatedUnions.Test/SeedUndiscriminatedUnions.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.1.0" />
+    <PackageReference Include="WireMock.Net" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/undiscriminated-unions/src/SeedUndiscriminatedUnions.Test/SeedUndiscriminatedUnions.Test.csproj
+++ b/seed/csharp-model/undiscriminated-unions/src/SeedUndiscriminatedUnions.Test/SeedUndiscriminatedUnions.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="1.25.0" />
+    <PackageReference Include="WireMock.Net" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/unions-with-local-date/src/SeedUnions.Test/SeedUnions.Test.csproj
+++ b/seed/csharp-model/unions-with-local-date/src/SeedUnions.Test/SeedUnions.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.1.0" />
+    <PackageReference Include="WireMock.Net" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/unions-with-local-date/src/SeedUnions.Test/SeedUnions.Test.csproj
+++ b/seed/csharp-model/unions-with-local-date/src/SeedUnions.Test/SeedUnions.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="1.25.0" />
+    <PackageReference Include="WireMock.Net" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/unions/src/SeedUnions.Test/SeedUnions.Test.csproj
+++ b/seed/csharp-model/unions/src/SeedUnions.Test/SeedUnions.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.1.0" />
+    <PackageReference Include="WireMock.Net" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/unions/src/SeedUnions.Test/SeedUnions.Test.csproj
+++ b/seed/csharp-model/unions/src/SeedUnions.Test/SeedUnions.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="1.25.0" />
+    <PackageReference Include="WireMock.Net" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/unknown/src/SeedUnknownAsAny.Test/SeedUnknownAsAny.Test.csproj
+++ b/seed/csharp-model/unknown/src/SeedUnknownAsAny.Test/SeedUnknownAsAny.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.1.0" />
+    <PackageReference Include="WireMock.Net" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/unknown/src/SeedUnknownAsAny.Test/SeedUnknownAsAny.Test.csproj
+++ b/seed/csharp-model/unknown/src/SeedUnknownAsAny.Test/SeedUnknownAsAny.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="1.25.0" />
+    <PackageReference Include="WireMock.Net" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/url-form-encoded/src/SeedApi.Test/SeedApi.Test.csproj
+++ b/seed/csharp-model/url-form-encoded/src/SeedApi.Test/SeedApi.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.1.0" />
+    <PackageReference Include="WireMock.Net" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/url-form-encoded/src/SeedApi.Test/SeedApi.Test.csproj
+++ b/seed/csharp-model/url-form-encoded/src/SeedApi.Test/SeedApi.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="1.25.0" />
+    <PackageReference Include="WireMock.Net" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/validation/src/SeedValidation.Test/SeedValidation.Test.csproj
+++ b/seed/csharp-model/validation/src/SeedValidation.Test/SeedValidation.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.1.0" />
+    <PackageReference Include="WireMock.Net" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/validation/src/SeedValidation.Test/SeedValidation.Test.csproj
+++ b/seed/csharp-model/validation/src/SeedValidation.Test/SeedValidation.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="1.25.0" />
+    <PackageReference Include="WireMock.Net" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/variables/src/SeedVariables.Test/SeedVariables.Test.csproj
+++ b/seed/csharp-model/variables/src/SeedVariables.Test/SeedVariables.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.1.0" />
+    <PackageReference Include="WireMock.Net" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/variables/src/SeedVariables.Test/SeedVariables.Test.csproj
+++ b/seed/csharp-model/variables/src/SeedVariables.Test/SeedVariables.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="1.25.0" />
+    <PackageReference Include="WireMock.Net" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/version-no-default/src/SeedVersion.Test/SeedVersion.Test.csproj
+++ b/seed/csharp-model/version-no-default/src/SeedVersion.Test/SeedVersion.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.1.0" />
+    <PackageReference Include="WireMock.Net" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/version-no-default/src/SeedVersion.Test/SeedVersion.Test.csproj
+++ b/seed/csharp-model/version-no-default/src/SeedVersion.Test/SeedVersion.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="1.25.0" />
+    <PackageReference Include="WireMock.Net" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/version/src/SeedVersion.Test/SeedVersion.Test.csproj
+++ b/seed/csharp-model/version/src/SeedVersion.Test/SeedVersion.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.1.0" />
+    <PackageReference Include="WireMock.Net" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/version/src/SeedVersion.Test/SeedVersion.Test.csproj
+++ b/seed/csharp-model/version/src/SeedVersion.Test/SeedVersion.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="1.25.0" />
+    <PackageReference Include="WireMock.Net" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/webhook-audience/src/SeedApi.Test/SeedApi.Test.csproj
+++ b/seed/csharp-model/webhook-audience/src/SeedApi.Test/SeedApi.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.1.0" />
+    <PackageReference Include="WireMock.Net" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/webhook-audience/src/SeedApi.Test/SeedApi.Test.csproj
+++ b/seed/csharp-model/webhook-audience/src/SeedApi.Test/SeedApi.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="1.25.0" />
+    <PackageReference Include="WireMock.Net" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/webhooks/src/SeedWebhooks.Test/SeedWebhooks.Test.csproj
+++ b/seed/csharp-model/webhooks/src/SeedWebhooks.Test/SeedWebhooks.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.1.0" />
+    <PackageReference Include="WireMock.Net" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/webhooks/src/SeedWebhooks.Test/SeedWebhooks.Test.csproj
+++ b/seed/csharp-model/webhooks/src/SeedWebhooks.Test/SeedWebhooks.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="1.25.0" />
+    <PackageReference Include="WireMock.Net" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/websocket-bearer-auth/src/SeedWebsocketBearerAuth.Test/SeedWebsocketBearerAuth.Test.csproj
+++ b/seed/csharp-model/websocket-bearer-auth/src/SeedWebsocketBearerAuth.Test/SeedWebsocketBearerAuth.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.1.0" />
+    <PackageReference Include="WireMock.Net" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/websocket-bearer-auth/src/SeedWebsocketBearerAuth.Test/SeedWebsocketBearerAuth.Test.csproj
+++ b/seed/csharp-model/websocket-bearer-auth/src/SeedWebsocketBearerAuth.Test/SeedWebsocketBearerAuth.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="1.25.0" />
+    <PackageReference Include="WireMock.Net" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/websocket-inferred-auth/src/SeedWebsocketAuth.Test/SeedWebsocketAuth.Test.csproj
+++ b/seed/csharp-model/websocket-inferred-auth/src/SeedWebsocketAuth.Test/SeedWebsocketAuth.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.1.0" />
+    <PackageReference Include="WireMock.Net" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/websocket-inferred-auth/src/SeedWebsocketAuth.Test/SeedWebsocketAuth.Test.csproj
+++ b/seed/csharp-model/websocket-inferred-auth/src/SeedWebsocketAuth.Test/SeedWebsocketAuth.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="1.25.0" />
+    <PackageReference Include="WireMock.Net" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/websocket-multi-url/src/SeedWebsocketMultiUrl.Test/SeedWebsocketMultiUrl.Test.csproj
+++ b/seed/csharp-model/websocket-multi-url/src/SeedWebsocketMultiUrl.Test/SeedWebsocketMultiUrl.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.1.0" />
+    <PackageReference Include="WireMock.Net" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/websocket-multi-url/src/SeedWebsocketMultiUrl.Test/SeedWebsocketMultiUrl.Test.csproj
+++ b/seed/csharp-model/websocket-multi-url/src/SeedWebsocketMultiUrl.Test/SeedWebsocketMultiUrl.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="1.25.0" />
+    <PackageReference Include="WireMock.Net" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/websocket/src/SeedWebsocket.Test/SeedWebsocket.Test.csproj
+++ b/seed/csharp-model/websocket/src/SeedWebsocket.Test/SeedWebsocket.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.1.0" />
+    <PackageReference Include="WireMock.Net" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-model/websocket/src/SeedWebsocket.Test/SeedWebsocket.Test.csproj
+++ b/seed/csharp-model/websocket/src/SeedWebsocket.Test/SeedWebsocket.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="1.25.0" />
+    <PackageReference Include="WireMock.Net" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/accept-header/src/SeedAccept.Test/SeedAccept.Test.csproj
+++ b/seed/csharp-sdk/accept-header/src/SeedAccept.Test/SeedAccept.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.1.0" />
+    <PackageReference Include="WireMock.Net" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/accept-header/src/SeedAccept.Test/SeedAccept.Test.csproj
+++ b/seed/csharp-sdk/accept-header/src/SeedAccept.Test/SeedAccept.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="1.25.0" />
+    <PackageReference Include="WireMock.Net" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/alias-extends/src/SeedAliasExtends.Test/SeedAliasExtends.Test.csproj
+++ b/seed/csharp-sdk/alias-extends/src/SeedAliasExtends.Test/SeedAliasExtends.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.1.0" />
+    <PackageReference Include="WireMock.Net" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/alias-extends/src/SeedAliasExtends.Test/SeedAliasExtends.Test.csproj
+++ b/seed/csharp-sdk/alias-extends/src/SeedAliasExtends.Test/SeedAliasExtends.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="1.25.0" />
+    <PackageReference Include="WireMock.Net" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/alias/src/SeedAlias.Test/SeedAlias.Test.csproj
+++ b/seed/csharp-sdk/alias/src/SeedAlias.Test/SeedAlias.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.1.0" />
+    <PackageReference Include="WireMock.Net" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/alias/src/SeedAlias.Test/SeedAlias.Test.csproj
+++ b/seed/csharp-sdk/alias/src/SeedAlias.Test/SeedAlias.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="1.25.0" />
+    <PackageReference Include="WireMock.Net" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/any-auth/src/SeedAnyAuth.Test/SeedAnyAuth.Test.csproj
+++ b/seed/csharp-sdk/any-auth/src/SeedAnyAuth.Test/SeedAnyAuth.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.1.0" />
+    <PackageReference Include="WireMock.Net" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/any-auth/src/SeedAnyAuth.Test/SeedAnyAuth.Test.csproj
+++ b/seed/csharp-sdk/any-auth/src/SeedAnyAuth.Test/SeedAnyAuth.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="1.25.0" />
+    <PackageReference Include="WireMock.Net" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/api-wide-base-path/src/SeedApiWideBasePath.Test/SeedApiWideBasePath.Test.csproj
+++ b/seed/csharp-sdk/api-wide-base-path/src/SeedApiWideBasePath.Test/SeedApiWideBasePath.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.1.0" />
+    <PackageReference Include="WireMock.Net" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/api-wide-base-path/src/SeedApiWideBasePath.Test/SeedApiWideBasePath.Test.csproj
+++ b/seed/csharp-sdk/api-wide-base-path/src/SeedApiWideBasePath.Test/SeedApiWideBasePath.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="1.25.0" />
+    <PackageReference Include="WireMock.Net" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/audiences/src/SeedAudiences.Test/SeedAudiences.Test.csproj
+++ b/seed/csharp-sdk/audiences/src/SeedAudiences.Test/SeedAudiences.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.1.0" />
+    <PackageReference Include="WireMock.Net" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/audiences/src/SeedAudiences.Test/SeedAudiences.Test.csproj
+++ b/seed/csharp-sdk/audiences/src/SeedAudiences.Test/SeedAudiences.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="1.25.0" />
+    <PackageReference Include="WireMock.Net" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/basic-auth-environment-variables/src/SeedBasicAuthEnvironmentVariables.Test/SeedBasicAuthEnvironmentVariables.Test.csproj
+++ b/seed/csharp-sdk/basic-auth-environment-variables/src/SeedBasicAuthEnvironmentVariables.Test/SeedBasicAuthEnvironmentVariables.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.1.0" />
+    <PackageReference Include="WireMock.Net" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/basic-auth-environment-variables/src/SeedBasicAuthEnvironmentVariables.Test/SeedBasicAuthEnvironmentVariables.Test.csproj
+++ b/seed/csharp-sdk/basic-auth-environment-variables/src/SeedBasicAuthEnvironmentVariables.Test/SeedBasicAuthEnvironmentVariables.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="1.25.0" />
+    <PackageReference Include="WireMock.Net" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/basic-auth/no-custom-config/src/SeedBasicAuth.Test/SeedBasicAuth.Test.csproj
+++ b/seed/csharp-sdk/basic-auth/no-custom-config/src/SeedBasicAuth.Test/SeedBasicAuth.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.1.0" />
+    <PackageReference Include="WireMock.Net" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/basic-auth/no-custom-config/src/SeedBasicAuth.Test/SeedBasicAuth.Test.csproj
+++ b/seed/csharp-sdk/basic-auth/no-custom-config/src/SeedBasicAuth.Test/SeedBasicAuth.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="1.25.0" />
+    <PackageReference Include="WireMock.Net" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/basic-auth/unified-client-options/src/SeedBasicAuth.Test/SeedBasicAuth.Test.csproj
+++ b/seed/csharp-sdk/basic-auth/unified-client-options/src/SeedBasicAuth.Test/SeedBasicAuth.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.1.0" />
+    <PackageReference Include="WireMock.Net" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/basic-auth/unified-client-options/src/SeedBasicAuth.Test/SeedBasicAuth.Test.csproj
+++ b/seed/csharp-sdk/basic-auth/unified-client-options/src/SeedBasicAuth.Test/SeedBasicAuth.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="1.25.0" />
+    <PackageReference Include="WireMock.Net" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/basic-auth/wire-tests/src/SeedBasicAuth.Test/SeedBasicAuth.Test.csproj
+++ b/seed/csharp-sdk/basic-auth/wire-tests/src/SeedBasicAuth.Test/SeedBasicAuth.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.1.0" />
+    <PackageReference Include="WireMock.Net" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/basic-auth/wire-tests/src/SeedBasicAuth.Test/SeedBasicAuth.Test.csproj
+++ b/seed/csharp-sdk/basic-auth/wire-tests/src/SeedBasicAuth.Test/SeedBasicAuth.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="1.25.0" />
+    <PackageReference Include="WireMock.Net" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/bearer-token-environment-variable/no-custom-config/src/SeedBearerTokenEnvironmentVariable.Test/SeedBearerTokenEnvironmentVariable.Test.csproj
+++ b/seed/csharp-sdk/bearer-token-environment-variable/no-custom-config/src/SeedBearerTokenEnvironmentVariable.Test/SeedBearerTokenEnvironmentVariable.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.1.0" />
+    <PackageReference Include="WireMock.Net" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/bearer-token-environment-variable/no-custom-config/src/SeedBearerTokenEnvironmentVariable.Test/SeedBearerTokenEnvironmentVariable.Test.csproj
+++ b/seed/csharp-sdk/bearer-token-environment-variable/no-custom-config/src/SeedBearerTokenEnvironmentVariable.Test/SeedBearerTokenEnvironmentVariable.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="1.25.0" />
+    <PackageReference Include="WireMock.Net" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/bearer-token-environment-variable/unified-client-options/src/SeedBearerTokenEnvironmentVariable.Test/SeedBearerTokenEnvironmentVariable.Test.csproj
+++ b/seed/csharp-sdk/bearer-token-environment-variable/unified-client-options/src/SeedBearerTokenEnvironmentVariable.Test/SeedBearerTokenEnvironmentVariable.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.1.0" />
+    <PackageReference Include="WireMock.Net" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/bearer-token-environment-variable/unified-client-options/src/SeedBearerTokenEnvironmentVariable.Test/SeedBearerTokenEnvironmentVariable.Test.csproj
+++ b/seed/csharp-sdk/bearer-token-environment-variable/unified-client-options/src/SeedBearerTokenEnvironmentVariable.Test/SeedBearerTokenEnvironmentVariable.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="1.25.0" />
+    <PackageReference Include="WireMock.Net" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/bytes-download/src/SeedBytesDownload.Test/SeedBytesDownload.Test.csproj
+++ b/seed/csharp-sdk/bytes-download/src/SeedBytesDownload.Test/SeedBytesDownload.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.1.0" />
+    <PackageReference Include="WireMock.Net" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/bytes-download/src/SeedBytesDownload.Test/SeedBytesDownload.Test.csproj
+++ b/seed/csharp-sdk/bytes-download/src/SeedBytesDownload.Test/SeedBytesDownload.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="1.25.0" />
+    <PackageReference Include="WireMock.Net" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/bytes-upload/src/SeedBytesUpload.Test/SeedBytesUpload.Test.csproj
+++ b/seed/csharp-sdk/bytes-upload/src/SeedBytesUpload.Test/SeedBytesUpload.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.1.0" />
+    <PackageReference Include="WireMock.Net" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/bytes-upload/src/SeedBytesUpload.Test/SeedBytesUpload.Test.csproj
+++ b/seed/csharp-sdk/bytes-upload/src/SeedBytesUpload.Test/SeedBytesUpload.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="1.25.0" />
+    <PackageReference Include="WireMock.Net" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/circular-references-advanced/src/SeedApi.Test/SeedApi.Test.csproj
+++ b/seed/csharp-sdk/circular-references-advanced/src/SeedApi.Test/SeedApi.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.1.0" />
+    <PackageReference Include="WireMock.Net" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/circular-references-advanced/src/SeedApi.Test/SeedApi.Test.csproj
+++ b/seed/csharp-sdk/circular-references-advanced/src/SeedApi.Test/SeedApi.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="1.25.0" />
+    <PackageReference Include="WireMock.Net" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/circular-references/src/SeedApi.Test/SeedApi.Test.csproj
+++ b/seed/csharp-sdk/circular-references/src/SeedApi.Test/SeedApi.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.1.0" />
+    <PackageReference Include="WireMock.Net" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/circular-references/src/SeedApi.Test/SeedApi.Test.csproj
+++ b/seed/csharp-sdk/circular-references/src/SeedApi.Test/SeedApi.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="1.25.0" />
+    <PackageReference Include="WireMock.Net" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/client-side-params/src/SeedClientSideParams.Test/SeedClientSideParams.Test.csproj
+++ b/seed/csharp-sdk/client-side-params/src/SeedClientSideParams.Test/SeedClientSideParams.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.1.0" />
+    <PackageReference Include="WireMock.Net" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/client-side-params/src/SeedClientSideParams.Test/SeedClientSideParams.Test.csproj
+++ b/seed/csharp-sdk/client-side-params/src/SeedClientSideParams.Test/SeedClientSideParams.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="1.25.0" />
+    <PackageReference Include="WireMock.Net" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/content-type/src/SeedContentTypes.Test/SeedContentTypes.Test.csproj
+++ b/seed/csharp-sdk/content-type/src/SeedContentTypes.Test/SeedContentTypes.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.1.0" />
+    <PackageReference Include="WireMock.Net" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/content-type/src/SeedContentTypes.Test/SeedContentTypes.Test.csproj
+++ b/seed/csharp-sdk/content-type/src/SeedContentTypes.Test/SeedContentTypes.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="1.25.0" />
+    <PackageReference Include="WireMock.Net" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/cross-package-type-names/src/SeedCrossPackageTypeNames.Test/SeedCrossPackageTypeNames.Test.csproj
+++ b/seed/csharp-sdk/cross-package-type-names/src/SeedCrossPackageTypeNames.Test/SeedCrossPackageTypeNames.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.1.0" />
+    <PackageReference Include="WireMock.Net" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/cross-package-type-names/src/SeedCrossPackageTypeNames.Test/SeedCrossPackageTypeNames.Test.csproj
+++ b/seed/csharp-sdk/cross-package-type-names/src/SeedCrossPackageTypeNames.Test/SeedCrossPackageTypeNames.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="1.25.0" />
+    <PackageReference Include="WireMock.Net" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/csharp-grpc-proto-exhaustive/include-exception-handler/src/SeedApi.Test/SeedApi.Test.csproj
+++ b/seed/csharp-sdk/csharp-grpc-proto-exhaustive/include-exception-handler/src/SeedApi.Test/SeedApi.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.1.0" />
+    <PackageReference Include="WireMock.Net" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/csharp-grpc-proto-exhaustive/include-exception-handler/src/SeedApi.Test/SeedApi.Test.csproj
+++ b/seed/csharp-sdk/csharp-grpc-proto-exhaustive/include-exception-handler/src/SeedApi.Test/SeedApi.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="1.25.0" />
+    <PackageReference Include="WireMock.Net" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/csharp-grpc-proto-exhaustive/no-custom-config/src/SeedApi.Test/SeedApi.Test.csproj
+++ b/seed/csharp-sdk/csharp-grpc-proto-exhaustive/no-custom-config/src/SeedApi.Test/SeedApi.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.1.0" />
+    <PackageReference Include="WireMock.Net" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/csharp-grpc-proto-exhaustive/no-custom-config/src/SeedApi.Test/SeedApi.Test.csproj
+++ b/seed/csharp-sdk/csharp-grpc-proto-exhaustive/no-custom-config/src/SeedApi.Test/SeedApi.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="1.25.0" />
+    <PackageReference Include="WireMock.Net" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/csharp-grpc-proto-exhaustive/package-id/src/SeedApi.Test/SeedApi.Test.csproj
+++ b/seed/csharp-sdk/csharp-grpc-proto-exhaustive/package-id/src/SeedApi.Test/SeedApi.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.1.0" />
+    <PackageReference Include="WireMock.Net" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/csharp-grpc-proto-exhaustive/package-id/src/SeedApi.Test/SeedApi.Test.csproj
+++ b/seed/csharp-sdk/csharp-grpc-proto-exhaustive/package-id/src/SeedApi.Test/SeedApi.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="1.25.0" />
+    <PackageReference Include="WireMock.Net" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/csharp-grpc-proto-exhaustive/read-only-memory/src/SeedApi.Test/SeedApi.Test.csproj
+++ b/seed/csharp-sdk/csharp-grpc-proto-exhaustive/read-only-memory/src/SeedApi.Test/SeedApi.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.1.0" />
+    <PackageReference Include="WireMock.Net" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/csharp-grpc-proto-exhaustive/read-only-memory/src/SeedApi.Test/SeedApi.Test.csproj
+++ b/seed/csharp-sdk/csharp-grpc-proto-exhaustive/read-only-memory/src/SeedApi.Test/SeedApi.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="1.25.0" />
+    <PackageReference Include="WireMock.Net" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/csharp-grpc-proto/no-custom-config/src/SeedApi.Test/SeedApi.Test.csproj
+++ b/seed/csharp-sdk/csharp-grpc-proto/no-custom-config/src/SeedApi.Test/SeedApi.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.1.0" />
+    <PackageReference Include="WireMock.Net" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/csharp-grpc-proto/no-custom-config/src/SeedApi.Test/SeedApi.Test.csproj
+++ b/seed/csharp-sdk/csharp-grpc-proto/no-custom-config/src/SeedApi.Test/SeedApi.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="1.25.0" />
+    <PackageReference Include="WireMock.Net" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/csharp-namespace-collision/fully-qualified-namespaces/src/SeedCsharpNamespaceCollision.Test/SeedCsharpNamespaceCollision.Test.csproj
+++ b/seed/csharp-sdk/csharp-namespace-collision/fully-qualified-namespaces/src/SeedCsharpNamespaceCollision.Test/SeedCsharpNamespaceCollision.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.1.0" />
+    <PackageReference Include="WireMock.Net" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/csharp-namespace-collision/fully-qualified-namespaces/src/SeedCsharpNamespaceCollision.Test/SeedCsharpNamespaceCollision.Test.csproj
+++ b/seed/csharp-sdk/csharp-namespace-collision/fully-qualified-namespaces/src/SeedCsharpNamespaceCollision.Test/SeedCsharpNamespaceCollision.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="1.25.0" />
+    <PackageReference Include="WireMock.Net" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/csharp-namespace-collision/namespace-client-collision/src/Contoso.Net.Test/Contoso.Net.Test.csproj
+++ b/seed/csharp-sdk/csharp-namespace-collision/namespace-client-collision/src/Contoso.Net.Test/Contoso.Net.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.1.0" />
+    <PackageReference Include="WireMock.Net" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/csharp-namespace-collision/namespace-client-collision/src/Contoso.Net.Test/Contoso.Net.Test.csproj
+++ b/seed/csharp-sdk/csharp-namespace-collision/namespace-client-collision/src/Contoso.Net.Test/Contoso.Net.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="1.25.0" />
+    <PackageReference Include="WireMock.Net" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/csharp-namespace-conflict/client-class-name-matches-namespace-root/src/Seed.CsharpNamespaceConflict.Test/Seed.CsharpNamespaceConflict.Test.csproj
+++ b/seed/csharp-sdk/csharp-namespace-conflict/client-class-name-matches-namespace-root/src/Seed.CsharpNamespaceConflict.Test/Seed.CsharpNamespaceConflict.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.1.0" />
+    <PackageReference Include="WireMock.Net" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/csharp-namespace-conflict/client-class-name-matches-namespace-root/src/Seed.CsharpNamespaceConflict.Test/Seed.CsharpNamespaceConflict.Test.csproj
+++ b/seed/csharp-sdk/csharp-namespace-conflict/client-class-name-matches-namespace-root/src/Seed.CsharpNamespaceConflict.Test/Seed.CsharpNamespaceConflict.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="1.25.0" />
+    <PackageReference Include="WireMock.Net" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/csharp-readonly-request/src/SeedCsharpReadonlyRequest.Test/SeedCsharpReadonlyRequest.Test.csproj
+++ b/seed/csharp-sdk/csharp-readonly-request/src/SeedCsharpReadonlyRequest.Test/SeedCsharpReadonlyRequest.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.1.0" />
+    <PackageReference Include="WireMock.Net" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/csharp-readonly-request/src/SeedCsharpReadonlyRequest.Test/SeedCsharpReadonlyRequest.Test.csproj
+++ b/seed/csharp-sdk/csharp-readonly-request/src/SeedCsharpReadonlyRequest.Test/SeedCsharpReadonlyRequest.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="1.25.0" />
+    <PackageReference Include="WireMock.Net" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/csharp-system-collision/system-client/src/SeedCsharpSystemCollision.Test/SeedCsharpSystemCollision.Test.csproj
+++ b/seed/csharp-sdk/csharp-system-collision/system-client/src/SeedCsharpSystemCollision.Test/SeedCsharpSystemCollision.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.1.0" />
+    <PackageReference Include="WireMock.Net" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/csharp-system-collision/system-client/src/SeedCsharpSystemCollision.Test/SeedCsharpSystemCollision.Test.csproj
+++ b/seed/csharp-sdk/csharp-system-collision/system-client/src/SeedCsharpSystemCollision.Test/SeedCsharpSystemCollision.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="1.25.0" />
+    <PackageReference Include="WireMock.Net" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/csharp-xml-entities/no-custom-config/src/SeedCsharpXmlEntities.Test/SeedCsharpXmlEntities.Test.csproj
+++ b/seed/csharp-sdk/csharp-xml-entities/no-custom-config/src/SeedCsharpXmlEntities.Test/SeedCsharpXmlEntities.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.1.0" />
+    <PackageReference Include="WireMock.Net" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/csharp-xml-entities/no-custom-config/src/SeedCsharpXmlEntities.Test/SeedCsharpXmlEntities.Test.csproj
+++ b/seed/csharp-sdk/csharp-xml-entities/no-custom-config/src/SeedCsharpXmlEntities.Test/SeedCsharpXmlEntities.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="1.25.0" />
+    <PackageReference Include="WireMock.Net" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/dollar-string-examples/src/SeedDollarStringExamples.Test/SeedDollarStringExamples.Test.csproj
+++ b/seed/csharp-sdk/dollar-string-examples/src/SeedDollarStringExamples.Test/SeedDollarStringExamples.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.1.0" />
+    <PackageReference Include="WireMock.Net" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/dollar-string-examples/src/SeedDollarStringExamples.Test/SeedDollarStringExamples.Test.csproj
+++ b/seed/csharp-sdk/dollar-string-examples/src/SeedDollarStringExamples.Test/SeedDollarStringExamples.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="1.25.0" />
+    <PackageReference Include="WireMock.Net" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/empty-clients/src/SeedEmptyClients.Test/SeedEmptyClients.Test.csproj
+++ b/seed/csharp-sdk/empty-clients/src/SeedEmptyClients.Test/SeedEmptyClients.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.1.0" />
+    <PackageReference Include="WireMock.Net" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/empty-clients/src/SeedEmptyClients.Test/SeedEmptyClients.Test.csproj
+++ b/seed/csharp-sdk/empty-clients/src/SeedEmptyClients.Test/SeedEmptyClients.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="1.25.0" />
+    <PackageReference Include="WireMock.Net" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/endpoint-security-auth/src/SeedEndpointSecurityAuth.Test/SeedEndpointSecurityAuth.Test.csproj
+++ b/seed/csharp-sdk/endpoint-security-auth/src/SeedEndpointSecurityAuth.Test/SeedEndpointSecurityAuth.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.1.0" />
+    <PackageReference Include="WireMock.Net" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/endpoint-security-auth/src/SeedEndpointSecurityAuth.Test/SeedEndpointSecurityAuth.Test.csproj
+++ b/seed/csharp-sdk/endpoint-security-auth/src/SeedEndpointSecurityAuth.Test/SeedEndpointSecurityAuth.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="1.25.0" />
+    <PackageReference Include="WireMock.Net" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/enum/forward-compatible-enums/src/SeedEnum.Test/SeedEnum.Test.csproj
+++ b/seed/csharp-sdk/enum/forward-compatible-enums/src/SeedEnum.Test/SeedEnum.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.1.0" />
+    <PackageReference Include="WireMock.Net" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/enum/forward-compatible-enums/src/SeedEnum.Test/SeedEnum.Test.csproj
+++ b/seed/csharp-sdk/enum/forward-compatible-enums/src/SeedEnum.Test/SeedEnum.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="1.25.0" />
+    <PackageReference Include="WireMock.Net" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/enum/plain-enums/src/SeedEnum.Test/SeedEnum.Test.csproj
+++ b/seed/csharp-sdk/enum/plain-enums/src/SeedEnum.Test/SeedEnum.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.1.0" />
+    <PackageReference Include="WireMock.Net" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/enum/plain-enums/src/SeedEnum.Test/SeedEnum.Test.csproj
+++ b/seed/csharp-sdk/enum/plain-enums/src/SeedEnum.Test/SeedEnum.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="1.25.0" />
+    <PackageReference Include="WireMock.Net" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/error-property/src/SeedErrorProperty.Test/SeedErrorProperty.Test.csproj
+++ b/seed/csharp-sdk/error-property/src/SeedErrorProperty.Test/SeedErrorProperty.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.1.0" />
+    <PackageReference Include="WireMock.Net" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/error-property/src/SeedErrorProperty.Test/SeedErrorProperty.Test.csproj
+++ b/seed/csharp-sdk/error-property/src/SeedErrorProperty.Test/SeedErrorProperty.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="1.25.0" />
+    <PackageReference Include="WireMock.Net" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/errors/src/SeedErrors.Test/SeedErrors.Test.csproj
+++ b/seed/csharp-sdk/errors/src/SeedErrors.Test/SeedErrors.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.1.0" />
+    <PackageReference Include="WireMock.Net" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/errors/src/SeedErrors.Test/SeedErrors.Test.csproj
+++ b/seed/csharp-sdk/errors/src/SeedErrors.Test/SeedErrors.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="1.25.0" />
+    <PackageReference Include="WireMock.Net" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/examples/no-custom-config/src/SeedExamples.Test/SeedExamples.Test.csproj
+++ b/seed/csharp-sdk/examples/no-custom-config/src/SeedExamples.Test/SeedExamples.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.1.0" />
+    <PackageReference Include="WireMock.Net" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/examples/no-custom-config/src/SeedExamples.Test/SeedExamples.Test.csproj
+++ b/seed/csharp-sdk/examples/no-custom-config/src/SeedExamples.Test/SeedExamples.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="1.25.0" />
+    <PackageReference Include="WireMock.Net" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/examples/readme-config/src/SeedExamples.Test/SeedExamples.Test.csproj
+++ b/seed/csharp-sdk/examples/readme-config/src/SeedExamples.Test/SeedExamples.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.1.0" />
+    <PackageReference Include="WireMock.Net" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/examples/readme-config/src/SeedExamples.Test/SeedExamples.Test.csproj
+++ b/seed/csharp-sdk/examples/readme-config/src/SeedExamples.Test/SeedExamples.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="1.25.0" />
+    <PackageReference Include="WireMock.Net" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/exhaustive/explicit-namespaces/src/SeedExhaustive.Test/SeedExhaustive.Test.csproj
+++ b/seed/csharp-sdk/exhaustive/explicit-namespaces/src/SeedExhaustive.Test/SeedExhaustive.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.1.0" />
+    <PackageReference Include="WireMock.Net" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/exhaustive/explicit-namespaces/src/SeedExhaustive.Test/SeedExhaustive.Test.csproj
+++ b/seed/csharp-sdk/exhaustive/explicit-namespaces/src/SeedExhaustive.Test/SeedExhaustive.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="1.25.0" />
+    <PackageReference Include="WireMock.Net" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/exhaustive/include-exception-handler/src/SeedExhaustive.Test/SeedExhaustive.Test.csproj
+++ b/seed/csharp-sdk/exhaustive/include-exception-handler/src/SeedExhaustive.Test/SeedExhaustive.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.1.0" />
+    <PackageReference Include="WireMock.Net" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/exhaustive/include-exception-handler/src/SeedExhaustive.Test/SeedExhaustive.Test.csproj
+++ b/seed/csharp-sdk/exhaustive/include-exception-handler/src/SeedExhaustive.Test/SeedExhaustive.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="1.25.0" />
+    <PackageReference Include="WireMock.Net" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/exhaustive/no-generate-error-types/src/SeedExhaustive.Test/SeedExhaustive.Test.csproj
+++ b/seed/csharp-sdk/exhaustive/no-generate-error-types/src/SeedExhaustive.Test/SeedExhaustive.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.1.0" />
+    <PackageReference Include="WireMock.Net" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/exhaustive/no-generate-error-types/src/SeedExhaustive.Test/SeedExhaustive.Test.csproj
+++ b/seed/csharp-sdk/exhaustive/no-generate-error-types/src/SeedExhaustive.Test/SeedExhaustive.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="1.25.0" />
+    <PackageReference Include="WireMock.Net" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/exhaustive/no-root-namespace-for-core-classes/src/SeedExhaustive.Test/SeedExhaustive.Test.csproj
+++ b/seed/csharp-sdk/exhaustive/no-root-namespace-for-core-classes/src/SeedExhaustive.Test/SeedExhaustive.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.1.0" />
+    <PackageReference Include="WireMock.Net" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/exhaustive/no-root-namespace-for-core-classes/src/SeedExhaustive.Test/SeedExhaustive.Test.csproj
+++ b/seed/csharp-sdk/exhaustive/no-root-namespace-for-core-classes/src/SeedExhaustive.Test/SeedExhaustive.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="1.25.0" />
+    <PackageReference Include="WireMock.Net" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/exhaustive/redact-response-body-on-error/src/SeedExhaustive.Test/SeedExhaustive.Test.csproj
+++ b/seed/csharp-sdk/exhaustive/redact-response-body-on-error/src/SeedExhaustive.Test/SeedExhaustive.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.1.0" />
+    <PackageReference Include="WireMock.Net" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/exhaustive/redact-response-body-on-error/src/SeedExhaustive.Test/SeedExhaustive.Test.csproj
+++ b/seed/csharp-sdk/exhaustive/redact-response-body-on-error/src/SeedExhaustive.Test/SeedExhaustive.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="1.25.0" />
+    <PackageReference Include="WireMock.Net" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/exhaustive/use-undiscriminated-unions/src/SeedExhaustive.Test/SeedExhaustive.Test.csproj
+++ b/seed/csharp-sdk/exhaustive/use-undiscriminated-unions/src/SeedExhaustive.Test/SeedExhaustive.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.1.0" />
+    <PackageReference Include="WireMock.Net" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/exhaustive/use-undiscriminated-unions/src/SeedExhaustive.Test/SeedExhaustive.Test.csproj
+++ b/seed/csharp-sdk/exhaustive/use-undiscriminated-unions/src/SeedExhaustive.Test/SeedExhaustive.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="1.25.0" />
+    <PackageReference Include="WireMock.Net" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/extends/src/SeedExtends.Test/SeedExtends.Test.csproj
+++ b/seed/csharp-sdk/extends/src/SeedExtends.Test/SeedExtends.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.1.0" />
+    <PackageReference Include="WireMock.Net" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/extends/src/SeedExtends.Test/SeedExtends.Test.csproj
+++ b/seed/csharp-sdk/extends/src/SeedExtends.Test/SeedExtends.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="1.25.0" />
+    <PackageReference Include="WireMock.Net" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/extra-properties/src/SeedExtraProperties.Test/SeedExtraProperties.Test.csproj
+++ b/seed/csharp-sdk/extra-properties/src/SeedExtraProperties.Test/SeedExtraProperties.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.1.0" />
+    <PackageReference Include="WireMock.Net" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/extra-properties/src/SeedExtraProperties.Test/SeedExtraProperties.Test.csproj
+++ b/seed/csharp-sdk/extra-properties/src/SeedExtraProperties.Test/SeedExtraProperties.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="1.25.0" />
+    <PackageReference Include="WireMock.Net" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/file-download/src/SeedFileDownload.Test/SeedFileDownload.Test.csproj
+++ b/seed/csharp-sdk/file-download/src/SeedFileDownload.Test/SeedFileDownload.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.1.0" />
+    <PackageReference Include="WireMock.Net" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/file-download/src/SeedFileDownload.Test/SeedFileDownload.Test.csproj
+++ b/seed/csharp-sdk/file-download/src/SeedFileDownload.Test/SeedFileDownload.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="1.25.0" />
+    <PackageReference Include="WireMock.Net" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/file-upload-openapi/src/SeedApi.Test/SeedApi.Test.csproj
+++ b/seed/csharp-sdk/file-upload-openapi/src/SeedApi.Test/SeedApi.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.1.0" />
+    <PackageReference Include="WireMock.Net" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/file-upload-openapi/src/SeedApi.Test/SeedApi.Test.csproj
+++ b/seed/csharp-sdk/file-upload-openapi/src/SeedApi.Test/SeedApi.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="1.25.0" />
+    <PackageReference Include="WireMock.Net" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/file-upload/src/SeedFileUpload.Test/SeedFileUpload.Test.csproj
+++ b/seed/csharp-sdk/file-upload/src/SeedFileUpload.Test/SeedFileUpload.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.1.0" />
+    <PackageReference Include="WireMock.Net" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/file-upload/src/SeedFileUpload.Test/SeedFileUpload.Test.csproj
+++ b/seed/csharp-sdk/file-upload/src/SeedFileUpload.Test/SeedFileUpload.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="1.25.0" />
+    <PackageReference Include="WireMock.Net" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/folders/src/SeedApi.Test/SeedApi.Test.csproj
+++ b/seed/csharp-sdk/folders/src/SeedApi.Test/SeedApi.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.1.0" />
+    <PackageReference Include="WireMock.Net" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/folders/src/SeedApi.Test/SeedApi.Test.csproj
+++ b/seed/csharp-sdk/folders/src/SeedApi.Test/SeedApi.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="1.25.0" />
+    <PackageReference Include="WireMock.Net" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/header-auth-environment-variable/src/SeedHeaderTokenEnvironmentVariable.Test/SeedHeaderTokenEnvironmentVariable.Test.csproj
+++ b/seed/csharp-sdk/header-auth-environment-variable/src/SeedHeaderTokenEnvironmentVariable.Test/SeedHeaderTokenEnvironmentVariable.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.1.0" />
+    <PackageReference Include="WireMock.Net" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/header-auth-environment-variable/src/SeedHeaderTokenEnvironmentVariable.Test/SeedHeaderTokenEnvironmentVariable.Test.csproj
+++ b/seed/csharp-sdk/header-auth-environment-variable/src/SeedHeaderTokenEnvironmentVariable.Test/SeedHeaderTokenEnvironmentVariable.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="1.25.0" />
+    <PackageReference Include="WireMock.Net" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/header-auth/src/SeedHeaderToken.Test/SeedHeaderToken.Test.csproj
+++ b/seed/csharp-sdk/header-auth/src/SeedHeaderToken.Test/SeedHeaderToken.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.1.0" />
+    <PackageReference Include="WireMock.Net" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/header-auth/src/SeedHeaderToken.Test/SeedHeaderToken.Test.csproj
+++ b/seed/csharp-sdk/header-auth/src/SeedHeaderToken.Test/SeedHeaderToken.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="1.25.0" />
+    <PackageReference Include="WireMock.Net" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/http-head/src/SeedHttpHead.Test/SeedHttpHead.Test.csproj
+++ b/seed/csharp-sdk/http-head/src/SeedHttpHead.Test/SeedHttpHead.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.1.0" />
+    <PackageReference Include="WireMock.Net" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/http-head/src/SeedHttpHead.Test/SeedHttpHead.Test.csproj
+++ b/seed/csharp-sdk/http-head/src/SeedHttpHead.Test/SeedHttpHead.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="1.25.0" />
+    <PackageReference Include="WireMock.Net" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/idempotency-headers/src/SeedIdempotencyHeaders.Test/SeedIdempotencyHeaders.Test.csproj
+++ b/seed/csharp-sdk/idempotency-headers/src/SeedIdempotencyHeaders.Test/SeedIdempotencyHeaders.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.1.0" />
+    <PackageReference Include="WireMock.Net" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/idempotency-headers/src/SeedIdempotencyHeaders.Test/SeedIdempotencyHeaders.Test.csproj
+++ b/seed/csharp-sdk/idempotency-headers/src/SeedIdempotencyHeaders.Test/SeedIdempotencyHeaders.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="1.25.0" />
+    <PackageReference Include="WireMock.Net" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/imdb/exception-class-names/src/SeedApi.Test/SeedApi.Test.csproj
+++ b/seed/csharp-sdk/imdb/exception-class-names/src/SeedApi.Test/SeedApi.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.1.0" />
+    <PackageReference Include="WireMock.Net" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/imdb/exception-class-names/src/SeedApi.Test/SeedApi.Test.csproj
+++ b/seed/csharp-sdk/imdb/exception-class-names/src/SeedApi.Test/SeedApi.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="1.25.0" />
+    <PackageReference Include="WireMock.Net" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/imdb/exported-client-class-name/src/SeedApi.Test/SeedApi.Test.csproj
+++ b/seed/csharp-sdk/imdb/exported-client-class-name/src/SeedApi.Test/SeedApi.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.1.0" />
+    <PackageReference Include="WireMock.Net" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/imdb/exported-client-class-name/src/SeedApi.Test/SeedApi.Test.csproj
+++ b/seed/csharp-sdk/imdb/exported-client-class-name/src/SeedApi.Test/SeedApi.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="1.25.0" />
+    <PackageReference Include="WireMock.Net" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/imdb/extra-dependencies/src/SeedApi.Test/SeedApi.Test.csproj
+++ b/seed/csharp-sdk/imdb/extra-dependencies/src/SeedApi.Test/SeedApi.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.1.0" />
+    <PackageReference Include="WireMock.Net" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/imdb/extra-dependencies/src/SeedApi.Test/SeedApi.Test.csproj
+++ b/seed/csharp-sdk/imdb/extra-dependencies/src/SeedApi.Test/SeedApi.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="1.25.0" />
+    <PackageReference Include="WireMock.Net" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/imdb/include-exception-handler/src/SeedApi.Test/SeedApi.Test.csproj
+++ b/seed/csharp-sdk/imdb/include-exception-handler/src/SeedApi.Test/SeedApi.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.1.0" />
+    <PackageReference Include="WireMock.Net" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/imdb/include-exception-handler/src/SeedApi.Test/SeedApi.Test.csproj
+++ b/seed/csharp-sdk/imdb/include-exception-handler/src/SeedApi.Test/SeedApi.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="1.25.0" />
+    <PackageReference Include="WireMock.Net" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/imdb/no-custom-config/src/SeedApi.Test/SeedApi.Test.csproj
+++ b/seed/csharp-sdk/imdb/no-custom-config/src/SeedApi.Test/SeedApi.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.1.0" />
+    <PackageReference Include="WireMock.Net" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/imdb/no-custom-config/src/SeedApi.Test/SeedApi.Test.csproj
+++ b/seed/csharp-sdk/imdb/no-custom-config/src/SeedApi.Test/SeedApi.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="1.25.0" />
+    <PackageReference Include="WireMock.Net" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/imdb/omit-fern-headers/src/SeedApi.Test/SeedApi.Test.csproj
+++ b/seed/csharp-sdk/imdb/omit-fern-headers/src/SeedApi.Test/SeedApi.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.1.0" />
+    <PackageReference Include="WireMock.Net" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/imdb/omit-fern-headers/src/SeedApi.Test/SeedApi.Test.csproj
+++ b/seed/csharp-sdk/imdb/omit-fern-headers/src/SeedApi.Test/SeedApi.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="1.25.0" />
+    <PackageReference Include="WireMock.Net" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/inferred-auth-explicit/src/SeedInferredAuthExplicit.Test/SeedInferredAuthExplicit.Test.csproj
+++ b/seed/csharp-sdk/inferred-auth-explicit/src/SeedInferredAuthExplicit.Test/SeedInferredAuthExplicit.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.1.0" />
+    <PackageReference Include="WireMock.Net" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/inferred-auth-explicit/src/SeedInferredAuthExplicit.Test/SeedInferredAuthExplicit.Test.csproj
+++ b/seed/csharp-sdk/inferred-auth-explicit/src/SeedInferredAuthExplicit.Test/SeedInferredAuthExplicit.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="1.25.0" />
+    <PackageReference Include="WireMock.Net" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/inferred-auth-implicit-api-key/src/SeedInferredAuthImplicitApiKey.Test/SeedInferredAuthImplicitApiKey.Test.csproj
+++ b/seed/csharp-sdk/inferred-auth-implicit-api-key/src/SeedInferredAuthImplicitApiKey.Test/SeedInferredAuthImplicitApiKey.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.1.0" />
+    <PackageReference Include="WireMock.Net" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/inferred-auth-implicit-api-key/src/SeedInferredAuthImplicitApiKey.Test/SeedInferredAuthImplicitApiKey.Test.csproj
+++ b/seed/csharp-sdk/inferred-auth-implicit-api-key/src/SeedInferredAuthImplicitApiKey.Test/SeedInferredAuthImplicitApiKey.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="1.25.0" />
+    <PackageReference Include="WireMock.Net" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/inferred-auth-implicit-no-expiry/src/SeedInferredAuthImplicitNoExpiry.Test/SeedInferredAuthImplicitNoExpiry.Test.csproj
+++ b/seed/csharp-sdk/inferred-auth-implicit-no-expiry/src/SeedInferredAuthImplicitNoExpiry.Test/SeedInferredAuthImplicitNoExpiry.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.1.0" />
+    <PackageReference Include="WireMock.Net" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/inferred-auth-implicit-no-expiry/src/SeedInferredAuthImplicitNoExpiry.Test/SeedInferredAuthImplicitNoExpiry.Test.csproj
+++ b/seed/csharp-sdk/inferred-auth-implicit-no-expiry/src/SeedInferredAuthImplicitNoExpiry.Test/SeedInferredAuthImplicitNoExpiry.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="1.25.0" />
+    <PackageReference Include="WireMock.Net" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/inferred-auth-implicit-reference/src/SeedInferredAuthImplicit.Test/SeedInferredAuthImplicit.Test.csproj
+++ b/seed/csharp-sdk/inferred-auth-implicit-reference/src/SeedInferredAuthImplicit.Test/SeedInferredAuthImplicit.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.1.0" />
+    <PackageReference Include="WireMock.Net" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/inferred-auth-implicit-reference/src/SeedInferredAuthImplicit.Test/SeedInferredAuthImplicit.Test.csproj
+++ b/seed/csharp-sdk/inferred-auth-implicit-reference/src/SeedInferredAuthImplicit.Test/SeedInferredAuthImplicit.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="1.25.0" />
+    <PackageReference Include="WireMock.Net" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/inferred-auth-implicit/src/SeedInferredAuthImplicit.Test/SeedInferredAuthImplicit.Test.csproj
+++ b/seed/csharp-sdk/inferred-auth-implicit/src/SeedInferredAuthImplicit.Test/SeedInferredAuthImplicit.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.1.0" />
+    <PackageReference Include="WireMock.Net" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/inferred-auth-implicit/src/SeedInferredAuthImplicit.Test/SeedInferredAuthImplicit.Test.csproj
+++ b/seed/csharp-sdk/inferred-auth-implicit/src/SeedInferredAuthImplicit.Test/SeedInferredAuthImplicit.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="1.25.0" />
+    <PackageReference Include="WireMock.Net" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/license/custom-license/src/SeedLicense.Test/SeedLicense.Test.csproj
+++ b/seed/csharp-sdk/license/custom-license/src/SeedLicense.Test/SeedLicense.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.1.0" />
+    <PackageReference Include="WireMock.Net" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/license/custom-license/src/SeedLicense.Test/SeedLicense.Test.csproj
+++ b/seed/csharp-sdk/license/custom-license/src/SeedLicense.Test/SeedLicense.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="1.25.0" />
+    <PackageReference Include="WireMock.Net" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/license/mit-license/src/SeedLicense.Test/SeedLicense.Test.csproj
+++ b/seed/csharp-sdk/license/mit-license/src/SeedLicense.Test/SeedLicense.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.1.0" />
+    <PackageReference Include="WireMock.Net" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/license/mit-license/src/SeedLicense.Test/SeedLicense.Test.csproj
+++ b/seed/csharp-sdk/license/mit-license/src/SeedLicense.Test/SeedLicense.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="1.25.0" />
+    <PackageReference Include="WireMock.Net" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/literal/no-custom-config/src/SeedLiteral.Test/SeedLiteral.Test.csproj
+++ b/seed/csharp-sdk/literal/no-custom-config/src/SeedLiteral.Test/SeedLiteral.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.1.0" />
+    <PackageReference Include="WireMock.Net" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/literal/no-custom-config/src/SeedLiteral.Test/SeedLiteral.Test.csproj
+++ b/seed/csharp-sdk/literal/no-custom-config/src/SeedLiteral.Test/SeedLiteral.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="1.25.0" />
+    <PackageReference Include="WireMock.Net" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/literal/readonly-constants/src/SeedLiteral.Test/SeedLiteral.Test.csproj
+++ b/seed/csharp-sdk/literal/readonly-constants/src/SeedLiteral.Test/SeedLiteral.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.1.0" />
+    <PackageReference Include="WireMock.Net" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/literal/readonly-constants/src/SeedLiteral.Test/SeedLiteral.Test.csproj
+++ b/seed/csharp-sdk/literal/readonly-constants/src/SeedLiteral.Test/SeedLiteral.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="1.25.0" />
+    <PackageReference Include="WireMock.Net" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/literals-unions/src/SeedLiteralsUnions.Test/SeedLiteralsUnions.Test.csproj
+++ b/seed/csharp-sdk/literals-unions/src/SeedLiteralsUnions.Test/SeedLiteralsUnions.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.1.0" />
+    <PackageReference Include="WireMock.Net" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/literals-unions/src/SeedLiteralsUnions.Test/SeedLiteralsUnions.Test.csproj
+++ b/seed/csharp-sdk/literals-unions/src/SeedLiteralsUnions.Test/SeedLiteralsUnions.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="1.25.0" />
+    <PackageReference Include="WireMock.Net" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/mixed-case/src/SeedMixedCase.Test/SeedMixedCase.Test.csproj
+++ b/seed/csharp-sdk/mixed-case/src/SeedMixedCase.Test/SeedMixedCase.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.1.0" />
+    <PackageReference Include="WireMock.Net" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/mixed-case/src/SeedMixedCase.Test/SeedMixedCase.Test.csproj
+++ b/seed/csharp-sdk/mixed-case/src/SeedMixedCase.Test/SeedMixedCase.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="1.25.0" />
+    <PackageReference Include="WireMock.Net" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/mixed-file-directory/src/SeedMixedFileDirectory.Test/SeedMixedFileDirectory.Test.csproj
+++ b/seed/csharp-sdk/mixed-file-directory/src/SeedMixedFileDirectory.Test/SeedMixedFileDirectory.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.1.0" />
+    <PackageReference Include="WireMock.Net" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/mixed-file-directory/src/SeedMixedFileDirectory.Test/SeedMixedFileDirectory.Test.csproj
+++ b/seed/csharp-sdk/mixed-file-directory/src/SeedMixedFileDirectory.Test/SeedMixedFileDirectory.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="1.25.0" />
+    <PackageReference Include="WireMock.Net" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/multi-line-docs/src/SeedMultiLineDocs.Test/SeedMultiLineDocs.Test.csproj
+++ b/seed/csharp-sdk/multi-line-docs/src/SeedMultiLineDocs.Test/SeedMultiLineDocs.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.1.0" />
+    <PackageReference Include="WireMock.Net" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/multi-line-docs/src/SeedMultiLineDocs.Test/SeedMultiLineDocs.Test.csproj
+++ b/seed/csharp-sdk/multi-line-docs/src/SeedMultiLineDocs.Test/SeedMultiLineDocs.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="1.25.0" />
+    <PackageReference Include="WireMock.Net" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/multi-url-environment-no-default/src/SeedMultiUrlEnvironmentNoDefault.Test/SeedMultiUrlEnvironmentNoDefault.Test.csproj
+++ b/seed/csharp-sdk/multi-url-environment-no-default/src/SeedMultiUrlEnvironmentNoDefault.Test/SeedMultiUrlEnvironmentNoDefault.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.1.0" />
+    <PackageReference Include="WireMock.Net" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/multi-url-environment-no-default/src/SeedMultiUrlEnvironmentNoDefault.Test/SeedMultiUrlEnvironmentNoDefault.Test.csproj
+++ b/seed/csharp-sdk/multi-url-environment-no-default/src/SeedMultiUrlEnvironmentNoDefault.Test/SeedMultiUrlEnvironmentNoDefault.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="1.25.0" />
+    <PackageReference Include="WireMock.Net" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/multi-url-environment/environment-class-name/src/SeedMultiUrlEnvironment.Test/SeedMultiUrlEnvironment.Test.csproj
+++ b/seed/csharp-sdk/multi-url-environment/environment-class-name/src/SeedMultiUrlEnvironment.Test/SeedMultiUrlEnvironment.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.1.0" />
+    <PackageReference Include="WireMock.Net" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/multi-url-environment/environment-class-name/src/SeedMultiUrlEnvironment.Test/SeedMultiUrlEnvironment.Test.csproj
+++ b/seed/csharp-sdk/multi-url-environment/environment-class-name/src/SeedMultiUrlEnvironment.Test/SeedMultiUrlEnvironment.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="1.25.0" />
+    <PackageReference Include="WireMock.Net" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/multi-url-environment/no-pascal-case-environments/src/SeedMultiUrlEnvironment.Test/SeedMultiUrlEnvironment.Test.csproj
+++ b/seed/csharp-sdk/multi-url-environment/no-pascal-case-environments/src/SeedMultiUrlEnvironment.Test/SeedMultiUrlEnvironment.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.1.0" />
+    <PackageReference Include="WireMock.Net" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/multi-url-environment/no-pascal-case-environments/src/SeedMultiUrlEnvironment.Test/SeedMultiUrlEnvironment.Test.csproj
+++ b/seed/csharp-sdk/multi-url-environment/no-pascal-case-environments/src/SeedMultiUrlEnvironment.Test/SeedMultiUrlEnvironment.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="1.25.0" />
+    <PackageReference Include="WireMock.Net" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/multiple-request-bodies/src/SeedApi.Test/SeedApi.Test.csproj
+++ b/seed/csharp-sdk/multiple-request-bodies/src/SeedApi.Test/SeedApi.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.1.0" />
+    <PackageReference Include="WireMock.Net" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/multiple-request-bodies/src/SeedApi.Test/SeedApi.Test.csproj
+++ b/seed/csharp-sdk/multiple-request-bodies/src/SeedApi.Test/SeedApi.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="1.25.0" />
+    <PackageReference Include="WireMock.Net" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/no-content-response/src/SeedApi.Test/SeedApi.Test.csproj
+++ b/seed/csharp-sdk/no-content-response/src/SeedApi.Test/SeedApi.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.1.0" />
+    <PackageReference Include="WireMock.Net" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/no-content-response/src/SeedApi.Test/SeedApi.Test.csproj
+++ b/seed/csharp-sdk/no-content-response/src/SeedApi.Test/SeedApi.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="1.25.0" />
+    <PackageReference Include="WireMock.Net" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/no-environment/src/SeedNoEnvironment.Test/SeedNoEnvironment.Test.csproj
+++ b/seed/csharp-sdk/no-environment/src/SeedNoEnvironment.Test/SeedNoEnvironment.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.1.0" />
+    <PackageReference Include="WireMock.Net" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/no-environment/src/SeedNoEnvironment.Test/SeedNoEnvironment.Test.csproj
+++ b/seed/csharp-sdk/no-environment/src/SeedNoEnvironment.Test/SeedNoEnvironment.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="1.25.0" />
+    <PackageReference Include="WireMock.Net" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/no-retries/src/SeedNoRetries.Test/SeedNoRetries.Test.csproj
+++ b/seed/csharp-sdk/no-retries/src/SeedNoRetries.Test/SeedNoRetries.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.1.0" />
+    <PackageReference Include="WireMock.Net" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/no-retries/src/SeedNoRetries.Test/SeedNoRetries.Test.csproj
+++ b/seed/csharp-sdk/no-retries/src/SeedNoRetries.Test/SeedNoRetries.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="1.25.0" />
+    <PackageReference Include="WireMock.Net" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/null-type/src/SeedApi.Test/SeedApi.Test.csproj
+++ b/seed/csharp-sdk/null-type/src/SeedApi.Test/SeedApi.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.1.0" />
+    <PackageReference Include="WireMock.Net" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/null-type/src/SeedApi.Test/SeedApi.Test.csproj
+++ b/seed/csharp-sdk/null-type/src/SeedApi.Test/SeedApi.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="1.25.0" />
+    <PackageReference Include="WireMock.Net" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/nullable-allof-extends/src/SeedApi.Test/SeedApi.Test.csproj
+++ b/seed/csharp-sdk/nullable-allof-extends/src/SeedApi.Test/SeedApi.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.1.0" />
+    <PackageReference Include="WireMock.Net" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/nullable-allof-extends/src/SeedApi.Test/SeedApi.Test.csproj
+++ b/seed/csharp-sdk/nullable-allof-extends/src/SeedApi.Test/SeedApi.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="1.25.0" />
+    <PackageReference Include="WireMock.Net" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/nullable-optional/explicit-nullable-optional/src/SeedNullableOptional.Test/SeedNullableOptional.Test.csproj
+++ b/seed/csharp-sdk/nullable-optional/explicit-nullable-optional/src/SeedNullableOptional.Test/SeedNullableOptional.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.1.0" />
+    <PackageReference Include="WireMock.Net" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/nullable-optional/explicit-nullable-optional/src/SeedNullableOptional.Test/SeedNullableOptional.Test.csproj
+++ b/seed/csharp-sdk/nullable-optional/explicit-nullable-optional/src/SeedNullableOptional.Test/SeedNullableOptional.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="1.25.0" />
+    <PackageReference Include="WireMock.Net" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/nullable-optional/no-custom-config/src/SeedNullableOptional.Test/SeedNullableOptional.Test.csproj
+++ b/seed/csharp-sdk/nullable-optional/no-custom-config/src/SeedNullableOptional.Test/SeedNullableOptional.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.1.0" />
+    <PackageReference Include="WireMock.Net" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/nullable-optional/no-custom-config/src/SeedNullableOptional.Test/SeedNullableOptional.Test.csproj
+++ b/seed/csharp-sdk/nullable-optional/no-custom-config/src/SeedNullableOptional.Test/SeedNullableOptional.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="1.25.0" />
+    <PackageReference Include="WireMock.Net" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/nullable-request-body/src/SeedApi.Test/SeedApi.Test.csproj
+++ b/seed/csharp-sdk/nullable-request-body/src/SeedApi.Test/SeedApi.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.1.0" />
+    <PackageReference Include="WireMock.Net" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/nullable-request-body/src/SeedApi.Test/SeedApi.Test.csproj
+++ b/seed/csharp-sdk/nullable-request-body/src/SeedApi.Test/SeedApi.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="1.25.0" />
+    <PackageReference Include="WireMock.Net" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/nullable/explicit-nullable-optional/src/SeedNullable.Test/SeedNullable.Test.csproj
+++ b/seed/csharp-sdk/nullable/explicit-nullable-optional/src/SeedNullable.Test/SeedNullable.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.1.0" />
+    <PackageReference Include="WireMock.Net" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/nullable/explicit-nullable-optional/src/SeedNullable.Test/SeedNullable.Test.csproj
+++ b/seed/csharp-sdk/nullable/explicit-nullable-optional/src/SeedNullable.Test/SeedNullable.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="1.25.0" />
+    <PackageReference Include="WireMock.Net" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/nullable/no-custom-config/src/SeedNullable.Test/SeedNullable.Test.csproj
+++ b/seed/csharp-sdk/nullable/no-custom-config/src/SeedNullable.Test/SeedNullable.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.1.0" />
+    <PackageReference Include="WireMock.Net" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/nullable/no-custom-config/src/SeedNullable.Test/SeedNullable.Test.csproj
+++ b/seed/csharp-sdk/nullable/no-custom-config/src/SeedNullable.Test/SeedNullable.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="1.25.0" />
+    <PackageReference Include="WireMock.Net" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/oauth-client-credentials-custom/src/SeedOauthClientCredentials.Test/SeedOauthClientCredentials.Test.csproj
+++ b/seed/csharp-sdk/oauth-client-credentials-custom/src/SeedOauthClientCredentials.Test/SeedOauthClientCredentials.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.1.0" />
+    <PackageReference Include="WireMock.Net" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/oauth-client-credentials-custom/src/SeedOauthClientCredentials.Test/SeedOauthClientCredentials.Test.csproj
+++ b/seed/csharp-sdk/oauth-client-credentials-custom/src/SeedOauthClientCredentials.Test/SeedOauthClientCredentials.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="1.25.0" />
+    <PackageReference Include="WireMock.Net" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/oauth-client-credentials-default/src/SeedOauthClientCredentialsDefault.Test/SeedOauthClientCredentialsDefault.Test.csproj
+++ b/seed/csharp-sdk/oauth-client-credentials-default/src/SeedOauthClientCredentialsDefault.Test/SeedOauthClientCredentialsDefault.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.1.0" />
+    <PackageReference Include="WireMock.Net" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/oauth-client-credentials-default/src/SeedOauthClientCredentialsDefault.Test/SeedOauthClientCredentialsDefault.Test.csproj
+++ b/seed/csharp-sdk/oauth-client-credentials-default/src/SeedOauthClientCredentialsDefault.Test/SeedOauthClientCredentialsDefault.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="1.25.0" />
+    <PackageReference Include="WireMock.Net" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/oauth-client-credentials-environment-variables/src/SeedOauthClientCredentialsEnvironmentVariables.Test/SeedOauthClientCredentialsEnvironmentVariables.Test.csproj
+++ b/seed/csharp-sdk/oauth-client-credentials-environment-variables/src/SeedOauthClientCredentialsEnvironmentVariables.Test/SeedOauthClientCredentialsEnvironmentVariables.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.1.0" />
+    <PackageReference Include="WireMock.Net" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/oauth-client-credentials-environment-variables/src/SeedOauthClientCredentialsEnvironmentVariables.Test/SeedOauthClientCredentialsEnvironmentVariables.Test.csproj
+++ b/seed/csharp-sdk/oauth-client-credentials-environment-variables/src/SeedOauthClientCredentialsEnvironmentVariables.Test/SeedOauthClientCredentialsEnvironmentVariables.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="1.25.0" />
+    <PackageReference Include="WireMock.Net" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/oauth-client-credentials-mandatory-auth/no-custom-config/src/SeedOauthClientCredentialsMandatoryAuth.Test/SeedOauthClientCredentialsMandatoryAuth.Test.csproj
+++ b/seed/csharp-sdk/oauth-client-credentials-mandatory-auth/no-custom-config/src/SeedOauthClientCredentialsMandatoryAuth.Test/SeedOauthClientCredentialsMandatoryAuth.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.1.0" />
+    <PackageReference Include="WireMock.Net" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/oauth-client-credentials-mandatory-auth/no-custom-config/src/SeedOauthClientCredentialsMandatoryAuth.Test/SeedOauthClientCredentialsMandatoryAuth.Test.csproj
+++ b/seed/csharp-sdk/oauth-client-credentials-mandatory-auth/no-custom-config/src/SeedOauthClientCredentialsMandatoryAuth.Test/SeedOauthClientCredentialsMandatoryAuth.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="1.25.0" />
+    <PackageReference Include="WireMock.Net" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/oauth-client-credentials-mandatory-auth/unified-client-options/src/SeedOauthClientCredentialsMandatoryAuth.Test/SeedOauthClientCredentialsMandatoryAuth.Test.csproj
+++ b/seed/csharp-sdk/oauth-client-credentials-mandatory-auth/unified-client-options/src/SeedOauthClientCredentialsMandatoryAuth.Test/SeedOauthClientCredentialsMandatoryAuth.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.1.0" />
+    <PackageReference Include="WireMock.Net" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/oauth-client-credentials-mandatory-auth/unified-client-options/src/SeedOauthClientCredentialsMandatoryAuth.Test/SeedOauthClientCredentialsMandatoryAuth.Test.csproj
+++ b/seed/csharp-sdk/oauth-client-credentials-mandatory-auth/unified-client-options/src/SeedOauthClientCredentialsMandatoryAuth.Test/SeedOauthClientCredentialsMandatoryAuth.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="1.25.0" />
+    <PackageReference Include="WireMock.Net" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/oauth-client-credentials-nested-root/src/SeedOauthClientCredentials.Test/SeedOauthClientCredentials.Test.csproj
+++ b/seed/csharp-sdk/oauth-client-credentials-nested-root/src/SeedOauthClientCredentials.Test/SeedOauthClientCredentials.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.1.0" />
+    <PackageReference Include="WireMock.Net" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/oauth-client-credentials-nested-root/src/SeedOauthClientCredentials.Test/SeedOauthClientCredentials.Test.csproj
+++ b/seed/csharp-sdk/oauth-client-credentials-nested-root/src/SeedOauthClientCredentials.Test/SeedOauthClientCredentials.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="1.25.0" />
+    <PackageReference Include="WireMock.Net" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/oauth-client-credentials-openapi/src/SeedApi.Test/SeedApi.Test.csproj
+++ b/seed/csharp-sdk/oauth-client-credentials-openapi/src/SeedApi.Test/SeedApi.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.1.0" />
+    <PackageReference Include="WireMock.Net" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/oauth-client-credentials-openapi/src/SeedApi.Test/SeedApi.Test.csproj
+++ b/seed/csharp-sdk/oauth-client-credentials-openapi/src/SeedApi.Test/SeedApi.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="1.25.0" />
+    <PackageReference Include="WireMock.Net" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/oauth-client-credentials-reference/src/SeedOauthClientCredentialsReference.Test/SeedOauthClientCredentialsReference.Test.csproj
+++ b/seed/csharp-sdk/oauth-client-credentials-reference/src/SeedOauthClientCredentialsReference.Test/SeedOauthClientCredentialsReference.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.1.0" />
+    <PackageReference Include="WireMock.Net" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/oauth-client-credentials-reference/src/SeedOauthClientCredentialsReference.Test/SeedOauthClientCredentialsReference.Test.csproj
+++ b/seed/csharp-sdk/oauth-client-credentials-reference/src/SeedOauthClientCredentialsReference.Test/SeedOauthClientCredentialsReference.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="1.25.0" />
+    <PackageReference Include="WireMock.Net" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/oauth-client-credentials-with-variables/src/SeedOauthClientCredentialsWithVariables.Test/SeedOauthClientCredentialsWithVariables.Test.csproj
+++ b/seed/csharp-sdk/oauth-client-credentials-with-variables/src/SeedOauthClientCredentialsWithVariables.Test/SeedOauthClientCredentialsWithVariables.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.1.0" />
+    <PackageReference Include="WireMock.Net" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/oauth-client-credentials-with-variables/src/SeedOauthClientCredentialsWithVariables.Test/SeedOauthClientCredentialsWithVariables.Test.csproj
+++ b/seed/csharp-sdk/oauth-client-credentials-with-variables/src/SeedOauthClientCredentialsWithVariables.Test/SeedOauthClientCredentialsWithVariables.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="1.25.0" />
+    <PackageReference Include="WireMock.Net" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/oauth-client-credentials/include-exception-handler/src/SeedOauthClientCredentials.Test/SeedOauthClientCredentials.Test.csproj
+++ b/seed/csharp-sdk/oauth-client-credentials/include-exception-handler/src/SeedOauthClientCredentials.Test/SeedOauthClientCredentials.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.1.0" />
+    <PackageReference Include="WireMock.Net" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/oauth-client-credentials/include-exception-handler/src/SeedOauthClientCredentials.Test/SeedOauthClientCredentials.Test.csproj
+++ b/seed/csharp-sdk/oauth-client-credentials/include-exception-handler/src/SeedOauthClientCredentials.Test/SeedOauthClientCredentials.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="1.25.0" />
+    <PackageReference Include="WireMock.Net" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/oauth-client-credentials/no-custom-config/src/SeedOauthClientCredentials.Test/SeedOauthClientCredentials.Test.csproj
+++ b/seed/csharp-sdk/oauth-client-credentials/no-custom-config/src/SeedOauthClientCredentials.Test/SeedOauthClientCredentials.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.1.0" />
+    <PackageReference Include="WireMock.Net" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/oauth-client-credentials/no-custom-config/src/SeedOauthClientCredentials.Test/SeedOauthClientCredentials.Test.csproj
+++ b/seed/csharp-sdk/oauth-client-credentials/no-custom-config/src/SeedOauthClientCredentials.Test/SeedOauthClientCredentials.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="1.25.0" />
+    <PackageReference Include="WireMock.Net" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/object/src/SeedObject.Test/SeedObject.Test.csproj
+++ b/seed/csharp-sdk/object/src/SeedObject.Test/SeedObject.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.1.0" />
+    <PackageReference Include="WireMock.Net" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/object/src/SeedObject.Test/SeedObject.Test.csproj
+++ b/seed/csharp-sdk/object/src/SeedObject.Test/SeedObject.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="1.25.0" />
+    <PackageReference Include="WireMock.Net" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/objects-with-imports/src/SeedObjectsWithImports.Test/SeedObjectsWithImports.Test.csproj
+++ b/seed/csharp-sdk/objects-with-imports/src/SeedObjectsWithImports.Test/SeedObjectsWithImports.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.1.0" />
+    <PackageReference Include="WireMock.Net" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/objects-with-imports/src/SeedObjectsWithImports.Test/SeedObjectsWithImports.Test.csproj
+++ b/seed/csharp-sdk/objects-with-imports/src/SeedObjectsWithImports.Test/SeedObjectsWithImports.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="1.25.0" />
+    <PackageReference Include="WireMock.Net" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/optional/no-custom-config/src/SeedObjectsWithImports.Test/SeedObjectsWithImports.Test.csproj
+++ b/seed/csharp-sdk/optional/no-custom-config/src/SeedObjectsWithImports.Test/SeedObjectsWithImports.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.1.0" />
+    <PackageReference Include="WireMock.Net" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/optional/no-custom-config/src/SeedObjectsWithImports.Test/SeedObjectsWithImports.Test.csproj
+++ b/seed/csharp-sdk/optional/no-custom-config/src/SeedObjectsWithImports.Test/SeedObjectsWithImports.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="1.25.0" />
+    <PackageReference Include="WireMock.Net" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/optional/simplify-object-dictionaries/src/SeedObjectsWithImports.Test/SeedObjectsWithImports.Test.csproj
+++ b/seed/csharp-sdk/optional/simplify-object-dictionaries/src/SeedObjectsWithImports.Test/SeedObjectsWithImports.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.1.0" />
+    <PackageReference Include="WireMock.Net" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/optional/simplify-object-dictionaries/src/SeedObjectsWithImports.Test/SeedObjectsWithImports.Test.csproj
+++ b/seed/csharp-sdk/optional/simplify-object-dictionaries/src/SeedObjectsWithImports.Test/SeedObjectsWithImports.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="1.25.0" />
+    <PackageReference Include="WireMock.Net" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/package-yml/src/SeedPackageYml.Test/SeedPackageYml.Test.csproj
+++ b/seed/csharp-sdk/package-yml/src/SeedPackageYml.Test/SeedPackageYml.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.1.0" />
+    <PackageReference Include="WireMock.Net" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/package-yml/src/SeedPackageYml.Test/SeedPackageYml.Test.csproj
+++ b/seed/csharp-sdk/package-yml/src/SeedPackageYml.Test/SeedPackageYml.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="1.25.0" />
+    <PackageReference Include="WireMock.Net" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/pagination-custom/src/SeedPagination.Test/SeedPagination.Test.csproj
+++ b/seed/csharp-sdk/pagination-custom/src/SeedPagination.Test/SeedPagination.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.1.0" />
+    <PackageReference Include="WireMock.Net" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/pagination-custom/src/SeedPagination.Test/SeedPagination.Test.csproj
+++ b/seed/csharp-sdk/pagination-custom/src/SeedPagination.Test/SeedPagination.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="1.25.0" />
+    <PackageReference Include="WireMock.Net" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/pagination-uri-path/src/SeedPaginationUriPath.Test/SeedPaginationUriPath.Test.csproj
+++ b/seed/csharp-sdk/pagination-uri-path/src/SeedPaginationUriPath.Test/SeedPaginationUriPath.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.1.0" />
+    <PackageReference Include="WireMock.Net" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/pagination-uri-path/src/SeedPaginationUriPath.Test/SeedPaginationUriPath.Test.csproj
+++ b/seed/csharp-sdk/pagination-uri-path/src/SeedPaginationUriPath.Test/SeedPaginationUriPath.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="1.25.0" />
+    <PackageReference Include="WireMock.Net" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/pagination/custom-pager-with-exception-handler/src/SeedPagination.Test/SeedPagination.Test.csproj
+++ b/seed/csharp-sdk/pagination/custom-pager-with-exception-handler/src/SeedPagination.Test/SeedPagination.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.1.0" />
+    <PackageReference Include="WireMock.Net" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/pagination/custom-pager-with-exception-handler/src/SeedPagination.Test/SeedPagination.Test.csproj
+++ b/seed/csharp-sdk/pagination/custom-pager-with-exception-handler/src/SeedPagination.Test/SeedPagination.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="1.25.0" />
+    <PackageReference Include="WireMock.Net" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/pagination/custom-pager/src/SeedPagination.Test/SeedPagination.Test.csproj
+++ b/seed/csharp-sdk/pagination/custom-pager/src/SeedPagination.Test/SeedPagination.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.1.0" />
+    <PackageReference Include="WireMock.Net" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/pagination/custom-pager/src/SeedPagination.Test/SeedPagination.Test.csproj
+++ b/seed/csharp-sdk/pagination/custom-pager/src/SeedPagination.Test/SeedPagination.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="1.25.0" />
+    <PackageReference Include="WireMock.Net" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/pagination/no-custom-config/src/SeedPagination.Test/SeedPagination.Test.csproj
+++ b/seed/csharp-sdk/pagination/no-custom-config/src/SeedPagination.Test/SeedPagination.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.1.0" />
+    <PackageReference Include="WireMock.Net" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/pagination/no-custom-config/src/SeedPagination.Test/SeedPagination.Test.csproj
+++ b/seed/csharp-sdk/pagination/no-custom-config/src/SeedPagination.Test/SeedPagination.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="1.25.0" />
+    <PackageReference Include="WireMock.Net" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/path-parameters/no-custom-config/src/SeedPathParameters.Test/SeedPathParameters.Test.csproj
+++ b/seed/csharp-sdk/path-parameters/no-custom-config/src/SeedPathParameters.Test/SeedPathParameters.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.1.0" />
+    <PackageReference Include="WireMock.Net" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/path-parameters/no-custom-config/src/SeedPathParameters.Test/SeedPathParameters.Test.csproj
+++ b/seed/csharp-sdk/path-parameters/no-custom-config/src/SeedPathParameters.Test/SeedPathParameters.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="1.25.0" />
+    <PackageReference Include="WireMock.Net" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/path-parameters/no-inline-path-parameters/src/SeedPathParameters.Test/SeedPathParameters.Test.csproj
+++ b/seed/csharp-sdk/path-parameters/no-inline-path-parameters/src/SeedPathParameters.Test/SeedPathParameters.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.1.0" />
+    <PackageReference Include="WireMock.Net" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/path-parameters/no-inline-path-parameters/src/SeedPathParameters.Test/SeedPathParameters.Test.csproj
+++ b/seed/csharp-sdk/path-parameters/no-inline-path-parameters/src/SeedPathParameters.Test/SeedPathParameters.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="1.25.0" />
+    <PackageReference Include="WireMock.Net" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/plain-text/src/SeedPlainText.Test/SeedPlainText.Test.csproj
+++ b/seed/csharp-sdk/plain-text/src/SeedPlainText.Test/SeedPlainText.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.1.0" />
+    <PackageReference Include="WireMock.Net" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/plain-text/src/SeedPlainText.Test/SeedPlainText.Test.csproj
+++ b/seed/csharp-sdk/plain-text/src/SeedPlainText.Test/SeedPlainText.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="1.25.0" />
+    <PackageReference Include="WireMock.Net" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/property-access/src/SeedPropertyAccess.Test/SeedPropertyAccess.Test.csproj
+++ b/seed/csharp-sdk/property-access/src/SeedPropertyAccess.Test/SeedPropertyAccess.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.1.0" />
+    <PackageReference Include="WireMock.Net" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/property-access/src/SeedPropertyAccess.Test/SeedPropertyAccess.Test.csproj
+++ b/seed/csharp-sdk/property-access/src/SeedPropertyAccess.Test/SeedPropertyAccess.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="1.25.0" />
+    <PackageReference Include="WireMock.Net" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/public-object/src/SeedPublicObject.Test/SeedPublicObject.Test.csproj
+++ b/seed/csharp-sdk/public-object/src/SeedPublicObject.Test/SeedPublicObject.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.1.0" />
+    <PackageReference Include="WireMock.Net" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/public-object/src/SeedPublicObject.Test/SeedPublicObject.Test.csproj
+++ b/seed/csharp-sdk/public-object/src/SeedPublicObject.Test/SeedPublicObject.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="1.25.0" />
+    <PackageReference Include="WireMock.Net" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/query-param-name-conflict/src/SeedApi.Test/SeedApi.Test.csproj
+++ b/seed/csharp-sdk/query-param-name-conflict/src/SeedApi.Test/SeedApi.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.1.0" />
+    <PackageReference Include="WireMock.Net" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/query-param-name-conflict/src/SeedApi.Test/SeedApi.Test.csproj
+++ b/seed/csharp-sdk/query-param-name-conflict/src/SeedApi.Test/SeedApi.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="1.25.0" />
+    <PackageReference Include="WireMock.Net" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/query-parameters-openapi-as-objects/src/SeedApi.Test/SeedApi.Test.csproj
+++ b/seed/csharp-sdk/query-parameters-openapi-as-objects/src/SeedApi.Test/SeedApi.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.1.0" />
+    <PackageReference Include="WireMock.Net" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/query-parameters-openapi-as-objects/src/SeedApi.Test/SeedApi.Test.csproj
+++ b/seed/csharp-sdk/query-parameters-openapi-as-objects/src/SeedApi.Test/SeedApi.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="1.25.0" />
+    <PackageReference Include="WireMock.Net" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/query-parameters-openapi/src/SeedApi.Test/SeedApi.Test.csproj
+++ b/seed/csharp-sdk/query-parameters-openapi/src/SeedApi.Test/SeedApi.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.1.0" />
+    <PackageReference Include="WireMock.Net" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/query-parameters-openapi/src/SeedApi.Test/SeedApi.Test.csproj
+++ b/seed/csharp-sdk/query-parameters-openapi/src/SeedApi.Test/SeedApi.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="1.25.0" />
+    <PackageReference Include="WireMock.Net" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/query-parameters/src/SeedQueryParameters.Test/SeedQueryParameters.Test.csproj
+++ b/seed/csharp-sdk/query-parameters/src/SeedQueryParameters.Test/SeedQueryParameters.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.1.0" />
+    <PackageReference Include="WireMock.Net" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/query-parameters/src/SeedQueryParameters.Test/SeedQueryParameters.Test.csproj
+++ b/seed/csharp-sdk/query-parameters/src/SeedQueryParameters.Test/SeedQueryParameters.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="1.25.0" />
+    <PackageReference Include="WireMock.Net" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/request-parameters/no-custom-config/src/SeedRequestParameters.Test/SeedRequestParameters.Test.csproj
+++ b/seed/csharp-sdk/request-parameters/no-custom-config/src/SeedRequestParameters.Test/SeedRequestParameters.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.1.0" />
+    <PackageReference Include="WireMock.Net" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/request-parameters/no-custom-config/src/SeedRequestParameters.Test/SeedRequestParameters.Test.csproj
+++ b/seed/csharp-sdk/request-parameters/no-custom-config/src/SeedRequestParameters.Test/SeedRequestParameters.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="1.25.0" />
+    <PackageReference Include="WireMock.Net" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/request-parameters/with-defaults/src/SeedRequestParameters.Test/SeedRequestParameters.Test.csproj
+++ b/seed/csharp-sdk/request-parameters/with-defaults/src/SeedRequestParameters.Test/SeedRequestParameters.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.1.0" />
+    <PackageReference Include="WireMock.Net" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/request-parameters/with-defaults/src/SeedRequestParameters.Test/SeedRequestParameters.Test.csproj
+++ b/seed/csharp-sdk/request-parameters/with-defaults/src/SeedRequestParameters.Test/SeedRequestParameters.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="1.25.0" />
+    <PackageReference Include="WireMock.Net" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/required-nullable/explicit-nullable-optional/src/SeedApi.Test/SeedApi.Test.csproj
+++ b/seed/csharp-sdk/required-nullable/explicit-nullable-optional/src/SeedApi.Test/SeedApi.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.1.0" />
+    <PackageReference Include="WireMock.Net" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/required-nullable/explicit-nullable-optional/src/SeedApi.Test/SeedApi.Test.csproj
+++ b/seed/csharp-sdk/required-nullable/explicit-nullable-optional/src/SeedApi.Test/SeedApi.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="1.25.0" />
+    <PackageReference Include="WireMock.Net" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/required-nullable/no-custom-config/src/SeedApi.Test/SeedApi.Test.csproj
+++ b/seed/csharp-sdk/required-nullable/no-custom-config/src/SeedApi.Test/SeedApi.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.1.0" />
+    <PackageReference Include="WireMock.Net" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/required-nullable/no-custom-config/src/SeedApi.Test/SeedApi.Test.csproj
+++ b/seed/csharp-sdk/required-nullable/no-custom-config/src/SeedApi.Test/SeedApi.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="1.25.0" />
+    <PackageReference Include="WireMock.Net" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/reserved-keywords/src/SeedNurseryApi.Test/SeedNurseryApi.Test.csproj
+++ b/seed/csharp-sdk/reserved-keywords/src/SeedNurseryApi.Test/SeedNurseryApi.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.1.0" />
+    <PackageReference Include="WireMock.Net" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/reserved-keywords/src/SeedNurseryApi.Test/SeedNurseryApi.Test.csproj
+++ b/seed/csharp-sdk/reserved-keywords/src/SeedNurseryApi.Test/SeedNurseryApi.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="1.25.0" />
+    <PackageReference Include="WireMock.Net" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/response-property/src/SeedResponseProperty.Test/SeedResponseProperty.Test.csproj
+++ b/seed/csharp-sdk/response-property/src/SeedResponseProperty.Test/SeedResponseProperty.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.1.0" />
+    <PackageReference Include="WireMock.Net" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/response-property/src/SeedResponseProperty.Test/SeedResponseProperty.Test.csproj
+++ b/seed/csharp-sdk/response-property/src/SeedResponseProperty.Test/SeedResponseProperty.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="1.25.0" />
+    <PackageReference Include="WireMock.Net" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/server-sent-event-examples/src/SeedServerSentEvents.Test/SeedServerSentEvents.Test.csproj
+++ b/seed/csharp-sdk/server-sent-event-examples/src/SeedServerSentEvents.Test/SeedServerSentEvents.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.1.0" />
+    <PackageReference Include="WireMock.Net" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/server-sent-event-examples/src/SeedServerSentEvents.Test/SeedServerSentEvents.Test.csproj
+++ b/seed/csharp-sdk/server-sent-event-examples/src/SeedServerSentEvents.Test/SeedServerSentEvents.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="1.25.0" />
+    <PackageReference Include="WireMock.Net" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/server-sent-events-openapi/src/SeedApi.Test/SeedApi.Test.csproj
+++ b/seed/csharp-sdk/server-sent-events-openapi/src/SeedApi.Test/SeedApi.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.1.0" />
+    <PackageReference Include="WireMock.Net" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/server-sent-events-openapi/src/SeedApi.Test/SeedApi.Test.csproj
+++ b/seed/csharp-sdk/server-sent-events-openapi/src/SeedApi.Test/SeedApi.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="1.25.0" />
+    <PackageReference Include="WireMock.Net" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/server-sent-events/src/SeedServerSentEvents.Test/SeedServerSentEvents.Test.csproj
+++ b/seed/csharp-sdk/server-sent-events/src/SeedServerSentEvents.Test/SeedServerSentEvents.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.1.0" />
+    <PackageReference Include="WireMock.Net" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/server-sent-events/src/SeedServerSentEvents.Test/SeedServerSentEvents.Test.csproj
+++ b/seed/csharp-sdk/server-sent-events/src/SeedServerSentEvents.Test/SeedServerSentEvents.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="1.25.0" />
+    <PackageReference Include="WireMock.Net" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/server-url-templating/src/SeedApi.Test/SeedApi.Test.csproj
+++ b/seed/csharp-sdk/server-url-templating/src/SeedApi.Test/SeedApi.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.1.0" />
+    <PackageReference Include="WireMock.Net" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/server-url-templating/src/SeedApi.Test/SeedApi.Test.csproj
+++ b/seed/csharp-sdk/server-url-templating/src/SeedApi.Test/SeedApi.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="1.25.0" />
+    <PackageReference Include="WireMock.Net" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/simple-api/custom-output-path-object/test/SeedApi.Test/SeedSimpleApi.Test/SeedSimpleApi.Test.csproj
+++ b/seed/csharp-sdk/simple-api/custom-output-path-object/test/SeedApi.Test/SeedSimpleApi.Test/SeedSimpleApi.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.1.0" />
+    <PackageReference Include="WireMock.Net" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/simple-api/custom-output-path-object/test/SeedApi.Test/SeedSimpleApi.Test/SeedSimpleApi.Test.csproj
+++ b/seed/csharp-sdk/simple-api/custom-output-path-object/test/SeedApi.Test/SeedSimpleApi.Test/SeedSimpleApi.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="1.25.0" />
+    <PackageReference Include="WireMock.Net" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/simple-api/custom-output-path/custom-src/SeedSimpleApi.Test/SeedSimpleApi.Test.csproj
+++ b/seed/csharp-sdk/simple-api/custom-output-path/custom-src/SeedSimpleApi.Test/SeedSimpleApi.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.1.0" />
+    <PackageReference Include="WireMock.Net" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/simple-api/custom-output-path/custom-src/SeedSimpleApi.Test/SeedSimpleApi.Test.csproj
+++ b/seed/csharp-sdk/simple-api/custom-output-path/custom-src/SeedSimpleApi.Test/SeedSimpleApi.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="1.25.0" />
+    <PackageReference Include="WireMock.Net" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/simple-api/no-custom-config/src/SeedSimpleApi.Test/SeedSimpleApi.Test.csproj
+++ b/seed/csharp-sdk/simple-api/no-custom-config/src/SeedSimpleApi.Test/SeedSimpleApi.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.1.0" />
+    <PackageReference Include="WireMock.Net" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/simple-api/no-custom-config/src/SeedSimpleApi.Test/SeedSimpleApi.Test.csproj
+++ b/seed/csharp-sdk/simple-api/no-custom-config/src/SeedSimpleApi.Test/SeedSimpleApi.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="1.25.0" />
+    <PackageReference Include="WireMock.Net" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/simple-api/use-sln-format/src/SeedSimpleApi.Test/SeedSimpleApi.Test.csproj
+++ b/seed/csharp-sdk/simple-api/use-sln-format/src/SeedSimpleApi.Test/SeedSimpleApi.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.1.0" />
+    <PackageReference Include="WireMock.Net" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/simple-api/use-sln-format/src/SeedSimpleApi.Test/SeedSimpleApi.Test.csproj
+++ b/seed/csharp-sdk/simple-api/use-sln-format/src/SeedSimpleApi.Test/SeedSimpleApi.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="1.25.0" />
+    <PackageReference Include="WireMock.Net" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/simple-fhir/src/SeedApi.Test/SeedApi.Test.csproj
+++ b/seed/csharp-sdk/simple-fhir/src/SeedApi.Test/SeedApi.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.1.0" />
+    <PackageReference Include="WireMock.Net" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/simple-fhir/src/SeedApi.Test/SeedApi.Test.csproj
+++ b/seed/csharp-sdk/simple-fhir/src/SeedApi.Test/SeedApi.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="1.25.0" />
+    <PackageReference Include="WireMock.Net" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/single-url-environment-default/src/SeedSingleUrlEnvironmentDefault.Test/SeedSingleUrlEnvironmentDefault.Test.csproj
+++ b/seed/csharp-sdk/single-url-environment-default/src/SeedSingleUrlEnvironmentDefault.Test/SeedSingleUrlEnvironmentDefault.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.1.0" />
+    <PackageReference Include="WireMock.Net" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/single-url-environment-default/src/SeedSingleUrlEnvironmentDefault.Test/SeedSingleUrlEnvironmentDefault.Test.csproj
+++ b/seed/csharp-sdk/single-url-environment-default/src/SeedSingleUrlEnvironmentDefault.Test/SeedSingleUrlEnvironmentDefault.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="1.25.0" />
+    <PackageReference Include="WireMock.Net" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/single-url-environment-no-default/src/SeedSingleUrlEnvironmentNoDefault.Test/SeedSingleUrlEnvironmentNoDefault.Test.csproj
+++ b/seed/csharp-sdk/single-url-environment-no-default/src/SeedSingleUrlEnvironmentNoDefault.Test/SeedSingleUrlEnvironmentNoDefault.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.1.0" />
+    <PackageReference Include="WireMock.Net" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/single-url-environment-no-default/src/SeedSingleUrlEnvironmentNoDefault.Test/SeedSingleUrlEnvironmentNoDefault.Test.csproj
+++ b/seed/csharp-sdk/single-url-environment-no-default/src/SeedSingleUrlEnvironmentNoDefault.Test/SeedSingleUrlEnvironmentNoDefault.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="1.25.0" />
+    <PackageReference Include="WireMock.Net" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/streaming-parameter/src/SeedStreaming.Test/SeedStreaming.Test.csproj
+++ b/seed/csharp-sdk/streaming-parameter/src/SeedStreaming.Test/SeedStreaming.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.1.0" />
+    <PackageReference Include="WireMock.Net" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/streaming-parameter/src/SeedStreaming.Test/SeedStreaming.Test.csproj
+++ b/seed/csharp-sdk/streaming-parameter/src/SeedStreaming.Test/SeedStreaming.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="1.25.0" />
+    <PackageReference Include="WireMock.Net" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/streaming/no-custom-config/src/SeedStreaming.Test/SeedStreaming.Test.csproj
+++ b/seed/csharp-sdk/streaming/no-custom-config/src/SeedStreaming.Test/SeedStreaming.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.1.0" />
+    <PackageReference Include="WireMock.Net" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/streaming/no-custom-config/src/SeedStreaming.Test/SeedStreaming.Test.csproj
+++ b/seed/csharp-sdk/streaming/no-custom-config/src/SeedStreaming.Test/SeedStreaming.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="1.25.0" />
+    <PackageReference Include="WireMock.Net" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/streaming/redact-response-body-on-error/src/SeedStreaming.Test/SeedStreaming.Test.csproj
+++ b/seed/csharp-sdk/streaming/redact-response-body-on-error/src/SeedStreaming.Test/SeedStreaming.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.1.0" />
+    <PackageReference Include="WireMock.Net" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/streaming/redact-response-body-on-error/src/SeedStreaming.Test/SeedStreaming.Test.csproj
+++ b/seed/csharp-sdk/streaming/redact-response-body-on-error/src/SeedStreaming.Test/SeedStreaming.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="1.25.0" />
+    <PackageReference Include="WireMock.Net" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/trace/src/SeedTrace.Test/SeedTrace.Test.csproj
+++ b/seed/csharp-sdk/trace/src/SeedTrace.Test/SeedTrace.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.1.0" />
+    <PackageReference Include="WireMock.Net" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/trace/src/SeedTrace.Test/SeedTrace.Test.csproj
+++ b/seed/csharp-sdk/trace/src/SeedTrace.Test/SeedTrace.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="1.25.0" />
+    <PackageReference Include="WireMock.Net" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/undiscriminated-union-with-response-property/src/SeedUndiscriminatedUnionWithResponseProperty.Test/SeedUndiscriminatedUnionWithResponseProperty.Test.csproj
+++ b/seed/csharp-sdk/undiscriminated-union-with-response-property/src/SeedUndiscriminatedUnionWithResponseProperty.Test/SeedUndiscriminatedUnionWithResponseProperty.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.1.0" />
+    <PackageReference Include="WireMock.Net" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/undiscriminated-union-with-response-property/src/SeedUndiscriminatedUnionWithResponseProperty.Test/SeedUndiscriminatedUnionWithResponseProperty.Test.csproj
+++ b/seed/csharp-sdk/undiscriminated-union-with-response-property/src/SeedUndiscriminatedUnionWithResponseProperty.Test/SeedUndiscriminatedUnionWithResponseProperty.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="1.25.0" />
+    <PackageReference Include="WireMock.Net" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/undiscriminated-unions/no-custom-config/src/SeedUndiscriminatedUnions.Test/SeedUndiscriminatedUnions.Test.csproj
+++ b/seed/csharp-sdk/undiscriminated-unions/no-custom-config/src/SeedUndiscriminatedUnions.Test/SeedUndiscriminatedUnions.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.1.0" />
+    <PackageReference Include="WireMock.Net" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/undiscriminated-unions/no-custom-config/src/SeedUndiscriminatedUnions.Test/SeedUndiscriminatedUnions.Test.csproj
+++ b/seed/csharp-sdk/undiscriminated-unions/no-custom-config/src/SeedUndiscriminatedUnions.Test/SeedUndiscriminatedUnions.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="1.25.0" />
+    <PackageReference Include="WireMock.Net" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/undiscriminated-unions/with-undiscriminated-unions/src/SeedUndiscriminatedUnions.Test/SeedUndiscriminatedUnions.Test.csproj
+++ b/seed/csharp-sdk/undiscriminated-unions/with-undiscriminated-unions/src/SeedUndiscriminatedUnions.Test/SeedUndiscriminatedUnions.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.1.0" />
+    <PackageReference Include="WireMock.Net" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/undiscriminated-unions/with-undiscriminated-unions/src/SeedUndiscriminatedUnions.Test/SeedUndiscriminatedUnions.Test.csproj
+++ b/seed/csharp-sdk/undiscriminated-unions/with-undiscriminated-unions/src/SeedUndiscriminatedUnions.Test/SeedUndiscriminatedUnions.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="1.25.0" />
+    <PackageReference Include="WireMock.Net" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/unions-with-local-date/src/SeedUnions.Test/SeedUnions.Test.csproj
+++ b/seed/csharp-sdk/unions-with-local-date/src/SeedUnions.Test/SeedUnions.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.1.0" />
+    <PackageReference Include="WireMock.Net" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/unions-with-local-date/src/SeedUnions.Test/SeedUnions.Test.csproj
+++ b/seed/csharp-sdk/unions-with-local-date/src/SeedUnions.Test/SeedUnions.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="1.25.0" />
+    <PackageReference Include="WireMock.Net" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/unions/no-custom-config/src/SeedUnions.Test/SeedUnions.Test.csproj
+++ b/seed/csharp-sdk/unions/no-custom-config/src/SeedUnions.Test/SeedUnions.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.1.0" />
+    <PackageReference Include="WireMock.Net" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/unions/no-custom-config/src/SeedUnions.Test/SeedUnions.Test.csproj
+++ b/seed/csharp-sdk/unions/no-custom-config/src/SeedUnions.Test/SeedUnions.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="1.25.0" />
+    <PackageReference Include="WireMock.Net" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/unions/no-discriminated-unions/src/SeedUnions.Test/SeedUnions.Test.csproj
+++ b/seed/csharp-sdk/unions/no-discriminated-unions/src/SeedUnions.Test/SeedUnions.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.1.0" />
+    <PackageReference Include="WireMock.Net" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/unions/no-discriminated-unions/src/SeedUnions.Test/SeedUnions.Test.csproj
+++ b/seed/csharp-sdk/unions/no-discriminated-unions/src/SeedUnions.Test/SeedUnions.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="1.25.0" />
+    <PackageReference Include="WireMock.Net" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/unknown/src/SeedUnknownAsAny.Test/SeedUnknownAsAny.Test.csproj
+++ b/seed/csharp-sdk/unknown/src/SeedUnknownAsAny.Test/SeedUnknownAsAny.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.1.0" />
+    <PackageReference Include="WireMock.Net" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/unknown/src/SeedUnknownAsAny.Test/SeedUnknownAsAny.Test.csproj
+++ b/seed/csharp-sdk/unknown/src/SeedUnknownAsAny.Test/SeedUnknownAsAny.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="1.25.0" />
+    <PackageReference Include="WireMock.Net" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/url-form-encoded/no-custom-config/src/SeedApi.Test/SeedApi.Test.csproj
+++ b/seed/csharp-sdk/url-form-encoded/no-custom-config/src/SeedApi.Test/SeedApi.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.1.0" />
+    <PackageReference Include="WireMock.Net" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/url-form-encoded/no-custom-config/src/SeedApi.Test/SeedApi.Test.csproj
+++ b/seed/csharp-sdk/url-form-encoded/no-custom-config/src/SeedApi.Test/SeedApi.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="1.25.0" />
+    <PackageReference Include="WireMock.Net" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/validation/src/SeedValidation.Test/SeedValidation.Test.csproj
+++ b/seed/csharp-sdk/validation/src/SeedValidation.Test/SeedValidation.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.1.0" />
+    <PackageReference Include="WireMock.Net" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/validation/src/SeedValidation.Test/SeedValidation.Test.csproj
+++ b/seed/csharp-sdk/validation/src/SeedValidation.Test/SeedValidation.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="1.25.0" />
+    <PackageReference Include="WireMock.Net" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/variables/src/SeedVariables.Test/SeedVariables.Test.csproj
+++ b/seed/csharp-sdk/variables/src/SeedVariables.Test/SeedVariables.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.1.0" />
+    <PackageReference Include="WireMock.Net" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/variables/src/SeedVariables.Test/SeedVariables.Test.csproj
+++ b/seed/csharp-sdk/variables/src/SeedVariables.Test/SeedVariables.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="1.25.0" />
+    <PackageReference Include="WireMock.Net" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/version-no-default/src/SeedVersion.Test/SeedVersion.Test.csproj
+++ b/seed/csharp-sdk/version-no-default/src/SeedVersion.Test/SeedVersion.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.1.0" />
+    <PackageReference Include="WireMock.Net" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/version-no-default/src/SeedVersion.Test/SeedVersion.Test.csproj
+++ b/seed/csharp-sdk/version-no-default/src/SeedVersion.Test/SeedVersion.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="1.25.0" />
+    <PackageReference Include="WireMock.Net" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/version/src/SeedVersion.Test/SeedVersion.Test.csproj
+++ b/seed/csharp-sdk/version/src/SeedVersion.Test/SeedVersion.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.1.0" />
+    <PackageReference Include="WireMock.Net" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/version/src/SeedVersion.Test/SeedVersion.Test.csproj
+++ b/seed/csharp-sdk/version/src/SeedVersion.Test/SeedVersion.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="1.25.0" />
+    <PackageReference Include="WireMock.Net" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/webhook-audience/src/SeedApi.Test/SeedApi.Test.csproj
+++ b/seed/csharp-sdk/webhook-audience/src/SeedApi.Test/SeedApi.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.1.0" />
+    <PackageReference Include="WireMock.Net" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/webhook-audience/src/SeedApi.Test/SeedApi.Test.csproj
+++ b/seed/csharp-sdk/webhook-audience/src/SeedApi.Test/SeedApi.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="1.25.0" />
+    <PackageReference Include="WireMock.Net" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/webhooks/src/SeedWebhooks.Test/SeedWebhooks.Test.csproj
+++ b/seed/csharp-sdk/webhooks/src/SeedWebhooks.Test/SeedWebhooks.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.1.0" />
+    <PackageReference Include="WireMock.Net" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/webhooks/src/SeedWebhooks.Test/SeedWebhooks.Test.csproj
+++ b/seed/csharp-sdk/webhooks/src/SeedWebhooks.Test/SeedWebhooks.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="1.25.0" />
+    <PackageReference Include="WireMock.Net" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/websocket-bearer-auth/src/SeedWebsocketBearerAuth.Test/SeedWebsocketBearerAuth.Test.csproj
+++ b/seed/csharp-sdk/websocket-bearer-auth/src/SeedWebsocketBearerAuth.Test/SeedWebsocketBearerAuth.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.1.0" />
+    <PackageReference Include="WireMock.Net" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/websocket-bearer-auth/src/SeedWebsocketBearerAuth.Test/SeedWebsocketBearerAuth.Test.csproj
+++ b/seed/csharp-sdk/websocket-bearer-auth/src/SeedWebsocketBearerAuth.Test/SeedWebsocketBearerAuth.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="1.25.0" />
+    <PackageReference Include="WireMock.Net" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/websocket-inferred-auth/src/SeedWebsocketAuth.Test/SeedWebsocketAuth.Test.csproj
+++ b/seed/csharp-sdk/websocket-inferred-auth/src/SeedWebsocketAuth.Test/SeedWebsocketAuth.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.1.0" />
+    <PackageReference Include="WireMock.Net" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/websocket-inferred-auth/src/SeedWebsocketAuth.Test/SeedWebsocketAuth.Test.csproj
+++ b/seed/csharp-sdk/websocket-inferred-auth/src/SeedWebsocketAuth.Test/SeedWebsocketAuth.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="1.25.0" />
+    <PackageReference Include="WireMock.Net" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/websocket-multi-url/no-custom-config/src/SeedWebsocketMultiUrl.Test/SeedWebsocketMultiUrl.Test.csproj
+++ b/seed/csharp-sdk/websocket-multi-url/no-custom-config/src/SeedWebsocketMultiUrl.Test/SeedWebsocketMultiUrl.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.1.0" />
+    <PackageReference Include="WireMock.Net" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/websocket-multi-url/no-custom-config/src/SeedWebsocketMultiUrl.Test/SeedWebsocketMultiUrl.Test.csproj
+++ b/seed/csharp-sdk/websocket-multi-url/no-custom-config/src/SeedWebsocketMultiUrl.Test/SeedWebsocketMultiUrl.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="1.25.0" />
+    <PackageReference Include="WireMock.Net" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/websocket/no-custom-config/src/SeedWebsocket.Test/SeedWebsocket.Test.csproj
+++ b/seed/csharp-sdk/websocket/no-custom-config/src/SeedWebsocket.Test/SeedWebsocket.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.1.0" />
+    <PackageReference Include="WireMock.Net" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/websocket/no-custom-config/src/SeedWebsocket.Test/SeedWebsocket.Test.csproj
+++ b/seed/csharp-sdk/websocket/no-custom-config/src/SeedWebsocket.Test/SeedWebsocket.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="1.25.0" />
+    <PackageReference Include="WireMock.Net" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/websocket/with-websockets/src/SeedWebsocket.Test/SeedWebsocket.Test.csproj
+++ b/seed/csharp-sdk/websocket/with-websockets/src/SeedWebsocket.Test/SeedWebsocket.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="2.1.0" />
+    <PackageReference Include="WireMock.Net" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/seed/csharp-sdk/websocket/with-websockets/src/SeedWebsocket.Test/SeedWebsocket.Test.csproj
+++ b/seed/csharp-sdk/websocket/with-websockets/src/SeedWebsocket.Test/SeedWebsocket.Test.csproj
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="WireMock.Net" Version="1.25.0" />
+    <PackageReference Include="WireMock.Net" Version="2.1.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Description

Upgrade WireMock.Net to the latest version (2.2.0) in the C# SDK generator. This is a major version bump (1.x → 2.x) but is a **test-only dependency** — it does not affect the shipped SDK.

The 2.0 major version primarily dropped old TFMs (netstandard1.3, net4.5.x) and added configurable JSON serialization (System.Text.Json option). The core fluent API (`WireMockServer.Start()`, `Request.Create()`, `Response.Create()`) is unchanged, so no generated test code needed modification.

## Changes Made

- Bump `WireMock.Net` from `1.25.0` → `2.2.0` in `Template.Test.csproj` (the generator template)
- Bump `WireMock.Net` from `1.7.4` → `2.2.0` in `Dockerfile.csharp` (NuGet cache warmup)
- Sync `Dockerfile.csharp` cached test package versions to match `Template.Test.csproj`:
  - `Microsoft.NET.Test.Sdk`: 17.13.0 → 18.3.0
  - `NUnit`: 4.3.2 → 4.5.1
  - `NUnit3TestAdapter`: 5.0.0 → 6.2.0
  - `NUnit.Analyzers`: 4.6.0 → 4.12.0
  - `coverlet.collector`: 6.0.4 → 8.0.1
- Update 278 seed snapshot `.csproj` files to reflect the new WireMock version
- Add changelog entries in `versions.yml` for `csharp-sdk` (v2.55.3) and `csharp-model` (v0.8.5)

## Testing

- [x] CI seed tests passed (csharp-sdk and csharp-model)

## Review Checklist

- [ ] Confirm generated test code patterns (`WireMockServer.Start()`, `Request.Create()`, `Response.Create()`) remain compatible with WireMock.Net 2.x
- [ ] Verify `versions.yml` entries have correct version numbers and IR version
- [ ] Verify `Dockerfile.csharp` cached versions now match `Template.Test.csproj`

Link to Devin session: https://app.devin.ai/sessions/489af3c91d3340269667edc4b5229dfb
Requested by: @Swimburger