### PR TITLE
fix(typescript): add --tag flag for prerelease npm publish

### DIFF
--- a/generators/typescript/utils/abstract-generator-cli/src/publishPackage.ts
+++ b/generators/typescript/utils/abstract-generator-cli/src/publishPackage.ts
@@ -33,7 +33,8 @@ export async function publishPackage({
         logger,
         dryRun,
         publishInfo: npmPackage.publishInfo,
-        shouldTolerateRepublish
+        shouldTolerateRepublish,
+        version: npmPackage.version
     });
 
     await generatorNotificationService.sendUpdate(FernGeneratorExec.GeneratorUpdate.published(packageCoordinate));

--- a/generators/typescript/utils/commons/src/typescript-project/PersistedTypescriptProject.ts
+++ b/generators/typescript/utils/commons/src/typescript-project/PersistedTypescriptProject.ts
@@ -4,7 +4,7 @@ import { createLoggingExecutable } from "@fern-api/logging-execa";
 import { PublishInfo } from "@fern-api/typescript-base";
 import { execFile } from "child_process";
 import decompress from "decompress";
-import { cp, readdir, readFile, rm, writeFile } from "fs/promises";
+import { cp, readdir, rm, writeFile } from "fs/promises";
 import tmp from "tmp-promise";
 import { promisify } from "util";
 
@@ -456,12 +456,14 @@ export class PersistedTypescriptProject {
         logger,
         publishInfo,
         dryRun,
-        shouldTolerateRepublish
+        shouldTolerateRepublish,
+        version
     }: {
         logger: Logger;
         publishInfo: PublishInfo;
         dryRun: boolean;
         shouldTolerateRepublish: boolean;
+        version?: string;
     }): Promise<void> {
         const npm = createLoggingExecutable("npm", {
             cwd: this.directory,
@@ -477,11 +479,8 @@ export class PersistedTypescriptProject {
 
         const publishCommand = ["publish", "--registry", publishInfo.registryUrl];
 
-        // npm requires --tag when publishing prerelease versions (e.g. 0.0.1-preview.123)
-        const packageJsonPath = join(this.directory, RelativeFilePath.of("package.json"));
-        const packageJsonContents = JSON.parse(await readFile(packageJsonPath, "utf-8"));
-        const packageVersion: string = packageJsonContents.version ?? "";
-        if (packageVersion.includes("-")) {
+        // npm 10.9+ requires --tag when publishing prerelease versions (e.g. 0.0.1-preview.123)
+        if (version != null && version.includes("-")) {
             publishCommand.push("--tag", "preview");
         }
 

--- a/generators/typescript/utils/commons/src/typescript-project/PersistedTypescriptProject.ts
+++ b/generators/typescript/utils/commons/src/typescript-project/PersistedTypescriptProject.ts
@@ -4,7 +4,7 @@ import { createLoggingExecutable } from "@fern-api/logging-execa";
 import { PublishInfo } from "@fern-api/typescript-base";
 import { execFile } from "child_process";
 import decompress from "decompress";
-import { cp, readdir, rm, writeFile } from "fs/promises";
+import { cp, readdir, readFile, rm, writeFile } from "fs/promises";
 import tmp from "tmp-promise";
 import { promisify } from "util";
 
@@ -476,6 +476,15 @@ export class PersistedTypescriptProject {
         });
 
         const publishCommand = ["publish", "--registry", publishInfo.registryUrl];
+
+        // npm requires --tag when publishing prerelease versions (e.g. 0.0.1-preview.123)
+        const packageJsonPath = join(this.directory, RelativeFilePath.of("package.json"));
+        const packageJsonContents = JSON.parse(await readFile(packageJsonPath, "utf-8"));
+        const packageVersion: string = packageJsonContents.version ?? "";
+        if (packageVersion.includes("-")) {
+            publishCommand.push("--tag", "preview");
+        }
+
         if (dryRun) {
             publishCommand.push("--dry-run");
         }

--- a/generators/typescript/utils/commons/src/typescript-project/__test__/PersistedTypescriptProject.test.ts
+++ b/generators/typescript/utils/commons/src/typescript-project/__test__/PersistedTypescriptProject.test.ts
@@ -150,7 +150,7 @@ describe("PersistedTypescriptProject", () => {
             });
 
             // Second call is the publish command (first is npm config set)
-            const publishCall = mockNpm.mock.calls[1]![0] as string[];
+            const publishCall = mockNpm.mock.calls[1]?.[0] as string[];
             expect(publishCall).toContain("--tag");
             expect(publishCall).toContain("preview");
         });
@@ -170,7 +170,7 @@ describe("PersistedTypescriptProject", () => {
                 version: "1.0.0"
             });
 
-            const publishCall = mockNpm.mock.calls[1]![0] as string[];
+            const publishCall = mockNpm.mock.calls[1]?.[0] as string[];
             expect(publishCall).not.toContain("--tag");
         });
 
@@ -188,7 +188,7 @@ describe("PersistedTypescriptProject", () => {
                 shouldTolerateRepublish: false
             });
 
-            const publishCall = mockNpm.mock.calls[1]![0] as string[];
+            const publishCall = mockNpm.mock.calls[1]?.[0] as string[];
             expect(publishCall).not.toContain("--tag");
         });
 
@@ -207,7 +207,7 @@ describe("PersistedTypescriptProject", () => {
                 version: "0.0.1-preview.123"
             });
 
-            const publishCall = mockNpm.mock.calls[1]![0] as string[];
+            const publishCall = mockNpm.mock.calls[1]?.[0] as string[];
             expect(publishCall).toContain("--tag");
             expect(publishCall).toContain("--dry-run");
             expect(publishCall).toContain("--tolerate-republish");
@@ -227,13 +227,8 @@ describe("PersistedTypescriptProject", () => {
                 shouldTolerateRepublish: false
             });
 
-            const configCall = mockNpm.mock.calls[0]![0] as string[];
-            expect(configCall).toEqual([
-                "config",
-                "set",
-                "//npm.buildwithfern.com/:_authToken",
-                "fern_test_token_123"
-            ]);
+            const configCall = mockNpm.mock.calls[0]?.[0] as string[];
+            expect(configCall).toEqual(["config", "set", "//npm.buildwithfern.com/:_authToken", "fern_test_token_123"]);
         });
     });
 

--- a/generators/typescript/utils/commons/src/typescript-project/__test__/PersistedTypescriptProject.test.ts
+++ b/generators/typescript/utils/commons/src/typescript-project/__test__/PersistedTypescriptProject.test.ts
@@ -128,6 +128,115 @@ describe("PersistedTypescriptProject", () => {
         });
     });
 
+    describe("publish", () => {
+        const publishInfo = {
+            registryUrl: "https://npm.buildwithfern.com",
+            token: "fern_test_token_123"
+        };
+
+        it("adds --tag preview for prerelease versions", async () => {
+            const mockNpm = vi.fn().mockResolvedValue({ stdout: "", stderr: "" });
+            mockedCreateLoggingExecutable.mockReturnValue(mockNpm);
+
+            const { logger } = collectLogs();
+            const project = makeProject();
+
+            await project.publish({
+                logger,
+                publishInfo,
+                dryRun: false,
+                shouldTolerateRepublish: false,
+                version: "0.0.1-abc123.1234567890"
+            });
+
+            // Second call is the publish command (first is npm config set)
+            const publishCall = mockNpm.mock.calls[1]![0] as string[];
+            expect(publishCall).toContain("--tag");
+            expect(publishCall).toContain("preview");
+        });
+
+        it("does not add --tag for stable versions", async () => {
+            const mockNpm = vi.fn().mockResolvedValue({ stdout: "", stderr: "" });
+            mockedCreateLoggingExecutable.mockReturnValue(mockNpm);
+
+            const { logger } = collectLogs();
+            const project = makeProject();
+
+            await project.publish({
+                logger,
+                publishInfo,
+                dryRun: false,
+                shouldTolerateRepublish: false,
+                version: "1.0.0"
+            });
+
+            const publishCall = mockNpm.mock.calls[1]![0] as string[];
+            expect(publishCall).not.toContain("--tag");
+        });
+
+        it("does not add --tag when version is undefined", async () => {
+            const mockNpm = vi.fn().mockResolvedValue({ stdout: "", stderr: "" });
+            mockedCreateLoggingExecutable.mockReturnValue(mockNpm);
+
+            const { logger } = collectLogs();
+            const project = makeProject();
+
+            await project.publish({
+                logger,
+                publishInfo,
+                dryRun: false,
+                shouldTolerateRepublish: false
+            });
+
+            const publishCall = mockNpm.mock.calls[1]![0] as string[];
+            expect(publishCall).not.toContain("--tag");
+        });
+
+        it("includes --dry-run and --tolerate-republish when requested", async () => {
+            const mockNpm = vi.fn().mockResolvedValue({ stdout: "", stderr: "" });
+            mockedCreateLoggingExecutable.mockReturnValue(mockNpm);
+
+            const { logger } = collectLogs();
+            const project = makeProject();
+
+            await project.publish({
+                logger,
+                publishInfo,
+                dryRun: true,
+                shouldTolerateRepublish: true,
+                version: "0.0.1-preview.123"
+            });
+
+            const publishCall = mockNpm.mock.calls[1]![0] as string[];
+            expect(publishCall).toContain("--tag");
+            expect(publishCall).toContain("--dry-run");
+            expect(publishCall).toContain("--tolerate-republish");
+        });
+
+        it("sets auth token with registry host", async () => {
+            const mockNpm = vi.fn().mockResolvedValue({ stdout: "", stderr: "" });
+            mockedCreateLoggingExecutable.mockReturnValue(mockNpm);
+
+            const { logger } = collectLogs();
+            const project = makeProject();
+
+            await project.publish({
+                logger,
+                publishInfo,
+                dryRun: false,
+                shouldTolerateRepublish: false
+            });
+
+            const configCall = mockNpm.mock.calls[0]![0] as string[];
+            expect(configCall).toEqual([
+                "config",
+                "set",
+                "//npm.buildwithfern.com/:_authToken",
+                "fern_test_token_123"
+            ]);
+        });
+    });
+
     describe("checkFix", () => {
         afterEach(async () => {
             try {


### PR DESCRIPTION
## Summary

- `fern sdk preview` generates prerelease versions (e.g. `0.0.1-a5693a39.123`) but the TypeScript generator's publish step runs `npm publish --registry ...` without `--tag`, causing npm to reject with: *"You must specify a tag using --tag when publishing a prerelease version."*
- Reads the version from the generated `package.json` and adds `--tag preview` when the version contains a `-` (semver prerelease indicator)

## Reproduction

```bash
# Setup minimal fern project with TypeScript SDK generator
cd /tmp/test-project
export FERN_TOKEN=<token>
fern sdk preview
```

**Error output:**
```
Preview version: 0.0.1-a5693a39.1775089949
...
+ npm publish --registry https://npm.buildwithfern.com
npm error You must specify a tag using --tag when publishing a prerelease version.
```

## Test plan

- [ ] Run `fern sdk preview` with a TypeScript SDK generator and verify it completes without the `--tag` error
- [ ] Verify stable (non-prerelease) versions still publish with default `latest` tag
- [ ] Verify the returned `npm install` command works

🤖 Generated with [Claude Code](https://claude.com/claude-code)