### PR TITLE
fix(internal): add npm@11 to publish workflows for OIDC trusted publishing

### DIFF
--- a/.github/actions/install/action.yaml
+++ b/.github/actions/install/action.yaml
@@ -15,6 +15,13 @@ runs:
         registry-url: "https://registry.npmjs.org"
         cache: pnpm
 
+    # npm >= 11.5.1 is required for OIDC trusted publishing (pnpm publish
+    # delegates to npm under the hood). Node 22 ships with npm 10.x which
+    # does not support OIDC, so we must upgrade explicitly.
+    - name: ⎔ Update npm for OIDC publishing
+      shell: bash
+      run: npm install -g npm@latest
+
     - name: ⎔ Cache turbo build
       uses: actions/cache@v5
       with:

--- a/.github/actions/install/action.yaml
+++ b/.github/actions/install/action.yaml
@@ -15,13 +15,6 @@ runs:
         registry-url: "https://registry.npmjs.org"
         cache: pnpm
 
-    # npm >= 11.5.1 is required for OIDC trusted publishing (pnpm publish
-    # delegates to npm under the hood). Node 22 ships with npm 10.x which
-    # does not support OIDC, so we must upgrade explicitly.
-    - name: ⎔ Update npm for OIDC publishing
-      shell: bash
-      run: npm install -g npm@latest
-
     - name: ⎔ Cache turbo build
       uses: actions/cache@v5
       with:

--- a/.github/workflows/publish-cli.yml
+++ b/.github/workflows/publish-cli.yml
@@ -81,6 +81,11 @@ jobs:
           git_version="$(./scripts/git-version.sh)"
           echo Publishing version: "${git_version}"
 
+      # npm >= 11.5.1 is required for OIDC trusted publishing (pnpm publish
+      # delegates to npm under the hood). Node 22 ships with npm 10.x.
+      - name: Update npm for OIDC publishing
+        run: npm install -g npm@11
+
       - name: Publish Dev CLI
         run: |
           git_version="$(./scripts/git-version.sh)"
@@ -133,6 +138,11 @@ jobs:
         run: |
           pnpm seed:build
 
+      # npm >= 11.5.1 is required for OIDC trusted publishing (pnpm publish
+      # delegates to npm under the hood). Node 22 ships with npm 10.x.
+      - name: Update npm for OIDC publishing
+        run: npm install -g npm@11
+
       - name: Publish + Register CLI
         env:
           FERN_TOKEN: ${{ secrets.FERN_TOKEN }}
@@ -177,6 +187,11 @@ jobs:
       - name: Build Seed
         run: |
           pnpm seed:build
+
+      # npm >= 11.5.1 is required for OIDC trusted publishing (pnpm publish
+      # delegates to npm under the hood). Node 22 ships with npm 10.x.
+      - name: Update npm for OIDC publishing
+        run: npm install -g npm@11
 
       - name: Publish Dev CLI
         run: |

--- a/.github/workflows/publish-generator-cli.yml
+++ b/.github/workflows/publish-generator-cli.yml
@@ -89,6 +89,11 @@ jobs:
           GITHUB_TOKEN: ${{ env.GITHUB_TOKEN }}
         run: pnpm turbo run test --filter=${{ env.PACKAGE_NAME }}
 
+      # npm >= 11.5.1 is required for OIDC trusted publishing (pnpm publish
+      # delegates to npm under the hood). Node 22 ships with npm 10.x.
+      - name: Update npm for OIDC publishing
+        run: npm install -g npm@11
+
       - name: Publish generator-cli
         run: |
           cd packages/generator-cli/dist

--- a/.github/workflows/publish-generator-migrations.yml
+++ b/.github/workflows/publish-generator-migrations.yml
@@ -94,9 +94,10 @@ jobs:
           registry-url: https://registry.npmjs.org
           scope: "@fern-api"
 
-      # npm >= 11.5.1 is required for OIDC trusted publishing
+      # npm >= 11.5.1 is required for OIDC trusted publishing.
+      # Node 22 ships with npm 10.x which does not support OIDC.
       - name: Update npm for OIDC publishing
-        run: npm install -g npm@latest
+        run: npm install -g npm@11
 
       - name: Build and publish generator-migrations
         env:

--- a/.github/workflows/publish-generator-migrations.yml
+++ b/.github/workflows/publish-generator-migrations.yml
@@ -94,6 +94,10 @@ jobs:
           registry-url: https://registry.npmjs.org
           scope: "@fern-api"
 
+      # npm >= 11.5.1 is required for OIDC trusted publishing
+      - name: Update npm for OIDC publishing
+        run: npm install -g npm@latest
+
       - name: Build and publish generator-migrations
         env:
           NEW_VERSION: ${{ needs.check-version.outputs.version }}

--- a/.github/workflows/publish-snippets-core.yml
+++ b/.github/workflows/publish-snippets-core.yml
@@ -52,4 +52,4 @@ jobs:
           cd packages/snippets/core
           pnpm turbo run dist --filter=${{ env.PACKAGE_NAME }} -- ${{ inputs.version }}
           cd dist
-          npx -y npm@latest publish --access public --tag latest
+          npx -y npm@11 publish --access public --tag latest


### PR DESCRIPTION
## Description

npm >= 11.5.1 is required for OIDC trusted publishing. `pnpm publish` delegates to `npm` under the hood, and Node 22 only ships with npm 10.x which does not support OIDC. The npm upgrade was removed from CI in fcc2929, which broke all npm publishes since 2026-04-01 20:24 UTC.

Rather than restoring `npm install -g npm@latest` in the shared install action (which was itself causing CI failures), this PR pins `npm@11` only in the publish workflows that need it for OIDC.

## Changes Made

- **`publish-cli.yml`**: Added `npm install -g npm@11` before publish steps in `dev`, `prod`, and `manual` jobs
- **`publish-generator-cli.yml`**: Added `npm install -g npm@11` before `pnpm publish`
- **`publish-generator-migrations.yml`**: Added `npm install -g npm@11` before `npm publish`
- **`publish-snippets-core.yml`**: Changed `npx -y npm@latest` → `npx -y npm@11` for consistency
- Shared install action (`.github/actions/install/action.yaml`) is **not modified** — kept clean intentionally
- [ ] Updated README.md generator (if applicable)

## Testing

- [ ] Unit tests added/updated
- [ ] Manual testing completed

> **Note:** These are CI-only workflow changes — they can only be fully validated when the publish workflows run on main after merge.

### Human Review Checklist
- [ ] Verify all publish workflows using OIDC (`id-token: write`) that do npm/pnpm publish are covered
- [ ] Confirm `npm@11` (major pin with minor+patch float) is acceptable vs an exact version pin
- [ ] Confirm no regressions to the shared install action used by non-publish CI jobs

Link to Devin session: https://app.devin.ai/sessions/3948a95bb5a54f33a4513f2b6d27b734
Requested by: @Swimburger
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/14526" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
