### PR TITLE
feat(java): add `maxRetries` custom config option

### DIFF
--- a/generators/java-v2/ast/src/custom-config/BaseJavaCustomConfigSchema.ts
+++ b/generators/java-v2/ast/src/custom-config/BaseJavaCustomConfigSchema.ts
@@ -39,7 +39,8 @@ export const BaseJavaCustomConfigSchema = z.object({
     "enable-gradle-profiling": z.boolean().optional(),
 
     // Deprecated.
-    "wrapped-aliases": z.boolean().optional()
+    "wrapped-aliases": z.boolean().optional(),
+    maxRetries: z.number().int().min(0).optional()
 });
 
 export type BaseJavaCustomConfigSchema = z.infer<typeof BaseJavaCustomConfigSchema>;

--- a/generators/java-v2/ast/src/custom-config/__test__/maxRetries.test.ts
+++ b/generators/java-v2/ast/src/custom-config/__test__/maxRetries.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+import { BaseJavaCustomConfigSchema } from "../BaseJavaCustomConfigSchema.js";
+
+describe("Java v2 maxRetries config", () => {
+    it("should accept valid maxRetries value", () => {
+        const result = BaseJavaCustomConfigSchema.safeParse({ maxRetries: 5 });
+        expect(result.success).toBe(true);
+        if (result.success) {
+            expect(result.data.maxRetries).toBe(5);
+        }
+    });
+
+    it("should accept zero to disable retries", () => {
+        const result = BaseJavaCustomConfigSchema.safeParse({ maxRetries: 0 });
+        expect(result.success).toBe(true);
+        if (result.success) {
+            expect(result.data.maxRetries).toBe(0);
+        }
+    });
+
+    it("should accept config without maxRetries (optional)", () => {
+        const result = BaseJavaCustomConfigSchema.safeParse({});
+        expect(result.success).toBe(true);
+        if (result.success) {
+            expect(result.data.maxRetries).toBeUndefined();
+        }
+    });
+
+    it("should reject negative maxRetries", () => {
+        const result = BaseJavaCustomConfigSchema.safeParse({ maxRetries: -1 });
+        expect(result.success).toBe(false);
+    });
+
+    it("should reject non-integer maxRetries", () => {
+        const result = BaseJavaCustomConfigSchema.safeParse({ maxRetries: 2.5 });
+        expect(result.success).toBe(false);
+    });
+
+    it("should reject string maxRetries", () => {
+        const result = BaseJavaCustomConfigSchema.safeParse({ maxRetries: "2" });
+        expect(result.success).toBe(false);
+    });
+});

--- a/generators/java/generator-utils/src/main/java/com/fern/java/ICustomConfig.java
+++ b/generators/java/generator-utils/src/main/java/com/fern/java/ICustomConfig.java
@@ -198,4 +198,7 @@ public interface ICustomConfig {
     default OutputDirectory outputDirectory() {
         return OutputDirectory.PROJECT_ROOT;
     }
+
+    @JsonProperty("maxRetries")
+    Optional<Integer> maxRetries();
 }

--- a/generators/java/sdk/src/main/java/com/fern/java/client/generators/ClientOptionsGenerator.java
+++ b/generators/java/sdk/src/main/java/com/fern/java/client/generators/ClientOptionsGenerator.java
@@ -652,7 +652,7 @@ public final class ClientOptionsGenerator extends AbstractFileGenerator {
                         .initializer("new $T<>()", HashMap.class)
                         .build())
                 .addField(FieldSpec.builder(TypeName.INT, MAX_RETRIES_FIELD.name, Modifier.PRIVATE)
-                        .initializer("2")
+                        .initializer("$L", getDefaultMaxRetries())
                         .build())
                 .addField(FieldSpec.builder(
                                 ParameterizedTypeName.get(ClassName.get(Optional.class), ClassName.get(Integer.class)),
@@ -716,7 +716,8 @@ public final class ClientOptionsGenerator extends AbstractFileGenerator {
                         .build())
                 .addMethod(MethodSpec.methodBuilder(MAX_RETRIES_FIELD.name)
                         .addModifiers(Modifier.PUBLIC)
-                        .addJavadoc("Override the maximum number of retries. Defaults to 2 retries.")
+                        .addJavadoc("Override the maximum number of retries. Defaults to " + getDefaultMaxRetries()
+                                + " retries.")
                         .returns(builderClassName)
                         .addParameter(TypeName.INT, MAX_RETRIES_FIELD.name)
                         .addStatement("this.$L = $L", MAX_RETRIES_FIELD.name, MAX_RETRIES_FIELD.name)
@@ -1231,5 +1232,9 @@ public final class ClientOptionsGenerator extends AbstractFileGenerator {
                 .getCustomConfig()
                 .defaultTimeoutInSeconds()
                 .orElse(60);
+    }
+
+    private int getDefaultMaxRetries() {
+        return clientGeneratorContext.getCustomConfig().maxRetries().orElse(2);
     }
 }

--- a/generators/java/sdk/versions.yml
+++ b/generators/java/sdk/versions.yml
@@ -1,4 +1,14 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 4.1.0
+  changelogEntry:
+    - summary: |
+        Add `maxRetries` custom config option to override the default maximum
+        number of retries for failed requests. The default remains 2 when not
+        specified.
+      type: feat
+  createdAt: "2026-04-02"
+  irVersion: 65
+
 - version: 4.0.9
   changelogEntry:
     - summary: |

--- a/seed/java-sdk/imdb/omit-fern-headers/src/main/java/com/seed/api/core/ClientOptions.java
+++ b/seed/java-sdk/imdb/omit-fern-headers/src/main/java/com/seed/api/core/ClientOptions.java
@@ -101,7 +101,7 @@ public final class ClientOptions {
 
         private final Map<String, Supplier<String>> headerSuppliers = new HashMap<>();
 
-        private int maxRetries = 2;
+        private int maxRetries = 5;
 
         private Optional<Integer> timeout = Optional.empty();
 
@@ -141,7 +141,7 @@ public final class ClientOptions {
         }
 
         /**
-         * Override the maximum number of retries. Defaults to 2 retries.
+         * Override the maximum number of retries. Defaults to 5 retries.
          */
         public Builder maxRetries(int maxRetries) {
             this.maxRetries = maxRetries;

--- a/seed/java-sdk/seed.yml
+++ b/seed/java-sdk/seed.yml
@@ -164,6 +164,7 @@ fixtures:
       outputFolder: flat-package-layout
     - customConfig:
         omit-fern-headers: true
+        maxRetries: 5
       outputFolder: omit-fern-headers
   java-custom-package-prefix:
     - customConfig:


### PR DESCRIPTION
## Description

Adds a `maxRetries` custom config option to the Java SDK generator, allowing API authors to override the default maximum retry count in `generators.yml`:

```yaml
generators:
  - name: fernapi/fern-java-sdk
    config:
      maxRetries: 0  # disables retries globally
```

SDK end-users can still override per-request via `RequestOptions`. Split out from #14386 for per-generator rollback.

## Changes Made

- Added `maxRetries: z.number().int().min(0).optional()` to `BaseJavaCustomConfigSchema` (Java v2 schema)
- Added `Optional<Integer> maxRetries()` to `ICustomConfig` interface (Java v1 config interface)
- Updated `ClientOptionsGenerator` to read `maxRetries` from config via new `getDefaultMaxRetries()` helper, replacing hardcoded `"2"` in the field initializer and Javadoc
- Added `versions.yml` entry for v4.1.0
- Merged `maxRetries: 5` into `imdb:omit-fern-headers` seed fixture to verify code generation end-to-end (updated expected `ClientOptions.java` output: `maxRetries = 2` → `maxRetries = 5`, Javadoc updated accordingly)

## Testing

- [x] Unit tests added (6 schema validation tests for the Zod schema)
- [x] Seed fixture with `maxRetries: 5` merged into `imdb:omit-fern-headers` — generated `ClientOptions.java` shows `private int maxRetries = 5` and Javadoc says "Defaults to 5 retries"

## Human Review Checklist

- [ ] **`ICustomConfig.maxRetries()` is abstract, not default**: Unlike other methods in the interface (e.g. `outputDirectory()` which has `default`), this new method has no default implementation. All implementors must provide it. Verify that every class implementing `ICustomConfig` is `@Value.Immutable`-generated (which auto-implements `Optional` fields as empty), or add `default Optional<Integer> maxRetries() { return Optional.empty(); }` to avoid a breaking compilation error.
- [ ] **JavaPoet `$L` with `int`**: `getDefaultMaxRetries()` returns an `int`, and the initializer uses `"$L"` format. The seed fixture output confirms this works (`private int maxRetries = 5`), but verify edge case with `maxRetries: 0`.
- [ ] **Javadoc concatenation**: The Javadoc line uses `"Defaults to " + getDefaultMaxRetries() + " retries."` — this runs at generation time, so the output is static. Seed fixture confirms it produces `"Defaults to 5 retries."` correctly.
- [ ] **Seed fixture naming**: The `imdb:omit-fern-headers` fixture now includes `maxRetries: 5` alongside `omit-fern-headers: true`. This was done per instruction to merge into existing fixtures rather than create new output directories.

Link to Devin session: https://app.devin.ai/sessions/3f182e0b32934731b90175d656217e95
Requested by: @Swimburger
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/14506" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
