### PR TITLE
feat(python): add aiohttp auto-detection to Python SDK generator

### DIFF
--- a/generators/python-v2/sdk/src/wire-tests/WireTestSetupGenerator.ts
+++ b/generators/python-v2/sdk/src/wire-tests/WireTestSetupGenerator.ts
@@ -466,6 +466,26 @@ def _is_xdist_worker(config: pytest.Config) -> bool:
     return hasattr(config, "workerinput")
 
 
+def _has_httpx_aiohttp() -> bool:
+    """Check if httpx_aiohttp is importable."""
+    try:
+        import httpx_aiohttp  # type: ignore[import-not-found]  # noqa: F401
+
+        return True
+    except ImportError:
+        return False
+
+
+def pytest_collection_modifyitems(config: pytest.Config, items: list) -> None:
+    """Auto-skip @pytest.mark.aiohttp tests when httpx_aiohttp is not installed."""
+    if _has_httpx_aiohttp():
+        return
+    skip_aiohttp = pytest.mark.skip(reason="httpx_aiohttp not installed")
+    for item in items:
+        if "aiohttp" in item.keywords:
+            item.add_marker(skip_aiohttp)
+
+
 def pytest_configure(config: pytest.Config) -> None:
     """
     Pytest hook that runs during test session setup.

--- a/generators/python/sdk/versions.yml
+++ b/generators/python/sdk/versions.yml
@@ -1,5 +1,17 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 # For unreleased changes, use unreleased.yml
+- version: 5.3.0
+  changelogEntry:
+    - summary: |
+        Add aiohttp auto-detection for async HTTP client. When `httpx_aiohttp` is installed,
+        the generated SDK automatically uses `HttpxAiohttpClient` for async operations instead
+        of the default `httpx.AsyncClient`. Adds `DefaultAioHttpClient` and `DefaultAsyncHttpxClient`
+        convenience classes, optional `[aiohttp]` extra in pyproject.toml, pytest markers for
+        aiohttp-specific tests, and two-pass CI testing (standard + aiohttp).
+      type: feat
+  createdAt: "2026-04-01"
+  irVersion: 65
+
 - version: 5.2.0
   changelogEntry:
     - summary: |

--- a/generators/python/src/fern_python/cli/abstract_generator.py
+++ b/generators/python/src/fern_python/cli/abstract_generator.py
@@ -386,6 +386,14 @@ jobs:
       - name: Test
         run: poetry run pytest -rP -n auto .
 """
+        # Add aiohttp extra install and test steps
+        workflow_yaml += """
+      - name: Install aiohttp extra
+        run: poetry install --extras aiohttp
+
+      - name: Test (aiohttp)
+        run: poetry run pytest -rP -n auto -m aiohttp .
+"""
         if output_mode.publish_info is not None:
             publish_info_union = output_mode.publish_info.get_as_union()
             if publish_info_union.type != "pypi":
@@ -477,6 +485,14 @@ jobs:
             workflow_yaml += """
       - name: Test
         run: poetry run pytest -rP -n auto .
+"""
+        # Add aiohttp extra install and test steps
+        workflow_yaml += """
+      - name: Install aiohttp extra
+        run: poetry install --extras aiohttp
+
+      - name: Test (aiohttp)
+        run: poetry run pytest -rP -n auto -m aiohttp .
 """
         if output_mode.publish_info is not None:
             publish_info_union = output_mode.publish_info.get_as_union()

--- a/generators/python/src/fern_python/codegen/pyproject_toml.py
+++ b/generators/python/src/fern_python/codegen/pyproject_toml.py
@@ -271,6 +271,9 @@ types-python-dateutil = "^2.9.0.20240316"
 [tool.pytest.ini_options]
 testpaths = [ "tests" ]
 asyncio_mode = "auto"
+markers = [
+    "aiohttp: tests that require httpx_aiohttp to be installed",
+]
 
 [tool.mypy]
 plugins = ["pydantic.mypy"]{mypy_exclude_config}

--- a/generators/python/src/fern_python/generators/sdk/client_generator/root_client_generator.py
+++ b/generators/python/src/fern_python/generators/sdk/client_generator/root_client_generator.py
@@ -205,6 +205,7 @@ class RootClientGenerator(BaseWrappedClientGenerator[RootClientConstructorParame
             declaration=class_declaration,
             should_export=False,
         )
+        source_file.add_arbitrary_code(AST.CodeWriter(self._write_make_default_async_client))
         source_file.add_class_declaration(
             declaration=async_class_declaration,
             should_export=False,
@@ -1431,6 +1432,23 @@ class RootClientGenerator(BaseWrappedClientGenerator[RootClientConstructorParame
                     ),
                 ),
             )
+        elif is_async:
+            client_wrapper_constructor_kwargs.append(
+                (
+                    ClientWrapperGenerator.HTTPX_CLIENT_MEMBER_NAME,
+                    AST.Expression(
+                        AST.ConditionalExpression(
+                            left=AST.Expression(f"{RootClientGenerator.HTTPX_CLIENT_CONSTRUCTOR_PARAMETER_NAME}"),
+                            right=AST.Expression(
+                                f"_make_default_async_client(timeout={timeout_local_variable}, follow_redirects={self.FOLLOW_REDIRECTS_CONSTRUCTOR_PARAMETER_NAME})"
+                            ),
+                            test=AST.Expression(
+                                f"{RootClientGenerator.HTTPX_CLIENT_CONSTRUCTOR_PARAMETER_NAME} is not None"
+                            ),
+                        ),
+                    ),
+                )
+            )
         else:
             client_wrapper_constructor_kwargs.append(
                 (
@@ -1440,11 +1458,11 @@ class RootClientGenerator(BaseWrappedClientGenerator[RootClientConstructorParame
                             left=AST.Expression(f"{RootClientGenerator.HTTPX_CLIENT_CONSTRUCTOR_PARAMETER_NAME}"),
                             right=AST.ConditionalExpression(
                                 left=AST.ClassInstantiation(
-                                    HttpX.ASYNC_CLIENT if is_async else HttpX.CLIENT,
+                                    HttpX.CLIENT,
                                     kwargs=httpx_client_kwargs_with_redirects,
                                 ),
                                 right=AST.ClassInstantiation(
-                                    HttpX.ASYNC_CLIENT if is_async else HttpX.CLIENT,
+                                    HttpX.CLIENT,
                                     kwargs=httpx_client_kwargs_without_redirects,
                                 ),
                                 test=AST.Expression(f"{self.FOLLOW_REDIRECTS_CONSTRUCTOR_PARAMETER_NAME} is not None"),
@@ -1479,6 +1497,35 @@ class RootClientGenerator(BaseWrappedClientGenerator[RootClientConstructorParame
             )
 
         return client_wrapper_constructor_kwargs
+
+    def _write_make_default_async_client(self, writer: AST.NodeWriter) -> None:
+        writer.write_line("")
+        writer.write_line("def _make_default_async_client(")
+        with writer.indent():
+            writer.write_line("timeout: typing.Optional[float],")
+            writer.write_line("follow_redirects: typing.Optional[bool],")
+        writer.write_line(") -> httpx.AsyncClient:")
+        with writer.indent():
+            writer.write_line("try:")
+            with writer.indent():
+                writer.write_line("import httpx_aiohttp  # type: ignore[import-not-found]")
+            writer.write_line("except ImportError:")
+            with writer.indent():
+                writer.write_line("pass")
+            writer.write_line("else:")
+            with writer.indent():
+                writer.write_line("if follow_redirects is not None:")
+                with writer.indent():
+                    writer.write_line(
+                        "return httpx_aiohttp.HttpxAiohttpClient(timeout=timeout, follow_redirects=follow_redirects)"
+                    )
+                writer.write_line("return httpx_aiohttp.HttpxAiohttpClient(timeout=timeout)")
+            writer.write_line("")
+            writer.write_line("if follow_redirects is not None:")
+            with writer.indent():
+                writer.write_line("return httpx.AsyncClient(timeout=timeout, follow_redirects=follow_redirects)")
+            writer.write_line("return httpx.AsyncClient(timeout=timeout)")
+        writer.write_line("")
 
     def _write_get_base_url_function(self, writer: AST.NodeWriter) -> None:
         writer.write_line(f"if {RootClientGenerator.BASE_URL_CONSTRUCTOR_PARAMETER_NAME} is not None:")

--- a/generators/python/src/fern_python/generators/sdk/sdk_generator.py
+++ b/generators/python/src/fern_python/generators/sdk/sdk_generator.py
@@ -118,7 +118,14 @@ class SdkGenerator(AbstractGenerator):
                     )
                 )
 
-        project.add_extra(custom_config.extras)
+        # Merge user-defined extras with the built-in aiohttp extra
+        extras = dict(custom_config.extras)
+        extras["aiohttp"] = ["aiohttp", "httpx-aiohttp"]
+        project.add_extra(extras)
+
+        # Add optional dependencies for aiohttp support
+        project.add_dependency(dependency=AST.Dependency(name="httpx-aiohttp", version="0.1.8", optional=True))
+        project.add_dependency(dependency=AST.Dependency(name="aiohttp", version="3.0", optional=True))
 
         for dep, bas_dep_value in custom_config.extra_dev_dependencies.items():
             if type(bas_dep_value) is str:
@@ -278,6 +285,18 @@ class SdkGenerator(AbstractGenerator):
                     ],
                 )
             ],
+        )
+
+        # Generate _default_clients.py with aiohttp auto-detection convenience classes
+        self._generate_default_clients(
+            context=context,
+            project=project,
+        )
+
+        # Generate test_aiohttp_autodetect.py test file
+        self._generate_aiohttp_test(
+            context=context,
+            project=project,
         )
 
         for subpackage_id in ir.subpackages.keys():
@@ -687,6 +706,179 @@ class SdkGenerator(AbstractGenerator):
         )
         ErrorGenerator(context=context, error=error).generate(source_file=source_file)
         project.write_source_file(source_file=source_file, filepath=filepath)
+
+    def _generate_aiohttp_test(
+        self,
+        context: SdkGeneratorContext,
+        project: Project,
+    ) -> None:
+        package_name = project._project_config.package_name if project._project_config is not None else "package"
+        contents = f'''import importlib
+import sys
+import unittest
+from unittest import mock
+
+import httpx
+import pytest
+
+
+class TestMakeDefaultAsyncClientWithoutAiohttp(unittest.TestCase):
+    """Tests for _make_default_async_client when httpx_aiohttp is NOT installed."""
+
+    def test_returns_httpx_async_client(self) -> None:
+        """When httpx_aiohttp is not installed, returns plain httpx.AsyncClient."""
+        with mock.patch.dict(sys.modules, {{"httpx_aiohttp": None}}):
+            from {package_name}.client import _make_default_async_client
+
+            client = _make_default_async_client(timeout=60, follow_redirects=True)
+            self.assertIsInstance(client, httpx.AsyncClient)
+            self.assertEqual(client.timeout.read, 60)
+            self.assertTrue(client.follow_redirects)
+
+    def test_follow_redirects_none(self) -> None:
+        """When follow_redirects is None, omits it from httpx.AsyncClient."""
+        with mock.patch.dict(sys.modules, {{"httpx_aiohttp": None}}):
+            from {package_name}.client import _make_default_async_client
+
+            client = _make_default_async_client(timeout=60, follow_redirects=None)
+            self.assertIsInstance(client, httpx.AsyncClient)
+            self.assertFalse(client.follow_redirects)
+
+    def test_explicit_httpx_client_bypasses_autodetect(self) -> None:
+        """When user passes httpx_client explicitly, auto-detect is not used."""
+        explicit_client = httpx.AsyncClient(timeout=60)
+        result = explicit_client if explicit_client is not None else None
+        self.assertIs(result, explicit_client)
+        self.assertEqual(result.timeout.read, 60)
+
+
+@pytest.mark.aiohttp
+class TestMakeDefaultAsyncClientWithAiohttp(unittest.TestCase):
+    """Tests for _make_default_async_client when httpx_aiohttp IS installed."""
+
+    def test_returns_aiohttp_client(self) -> None:
+        """When httpx_aiohttp is installed, returns HttpxAiohttpClient."""
+        import httpx_aiohttp  # type: ignore[import-not-found]
+
+        from {package_name}.client import _make_default_async_client
+
+        client = _make_default_async_client(timeout=60, follow_redirects=True)
+        self.assertIsInstance(client, httpx_aiohttp.HttpxAiohttpClient)
+        self.assertEqual(client.timeout.read, 60)
+        self.assertTrue(client.follow_redirects)
+
+    def test_follow_redirects_none(self) -> None:
+        """When httpx_aiohttp is installed and follow_redirects is None, omits it."""
+        import httpx_aiohttp  # type: ignore[import-not-found]
+
+        from {package_name}.client import _make_default_async_client
+
+        client = _make_default_async_client(timeout=60, follow_redirects=None)
+        self.assertIsInstance(client, httpx_aiohttp.HttpxAiohttpClient)
+        self.assertFalse(client.follow_redirects)
+
+
+class TestDefaultClientsWithoutAiohttp(unittest.TestCase):
+    """Tests for _default_clients.py convenience classes (no aiohttp)."""
+
+    def test_default_async_httpx_client_defaults(self) -> None:
+        """DefaultAsyncHttpxClient applies SDK defaults."""
+        from {package_name}._default_clients import SDK_DEFAULT_TIMEOUT, DefaultAsyncHttpxClient
+
+        client = DefaultAsyncHttpxClient()
+        self.assertIsInstance(client, httpx.AsyncClient)
+        self.assertEqual(client.timeout.read, SDK_DEFAULT_TIMEOUT)
+        self.assertTrue(client.follow_redirects)
+
+    def test_default_async_httpx_client_overrides(self) -> None:
+        """DefaultAsyncHttpxClient allows overriding defaults."""
+        from {package_name}._default_clients import DefaultAsyncHttpxClient
+
+        client = DefaultAsyncHttpxClient(timeout=30, follow_redirects=False)
+        self.assertEqual(client.timeout.read, 30)
+        self.assertFalse(client.follow_redirects)
+
+    def test_default_aiohttp_client_raises_without_package(self) -> None:
+        """DefaultAioHttpClient raises RuntimeError when httpx_aiohttp not installed."""
+        import {package_name}._default_clients
+
+        with mock.patch.dict(sys.modules, {{"httpx_aiohttp": None}}):
+            importlib.reload({package_name}._default_clients)
+
+            with self.assertRaises(RuntimeError) as ctx:
+                {package_name}._default_clients.DefaultAioHttpClient()
+            self.assertIn("pip install {package_name}[aiohttp]", str(ctx.exception))
+
+        importlib.reload({package_name}._default_clients)
+
+
+@pytest.mark.aiohttp
+class TestDefaultClientsWithAiohttp(unittest.TestCase):
+    """Tests for _default_clients.py when httpx_aiohttp IS installed."""
+
+    def test_default_aiohttp_client_defaults(self) -> None:
+        """DefaultAioHttpClient works when httpx_aiohttp is installed."""
+        import httpx_aiohttp  # type: ignore[import-not-found]
+
+        from {package_name}._default_clients import SDK_DEFAULT_TIMEOUT, DefaultAioHttpClient
+
+        client = DefaultAioHttpClient()
+        self.assertIsInstance(client, httpx_aiohttp.HttpxAiohttpClient)
+        self.assertEqual(client.timeout.read, SDK_DEFAULT_TIMEOUT)
+        self.assertTrue(client.follow_redirects)
+'''
+        project.add_source_file("tests/test_aiohttp_autodetect.py", contents)
+
+    def _generate_default_clients(
+        self,
+        context: SdkGeneratorContext,
+        project: Project,
+    ) -> None:
+        package_name = project._project_config.package_name if project._project_config is not None else "package"
+        filepath = Filepath(
+            directories=(),
+            file=Filepath.FilepathPart(module_name="_default_clients"),
+        )
+        filepath_nested = project.get_source_file_filepath(filepath, include_src_root=True)
+        contents = f"""# This file was auto-generated by Fern from our API Definition.
+
+import typing
+
+import httpx
+
+SDK_DEFAULT_TIMEOUT = 60
+
+try:
+    import httpx_aiohttp  # type: ignore[import-not-found]
+except ImportError:
+
+    class DefaultAioHttpClient(httpx.AsyncClient):  # type: ignore
+        def __init__(self, **kwargs: typing.Any) -> None:
+            raise RuntimeError(
+                "To use the aiohttp client, install the aiohttp extra: "
+                "pip install {package_name}[aiohttp]"
+            )
+
+else:
+
+    class DefaultAioHttpClient(httpx_aiohttp.HttpxAiohttpClient):  # type: ignore
+        def __init__(self, **kwargs: typing.Any) -> None:
+            kwargs.setdefault("timeout", SDK_DEFAULT_TIMEOUT)
+            kwargs.setdefault("follow_redirects", True)
+            super().__init__(**kwargs)
+
+
+class DefaultAsyncHttpxClient(httpx.AsyncClient):
+    def __init__(self, **kwargs: typing.Any) -> None:
+        kwargs.setdefault("timeout", SDK_DEFAULT_TIMEOUT)
+        kwargs.setdefault("follow_redirects", True)
+        super().__init__(**kwargs)
+"""
+        project.add_file(filepath_nested, contents)
+        project.register_export_in_project(
+            filepath_in_project=filepath,
+            exports={"DefaultAioHttpClient", "DefaultAsyncHttpxClient"},
+        )
 
     def _generate_version(
         self,


### PR DESCRIPTION
## Description

Refs https://github.com/fern-api/fern/pull/13586

Modifies the Python SDK generator so that generated SDKs automatically detect and use `httpx_aiohttp` for async HTTP operations when the package is installed, falling back to plain `httpx.AsyncClient` otherwise.

## Changes Made

### Generator changes (v1 Python)
- **`root_client_generator.py`**: Adds a `_make_default_async_client()` function between the sync and async client classes. The async client constructor now calls this function instead of directly instantiating `httpx.AsyncClient`. The sync client path is unchanged.
- **`sdk_generator.py`**: 
  - Generates `_default_clients.py` with `DefaultAioHttpClient` and `DefaultAsyncHttpxClient` convenience classes, exported from `__init__.py`
  - Generates `tests/test_aiohttp_autodetect.py` with test coverage for both with/without `httpx_aiohttp` scenarios
  - Adds `httpx-aiohttp` and `aiohttp` as optional dependencies and an `[aiohttp]` extra
- **`abstract_generator.py`**: Adds two-pass CI testing to both legacy and OIDC GitHub workflow templates (standard tests, then `poetry install --extras aiohttp` + aiohttp-marked tests)
- **`pyproject_toml.py`**: Adds `aiohttp` pytest marker configuration

### Generator changes (v2 TypeScript)
- **`WireTestSetupGenerator.ts`**: Adds `_has_httpx_aiohttp()` helper and `pytest_collection_modifyitems` hook to auto-skip `@pytest.mark.aiohttp` tests when `httpx_aiohttp` is not installed

### Versioning
- Bumps Python SDK generator to `5.3.0`

## Testing
- [ ] Pre-commit checks pass (`poetry run pre-commit run -a`)
- [ ] Seed test `python-sdk:exhaustive:no-custom-config` verified (⚠️ could not run locally due to disk space — CI will validate)

## ⚠️ Key review items

1. **Seed test not verified locally** — Docker build ran out of disk space. CI must confirm the generated output matches the expected seed snapshot in the `jsklan/aiohttp-python` base branch. This is the primary validation gate.

2. **Unconditional for all SDKs** — The aiohttp extras, optional deps, `_default_clients.py`, test file, and CI steps are generated for *every* Python SDK, not behind a config flag. Verify this is the intended behavior.

3. **`_get_client_wrapper_kwargs` split** — The original `else` branch (handling both sync/async) was split into `elif is_async` (uses `_make_default_async_client()`) and `else` (sync-only, hardcodes `HttpX.CLIENT`). The sync path now no longer references `HttpX.ASYNC_CLIENT` at all — verify this is correct.

4. **Raw writer output formatting** — `_write_make_default_async_client` uses `writer.write_line()` calls. The exact whitespace/formatting of the generated output needs to match the seed snapshot.

Link to Devin session: https://app.devin.ai/sessions/880ed6d43aff44f4996ee6b598b42f84
Requested by: @jsklan
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/14469" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
