### PR TITLE
fix(internal): use merge commit parent for affected detection in PRs

### DIFF
--- a/.github/workflows/seed.yml
+++ b/.github/workflows/seed.yml
@@ -136,11 +136,19 @@ jobs:
         run: |
           # Determine base ref for affected detection.
           if [[ "${{ github.event_name }}" == "pull_request" ]]; then
-            # Use the PR base SHA from the event payload and fetch only that
-            # specific commit. This is much faster than `git fetch --deepen=1`
-            # which negotiates the entire repo graph (~4 min on this repo).
-            BASE_REF="${{ github.event.pull_request.base.sha }}"
-            echo "Using PR base SHA: $BASE_REF"
+            # CI checks out pull/N/merge — a merge commit whose first parent
+            # is the exact main tip used to create the merge ref. Using HEAD^1
+            # instead of base.sha avoids a race where main advances between the
+            # webhook event and the merge ref computation, which caused unrelated
+            # generators to run (e.g. go-model on PHP-only PRs).
+            if git rev-parse --verify HEAD^2 >/dev/null 2>&1; then
+              BASE_REF=$(git rev-parse HEAD^1)
+              echo "Using merge commit first parent: $BASE_REF"
+            else
+              # Fallback: not a merge commit (shouldn't happen for PRs, but be safe)
+              BASE_REF="${{ github.event.pull_request.base.sha }}"
+              echo "Using PR base SHA (fallback): $BASE_REF"
+            fi
             # Fetch just the base commit so git diff can reach it
             git fetch --no-tags --depth=1 origin "$BASE_REF" 2>/dev/null || true
           else


### PR DESCRIPTION
## Description

Fixes a race condition in the seed workflow's affected detection that caused unrelated generators to run on PRs (e.g., `go-model` running on PHP-only PRs like #14521).

## Problem

The workflow used `github.event.pull_request.base.sha` as the base ref for `git diff`. This SHA is captured when the webhook event fires, but GitHub computes the `pull/N/merge` ref against the **latest** main tip. When main advances between those two moments (common on an active repo), the diff includes changes from other merged PRs, triggering unrelated generators.

Example from #14521: `base.sha` was `c8d2ebc94` but the merge ref used `60cda3df6`. The gap included Go generator changes from the maxRetries feature, so `go-model` and `go-sdk` ran unnecessarily alongside `php-model` and `php-sdk`.

## Changes Made

- For PR events, extract the merge commit's first parent via `git rev-parse HEAD^1` instead of using `base.sha`. This is the exact main tip GitHub used to create the merge ref — no race possible.
- Added a safety check (`HEAD^2` exists) to confirm HEAD is a merge commit before using `HEAD^1`, with fallback to the old `base.sha` behavior.
- Non-PR event paths (push, dispatch) are unchanged.

## Testing

- [ ] Manual testing not feasible — the race condition depends on main advancing during CI
- [x] YAML validation passes
- [x] Logical review: `actions/checkout@v6` checks out `pull/N/merge` (a merge commit) for PRs, so `HEAD^1` is always the main-side parent. `git rev-parse` reads parent SHAs from the commit object, which is available even in depth=1 shallow clones.

## Review Checklist

- [ ] Confirm `git rev-parse HEAD^1` works in GitHub Actions depth=1 shallow clones (parent SHA is stored in the commit object, but worth verifying)
- [ ] Confirm fallback to `base.sha` is acceptable if `actions/checkout` behavior ever changes
- [ ] Verify non-PR paths (push to main, workflow_dispatch) are unaffected by this change

Link to Devin session: https://app.devin.ai/sessions/a467004ae4044652881918bd8a574ff3
Requested by: @Swimburger
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/14533" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
