### PR TITLE
fix(openapi): fix tokenization for multi-word resource names in operationIds

### DIFF
--- a/packages/cli/api-importers/openapi-to-ir/src/3.1/paths/operations/AbstractOperationConverter.ts
+++ b/packages/cli/api-importers/openapi-to-ir/src/3.1/paths/operations/AbstractOperationConverter.ts
@@ -342,7 +342,17 @@ export abstract class AbstractOperationConverter extends AbstractConverter<
 }
 
 function tokenizeString(input: string): string[] {
-    let tokens = isCamelOrPascalCase(input) ? splitOnCapitalLetters(input) : splitOnNonAlphanumericCharacters(input);
+    let tokens: string[];
+    if (isCamelOrPascalCase(input)) {
+        tokens = splitOnCapitalLetters(input);
+    } else {
+        // Split on non-alphanumeric characters first, then further split
+        // each segment on camelCase boundaries to handle mixed formats
+        // like "phoneNumbers_list" → ["phone", "numbers", "list"]
+        tokens = splitOnNonAlphanumericCharacters(input).flatMap((segment) =>
+            isCamelOrPascalCase(segment) ? splitOnCapitalLetters(segment) : [segment]
+        );
+    }
     tokens = tokens.map((token) => token.toLowerCase());
     tokens = compact(tokens);
     return tokens;


### PR DESCRIPTION
## Description

Fixes URL slug duplication for multi-word resources in generated documentation. When OpenAPI tags use camelCase multi-word names (e.g., `phoneNumbers`) and operationIds combine tag + method with a separator (e.g., `phoneNumbers_list`), the generated URL paths were duplicating the resource name: `/phone-numbers/phone-numbers-list` instead of `/phone-numbers/list`.

## Changes Made

- Updated `tokenizeString` in `AbstractOperationConverter.ts` to further split segments on camelCase boundaries after the initial split on non-alphanumeric characters. This ensures consistent tokenization between tag names and operationIds so that tag-prefix stripping works correctly for multi-word resources.

**Before:** `tokenizeString("phoneNumbers_list")` → split on `_` → `["phonenumbers", "list"]`  
**After:** `tokenizeString("phoneNumbers_list")` → split on `_`, then camelCase split each segment → `["phone", "numbers", "list"]`

This allows the tag tokens `["phone", "numbers"]` (from `phoneNumbers`) to correctly match as a prefix, producing method name `list` instead of `phoneNumbers_list`.

Single-word resources (e.g., `dialers_list` with tag `dialers`) were already working and continue to work.

## Testing

- [x] Lint passes (`pnpm run check`)
- [ ] Unit tests added/updated — no new tests added; relying on existing seed test snapshots to catch regressions
- [ ] Manual testing completed

## Review Checklist

- **Verify seed snapshot diffs in CI** — this change affects how *all* mixed-format operationIds (camelCase + separators) are tokenized. If existing fixtures use this pattern, their generated output may change. Those changes should be improvements (shorter method names with prefix stripped), but worth reviewing.
- **Edge case: consecutive capitals** — segments like `getHTTPResponse` won't match the `isCamelOrPascalCase` regex (`/^[a-z]+(?:[A-Z][a-z]+)*$/`), so they won't be further split. This matches pre-existing behavior.
- **Edge case: PascalCase segments** — `PascalCase` segments (uppercase start) also won't match the regex and won't be split. This is consistent with existing behavior since the regex specifically checks for camelCase.

Link to Devin session: https://app.devin.ai/sessions/20783360195245ae8cc679bfb9d14f68
Requested by: @fern-support