### PR TITLE
chore(csharp): use persistent CSharpier process for code formatting

### DIFF
--- a/generators/browser-compatible-base/src/ast/AbstractFormatter.ts
+++ b/generators/browser-compatible-base/src/ast/AbstractFormatter.ts
@@ -7,6 +7,9 @@ export abstract class AbstractFormatter {
     formatMultipleSync(contents: string[]): string[] {
         return contents.map((content) => this.formatSync(content));
     }
+    dispose(): void {
+        // no-op by default; subclasses may override to clean up resources
+    }
 }
 
 export class NopFormatter extends AbstractFormatter {

--- a/generators/csharp/formatter/src/CsharpFormatter.ts
+++ b/generators/csharp/formatter/src/CsharpFormatter.ts
@@ -10,7 +10,7 @@ export class CsharpFormatter extends AbstractFormatter {
     private process: ChildProcessWithoutNullStreams | undefined;
     private callbacks: ((result: string) => void)[] = [];
     private buffer: string = "";
-    private processFailedToStart = false;
+    private processDead = false;
     private fileCounter = 0;
 
     constructor() {
@@ -28,14 +28,22 @@ export class CsharpFormatter extends AbstractFormatter {
             env: { ...process.env, DOTNET_NOLOGO: "1" }
         });
 
-        csharpierProcess.on("error", () => {
-            this.processFailedToStart = true;
-            while (this.callbacks.length > 0) {
-                const callback = this.callbacks.shift();
-                if (callback) {
-                    callback("");
-                }
+        csharpierProcess.on("error", (error: Error) => {
+            process.stderr.write(`CSharpier process failed to start: ${error.message}\n`);
+            this.processDead = true;
+            this.drainCallbacks();
+        });
+
+        csharpierProcess.on("close", (code: number | null) => {
+            if (code != null && code !== 0) {
+                process.stderr.write(`CSharpier process exited unexpectedly with code ${code}\n`);
             }
+            this.process = undefined;
+            this.drainCallbacks();
+        });
+
+        csharpierProcess.stdin.on("error", () => {
+            // EPIPE errors are expected if the process exits while we're writing
         });
 
         csharpierProcess.stderr.on("data", () => {
@@ -64,8 +72,17 @@ export class CsharpFormatter extends AbstractFormatter {
         return content.endsWith(";") ? content : `${content};`;
     }
 
+    private drainCallbacks(): void {
+        while (this.callbacks.length > 0) {
+            const callback = this.callbacks.shift();
+            if (callback) {
+                callback("");
+            }
+        }
+    }
+
     private pipeFile(content: string): Promise<string> {
-        if (this.processFailedToStart) {
+        if (this.processDead) {
             return Promise.resolve("");
         }
 

--- a/generators/csharp/formatter/src/CsharpFormatter.ts
+++ b/generators/csharp/formatter/src/CsharpFormatter.ts
@@ -8,7 +8,7 @@ const DELIMITER = "\u0003";
 export class CsharpFormatter extends AbstractFormatter {
     private readonly csharpierPath: string;
     private process: ChildProcessWithoutNullStreams | undefined;
-    private callbacks: ((result: string) => void)[] = [];
+    private callbacks: { resolve: (result: string) => void; reject: (error: Error) => void }[] = [];
     private buffer: string = "";
     private processDead = false;
     private fileCounter = 0;
@@ -58,7 +58,7 @@ export class CsharpFormatter extends AbstractFormatter {
                 this.buffer = this.buffer.substring(delimiterIndex + 1);
                 const callback = this.callbacks.shift();
                 if (callback) {
-                    callback(result);
+                    callback.resolve(result);
                 }
                 delimiterIndex = this.buffer.indexOf(DELIMITER);
             }
@@ -73,17 +73,18 @@ export class CsharpFormatter extends AbstractFormatter {
     }
 
     private drainCallbacks(): void {
+        const error = new Error("CSharpier process exited unexpectedly");
         while (this.callbacks.length > 0) {
             const callback = this.callbacks.shift();
             if (callback) {
-                callback("");
+                callback.reject(error);
             }
         }
     }
 
     private pipeFile(content: string): Promise<string> {
         if (this.processDead) {
-            return Promise.resolve("");
+            return Promise.reject(new Error("CSharpier process is not available"));
         }
 
         const proc = this.ensureProcess();
@@ -93,8 +94,8 @@ export class CsharpFormatter extends AbstractFormatter {
         proc.stdin.write(content);
         proc.stdin.write(DELIMITER);
 
-        return new Promise<string>((resolve) => {
-            this.callbacks.push(resolve);
+        return new Promise<string>((resolve, reject) => {
+            this.callbacks.push({ resolve, reject });
         });
     }
 

--- a/generators/csharp/formatter/src/CsharpFormatter.ts
+++ b/generators/csharp/formatter/src/CsharpFormatter.ts
@@ -1,50 +1,99 @@
 import { AbstractFormatter } from "@fern-api/base-generator";
 import { findDotnetToolPath } from "@fern-api/csharp-base";
+import { ChildProcessWithoutNullStreams, spawn } from "child_process";
 import execa from "execa";
 
+const DELIMITER = "\u0003";
+
 export class CsharpFormatter extends AbstractFormatter {
-    private readonly csharpier: string;
+    private readonly csharpierPath: string;
+    private process: ChildProcessWithoutNullStreams | undefined;
+    private callbacks: ((result: string) => void)[] = [];
+    private buffer: string = "";
+    private processFailedToStart = false;
+    private fileCounter = 0;
 
     constructor() {
         super();
-        this.csharpier = findDotnetToolPath("csharpier");
+        this.csharpierPath = findDotnetToolPath("csharpier");
+    }
+
+    private ensureProcess(): ChildProcessWithoutNullStreams {
+        if (this.process != null && !this.process.killed) {
+            return this.process;
+        }
+
+        const csharpierProcess = spawn(this.csharpierPath, ["pipe-files"], {
+            stdio: "pipe",
+            env: { ...process.env, DOTNET_NOLOGO: "1" }
+        });
+
+        csharpierProcess.on("error", () => {
+            this.processFailedToStart = true;
+            while (this.callbacks.length > 0) {
+                const callback = this.callbacks.shift();
+                if (callback) {
+                    callback("");
+                }
+            }
+        });
+
+        csharpierProcess.stderr.on("data", () => {
+            // stderr output is ignored; CSharpier may emit warnings
+        });
+
+        csharpierProcess.stdout.on("data", (chunk: Buffer) => {
+            this.buffer += chunk.toString();
+            let delimiterIndex = this.buffer.indexOf(DELIMITER);
+            while (delimiterIndex >= 0) {
+                const result = this.buffer.substring(0, delimiterIndex);
+                this.buffer = this.buffer.substring(delimiterIndex + 1);
+                const callback = this.callbacks.shift();
+                if (callback) {
+                    callback(result);
+                }
+                delimiterIndex = this.buffer.indexOf(DELIMITER);
+            }
+        });
+
+        this.process = csharpierProcess;
+        return csharpierProcess;
     }
 
     private appendSemicolon(content: string): string {
         return content.endsWith(";") ? content : `${content};`;
     }
 
-    public async format(content: string): Promise<string> {
-        content = this.appendSemicolon(content);
+    private pipeFile(content: string): Promise<string> {
+        if (this.processFailedToStart) {
+            return Promise.resolve("");
+        }
 
-        const { stdout } = await execa(
-            this.csharpier,
-            ["format", "--no-msbuild-check", "--skip-validation", "--compilation-errors-as-warnings"],
-            {
-                input: content,
-                encoding: "utf-8",
-                stripFinalNewline: false
-            }
-        );
-        return stdout;
+        const proc = this.ensureProcess();
+        const filePath = `Dummy${this.fileCounter++}.cs`;
+        proc.stdin.write(filePath);
+        proc.stdin.write(DELIMITER);
+        proc.stdin.write(content);
+        proc.stdin.write(DELIMITER);
+
+        return new Promise<string>((resolve) => {
+            this.callbacks.push(resolve);
+        });
+    }
+
+    public async format(content: string): Promise<string> {
+        return this.pipeFile(this.appendSemicolon(content));
     }
 
     public override async formatMultiple(contents: string[]): Promise<string[]> {
-        const content = contents.map((c, index) => `Dummy${index}.cs\u0003${this.appendSemicolon(c)}\u0003`).join();
-
-        const { stdout } = await execa(this.csharpier, ["pipe-files"], {
-            input: content,
-            encoding: "utf-8",
-            stripFinalNewline: false
-        });
-        return stdout.split("\u0003");
+        return Promise.all(contents.map((c) => this.pipeFile(this.appendSemicolon(c))));
     }
 
     public formatSync(content: string): string {
         content = this.appendSemicolon(content);
 
         const { stdout } = execa.sync(
-            this.csharpier,
+            this.csharpierPath,
             ["format", "--no-msbuild-check", "--skip-validation", "--compilation-errors-as-warnings"],
             {
                 input: content,
@@ -53,5 +102,13 @@ export class CsharpFormatter extends AbstractFormatter {
             }
         );
         return stdout;
+    }
+
+    public dispose(): void {
+        if (this.process != null && !this.process.killed) {
+            this.process.stdin.end();
+            this.process.kill();
+            this.process = undefined;
+        }
     }
 }

--- a/generators/csharp/formatter/src/CsharpFormatter.ts
+++ b/generators/csharp/formatter/src/CsharpFormatter.ts
@@ -39,6 +39,7 @@ export class CsharpFormatter extends AbstractFormatter {
                 process.stderr.write(`CSharpier process exited unexpectedly with code ${code}\n`);
             }
             this.process = undefined;
+            this.buffer = "";
             this.drainCallbacks();
         });
 

--- a/generators/csharp/model/src/ModelGeneratorCli.ts
+++ b/generators/csharp/model/src/ModelGeneratorCli.ts
@@ -78,5 +78,6 @@ export class ModelGeneratorCLI extends AbstractCsharpGeneratorCli {
 
         context.logger.debug(`[TIMING] code generation took ${Date.now() - generateStartTime}ms`);
         await context.project.persist();
+        context.formatter.dispose();
     }
 }

--- a/generators/csharp/model/versions.yml
+++ b/generators/csharp/model/versions.yml
@@ -1,4 +1,16 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 0.8.6
+  changelogEntry:
+    - summary: |
+        Use a persistent CSharpier process for code formatting. Instead of
+        spawning a new process per format call, a single `csharpier pipe-files`
+        process is kept alive and files are piped to it on demand. This
+        eliminates repeated .NET startup overhead and significantly speeds up
+        formatting during model generation.
+      type: chore
+  createdAt: "2026-04-02"
+  irVersion: 65
+
 - version: 0.8.5
   changelogEntry:
     - summary: |

--- a/generators/csharp/sdk/src/SdkGeneratorCli.ts
+++ b/generators/csharp/sdk/src/SdkGeneratorCli.ts
@@ -303,6 +303,7 @@ export class SdkGeneratorCLI extends AbstractCsharpGeneratorCli {
         }
         context.logger.debug(`[TIMING] code generation took ${Date.now() - generateStartTime}ms`);
         await context.project.persist();
+        context.formatter.dispose();
     }
 
     private async generateReadme({

--- a/generators/csharp/sdk/versions.yml
+++ b/generators/csharp/sdk/versions.yml
@@ -1,4 +1,16 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 2.56.1
+  changelogEntry:
+    - summary: |
+        Use a persistent CSharpier process for code formatting. Instead of
+        spawning a new process per format call, a single `csharpier pipe-files`
+        process is kept alive and files are piped to it on demand. This
+        eliminates repeated .NET startup overhead and significantly speeds up
+        formatting during SDK generation.
+      type: chore
+  createdAt: "2026-04-02"
+  irVersion: 65
+
 - version: 2.56.0
   changelogEntry:
     - summary: |


### PR DESCRIPTION
## Description

Replaces the per-call process spawning in `CsharpFormatter` with a single persistent `csharpier pipe-files` process that stays alive across the entire generation run. Files are piped to it on demand via stdin/stdout using the `\u0003` delimiter protocol.

Previously, every `format()` call spawned a new `csharpier format` process (paying .NET startup cost each time), and `formatMultiple()` spawned a one-shot `pipe-files` process. Now both route through a single long-lived process, matching how the [CSharpier VS Code extension](https://github.com/belav/csharpier/blob/main/Src/CSharpier.VSCode/src/CSharpierProcessPipeMultipleFiles.ts) works.

`formatSync()` is unchanged — it still spawns a new process per call since the pipe protocol is inherently async.

## Changes Made
- **`CsharpFormatter.ts`**: Rewritten to maintain a persistent `csharpier pipe-files` child process with a callback queue for matching async responses to requests
- **`AbstractFormatter.ts`**: Added no-op `dispose()` method so subclasses can override to clean up resources
- **`SdkGeneratorCli.ts` / `ModelGeneratorCli.ts`**: Call `context.formatter.dispose()` after `project.persist()` to kill the child process
- **`versions.yml`**: Changelog entries for SDK (2.56.1) and model (0.8.6)

## Error handling
- **Spawn failure** (`error` event): logs via `process.stderr.write`, sets `processDead = true`, rejects all pending callbacks
- **Unexpected exit** (`close` event): logs non-zero exit codes, clears `this.process` and `this.buffer`, rejects pending callbacks. Process will be respawned on next `pipeFile()` call.
- **EPIPE on stdin**: silently absorbed (expected when process dies mid-write)
- **`processDead` flag** (spawn failure only): all future `pipeFile()` calls immediately reject
- Callbacks store `{ resolve, reject }` pairs so process failures propagate as errors to callers, preserving the old `execa`-based error behavior

## Human Review Checklist
- **No timeout on pending callbacks**: If CSharpier hangs or produces malformed output, promises will never resolve. In practice this hasn't been an issue, but a timeout could be added as a follow-up.
- **FIFO ordering assumption**: The callback queue assumes CSharpier responds in the same order files were written to stdin. This matches the protocol spec but is worth confirming.
- **`dispose()` triggers `drainCallbacks`**: `dispose()` calls `kill()`, which fires `close`, which rejects pending callbacks. In practice this is safe since `dispose()` only runs after `project.persist()` completes.

## Testing
- [x] Lint checks pass (`pnpm run check`)
- [x] Seed tests pass for `csharp-sdk` (exhaustive fixture, all 6 configs) — output identical to baseline
- [x] Seed tests pass for `csharp-model` (exhaustive fixture) — output identical to baseline
- [ ] Unit tests added/updated

Link to Devin session: https://app.devin.ai/sessions/2055054d844b4fb0a627f40a9cfe7356
Requested by: @Swimburger
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/14518" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
