### PR TITLE
feat(rust): add `maxRetries` custom config option

### DIFF
--- a/generators/rust/codegen/src/custom-config/BaseRustConfigSchema.ts
+++ b/generators/rust/codegen/src/custom-config/BaseRustConfigSchema.ts
@@ -47,7 +47,8 @@ export const BaseRustCustomConfigSchema = z.object({
     features: z.record(z.array(z.string())).optional(),
     // Override which features are in the default feature set
     // Example: ["sse"] to only include SSE in default features
-    defaultFeatures: z.array(z.string()).optional()
+    defaultFeatures: z.array(z.string()).optional(),
+    maxRetries: z.number().int().min(0).optional()
 });
 
 export type BaseRustCustomConfigSchema = z.infer<typeof BaseRustCustomConfigSchema>;

--- a/generators/rust/codegen/src/custom-config/__test__/maxRetries.test.ts
+++ b/generators/rust/codegen/src/custom-config/__test__/maxRetries.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+import { BaseRustCustomConfigSchema } from "../BaseRustConfigSchema.js";
+
+describe("Rust maxRetries config", () => {
+    it("should accept valid maxRetries value", () => {
+        const result = BaseRustCustomConfigSchema.safeParse({ maxRetries: 5 });
+        expect(result.success).toBe(true);
+        if (result.success) {
+            expect(result.data.maxRetries).toBe(5);
+        }
+    });
+
+    it("should accept zero to disable retries", () => {
+        const result = BaseRustCustomConfigSchema.safeParse({ maxRetries: 0 });
+        expect(result.success).toBe(true);
+        if (result.success) {
+            expect(result.data.maxRetries).toBe(0);
+        }
+    });
+
+    it("should accept config without maxRetries (optional)", () => {
+        const result = BaseRustCustomConfigSchema.safeParse({});
+        expect(result.success).toBe(true);
+        if (result.success) {
+            expect(result.data.maxRetries).toBeUndefined();
+        }
+    });
+
+    it("should reject negative maxRetries", () => {
+        const result = BaseRustCustomConfigSchema.safeParse({ maxRetries: -1 });
+        expect(result.success).toBe(false);
+    });
+
+    it("should reject non-integer maxRetries", () => {
+        const result = BaseRustCustomConfigSchema.safeParse({ maxRetries: 2.5 });
+        expect(result.success).toBe(false);
+    });
+
+    it("should reject string maxRetries", () => {
+        const result = BaseRustCustomConfigSchema.safeParse({ maxRetries: "2" });
+        expect(result.success).toBe(false);
+    });
+});

--- a/generators/rust/sdk/src/generators/ClientConfigGenerator.ts
+++ b/generators/rust/sdk/src/generators/ClientConfigGenerator.ts
@@ -178,7 +178,7 @@ export class ClientConfigGenerator {
                     },
                     {
                         name: "max_retries",
-                        value: Expression.numberLiteral(3)
+                        value: Expression.numberLiteral(this.context.customConfig.maxRetries ?? 3)
                     },
                     {
                         name: "custom_headers",

--- a/generators/rust/sdk/versions.yml
+++ b/generators/rust/sdk/versions.yml
@@ -1,5 +1,15 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 
+- version: 0.31.0
+  changelogEntry:
+    - summary: |
+        Add `maxRetries` custom config option to override the default maximum
+        number of retries for failed requests. The default remains 3 when not
+        specified.
+      type: feat
+  createdAt: "2026-04-02"
+  irVersion: 65
+
 - version: 0.30.2
   changelogEntry:
     - summary: |
@@ -8,7 +18,6 @@
       type: fix
   createdAt: "2026-03-31"
   irVersion: 65
-
 - version: 0.30.1
   changelogEntry:
     - summary: |

--- a/seed/rust-sdk/imdb/imdb/src/config.rs
+++ b/seed/rust-sdk/imdb/imdb/src/config.rs
@@ -26,7 +26,7 @@ impl Default for ClientConfig {
             client_id: None,
             client_secret: None,
             timeout: Duration::from_secs(60),
-            max_retries: 3,
+            max_retries: 5,
             custom_headers: HashMap::from([
                 ("X-Fern-Language".to_string(), "Rust".to_string()),
                 ("X-Fern-SDK-Name".to_string(), "seed_api".to_string()),

--- a/seed/rust-sdk/seed.yml
+++ b/seed/rust-sdk/seed.yml
@@ -53,6 +53,7 @@ fixtures:
   imdb:
     - customConfig:
         clientName: ImdbClient
+        maxRetries: 5
       outputFolder: imdb
     - customConfig:
         crateName: custom_imdb_sdk


### PR DESCRIPTION
## Description

Adds a `maxRetries` custom config option to the Rust SDK generator, allowing API authors to override the default maximum retry count in `generators.yml`:

```yaml
generators:
  - name: fernapi/fern-rust-sdk
    config:
      maxRetries: 0  # disables retries globally
```

Split out from #14386 for per-generator rollback.

## Changes Made

- Added `maxRetries: z.number().int().min(0).optional()` to `BaseRustCustomConfigSchema`
- Updated `ClientConfigGenerator.ts` to use `this.context.customConfig.maxRetries ?? 3` instead of hardcoded `3`
- Added `versions.yml` entry for v0.31.0
- Merged `maxRetries: 5` into `imdb:imdb` seed fixture to verify code generation end-to-end (updated expected `config.rs` output: `max_retries: 3` → `max_retries: 5`)

## Testing

- [x] Unit tests added (6 schema validation tests)
- [x] Seed fixture with `maxRetries: 5` merged into `imdb:imdb` — generated `config.rs` output shows `max_retries: 5`

## Human Review Checklist

- [ ] **Rust default is 3, not 2**: All other generators default to 2 retries (Go defaults to 1). The `?? 3` preserves the existing Rust SDK behavior. Confirm this asymmetry is intentional.
- [ ] **`customConfig` typing**: Verify `this.context.customConfig.maxRetries` is correctly typed from `BaseRustCustomConfigSchema` inference, so the `?? 3` fallback triggers only when the field is `undefined` (not when it's `0`).
- [ ] **Seed fixture naming**: The `imdb:imdb` fixture now includes both `clientName: ImdbClient` and `maxRetries: 5` in its `customConfig`. Confirm the generator handles both options together correctly.

Link to Devin session: https://app.devin.ai/sessions/3f182e0b32934731b90175d656217e95
Requested by: @Swimburger
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/14505" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
