### PR TITLE
chore(python): use existing http client in OAuth token fetch rather than new instance

### DIFF
--- a/generators/python/sdk/versions.yml
+++ b/generators/python/sdk/versions.yml
@@ -1,5 +1,15 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 # For unreleased changes, use unreleased.yml
+- version: 5.2.1
+  changelogEntry:
+    - summary: |
+        Fix an issue where a user-provided `httpx_client` was ignored when instantiating the OAuth token
+        provider's internal HTTP client, causing custom transports, SSL certificates, and proxies to not
+        apply to token-refresh requests.
+      type: fix
+  createdAt: "2026-03-31"
+  irVersion: 65
+
 - version: 5.2.0
   changelogEntry:
     - summary: |

--- a/generators/python/src/fern_python/generators/sdk/client_generator/root_client_generator.py
+++ b/generators/python/src/fern_python/generators/sdk/client_generator/root_client_generator.py
@@ -1418,15 +1418,21 @@ class RootClientGenerator(BaseWrappedClientGenerator[RootClientConstructorParame
                     ClientWrapperGenerator.HTTPX_CLIENT_MEMBER_NAME,
                     AST.Expression(
                         AST.ConditionalExpression(
-                            left=AST.ClassInstantiation(
-                                HttpX.ASYNC_CLIENT if is_async else HttpX.CLIENT,
-                                kwargs=httpx_client_kwargs_with_redirects,
+                            left=AST.Expression(f"{RootClientGenerator.HTTPX_CLIENT_CONSTRUCTOR_PARAMETER_NAME}"),
+                            right=AST.ConditionalExpression(
+                                left=AST.ClassInstantiation(
+                                    HttpX.ASYNC_CLIENT if is_async else HttpX.CLIENT,
+                                    kwargs=httpx_client_kwargs_with_redirects,
+                                ),
+                                right=AST.ClassInstantiation(
+                                    HttpX.ASYNC_CLIENT if is_async else HttpX.CLIENT,
+                                    kwargs=httpx_client_kwargs_without_redirects,
+                                ),
+                                test=AST.Expression(f"{self.FOLLOW_REDIRECTS_CONSTRUCTOR_PARAMETER_NAME} is not None"),
                             ),
-                            right=AST.ClassInstantiation(
-                                HttpX.ASYNC_CLIENT if is_async else HttpX.CLIENT,
-                                kwargs=httpx_client_kwargs_without_redirects,
+                            test=AST.Expression(
+                                f"{RootClientGenerator.HTTPX_CLIENT_CONSTRUCTOR_PARAMETER_NAME} is not None"
                             ),
-                            test=AST.Expression(f"{self.FOLLOW_REDIRECTS_CONSTRUCTOR_PARAMETER_NAME} is not None"),
                         ),
                     ),
                 ),


### PR DESCRIPTION
## Description

Fixes a bug where a user-provided `httpx_client` was silently ignored when the SDK used OAuth credentials.

When an SDK is instantiated with OAuth credentials (`client_id` + `client_secret`), the generator creates an internal `ClientWrapper` that it passes to the `OAuthTokenProvider` / `AsyncOAuthTokenProvider`. This wrapper is responsible for making token-refresh requests. Previously, it always constructed a fresh `httpx.Client()` / `httpx.AsyncClient()`, discarding any `httpx_client` the user passed to the top-level constructor. This meant custom transports, SSL certificates, and proxies were applied to regular API calls but **not** to OAuth token fetches.

## Root Cause

In `root_client_generator.py`, the `_get_client_wrapper_kwargs()` method has two branches controlled by `ignore_httpx_constructor_parameter`:

- **`False` (normal path):** Correctly emits `httpx_client if httpx_client is not None else httpx.Client(...)`.
- **`True` (OAuth token provider path):** Always emitted `httpx.Client(...)`, never checking whether the user supplied their own client.

## Fix

The `ignore_httpx_constructor_parameter=True` branch now uses the same nested conditional as the normal path:

```
httpx_client is not None
  ? httpx_client                                        ← pass user's client through
  : follow_redirects is not None
      ? httpx.Client(timeout=..., follow_redirects=...) ← default with redirects
      : httpx.Client(timeout=...)                       ← default without
```

No other files were changed — the `OAuthTokenProvider` and `ClientWrapper` modules themselves were correct; the bug was purely in how `base_client.py` was being generated.

## Changes Made
- `generators/python/src/fern_python/generators/sdk/client_generator/root_client_generator.py`: updated the `ignore_httpx_constructor_parameter=True` branch to pass through a user-provided `httpx_client` before falling back to a new default client
- `generators/python/sdk/versions.yml`: updated changelog entry with accurate description and correct type (`fix`)

## Testing
- [ ] Unit tests added/updated
- [ ] Manual testing completed