### PR TITLE
chore(ruby): remove legacy dollar-sign workarounds in CI templates

### DIFF
--- a/generators/csharp/base/src/asIs/github-ci.yml
+++ b/generators/csharp/base/src/asIs/github-ci.yml
@@ -47,6 +47,6 @@ jobs:
       - name: Publish to NuGet.org
         if: github.event_name == 'push' && contains(github.ref, 'refs/tags/')
         env:
-          NUGET_API_KEY: $\{{ secrets.<%= nugetTokenEnvvar%> }}
+          NUGET_API_KEY: ${{ secrets.<%= nugetTokenEnvvar%> }}
         run: dotnet nuget push <%= libraryPath %>/bin/Release/*.nupkg --api-key $NUGET_API_KEY --source "nuget.org"
 <% } %>

--- a/generators/csharp/sdk/versions.yml
+++ b/generators/csharp/sdk/versions.yml
@@ -1,4 +1,13 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 2.56.3
+  changelogEntry:
+    - summary: |
+        Remove legacy backslash escape in generated CI workflow's NuGet publish
+        step now that Eta template engine does not interpret `${}` syntax.
+      type: chore
+  createdAt: "2026-04-02"
+  irVersion: 65
+
 - version: 2.56.2
   changelogEntry:
     - summary: |
@@ -14,7 +23,6 @@
       type: fix
   createdAt: "2026-04-02"
   irVersion: 65
-
 - version: 2.56.1
   changelogEntry:
     - summary: |

--- a/generators/ruby-v2/base/src/asIs/github-ci.yml
+++ b/generators/ruby-v2/base/src/asIs/github-ci.yml
@@ -3,7 +3,7 @@ name: ci
 on: [push, pull_request]
 
 concurrency:
-  group: <%= "$" %>{{ github.workflow }}-<%= "$" %>{{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: false
 
 jobs:

--- a/generators/ruby-v2/sdk/versions.yml
+++ b/generators/ruby-v2/sdk/versions.yml
@@ -1,5 +1,14 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 
+- version: 1.1.13
+  changelogEntry:
+    - summary: |
+        Remove legacy dollar-sign workaround in generated CI workflow now that Eta
+        template engine does not interpret `${}` syntax.
+      type: chore
+  createdAt: "2026-04-02"
+  irVersion: 61
+
 - version: 1.1.12
   changelogEntry:
     - summary: |


### PR DESCRIPTION
## Description

Cleans up legacy `${}` escape workarounds in CI workflow templates that are no longer needed after the Eta migration (PRs #14521, #14524). Lodash's `template()` interpreted `${}` as interpolation syntax, requiring workarounds. Eta does not, so these can be simplified.

## Changes Made

- **Ruby CI template**: Replace `<%= "$" %>{{ github.workflow }}` with direct `${{ github.workflow }}` (cosmetic — output was already correct)
- **C# CI template**: Remove backslash from `$\{{ secrets.<%= nugetTokenEnvvar%> }}` → `${{ secrets.<%= nugetTokenEnvvar%> }}` (bug fix — with Eta, the `\` was being rendered literally in the output)
- Version bumps: Ruby SDK → 1.1.13, C# SDK → 2.56.2

## Testing

- [x] `ruby-sdk-v2` seed tests: 118/118 passed
- [x] `csharp-sdk` seed tests: 161/161 passed
- [x] Lint (`pnpm run check`) passes

## Review Checklist

- [ ] Verify the C# publish block path (`shouldWritePublishBlock: true`) produces correct output — seed tests may not exercise this path since most fixtures don't have publish config. The `$\{{` with Eta would have produced a literal backslash, making the GitHub Actions expression invalid.
- [ ] Confirm no other templates have similar `${}` workarounds that were missed

Link to Devin session: https://app.devin.ai/sessions/d306210854084b35b3c5a0af06ddb20c
Requested by: @Swimburger
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/14534" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
