### PR TITLE
fix(csharp): use host paths for protobuf sources in local seed tests

### DIFF
--- a/packages/cli/generation/local-generation/local-workspace-runner/src/runGenerator.ts
+++ b/packages/cli/generation/local-generation/local-workspace-runner/src/runGenerator.ts
@@ -127,7 +127,7 @@ export async function writeFilesToDiskAndRunGenerator({
         irVersionOverride,
         packageName: generatorsYml.getPackageName({ generatorInvocation }),
         version: version ?? outputVersionOverride,
-        sourceConfig: getSourceConfig(workspace),
+        sourceConfig: getSourceConfig(workspace, executionEnvironment?.usesContainerPaths ?? true),
         includeOptionalRequestPropertyExamples,
         ir
     });
@@ -297,13 +297,16 @@ async function writeIrToFile({
     return absolutePathToIr;
 }
 
-function getSourceConfig(workspace: FernWorkspace): SourceConfig {
+function getSourceConfig(workspace: FernWorkspace, usesContainerPaths: boolean): SourceConfig {
     return {
         sources: workspace.getSources().map((source) => {
             if (source.type === "protobuf") {
+                const protoRootUrl = usesContainerPaths
+                    ? `file:///${getDockerDestinationForSource(source)}`
+                    : `file:///${source.absoluteFilePath}`;
                 return ApiDefinitionSource.proto({
                     id: source.id,
-                    protoRootUrl: `file:///${getDockerDestinationForSource(source)}`
+                    protoRootUrl
                 });
             }
             return ApiDefinitionSource.openapi();


### PR DESCRIPTION
## Description

Fixes `pnpm seed test --generator csharp-sdk --skip-scripts --local --fixture "*proto*"` failing with `ENOENT` when running locally.

## Changes Made

- Modified `getSourceConfig()` in `runGenerator.ts` to accept a `usesContainerPaths` boolean
- When running natively (`--local`), protobuf source URLs now use the actual host filesystem path (`source.absoluteFilePath`) instead of Docker container paths (`/fern/sources/{id}`)
- Defaults to container paths (`?? true`) when no execution environment is provided, preserving existing Docker behavior

**Root cause:** `getSourceConfig` always generated Docker container paths for protobuf sources. In Docker mode, `ContainerExecutionEnvironment` bind-mounts host directories to those paths. But in native/local mode, `NativeExecutionEnvironment` doesn't handle source mounts, so the generator tried to access `/fern/sources/{id}` which doesn't exist on the host.

## Human Review Checklist
- [ ] Verify the `?? true` default correctly preserves Docker/container behavior (fallback at L169 creates `ContainerExecutionEnvironment` with `usesContainerPaths = true`)
- [ ] Verify `source.absoluteFilePath` produces valid paths—it's already used for `sourceMounts[].hostPath` on L231, so this is consistent

## Testing

- [x] `pnpm seed test --generator csharp-sdk --skip-scripts --local --fixture "*proto*"` — 5/5 pass (was 0/5)
- [x] `pnpm seed test --generator csharp-sdk --skip-scripts --local --fixture "simple-api"` — 4/4 pass (no regression)
- [x] `pnpm run check` — passes

Link to Devin session: https://app.devin.ai/sessions/4910fbd6c76f42dca80dfae162df8686
Requested by: @Swimburger
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/14496" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
