### PR TITLE
feat(cli): add X-Deployer-Author header to docs registration

### DIFF
--- a/packages/cli/cli/src/commands/generate/generateDocsWorkspace.ts
+++ b/packages/cli/cli/src/commands/generate/generateDocsWorkspace.ts
@@ -10,7 +10,7 @@ import { runRemoteGenerationForDocsWorkspace } from "@fern-api/remote-workspace-
 import chalk from "chalk";
 
 import { CliContext } from "../../cli-context/CliContext.js";
-import { detectCISource, isCI } from "../../utils/environment.js";
+import { detectCISource, detectDeployerAuthor, isCI } from "../../utils/environment.js";
 import { validateDocsWorkspaceAndLogIssues } from "../validate/validateDocsWorkspaceAndLogIssues.js";
 
 const DOMAIN_SUFFIX = "docs.buildwithfern.com";
@@ -204,7 +204,8 @@ export async function generateDocsWorkspace({
             disableTemplates,
             skipUpload,
             cliVersion: cliContext.environment.packageVersion,
-            ciSource: detectCISource()
+            ciSource: detectCISource(),
+            deployerAuthor: detectDeployerAuthor()
         });
         const generationTime = performance.now() - generationStart;
         context.logger.debug(`Remote docs generation completed in ${generationTime.toFixed(0)}ms`);

--- a/packages/cli/cli/src/utils/__test__/environment.test.ts
+++ b/packages/cli/cli/src/utils/__test__/environment.test.ts
@@ -1,0 +1,71 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { detectDeployerAuthor } from "../environment.js";
+
+describe("detectDeployerAuthor", () => {
+    let originalEnv: NodeJS.ProcessEnv;
+
+    beforeEach(() => {
+        originalEnv = { ...process.env };
+        // Clear all CI-related env vars
+        delete process.env.GITHUB_ACTOR;
+        delete process.env.GITLAB_USER_LOGIN;
+        delete process.env.CIRCLE_USERNAME;
+        delete process.env.BUILD_REQUESTEDFOR;
+        delete process.env.GITLAB_USER_EMAIL;
+        delete process.env.BUILD_REQUESTEDFOREMAIL;
+    });
+
+    afterEach(() => {
+        process.env = originalEnv;
+    });
+
+    it("returns undefined when no CI env vars are set", () => {
+        expect(detectDeployerAuthor()).toBeUndefined();
+    });
+
+    it("detects GitHub Actions actor", () => {
+        process.env.GITHUB_ACTOR = "alice";
+        expect(detectDeployerAuthor()).toEqual({ username: "alice", email: undefined });
+    });
+
+    it("detects GitLab CI username and email", () => {
+        process.env.GITLAB_USER_LOGIN = "bob";
+        process.env.GITLAB_USER_EMAIL = "bob@example.com";
+        expect(detectDeployerAuthor()).toEqual({ username: "bob", email: "bob@example.com" });
+    });
+
+    it("detects CircleCI username", () => {
+        process.env.CIRCLE_USERNAME = "carol";
+        expect(detectDeployerAuthor()).toEqual({ username: "carol", email: undefined });
+    });
+
+    it("detects Azure DevOps username and email", () => {
+        process.env.BUILD_REQUESTEDFOR = "dave";
+        process.env.BUILD_REQUESTEDFOREMAIL = "dave@example.com";
+        expect(detectDeployerAuthor()).toEqual({ username: "dave", email: "dave@example.com" });
+    });
+
+    it("prefers GITHUB_ACTOR over other username vars", () => {
+        process.env.GITHUB_ACTOR = "alice";
+        process.env.GITLAB_USER_LOGIN = "bob";
+        expect(detectDeployerAuthor()?.username).toBe("alice");
+    });
+
+    it("prefers GITLAB_USER_EMAIL over BUILD_REQUESTEDFOREMAIL", () => {
+        process.env.GITLAB_USER_EMAIL = "gitlab@example.com";
+        process.env.BUILD_REQUESTEDFOREMAIL = "azure@example.com";
+        expect(detectDeployerAuthor()?.email).toBe("gitlab@example.com");
+    });
+
+    it("treats empty strings as absent", () => {
+        process.env.GITHUB_ACTOR = "";
+        process.env.GITLAB_USER_EMAIL = "";
+        expect(detectDeployerAuthor()).toBeUndefined();
+    });
+
+    it("returns email only when no username var is set", () => {
+        process.env.GITLAB_USER_EMAIL = "anon@example.com";
+        expect(detectDeployerAuthor()).toEqual({ username: undefined, email: "anon@example.com" });
+    });
+});

--- a/packages/cli/cli/src/utils/environment.ts
+++ b/packages/cli/cli/src/utils/environment.ts
@@ -58,6 +58,19 @@ export function detectCISource(): CISource | undefined {
 }
 
 /**
+ * Detects the deployer author from CI environment variables.
+ * Uses a fallback chain across CI providers. Returns undefined if no value is found.
+ */
+export function detectDeployerAuthor(): string | undefined {
+    const author =
+        process.env.GITHUB_ACTOR ??
+        process.env.GITLAB_USER_LOGIN ??
+        process.env.CIRCLE_USERNAME ??
+        process.env.BUILD_REQUESTEDFOR;
+    return author != null && author.length > 0 ? author : undefined;
+}
+
+/**
  * Checks if the current process is running in a CI/CD environment
  * @returns true if running in any common CI/CD environment
  */

--- a/packages/cli/cli/src/utils/environment.ts
+++ b/packages/cli/cli/src/utils/environment.ts
@@ -57,17 +57,33 @@ export function detectCISource(): CISource | undefined {
     return undefined;
 }
 
+export interface DeployerAuthor {
+    username?: string;
+    email?: string;
+}
+
 /**
  * Detects the deployer author from CI environment variables.
- * Uses a fallback chain across CI providers. Returns undefined if no value is found.
+ * Username fallback: GITHUB_ACTOR → GITLAB_USER_LOGIN → CIRCLE_USERNAME → BUILD_REQUESTEDFOR
+ * Email fallback: GITLAB_USER_EMAIL → BUILD_REQUESTEDFOREMAIL
+ * Returns undefined when neither username nor email is found.
  */
-export function detectDeployerAuthor(): string | undefined {
-    const author =
+export function detectDeployerAuthor(): DeployerAuthor | undefined {
+    const username = nonEmpty(
         process.env.GITHUB_ACTOR ??
-        process.env.GITLAB_USER_LOGIN ??
-        process.env.CIRCLE_USERNAME ??
-        process.env.BUILD_REQUESTEDFOR;
-    return author != null && author.length > 0 ? author : undefined;
+            process.env.GITLAB_USER_LOGIN ??
+            process.env.CIRCLE_USERNAME ??
+            process.env.BUILD_REQUESTEDFOR
+    );
+    const email = nonEmpty(process.env.GITLAB_USER_EMAIL ?? process.env.BUILD_REQUESTEDFOREMAIL);
+    if (username == null && email == null) {
+        return undefined;
+    }
+    return { username, email };
+}
+
+function nonEmpty(value: string | undefined): string | undefined {
+    return value != null && value.length > 0 ? value : undefined;
 }
 
 /**

--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -1,4 +1,14 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 4.55.0
+  changelogEntry:
+    - summary: |
+        Send `X-Deployer-Author` and `X-Deployer-Author-Email` headers on docs
+        registration requests so CI-triggered deployments can be attributed to
+        the user who initiated the deploy.
+      type: feat
+  createdAt: "2026-04-01"
+  irVersion: 65
+
 - version: 4.54.1
   changelogEntry:
     - summary: |

--- a/packages/cli/generation/remote-generation/remote-workspace-runner/src/publishDocs.ts
+++ b/packages/cli/generation/remote-generation/remote-workspace-runner/src/publishDocs.ts
@@ -152,7 +152,7 @@ export async function publishDocs({
     docsUrl?: string;
     cliVersion?: string;
     ciSource?: CISource;
-    deployerAuthor?: string;
+    deployerAuthor?: { username?: string; email?: string };
 }): Promise<string> {
     const fdrOrigin = process.env.DEFAULT_FDR_ORIGIN ?? "https://registry.buildwithfern.com";
     const isAirGapped = await detectAirGappedMode(`${fdrOrigin}/health`, context.logger);
@@ -168,8 +168,11 @@ export async function publishDocs({
         headers["X-CI-Source"] = JSON.stringify(ciSource);
         context.logger.debug(`CI source detected: ${ciSource.type} (${ciSource.repo ?? "unknown repo"})`);
     }
-    if (deployerAuthor != null) {
-        headers["X-Deployer-Author"] = deployerAuthor;
+    if (deployerAuthor?.username != null) {
+        headers["X-Deployer-Author"] = deployerAuthor.username;
+    }
+    if (deployerAuthor?.email != null) {
+        headers["X-Deployer-Author-Email"] = deployerAuthor.email;
     }
     const fdr = createFdrService({
         token: token.value,

--- a/packages/cli/generation/remote-generation/remote-workspace-runner/src/publishDocs.ts
+++ b/packages/cli/generation/remote-generation/remote-workspace-runner/src/publishDocs.ts
@@ -129,7 +129,8 @@ export async function publishDocs({
     targetAudiences,
     docsUrl,
     cliVersion,
-    ciSource
+    ciSource,
+    deployerAuthor
 }: {
     token: FernToken;
     organization: string;
@@ -151,6 +152,7 @@ export async function publishDocs({
     docsUrl?: string;
     cliVersion?: string;
     ciSource?: CISource;
+    deployerAuthor?: string;
 }): Promise<string> {
     const fdrOrigin = process.env.DEFAULT_FDR_ORIGIN ?? "https://registry.buildwithfern.com";
     const isAirGapped = await detectAirGappedMode(`${fdrOrigin}/health`, context.logger);
@@ -165,6 +167,9 @@ export async function publishDocs({
     if (ciSource != null) {
         headers["X-CI-Source"] = JSON.stringify(ciSource);
         context.logger.debug(`CI source detected: ${ciSource.type} (${ciSource.repo ?? "unknown repo"})`);
+    }
+    if (deployerAuthor != null) {
+        headers["X-Deployer-Author"] = deployerAuthor;
     }
     const fdr = createFdrService({
         token: token.value,

--- a/packages/cli/generation/remote-generation/remote-workspace-runner/src/runRemoteGenerationForDocsWorkspace.ts
+++ b/packages/cli/generation/remote-generation/remote-workspace-runner/src/runRemoteGenerationForDocsWorkspace.ts
@@ -50,7 +50,7 @@ export async function runRemoteGenerationForDocsWorkspace({
     skipUpload: boolean | undefined;
     cliVersion?: string;
     ciSource?: CISource;
-    deployerAuthor?: string;
+    deployerAuthor?: { username?: string; email?: string };
 }): Promise<string | undefined> {
     // Substitute templated environment variables:
     // If substitute-env-vars is enabled, we'll attempt to read and replace the templated

--- a/packages/cli/generation/remote-generation/remote-workspace-runner/src/runRemoteGenerationForDocsWorkspace.ts
+++ b/packages/cli/generation/remote-generation/remote-workspace-runner/src/runRemoteGenerationForDocsWorkspace.ts
@@ -34,7 +34,8 @@ export async function runRemoteGenerationForDocsWorkspace({
     disableTemplates,
     skipUpload,
     cliVersion,
-    ciSource
+    ciSource,
+    deployerAuthor
 }: {
     organization: string;
     apiWorkspaces: AbstractAPIWorkspace<unknown>[];
@@ -49,6 +50,7 @@ export async function runRemoteGenerationForDocsWorkspace({
     skipUpload: boolean | undefined;
     cliVersion?: string;
     ciSource?: CISource;
+    deployerAuthor?: string;
 }): Promise<string | undefined> {
     // Substitute templated environment variables:
     // If substitute-env-vars is enabled, we'll attempt to read and replace the templated
@@ -134,7 +136,8 @@ export async function runRemoteGenerationForDocsWorkspace({
                     : undefined,
                 docsUrl: maybeInstance.url,
                 cliVersion,
-                ciSource
+                ciSource,
+                deployerAuthor
             });
 
         for (let attempt = 0; ; attempt++) {


### PR DESCRIPTION
## Summary

Sends two new headers on docs registration requests (`/v2/init` and `/preview/init`) so the platform can attribute CI-triggered deployments to a user:

- `X-Deployer-Author` — CI username
- `X-Deployer-Author-Email` — CI email (only available on some providers)

Companion to fern-api/fern-platform#9303, which adds `resolveDeploymentAuthor()` on the platform side.

## Context

Deployment history logs on the Docs overview page show who triggered each deploy. When a developer runs the CLI directly, the auth token already identifies them. But CI deployments use an org-level `FERN_TOKEN` that doesn't map to a user, so `createdBy` was always null.

## How it works

**CLI (this PR):** Detects the CI actor from environment variables and sends both username and email as separate headers.

**Platform (#9303):** `resolveDeploymentAuthor()` resolves the deployer with a 3-step fallback:
1. Email from auth token (works when a signed-in user runs the CLI directly)
2. `X-Deployer-Author-Email` header (CI email)
3. `X-Deployer-Author` header (CI username)

Email is preferred because it's matchable against Fern org members.

## What each CI provider gives us

| Provider | `X-Deployer-Author` (username) | `X-Deployer-Author-Email` (email) |
|---|---|---|
| GitHub Actions | `GITHUB_ACTOR` | *not available* |
| GitLab CI | `GITLAB_USER_LOGIN` | `GITLAB_USER_EMAIL` |
| CircleCI | `CIRCLE_USERNAME` | *not available* |
| Azure DevOps | `BUILD_REQUESTEDFOR` | `BUILD_REQUESTEDFOREMAIL` |
| Bitbucket / other | *not available* | *not available* |

## Fern user matching

| Scenario | Value resolved | Matches Fern user? |
|---|---|---|
| CLI run by signed-in user (no CI) | Email from auth token | Yes |
| GitLab CI / Azure DevOps | Email from header | Likely — if same email is in Fern org |
| GitHub Actions / CircleCI | Username only | **No** — can't match without email |
| Bitbucket / unknown CI | Nothing | No — `createdBy` stays null |

For GitHub/CircleCI, the platform would need to resolve usernames to Fern users (e.g. match GitHub username to a linked identity). That's a platform-side concern — the CLI is already sending everything the CI environment provides.

## Test plan

- [ ] Verify existing non-CI deployments still populate `createdBy` from auth (no behavior change)
- [ ] Set `GITHUB_ACTOR=testuser` locally, verify `X-Deployer-Author: testuser` is sent
- [ ] Set `GITLAB_USER_EMAIL=test@example.com` + `GITLAB_USER_LOGIN=testuser`, verify both headers sent
- [ ] Verify headers are absent when no CI env vars are set