### PR TITLE
chore(internal): Remove `npm install -g npm@latest` from CI workflows

### DIFF
--- a/.github/actions/install/action.yaml
+++ b/.github/actions/install/action.yaml
@@ -24,11 +24,6 @@ runs:
           ${{ runner.os }}-turbo-${{ github.job }}-
           ${{ runner.os }}-turbo-
 
-    # Ensure npm 11.5.1 or later is installed
-    - name: ⎔ Update npm
-      shell: bash
-      run: npm install -g npm@latest
-
     - name: 📥 Install dependencies
       shell: bash
       run: |

--- a/.github/workflows/ci-dynamic-snippets.yml
+++ b/.github/workflows/ci-dynamic-snippets.yml
@@ -34,9 +34,6 @@ jobs:
       - name: 📥 Install
         uses: ./.github/actions/install
 
-      - name: Update npm
-        run: npm install -g npm@latest
-
       - uses: bufbuild/buf-setup-action@v1.50.0
         with:
           github_token: ${{ github.token }}
@@ -63,9 +60,6 @@ jobs:
 
       - name: 📥 Install
         uses: ./.github/actions/install
-
-      - name: Update npm
-        run: npm install -g npm@latest
 
       - uses: bufbuild/buf-setup-action@v1.50.0
         with:
@@ -94,9 +88,6 @@ jobs:
       - name: 📥 Install
         uses: ./.github/actions/install
 
-      - name: Update npm
-        run: npm install -g npm@latest
-
       - uses: bufbuild/buf-setup-action@v1.50.0
         with:
           github_token: ${{ github.token }}
@@ -123,9 +114,6 @@ jobs:
 
       - name: 📥 Install
         uses: ./.github/actions/install
-
-      - name: Update npm
-        run: npm install -g npm@latest
 
       - uses: bufbuild/buf-setup-action@v1.50.0
         with:
@@ -154,9 +142,6 @@ jobs:
       - name: 📥 Install
         uses: ./.github/actions/install
 
-      - name: Update npm
-        run: npm install -g npm@latest
-
       - uses: bufbuild/buf-setup-action@v1.50.0
         with:
           github_token: ${{ github.token }}
@@ -183,9 +168,6 @@ jobs:
 
       - name: 📥 Install
         uses: ./.github/actions/install
-
-      - name: Update npm
-        run: npm install -g npm@latest
 
       - uses: bufbuild/buf-setup-action@v1.50.0
         with:
@@ -214,9 +196,6 @@ jobs:
       - name: 📥 Install
         uses: ./.github/actions/install
 
-      - name: Update npm
-        run: npm install -g npm@latest
-
       - uses: bufbuild/buf-setup-action@v1.50.0
         with:
           github_token: ${{ github.token }}
@@ -243,9 +222,6 @@ jobs:
 
       - name: 📥 Install
         uses: ./.github/actions/install
-
-      - name: Update npm
-        run: npm install -g npm@latest
 
       - uses: bufbuild/buf-setup-action@v1.50.0
         with:

--- a/.github/workflows/publish-generator-migrations.yml
+++ b/.github/workflows/publish-generator-migrations.yml
@@ -82,9 +82,6 @@ jobs:
       - name: Install
         uses: ./.github/actions/install
 
-      - name: Update npm
-        run: npm install -g npm@latest
-
       - name: Test packages
         run: |
           pnpm turbo run test --filter=@fern-api/migrations-base

--- a/.github/workflows/publish-snippets-core.yml
+++ b/.github/workflows/publish-snippets-core.yml
@@ -30,9 +30,6 @@ jobs:
       - name: 📥 Install
         uses: ./.github/actions/install
 
-      - name: Update npm
-        run: npm install -g npm@latest
-
       - uses: bufbuild/buf-setup-action@v1.50.0
         with:
           github_token: ${{ github.token }}


### PR DESCRIPTION
The npm OIDC support has been available long enough that recent runners already ship a compatible version. The explicit upgrade was breaking CI.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/14441" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
