### PR TITLE
chore(internal): migrate Ruby generator from lodash template to Eta

### DIFF
--- a/generators/ruby-v2/base/package.json
+++ b/generators/ruby-v2/base/package.json
@@ -48,6 +48,7 @@
     "@types/node": "catalog:",
     "dedent": "catalog:",
     "eslint": "catalog:",
+    "eta": "^4.5.1",
     "lodash-es": "catalog:",
     "prettier": "catalog:",
     "typescript": "catalog:",

--- a/generators/ruby-v2/base/src/project/RubyProject.ts
+++ b/generators/ruby-v2/base/src/project/RubyProject.ts
@@ -3,12 +3,14 @@ import { AbsoluteFilePath, join, RelativeFilePath, relative } from "@fern-api/fs
 import { BaseRubyCustomConfigSchema } from "@fern-api/ruby-ast";
 import { FernIr } from "@fern-fern/ir-sdk";
 import dedent from "dedent";
+import { Eta } from "eta";
 import { mkdir, readFile, writeFile } from "fs/promises";
-import { template } from "lodash-es";
 import { join as pathJoin } from "path";
 import { AsIsFiles, topologicalCompareAsIsFiles } from "../AsIs.js";
 import { AbstractRubyGeneratorContext } from "../context/AbstractRubyGeneratorContext.js";
 import { RubocopFile } from "./RubocopFile.js";
+
+const eta = new Eta({ autoEscape: false, useWith: true, autoTrim: false });
 
 const GEMFILE_FILENAME = "Gemfile";
 const CUSTOM_GEMFILE_FILENAME = "Gemfile.custom";
@@ -103,7 +105,7 @@ export class RubyProject extends AbstractProject<AbstractRubyGeneratorContext<Ba
         // Use enableWireTests config to conditionally include wire-tests in the test command
         const enableWireTests = this.rubyContext.customConfig.enableWireTests ?? false;
 
-        const githubCiContents = template(githubCiTemplate)({ enableWireTests });
+        const githubCiContents = eta.renderString(githubCiTemplate, { enableWireTests });
         await writeFile(join(githubWorkflowsDir, RelativeFilePath.of("ci.yml")), githubCiContents);
     }
 
@@ -214,7 +216,7 @@ export class RubyProject extends AbstractProject<AbstractRubyGeneratorContext<Ba
 }
 
 function replaceTemplate({ contents, variables }: { contents: string; variables: Record<string, unknown> }): string {
-    return template(contents)(variables);
+    return eta.renderString(contents, variables);
 }
 
 function getTemplateVariables({

--- a/generators/ruby-v2/sdk/versions.yml
+++ b/generators/ruby-v2/sdk/versions.yml
@@ -1,5 +1,13 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 
+- version: 1.1.12
+  changelogEntry:
+    - summary: |
+        Migrate template engine from lodash to Eta for consistency with other generators.
+      type: chore
+  createdAt: "2026-04-02"
+  irVersion: 61
+
 - version: 1.1.11
   changelogEntry:
     - summary: |

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1998,6 +1998,9 @@ importers:
       eslint:
         specifier: 'catalog:'
         version: 9.39.2(jiti@2.6.1)
+      eta:
+        specifier: ^4.5.1
+        version: 4.5.1
       lodash-es:
         specifier: 'catalog:'
         version: 4.18.1


### PR DESCRIPTION
## Description

Migrate the Ruby v2 generator's template engine from lodash `template()` to Eta, for consistency with the TypeScript and C# generators which already use Eta.

Companion to #14521 (same migration for the PHP generator).

## Changes Made

- Added `eta` dependency (`^4.5.1`) to `generators/ruby-v2/base/package.json`
- Replaced `import { template } from "lodash-es"` with `import { Eta } from "eta"` in `RubyProject.ts`
- Initialized shared Eta instance with `{ autoEscape: false, useWith: true, autoTrim: false }` (same config as C#/TS generators)
- Replaced both `template()` call sites with `eta.renderString()`:
  - `replaceTemplate()` helper function
  - `createGithubCiWorkflow()` method
- `lodash-es` remains as a dependency — `upperFirst` is still used in `AbstractRubyGeneratorContext.ts`
- Added `versions.yml` entry (1.1.12)

## Important to review

- The Eta config (`useWith: true`) is required so templates can reference variables directly (e.g., `<%= name %>`) without `it.` prefix
- The GitHub CI template uses lodash-style control flow (`<% if (...) { %>`) and dollar escaping (`<%= "$" %>`) — both are supported by Eta's default delimiters
- Verify that `lodash-es` is still needed (it is — `upperFirst` is used in `AbstractRubyGeneratorContext.ts`)

## Testing

- [x] `pnpm run check` (biome lint) passes
- [x] Seed tests: `ruby-sdk-v2` — 118/118 passed, zero output diff (confirmed after rebase onto latest main)

Link to Devin session: https://app.devin.ai/sessions/d306210854084b35b3c5a0af06ddb20c
Requested by: @Swimburger
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/14524" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
