### PR TITLE
feat(swift): add `maxRetries` custom config option

### DIFF
--- a/generators/swift/base/src/context/AbstractSwiftGeneratorContext.ts
+++ b/generators/swift/base/src/context/AbstractSwiftGeneratorContext.ts
@@ -70,6 +70,9 @@ export abstract class AbstractSwiftGeneratorContext<
                 case "HTTPClient":
                     nameRegistry.registerSourceStaticSymbol(templateId, { type: "class" });
                     break;
+                case "ClientConfig":
+                    nameRegistry.registerSourceStaticSymbol(templateId, { type: "class" });
+                    break;
                 default:
                     assertNever(templateId);
             }

--- a/generators/swift/base/src/template/Sources/ClientConfig.Template.swift
+++ b/generators/swift/base/src/template/Sources/ClientConfig.Template.swift
@@ -5,7 +5,7 @@ public final class ClientConfig: Swift.Sendable {
 
     struct Defaults {
         static let timeout: Swift.Int = 60
-        static let maxRetries: Swift.Int = 2
+        static let maxRetries: Swift.Int = <%= defaultMaxRetries %>
     }
 
     struct HeaderAuth {

--- a/generators/swift/base/src/template/Tests/ClientRetryTests.Template.swift
+++ b/generators/swift/base/src/template/Tests/ClientRetryTests.Template.swift
@@ -117,10 +117,7 @@ import Testing
     @Test func testMaxRetriesExhausted() async throws {
         let stub = HTTPStub()
         stub.setResponseSequence([
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data()),
-            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data()),
+<%= maxRetriesExhaustedStubResponses %>
         ])
 
 <%= clientDeclaration %>
@@ -128,7 +125,7 @@ import Testing
 <%= endpointCallMaxRetriesExhausted %>
             Issue.record("Expected error to be thrown")
         } catch {
-            try #require(stub.getRequestCount() == 3)
+            try #require(stub.getRequestCount() == <%= defaultMaxRetries + 1 %>)
         }
     }
 

--- a/generators/swift/codegen/src/custom-config/BaseSwiftCustomConfigSchema.ts
+++ b/generators/swift/codegen/src/custom-config/BaseSwiftCustomConfigSchema.ts
@@ -7,7 +7,8 @@ export const BaseSwiftCustomConfigSchema = z.object({
     environmentEnumName: z.string().optional(),
     customReadmeSections: z.array(CustomReadmeSectionSchema).optional(),
     enableWireTests: z.boolean().optional(),
-    nullableAsOptional: z.boolean().optional()
+    nullableAsOptional: z.boolean().optional(),
+    maxRetries: z.number().int().min(0).optional()
 });
 
 export type BaseSwiftCustomConfigSchema = z.infer<typeof BaseSwiftCustomConfigSchema>;

--- a/generators/swift/codegen/src/custom-config/__test__/maxRetries.test.ts
+++ b/generators/swift/codegen/src/custom-config/__test__/maxRetries.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+import { BaseSwiftCustomConfigSchema } from "../BaseSwiftCustomConfigSchema.js";
+
+describe("Swift maxRetries config", () => {
+    it("should accept valid maxRetries value", () => {
+        const result = BaseSwiftCustomConfigSchema.safeParse({ maxRetries: 5 });
+        expect(result.success).toBe(true);
+        if (result.success) {
+            expect(result.data.maxRetries).toBe(5);
+        }
+    });
+
+    it("should accept zero to disable retries", () => {
+        const result = BaseSwiftCustomConfigSchema.safeParse({ maxRetries: 0 });
+        expect(result.success).toBe(true);
+        if (result.success) {
+            expect(result.data.maxRetries).toBe(0);
+        }
+    });
+
+    it("should accept config without maxRetries (optional)", () => {
+        const result = BaseSwiftCustomConfigSchema.safeParse({});
+        expect(result.success).toBe(true);
+        if (result.success) {
+            expect(result.data.maxRetries).toBeUndefined();
+        }
+    });
+
+    it("should reject negative maxRetries", () => {
+        const result = BaseSwiftCustomConfigSchema.safeParse({ maxRetries: -1 });
+        expect(result.success).toBe(false);
+    });
+
+    it("should reject non-integer maxRetries", () => {
+        const result = BaseSwiftCustomConfigSchema.safeParse({ maxRetries: 2.5 });
+        expect(result.success).toBe(false);
+    });
+
+    it("should reject string maxRetries", () => {
+        const result = BaseSwiftCustomConfigSchema.safeParse({ maxRetries: "2" });
+        expect(result.success).toBe(false);
+    });
+});

--- a/generators/swift/codegen/src/name-registry/name-registry.ts
+++ b/generators/swift/codegen/src/name-registry/name-registry.ts
@@ -56,6 +56,11 @@ export class NameRegistry {
                 const symbolId = this.symbolRegistry.inferSymbolIdForSourceModuleType(templateId);
                 return swift.Symbol.create(symbolId, templateId, { type: "class" });
             }
+            case "ClientConfig": {
+                const symbol = this.sourceStaticSymbolsByName.get(templateId);
+                assertDefined(symbol, `Source template symbol not found for name "${templateId}"`);
+                return symbol;
+            }
             default:
                 assertNever(templateId);
         }

--- a/generators/swift/codegen/src/symbol/as-is.ts
+++ b/generators/swift/codegen/src/symbol/as-is.ts
@@ -11,7 +11,6 @@ export type AsIsSymbolName =
     | "EncodableValue"
     | "Serde"
     | "StringKey"
-    | "ClientConfig"
     | "FormFile"
     | "HTTPError"
     | "Nullable"
@@ -123,11 +122,6 @@ export const SourceAsIsFileSpecs = {
         relativePathToDir: "Public",
         filenameWithoutExtension: "CalendarDate",
         symbols: [{ name: "CalendarDate", shape: { type: "struct" } }]
-    },
-    ClientConfig: {
-        relativePathToDir: "Public",
-        filenameWithoutExtension: "ClientConfig",
-        symbols: [{ name: "ClientConfig", shape: { type: "class" } }]
     },
     FormFile: {
         relativePathToDir: "Public",

--- a/generators/swift/codegen/src/symbol/template.ts
+++ b/generators/swift/codegen/src/symbol/template.ts
@@ -17,6 +17,11 @@ export const SourceTemplateFileSpecs = {
     HTTPClient: {
         relativePath: "Core/Networking",
         filenameWithoutExtension: () => "HTTPClient"
+    },
+    // Public
+    ClientConfig: {
+        relativePath: "Public",
+        filenameWithoutExtension: () => "ClientConfig"
     }
 } satisfies Record<string, TemplateFileSpec>;
 

--- a/generators/swift/dynamic-snippets/src/context/DynamicSnippetsGeneratorContext.ts
+++ b/generators/swift/dynamic-snippets/src/context/DynamicSnippetsGeneratorContext.ts
@@ -65,6 +65,9 @@ export class DynamicSnippetsGeneratorContext extends AbstractDynamicSnippetsGene
                 case "HTTPClient":
                     nameRegistry.registerSourceStaticSymbol(templateId, { type: "class" });
                     break;
+                case "ClientConfig":
+                    nameRegistry.registerSourceStaticSymbol(templateId, { type: "class" });
+                    break;
                 default:
                     assertNever(templateId);
             }

--- a/generators/swift/sdk/src/generators/client/RootClientGenerator.ts
+++ b/generators/swift/sdk/src/generators/client/RootClientGenerator.ts
@@ -83,10 +83,7 @@ export class RootClientGenerator {
             argumentLabel: "maxRetries",
             unsafeName: "maxRetries",
             type: swift.TypeReference.optional(this.referencer.referenceSwiftType("Int")),
-            defaultValue:
-                configuredMaxRetries != null
-                    ? swift.Expression.rawValue(String(configuredMaxRetries))
-                    : swift.Expression.rawValue("nil"),
+            defaultValue: swift.Expression.rawValue("nil"),
             docsContent: `Maximum number of retries for failed requests. Defaults to ${configuredMaxRetries ?? 2}.`
         });
     }
@@ -415,7 +412,10 @@ export class RootClientGenerator {
                 argumentLabel: "headerAuth",
                 unsafeName: "headerAuth",
                 type: swift.TypeReference.optional(
-                    swift.TypeReference.memberAccess(this.referencer.referenceAsIsType("ClientConfig"), "HeaderAuth")
+                    swift.TypeReference.memberAccess(
+                        this.referencer.referenceSourceTemplateType("ClientConfig"),
+                        "HeaderAuth"
+                    )
                 ),
                 defaultValue: swift.Expression.nil()
             }),
@@ -423,7 +423,10 @@ export class RootClientGenerator {
                 argumentLabel: "bearerAuth",
                 unsafeName: "bearerAuth",
                 type: swift.TypeReference.optional(
-                    swift.TypeReference.memberAccess(this.referencer.referenceAsIsType("ClientConfig"), "BearerAuth")
+                    swift.TypeReference.memberAccess(
+                        this.referencer.referenceSourceTemplateType("ClientConfig"),
+                        "BearerAuth"
+                    )
                 ),
                 defaultValue: swift.Expression.nil()
             }),
@@ -431,7 +434,10 @@ export class RootClientGenerator {
                 argumentLabel: "basicAuth",
                 unsafeName: "basicAuth",
                 type: swift.TypeReference.optional(
-                    swift.TypeReference.memberAccess(this.referencer.referenceAsIsType("ClientConfig"), "BasicAuth")
+                    swift.TypeReference.memberAccess(
+                        this.referencer.referenceSourceTemplateType("ClientConfig"),
+                        "BasicAuth"
+                    )
                 ),
                 defaultValue: swift.Expression.nil()
             }),
@@ -456,10 +462,7 @@ export class RootClientGenerator {
                 argumentLabel: "maxRetries",
                 unsafeName: "maxRetries",
                 type: swift.TypeReference.optional(this.referencer.referenceSwiftType("Int")),
-                defaultValue:
-                    this.sdkGeneratorContext.customConfig.maxRetries != null
-                        ? swift.Expression.rawValue(String(this.sdkGeneratorContext.customConfig.maxRetries))
-                        : swift.Expression.nil()
+                defaultValue: swift.Expression.nil()
             }),
             swift.functionParameter({
                 argumentLabel: "urlSession",
@@ -607,12 +610,12 @@ export class RootClientGenerator {
                         escaping: isAuthMandatory ? true : undefined,
                         type: isAuthMandatory
                             ? swift.TypeReference.memberAccess(
-                                  this.referencer.referenceAsIsType("ClientConfig"),
+                                  this.referencer.referenceSourceTemplateType("ClientConfig"),
                                   "CredentialProvider"
                               )
                             : swift.TypeReference.optional(
                                   swift.TypeReference.memberAccess(
-                                      this.referencer.referenceAsIsType("ClientConfig"),
+                                      this.referencer.referenceSourceTemplateType("ClientConfig"),
                                       "CredentialProvider"
                                   )
                               ),

--- a/generators/swift/sdk/src/generators/client/RootClientGenerator.ts
+++ b/generators/swift/sdk/src/generators/client/RootClientGenerator.ts
@@ -78,12 +78,16 @@ export class RootClientGenerator {
     }
 
     private get maxRetriesParam() {
+        const configuredMaxRetries = this.sdkGeneratorContext.customConfig.maxRetries;
         return swift.functionParameter({
             argumentLabel: "maxRetries",
             unsafeName: "maxRetries",
             type: swift.TypeReference.optional(this.referencer.referenceSwiftType("Int")),
-            defaultValue: swift.Expression.rawValue("nil"),
-            docsContent: "Maximum number of retries for failed requests. Defaults to 2."
+            defaultValue:
+                configuredMaxRetries != null
+                    ? swift.Expression.rawValue(String(configuredMaxRetries))
+                    : swift.Expression.rawValue("nil"),
+            docsContent: `Maximum number of retries for failed requests. Defaults to ${configuredMaxRetries ?? 2}.`
         });
     }
 
@@ -452,7 +456,10 @@ export class RootClientGenerator {
                 argumentLabel: "maxRetries",
                 unsafeName: "maxRetries",
                 type: swift.TypeReference.optional(this.referencer.referenceSwiftType("Int")),
-                defaultValue: swift.Expression.nil()
+                defaultValue:
+                    this.sdkGeneratorContext.customConfig.maxRetries != null
+                        ? swift.Expression.rawValue(String(this.sdkGeneratorContext.customConfig.maxRetries))
+                        : swift.Expression.nil()
             }),
             swift.functionParameter({
                 argumentLabel: "urlSession",

--- a/generators/swift/sdk/src/generators/client/SubClientGenerator.ts
+++ b/generators/swift/sdk/src/generators/client/SubClientGenerator.ts
@@ -58,7 +58,7 @@ export class SubClientGenerator {
                 swift.functionParameter({
                     argumentLabel: "config",
                     unsafeName: "config",
-                    type: this.referencer.referenceAsIsType("ClientConfig")
+                    type: this.referencer.referenceSourceTemplateType("ClientConfig")
                 })
             ],
             body: swift.CodeBlock.withStatements([

--- a/generators/swift/sdk/src/generators/test/TemplateDataGenerator.ts
+++ b/generators/swift/sdk/src/generators/test/TemplateDataGenerator.ts
@@ -41,6 +41,8 @@ export class TemplateDataGenerator {
                 return this.generateTemplateDataForClientError();
             case "HTTPClient":
                 return this.generateTemplateDataForHTTPClient();
+            case "ClientConfig":
+                return this.generateTemplateDataForClientConfig();
             default:
                 assertNever(templateId);
         }
@@ -57,6 +59,12 @@ export class TemplateDataGenerator {
         const errorEnumSymbol = this.context.project.nameRegistry.getErrorEnumSymbolOrThrow();
         return {
             errorEnumName: errorEnumSymbol.name
+        };
+    }
+
+    private generateTemplateDataForClientConfig() {
+        return {
+            defaultMaxRetries: this.context.customConfig.maxRetries ?? 2
         };
     }
 

--- a/generators/swift/sdk/src/generators/test/TemplateDataGenerator.ts
+++ b/generators/swift/sdk/src/generators/test/TemplateDataGenerator.ts
@@ -105,9 +105,12 @@ export class TemplateDataGenerator {
         if (!sampleEndpoint || !clientDeclaration || !endpointCallExpression) {
             return null;
         }
+        const defaultMaxRetries = this.context.customConfig.maxRetries ?? 2;
         const { dynamicEndpoint, dynamicEndpointExample } = sampleEndpoint;
         return {
             moduleName: moduleSymbol.name,
+            defaultMaxRetries,
+            maxRetriesExhaustedStubResponses: this.generateMaxRetriesExhaustedStubResponses(defaultMaxRetries),
             clientDeclaration: clientDeclaration.toStringWithIndentation(3),
             endpointCall: swift.Statement.discardAssignment(endpointCallExpression).toStringWithIndentation(4),
             endpointCall400BadRequest:
@@ -171,6 +174,17 @@ export class TemplateDataGenerator {
                 })
             ).toStringWithIndentation(4)
         };
+    }
+
+    private generateMaxRetriesExhaustedStubResponses(defaultMaxRetries: number): string {
+        const stubLine = '            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data()),';
+        // Need defaultMaxRetries + 2 stub responses so that there are more responses than
+        // the client will consume (1 initial + defaultMaxRetries retries = defaultMaxRetries + 1 requests).
+        const lines: string[] = [];
+        for (let i = 0; i < defaultMaxRetries + 2; i++) {
+            lines.push(stubLine);
+        }
+        return lines.join("\n");
     }
 
     private generateTemplateDataForHTTPStub() {

--- a/generators/swift/sdk/versions.yml
+++ b/generators/swift/sdk/versions.yml
@@ -1,5 +1,15 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 
+- version: 0.30.0
+  changelogEntry:
+    - summary: |
+        Add `maxRetries` custom config option to override the default maximum
+        number of retries for failed requests. The default remains 2 when not
+        specified.
+      type: feat
+  createdAt: "2026-04-02"
+  irVersion: 61
+
 - version: 0.29.0
   changelogEntry:
     - summary: |

--- a/seed/swift-sdk/seed.yml
+++ b/seed/swift-sdk/seed.yml
@@ -101,7 +101,8 @@ fixtures:
         decodeNullableToOptional: true
       outputFolder: nullable-as-optional
   single-url-environment-default:
-    - customConfig: null
+    - customConfig:
+        maxRetries: 5
       outputFolder: no-custom-config
     - customConfig:
         environmentEnumName: MyCustomEnvironment

--- a/seed/swift-sdk/single-url-environment-default/no-custom-config/.fern/metadata.json
+++ b/seed/swift-sdk/single-url-environment-default/no-custom-config/.fern/metadata.json
@@ -2,7 +2,9 @@
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-swift-sdk",
   "generatorVersion": "latest",
-  "generatorConfig": {},
+  "generatorConfig": {
+    "maxRetries": 5
+  },
   "originGitCommit": "DUMMY",
   "sdkVersion": "0.0.1"
 }

--- a/seed/swift-sdk/single-url-environment-default/no-custom-config/Sources/Public/ClientConfig.swift
+++ b/seed/swift-sdk/single-url-environment-default/no-custom-config/Sources/Public/ClientConfig.swift
@@ -5,7 +5,7 @@ public final class ClientConfig: Swift.Sendable {
 
     struct Defaults {
         static let timeout: Swift.Int = 60
-        static let maxRetries: Swift.Int = 2
+        static let maxRetries: Swift.Int = 5
     }
 
     struct HeaderAuth {

--- a/seed/swift-sdk/single-url-environment-default/no-custom-config/Sources/SingleUrlEnvironmentDefaultClient.swift
+++ b/seed/swift-sdk/single-url-environment-default/no-custom-config/Sources/SingleUrlEnvironmentDefaultClient.swift
@@ -11,14 +11,14 @@ public final class SingleUrlEnvironmentDefaultClient: Sendable {
     /// - Parameter token: Bearer token for authentication. If provided, will be sent as "Bearer {token}" in Authorization header.
     /// - Parameter headers: Additional headers to send with each request.
     /// - Parameter timeout: Request timeout in seconds. Defaults to 60 seconds. Ignored if a custom `urlSession` is provided.
-    /// - Parameter maxRetries: Maximum number of retries for failed requests. Defaults to 2.
+    /// - Parameter maxRetries: Maximum number of retries for failed requests. Defaults to 5.
     /// - Parameter urlSession: Custom `URLSession` to use for requests. If not provided, a default session will be created with the specified timeout.
     public convenience init(
         baseURL: String = SingleUrlEnvironmentDefaultEnvironment.production.rawValue,
         token: String,
         headers: [String: String]? = nil,
         timeout: Int? = nil,
-        maxRetries: Int? = nil,
+        maxRetries: Int? = 5,
         urlSession: Networking.URLSession? = nil
     ) {
         self.init(
@@ -39,14 +39,14 @@ public final class SingleUrlEnvironmentDefaultClient: Sendable {
     /// - Parameter token: An async function that returns the bearer token for authentication. If provided, will be sent as "Bearer {token}" in Authorization header.
     /// - Parameter headers: Additional headers to send with each request.
     /// - Parameter timeout: Request timeout in seconds. Defaults to 60 seconds. Ignored if a custom `urlSession` is provided.
-    /// - Parameter maxRetries: Maximum number of retries for failed requests. Defaults to 2.
+    /// - Parameter maxRetries: Maximum number of retries for failed requests. Defaults to 5.
     /// - Parameter urlSession: Custom `URLSession` to use for requests. If not provided, a default session will be created with the specified timeout.
     public convenience init(
         baseURL: String = SingleUrlEnvironmentDefaultEnvironment.production.rawValue,
         token: @escaping ClientConfig.CredentialProvider,
         headers: [String: String]? = nil,
         timeout: Int? = nil,
-        maxRetries: Int? = nil,
+        maxRetries: Int? = 5,
         urlSession: Networking.URLSession? = nil
     ) {
         self.init(
@@ -68,7 +68,7 @@ public final class SingleUrlEnvironmentDefaultClient: Sendable {
         basicAuth: ClientConfig.BasicAuth? = nil,
         headers: [String: String]? = nil,
         timeout: Int? = nil,
-        maxRetries: Int? = nil,
+        maxRetries: Int? = 5,
         urlSession: Networking.URLSession? = nil
     ) {
         let config = ClientConfig(

--- a/seed/swift-sdk/single-url-environment-default/no-custom-config/Sources/SingleUrlEnvironmentDefaultClient.swift
+++ b/seed/swift-sdk/single-url-environment-default/no-custom-config/Sources/SingleUrlEnvironmentDefaultClient.swift
@@ -18,7 +18,7 @@ public final class SingleUrlEnvironmentDefaultClient: Sendable {
         token: String,
         headers: [String: String]? = nil,
         timeout: Int? = nil,
-        maxRetries: Int? = 5,
+        maxRetries: Int? = nil,
         urlSession: Networking.URLSession? = nil
     ) {
         self.init(
@@ -46,7 +46,7 @@ public final class SingleUrlEnvironmentDefaultClient: Sendable {
         token: @escaping ClientConfig.CredentialProvider,
         headers: [String: String]? = nil,
         timeout: Int? = nil,
-        maxRetries: Int? = 5,
+        maxRetries: Int? = nil,
         urlSession: Networking.URLSession? = nil
     ) {
         self.init(
@@ -68,7 +68,7 @@ public final class SingleUrlEnvironmentDefaultClient: Sendable {
         basicAuth: ClientConfig.BasicAuth? = nil,
         headers: [String: String]? = nil,
         timeout: Int? = nil,
-        maxRetries: Int? = 5,
+        maxRetries: Int? = nil,
         urlSession: Networking.URLSession? = nil
     ) {
         let config = ClientConfig(

--- a/seed/swift-sdk/single-url-environment-default/no-custom-config/Tests/Core/ClientRetryTests.swift
+++ b/seed/swift-sdk/single-url-environment-default/no-custom-config/Tests/Core/ClientRetryTests.swift
@@ -157,6 +157,9 @@ import Testing
             (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data()),
             (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data()),
             (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data()),
+            (statusCode: 500, headers: ["Content-Type": "application/json"], body: Data()),
         ])
 
         let client = SingleUrlEnvironmentDefaultClient(
@@ -170,7 +173,7 @@ import Testing
 
             Issue.record("Expected error to be thrown")
         } catch {
-            try #require(stub.getRequestCount() == 3)
+            try #require(stub.getRequestCount() == 6)
         }
     }
 


### PR DESCRIPTION
## Description

Adds a `maxRetries` custom config option to the Swift SDK generator, allowing API authors to override the default maximum retry count in `generators.yml`:

```yaml
generators:
  - name: fernapi/fern-swift-sdk
    config:
      maxRetries: 0  # disables retries globally
```

SDK end-users can still override per-request. Split out from #14386 for per-generator rollback.

## Changes Made

**Architectural approach** — uses a template variable in `ClientConfig.swift` (consistent with Ruby, TypeScript, and other generators), rather than modifying constructor parameter defaults:

- Added `maxRetries: z.number().int().min(0).optional()` to `BaseSwiftCustomConfigSchema`
- **Converted `ClientConfig.swift` from as-is file → template file** with `<%= defaultMaxRetries %>` on the `Defaults.maxRetries` constant
- Moved `ClientConfig` from `SourceAsIsFileSpecs` (as-is.ts) to `SourceTemplateFileSpecs` (template.ts)
- Added `ClientConfig` case to `getSourceTemplateSymbolOrThrow` in `name-registry.ts`
- Registered `ClientConfig` as template symbol in `AbstractSwiftGeneratorContext.ts` and `DynamicSnippetsGeneratorContext.ts`
- Added `TemplateDataGenerator.generateTemplateDataForClientConfig()` — passes `customConfig.maxRetries ?? 2`
- Updated all `referenceAsIsType("ClientConfig")` → `referenceSourceTemplateType("ClientConfig")` in `RootClientGenerator.ts` and `SubClientGenerator.ts`
- Constructor parameters always default to `nil`; the internal `Defaults.maxRetries` constant (set via template) handles the actual default
- Doc comments dynamically reflect configured default (e.g. "Defaults to 5.")
- Added `versions.yml` entry for v0.30.0
- Merged `maxRetries: 5` into `single-url-environment-default:no-custom-config` seed fixture

**Test template fix** — made `testMaxRetriesExhausted` dynamic so it works with any `maxRetries` value:

- Replaced hardcoded 4 stub responses in `ClientRetryTests.Template.swift` with `<%= maxRetriesExhaustedStubResponses %>`
- Replaced hardcoded assertion `== 3` with `<%= defaultMaxRetries + 1 %>` (1 initial request + N retries)
- Added `generateMaxRetriesExhaustedStubResponses()` helper in `TemplateDataGenerator.ts` — generates `defaultMaxRetries + 2` stub responses (enough to exceed the client's retry attempts)
- Passes `defaultMaxRetries` and `maxRetriesExhaustedStubResponses` to the test template data

## Testing

- [x] Unit tests added (6 schema validation tests)
- [x] Seed fixture with `maxRetries: 5` — generated `ClientConfig.swift` shows `static let maxRetries: Swift.Int = 5`, constructor params remain `nil`, doc comments say "Defaults to 5"
- [x] Generated `ClientRetryTests.swift` has 7 stub responses and asserts `getRequestCount() == 6` (correct for `maxRetries: 5`)
- [x] Compilation passes across all Swift packages (`swift-codegen`, `swift-sdk`, `swift-base`, `swift-dynamic-snippets`)
- [x] Biome lint clean

## Human Review Checklist

- [ ] **Template registration order**: `ClientConfig` is now looked up via `sourceStaticSymbolsByName.get(templateId)` in `name-registry.ts`. Verify the symbol is always registered before it's resolved (registration happens in `AbstractSwiftGeneratorContext` / `DynamicSnippetsGeneratorContext` during the `SourceTemplateFileSpecs` loop).
- [ ] **As-is → template migration completeness**: `ClientConfig` was removed from `SourceAsIsFileSpecs` and the old `asIs/Sources/ClientConfig.swift` file deleted. Confirm no other code paths reference `ClientConfig` as an as-is symbol (grep for `referenceAsIsType.*ClientConfig` or `getAsIsSymbol.*ClientConfig`).
- [ ] **Stub count arithmetic**: `generateMaxRetriesExhaustedStubResponses` creates `defaultMaxRetries + 2` stubs, assertion checks `== defaultMaxRetries + 1`. The logic: client makes `1 initial + N retries = N+1` requests total, and we need `N+2` stubs so there are more stubs than requests consumed. Verify this holds for edge cases (`maxRetries: 0` → 2 stubs, asserts `== 1`; `maxRetries: 1` → 3 stubs, asserts `== 2`).
- [ ] **EJS arithmetic in template**: `<%= defaultMaxRetries + 1 %>` relies on EJS/Eta evaluating the addition. Confirm this produces the integer value (not string concatenation) in the generated output.
- [ ] **Dynamic snippets**: `DynamicSnippetsGeneratorContext.ts` was updated to register `ClientConfig` as a template symbol. Verify dynamic snippet generation still works correctly (it doesn't need template data since it only uses the symbol for type references, not file rendering).
- [ ] **Backward compatibility**: When `maxRetries` is not set in config, `defaultMaxRetries` falls back to `2`, so generated code is identical to before (4 stubs, asserts `== 3`).
- [ ] **Seed fixture naming**: The `single-url-environment-default:no-custom-config` fixture now has `customConfig: { maxRetries: 5 }`, making the directory name slightly misleading. This was done per instruction to merge into existing fixtures rather than create new output directories.

Link to Devin session: https://app.devin.ai/sessions/3f182e0b32934731b90175d656217e95
Requested by: @Swimburger
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/14503" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
