### PR TITLE
fix(go): Fix the model generator to no longer ignore configuration options

### DIFF
--- a/generators/go-v2/model/src/ModelGeneratorCli.ts
+++ b/generators/go-v2/model/src/ModelGeneratorCli.ts
@@ -22,6 +22,10 @@ export class ModelGeneratorCLI extends AbstractGoGeneratorCli<ModelCustomConfigS
     }
 
     protected parseCustomConfigOrThrow(customConfig: unknown): ModelCustomConfigSchema {
+        const parsed = customConfig != null ? ModelCustomConfigSchema.parse(customConfig) : undefined;
+        if (parsed != null) {
+            return parsed;
+        }
         return {};
     }
 

--- a/generators/go/model/versions.yml
+++ b/generators/go/model/versions.yml
@@ -1,4 +1,12 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 0.23.11
+  changelogEntry:
+    - summary: |
+        Fix the model generator to no longer ignore the configuration options.
+      type: fix
+  createdAt: "2026-04-01"
+  irVersion: 61
+  
 - version: 0.23.10
   changelogEntry:
     - summary: |


### PR DESCRIPTION
## Description
Fixes issue https://github.com/fern-api/fern/issues/14288

Currently the `go-v2` model generator does not respect configuration options which results in a `go.mod` and `go.sum` file being produced every time. This PR fixes this issue by parsing the configuration options in the generators/go-v2/model/src/ModelGeneratorCli.ts` `parseCustomConfigOrThrow` instead of always returning an empty object.

## Changes Made
- Updated the `parseCustomConfigOrThrow` method in `generators/go-v2/model/src/ModelGeneratorCli.ts` to enable parsing of the generators configuration options

## Testing
- No test changes made, tested locally with `pnpm seed run --generator go-model` against a local ir file and local generator configuration and `pnpm seed test --generator go-model`