### PR TITLE
chore(internal): migrate PHP generator from lodash template to Eta

### DIFF
--- a/generators/php/base/package.json
+++ b/generators/php/base/package.json
@@ -44,6 +44,7 @@
     "@fern-fern/ir-sdk": "^62.1.0",
     "@types/lodash-es": "catalog:",
     "@types/node": "catalog:",
+    "eta": "^4.5.1",
     "lodash-es": "catalog:",
     "typescript": "catalog:",
     "vitest": "catalog:"

--- a/generators/php/base/src/project/PhpProject.ts
+++ b/generators/php/base/src/project/PhpProject.ts
@@ -2,13 +2,16 @@ import { AbstractProject, File } from "@fern-api/base-generator";
 import { AbsoluteFilePath, join, RelativeFilePath } from "@fern-api/fs-utils";
 import { loggingExeca } from "@fern-api/logging-execa";
 import { BasePhpCustomConfigSchema } from "@fern-api/php-codegen";
+import { Eta } from "eta";
 import { mkdir, readFile, writeFile } from "fs/promises";
-import { cloneDeep, isArray, mergeWith, template } from "lodash-es";
+import { cloneDeep, isArray, mergeWith } from "lodash-es";
 import path from "path";
 
 import { AsIsFiles } from "../AsIs.js";
 import { AbstractPhpGeneratorContext } from "../context/AbstractPhpGeneratorContext.js";
 import { PhpFile } from "./PhpFile.js";
+
+const eta = new Eta({ autoEscape: false, useWith: true, autoTrim: false });
 
 const AS_IS_DIRECTORY = path.join(__dirname, "asIs");
 const CORE_DIRECTORY_NAME = "Core";
@@ -247,7 +250,7 @@ export class PhpProject extends AbstractProject<AbstractPhpGeneratorContext<Base
         namespace: string;
         extraTemplateVars?: Record<string, string>;
     }): string {
-        return template(contents)({
+        return eta.renderString(contents, {
             namespace,
             coreNamespace: this.context.getCoreNamespace(),
             ...extraTemplateVars

--- a/generators/php/model/versions.yml
+++ b/generators/php/model/versions.yml
@@ -1,5 +1,13 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 
+- version: 0.0.3
+  changelogEntry:
+    - summary: |
+        Migrate template engine from lodash to Eta for consistency with other generators.
+      type: chore
+  createdAt: "2026-04-02"
+  irVersion: 62
+
 - version: 0.0.2
   changelogEntry:
     - summary: |

--- a/generators/php/sdk/versions.yml
+++ b/generators/php/sdk/versions.yml
@@ -1,4 +1,12 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 2.3.1
+  changelogEntry:
+    - summary: |
+        Migrate template engine from lodash to Eta for consistency with other generators.
+      type: chore
+  createdAt: "2026-04-02"
+  irVersion: 62
+
 - version: 2.3.0
   changelogEntry:
     - summary: |

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1464,6 +1464,9 @@ importers:
       '@types/node':
         specifier: 'catalog:'
         version: 18.15.3
+      eta:
+        specifier: ^4.5.1
+        version: 4.5.1
       lodash-es:
         specifier: 'catalog:'
         version: 4.18.1

--- a/seed/php-sdk/imdb/clientName/.fern/metadata.json
+++ b/seed/php-sdk/imdb/clientName/.fern/metadata.json
@@ -3,7 +3,8 @@
   "generatorName": "fernapi/fern-php-sdk",
   "generatorVersion": "latest",
   "generatorConfig": {
-    "clientName": "FernClient"
+    "clientName": "FernClient",
+    "maxRetries": 5
   },
   "originGitCommit": "DUMMY",
   "sdkVersion": "0.0.1"


### PR DESCRIPTION
## Description

Migrates the PHP generator's template engine from lodash's `template()` to [Eta](https://eta.js.org/), matching the engine already used by the C# generator.

## Changes Made

- Added `eta` dependency to `generators/php/base/package.json`
- Replaced `template(contents)({...})` (lodash) with `eta.renderString(contents, {...})` in `PhpProject.ts`
- Eta instance configured with `{ autoEscape: false, useWith: true, autoTrim: false }` — identical to the C# generator's configuration
- `lodash-es` remains as a dependency since `cloneDeep`, `isArray`, and `mergeWith` are still used in this file and elsewhere in the PHP generator
- Added `versions.yml` entries: PHP SDK → 2.3.1, PHP Model → 0.0.3

### Unrelated change from rebase

- `seed/php-sdk/imdb/clientName/.fern/metadata.json` — picks up the `maxRetries` config field added by the `maxRetries` feature (#14502) that merged while this PR was in flight. Not caused by the Eta migration.

## Testing

- [x] All 113/113 php-model seed tests pass
- [x] All 131/131 php-sdk seed tests pass
- [x] Zero diff in seed output from the Eta migration — confirms behavioral equivalence between lodash `template()` and Eta for `<%= %>` syntax
- [x] Lint passes (`pnpm run check`)

## Review Checklist

- [ ] Verify the Eta config (`autoEscape: false, useWith: true, autoTrim: false`) is correct — `useWith: true` is critical so that `<%= namespace %>` works without needing `<%= it.namespace %>`
- [ ] Confirm `lodash-es` should remain (still used for `cloneDeep`, `isArray`, `mergeWith` in this file and other PHP generator files)
- [ ] Confirm the `metadata.json` diff is expected (unrelated rebase artifact from #14502)

Link to Devin session: https://app.devin.ai/sessions/d306210854084b35b3c5a0af06ddb20c
Requested by: @Swimburger
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/14521" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
