### PR TITLE
fix(typescript): correct import paths in generated test files for custom package paths

### DIFF
--- a/generators/typescript/sdk/versions.yml
+++ b/generators/typescript/sdk/versions.yml
@@ -1,4 +1,16 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 3.62.1
+  changelogEntry:
+    - summary: |
+        Fix incorrect import paths in generated test files when using a custom
+        package path (e.g. `src/management`). Multi-line imports in test files
+        like `makeRequest.test.ts` were emitting `../../../src/management/core/...`
+        instead of `../../../core/...`, causing the import to resolve to a
+        nonexistent path.
+      type: fix
+  createdAt: "2026-04-02"
+  irVersion: 66
+
 - version: 3.62.0
   changelogEntry:
     - summary: |

--- a/generators/typescript/utils/commons/src/core-utilities/CoreUtilitiesManager.ts
+++ b/generators/typescript/utils/commons/src/core-utilities/CoreUtilitiesManager.ts
@@ -322,10 +322,7 @@ export class CoreUtilitiesManager {
         // Replace relative import paths that reference the default package path (src/)
         // e.g. from "../../../src/core/fetcher/makeRequest" -> from "../../../core/fetcher/makeRequest"
         // where ../../../ resolves to the custom package path
-        contents = contents.replace(
-            /from "([^"]*\/)src\/([^"]*)"/g,
-            `from "${normalizedPath}/$2"`
-        );
+        contents = contents.replace(/from "([^"]*\/)src\/([^"]*)"/g, `from "${normalizedPath}/$2"`);
 
         if (contents !== originalContents) {
             await writeFile(filePath, contents);

--- a/generators/typescript/utils/commons/src/core-utilities/CoreUtilitiesManager.ts
+++ b/generators/typescript/utils/commons/src/core-utilities/CoreUtilitiesManager.ts
@@ -222,18 +222,23 @@ export class CoreUtilitiesManager {
 
                 // Update import paths after copying (customize findAndReplace as needed)
                 if (isCustomPackagePath) {
-                    const findAndReplace: Record<string, { importPath: string; body: string }> = {
-                        [DEFAULT_PACKAGE_PATH]: {
-                            importPath: this.getPackagePathImport(),
-                            body: this.relativePackagePath
-                        },
-                        [DEFAULT_TEST_PATH]: {
-                            importPath: this.getTestPathImport(),
-                            body: this.relativeTestPath
-                        }
-                    };
+                    const isTestFile = destinationFile.includes(this.relativeTestPath);
+                    if (isTestFile) {
+                        await this.updateTestFileImportPaths(destPath, destinationFile);
+                    } else {
+                        const findAndReplace: Record<string, { importPath: string; body: string }> = {
+                            [DEFAULT_PACKAGE_PATH]: {
+                                importPath: this.getPackagePathImport(),
+                                body: this.relativePackagePath
+                            },
+                            [DEFAULT_TEST_PATH]: {
+                                importPath: this.getTestPathImport(),
+                                body: this.relativeTestPath
+                            }
+                        };
 
-                    await this.updateImportPaths(destPath, findAndReplace);
+                        await this.updateImportPaths(destPath, findAndReplace);
+                    }
                 }
             })
         );
@@ -299,6 +304,31 @@ export class CoreUtilitiesManager {
                     encoding: "utf8"
                 });
             }
+        }
+    }
+
+    // Helper to update import paths in test files that use relative imports to source files.
+    // When both test and source files are moved under a custom package path (e.g. src/management),
+    // relative imports like "../../../src/core/..." need to strip the "src/" prefix since both
+    // files are already under the same custom prefix.
+    private async updateTestFileImportPaths(filePath: string, destinationFile: string) {
+        const testDir = path.dirname(destinationFile);
+        const relativePathToPackage = path.relative(testDir, this.relativePackagePath);
+        const normalizedPath = relativePathToPackage.replace(/\\/g, "/");
+
+        let contents = await readFile(filePath, "utf8");
+        const originalContents = contents;
+
+        // Replace relative import paths that reference the default package path (src/)
+        // e.g. from "../../../src/core/fetcher/makeRequest" -> from "../../../core/fetcher/makeRequest"
+        // where ../../../ resolves to the custom package path
+        contents = contents.replace(
+            /from "([^"]*\/)src\/([^"]*)"/g,
+            `from "${normalizedPath}/$2"`
+        );
+
+        if (contents !== originalContents) {
+            await writeFile(filePath, contents);
         }
     }
 

--- a/seed/ts-sdk/exhaustive/package-path/src/test-packagePath/tests/unit/auth/BasicAuth.test.ts
+++ b/seed/ts-sdk/exhaustive/package-path/src/test-packagePath/tests/unit/auth/BasicAuth.test.ts
@@ -1,4 +1,4 @@
-import { BasicAuth } from "../../../../../src/test-packagePath/core/auth/BasicAuth";
+import { BasicAuth } from "../../../core/auth/BasicAuth";
 
 describe("BasicAuth", () => {
     interface ToHeaderTestCase {

--- a/seed/ts-sdk/exhaustive/package-path/src/test-packagePath/tests/unit/auth/BearerToken.test.ts
+++ b/seed/ts-sdk/exhaustive/package-path/src/test-packagePath/tests/unit/auth/BearerToken.test.ts
@@ -1,4 +1,4 @@
-import { BearerToken } from "../../../../../src/test-packagePath/core/auth/BearerToken";
+import { BearerToken } from "../../../core/auth/BearerToken";
 
 describe("BearerToken", () => {
     describe("toAuthorizationHeader", () => {

--- a/seed/ts-sdk/exhaustive/package-path/src/test-packagePath/tests/unit/base64.test.ts
+++ b/seed/ts-sdk/exhaustive/package-path/src/test-packagePath/tests/unit/base64.test.ts
@@ -1,4 +1,4 @@
-import { base64Decode, base64Encode } from "../../../../src/test-packagePath/core/base64";
+import { base64Decode, base64Encode } from "../../core/base64";
 
 describe("base64", () => {
     describe("base64Encode", () => {

--- a/seed/ts-sdk/exhaustive/package-path/src/test-packagePath/tests/unit/fetcher/Fetcher.test.ts
+++ b/seed/ts-sdk/exhaustive/package-path/src/test-packagePath/tests/unit/fetcher/Fetcher.test.ts
@@ -1,8 +1,8 @@
 import fs from "fs";
 import { join } from "path";
 import stream from "stream";
-import type { BinaryResponse } from "../../../../../src/test-packagePath/core";
-import { type Fetcher, fetcherImpl } from "../../../../../src/test-packagePath/core/fetcher/Fetcher";
+import type { BinaryResponse } from "../../../core";
+import { type Fetcher, fetcherImpl } from "../../../core/fetcher/Fetcher";
 
 describe("Test fetcherImpl", () => {
     it("should handle successful request", async () => {

--- a/seed/ts-sdk/exhaustive/package-path/src/test-packagePath/tests/unit/fetcher/HttpResponsePromise.test.ts
+++ b/seed/ts-sdk/exhaustive/package-path/src/test-packagePath/tests/unit/fetcher/HttpResponsePromise.test.ts
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-import { HttpResponsePromise } from "../../../../../src/test-packagePath/core/fetcher/HttpResponsePromise";
-import type { RawResponse, WithRawResponse } from "../../../../../src/test-packagePath/core/fetcher/RawResponse";
+import { HttpResponsePromise } from "../../../core/fetcher/HttpResponsePromise";
+import type { RawResponse, WithRawResponse } from "../../../core/fetcher/RawResponse";
 
 describe("HttpResponsePromise", () => {
     const mockRawResponse: RawResponse = {

--- a/seed/ts-sdk/exhaustive/package-path/src/test-packagePath/tests/unit/fetcher/RawResponse.test.ts
+++ b/seed/ts-sdk/exhaustive/package-path/src/test-packagePath/tests/unit/fetcher/RawResponse.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { toRawResponse } from "../../../../../src/test-packagePath/core/fetcher/RawResponse";
+import { toRawResponse } from "../../../core/fetcher/RawResponse";
 
 describe("RawResponse", () => {
     describe("toRawResponse", () => {

--- a/seed/ts-sdk/exhaustive/package-path/src/test-packagePath/tests/unit/fetcher/createRequestUrl.test.ts
+++ b/seed/ts-sdk/exhaustive/package-path/src/test-packagePath/tests/unit/fetcher/createRequestUrl.test.ts
@@ -1,4 +1,4 @@
-import { createRequestUrl } from "../../../../../src/test-packagePath/core/fetcher/createRequestUrl";
+import { createRequestUrl } from "../../../core/fetcher/createRequestUrl";
 
 describe("Test createRequestUrl", () => {
     const BASE_URL = "https://api.example.com";

--- a/seed/ts-sdk/exhaustive/package-path/src/test-packagePath/tests/unit/fetcher/getRequestBody.test.ts
+++ b/seed/ts-sdk/exhaustive/package-path/src/test-packagePath/tests/unit/fetcher/getRequestBody.test.ts
@@ -1,5 +1,5 @@
-import { getRequestBody } from "../../../../../src/test-packagePath/core/fetcher/getRequestBody";
-import { RUNTIME } from "../../../../../src/test-packagePath/core/runtime";
+import { getRequestBody } from "../../../core/fetcher/getRequestBody";
+import { RUNTIME } from "../../../core/runtime";
 
 describe("Test getRequestBody", () => {
     interface TestCase {

--- a/seed/ts-sdk/exhaustive/package-path/src/test-packagePath/tests/unit/fetcher/getResponseBody.test.ts
+++ b/seed/ts-sdk/exhaustive/package-path/src/test-packagePath/tests/unit/fetcher/getResponseBody.test.ts
@@ -1,6 +1,6 @@
-import { getResponseBody } from "../../../../../src/test-packagePath/core/fetcher/getResponseBody";
+import { getResponseBody } from "../../../core/fetcher/getResponseBody";
 
-import { RUNTIME } from "../../../../../src/test-packagePath/core/runtime";
+import { RUNTIME } from "../../../core/runtime";
 
 describe("Test getResponseBody", () => {
     interface SimpleTestCase {

--- a/seed/ts-sdk/exhaustive/package-path/src/test-packagePath/tests/unit/fetcher/logging.test.ts
+++ b/seed/ts-sdk/exhaustive/package-path/src/test-packagePath/tests/unit/fetcher/logging.test.ts
@@ -1,4 +1,4 @@
-import { fetcherImpl } from "../../../../../src/test-packagePath/core/fetcher/Fetcher";
+import { fetcherImpl } from "../../../core/fetcher/Fetcher";
 
 function createMockLogger() {
     return {

--- a/seed/ts-sdk/exhaustive/package-path/src/test-packagePath/tests/unit/fetcher/makePassthroughRequest.test.ts
+++ b/seed/ts-sdk/exhaustive/package-path/src/test-packagePath/tests/unit/fetcher/makePassthroughRequest.test.ts
@@ -1,5 +1,5 @@
 import type { Mock } from "vitest";
-import { makePassthroughRequest } from "../../../../../src/test-packagePath/core/fetcher/makePassthroughRequest";
+import { makePassthroughRequest } from "../../../core/fetcher/makePassthroughRequest";
 
 describe("makePassthroughRequest", () => {
     let mockFetch: Mock;

--- a/seed/ts-sdk/exhaustive/package-path/src/test-packagePath/tests/unit/fetcher/makeRequest.test.ts
+++ b/seed/ts-sdk/exhaustive/package-path/src/test-packagePath/tests/unit/fetcher/makeRequest.test.ts
@@ -1,9 +1,5 @@
 import type { Mock } from "vitest";
-import {
-    isCacheNoStoreSupported,
-    makeRequest,
-    resetCacheNoStoreSupported,
-} from "../../../src/test-packagePath/core/fetcher/makeRequest";
+import { isCacheNoStoreSupported, makeRequest, resetCacheNoStoreSupported } from "../../../core/fetcher/makeRequest";
 
 describe("Test makeRequest", () => {
     const mockPostUrl = "https://httpbin.org/post";

--- a/seed/ts-sdk/exhaustive/package-path/src/test-packagePath/tests/unit/fetcher/redacting.test.ts
+++ b/seed/ts-sdk/exhaustive/package-path/src/test-packagePath/tests/unit/fetcher/redacting.test.ts
@@ -1,4 +1,4 @@
-import { fetcherImpl } from "../../../../../src/test-packagePath/core/fetcher/Fetcher";
+import { fetcherImpl } from "../../../core/fetcher/Fetcher";
 
 function createMockLogger() {
     return {

--- a/seed/ts-sdk/exhaustive/package-path/src/test-packagePath/tests/unit/fetcher/requestWithRetries.test.ts
+++ b/seed/ts-sdk/exhaustive/package-path/src/test-packagePath/tests/unit/fetcher/requestWithRetries.test.ts
@@ -1,5 +1,5 @@
 import type { Mock, MockInstance } from "vitest";
-import { requestWithRetries } from "../../../../../src/test-packagePath/core/fetcher/requestWithRetries";
+import { requestWithRetries } from "../../../core/fetcher/requestWithRetries";
 
 describe("requestWithRetries", () => {
     let mockFetch: Mock;

--- a/seed/ts-sdk/exhaustive/package-path/src/test-packagePath/tests/unit/fetcher/signals.test.ts
+++ b/seed/ts-sdk/exhaustive/package-path/src/test-packagePath/tests/unit/fetcher/signals.test.ts
@@ -1,4 +1,4 @@
-import { anySignal, getTimeoutSignal } from "../../../../../src/test-packagePath/core/fetcher/signals";
+import { anySignal, getTimeoutSignal } from "../../../core/fetcher/signals";
 
 describe("Test getTimeoutSignal", () => {
     beforeEach(() => {

--- a/seed/ts-sdk/exhaustive/package-path/src/test-packagePath/tests/unit/file/file.test.ts
+++ b/seed/ts-sdk/exhaustive/package-path/src/test-packagePath/tests/unit/file/file.test.ts
@@ -1,7 +1,7 @@
 import fs from "fs";
 import { join } from "path";
 import { Readable } from "stream";
-import { toBinaryUploadRequest, type Uploadable } from "../../../../../src/test-packagePath/core/file/index";
+import { toBinaryUploadRequest, type Uploadable } from "../../../core/file/index";
 
 describe("toBinaryUploadRequest", () => {
     const TEST_FILE_PATH = join(__dirname, "..", "test-file.txt");

--- a/seed/ts-sdk/exhaustive/package-path/src/test-packagePath/tests/unit/logging/logger.test.ts
+++ b/seed/ts-sdk/exhaustive/package-path/src/test-packagePath/tests/unit/logging/logger.test.ts
@@ -1,4 +1,4 @@
-import { ConsoleLogger, createLogger, Logger, LogLevel } from "../../../../../src/test-packagePath/core/logging/logger";
+import { ConsoleLogger, createLogger, Logger, LogLevel } from "../../../core/logging/logger";
 
 function createMockLogger() {
     return {

--- a/seed/ts-sdk/exhaustive/package-path/src/test-packagePath/tests/unit/url/join.test.ts
+++ b/seed/ts-sdk/exhaustive/package-path/src/test-packagePath/tests/unit/url/join.test.ts
@@ -1,4 +1,4 @@
-import { join } from "../../../../../src/test-packagePath/core/url/index";
+import { join } from "../../../core/url/index";
 
 describe("join", () => {
     interface TestCase {

--- a/seed/ts-sdk/exhaustive/package-path/src/test-packagePath/tests/unit/url/qs.test.ts
+++ b/seed/ts-sdk/exhaustive/package-path/src/test-packagePath/tests/unit/url/qs.test.ts
@@ -1,4 +1,4 @@
-import { toQueryString } from "../../../../../src/test-packagePath/core/url/index";
+import { toQueryString } from "../../../core/url/index";
 
 describe("Test qs toQueryString", () => {
     interface BasicTestCase {

--- a/seed/ts-sdk/exhaustive/package-path/src/test-packagePath/tests/unit/utils/setObjectProperty.test.ts
+++ b/seed/ts-sdk/exhaustive/package-path/src/test-packagePath/tests/unit/utils/setObjectProperty.test.ts
@@ -1,4 +1,4 @@
-import { setObjectProperty } from "../../../../../src/test-packagePath/core/utils/setObjectProperty";
+import { setObjectProperty } from "../../../core/utils/setObjectProperty";
 
 interface TestCase {
     description: string;


### PR DESCRIPTION
## Description

Fixes incorrect import paths in generated test files (e.g. `makeRequest.test.ts`) when the SDK is emitted under a custom package path like `src/management`.

**Root cause:** `updateImportPaths` checks `line.includes("import")` to decide how to rewrite paths, but multi-line imports have the `from "..."` clause on a separate line from the `import` keyword. The `from` line falls into the wrong (non-import) replacement branch, producing paths like `../../../src/management/core/fetcher/makeRequest` instead of `../../../core/fetcher/makeRequest`.

## Changes Made

- Added `updateTestFileImportPaths()` — a dedicated method for test files that uses a regex to correctly replace `from "…/src/…"` import paths with the computed relative path to the package directory. This mirrors the existing approach in `AsIsManager.addToTsProject`.
- `copyCoreUtilities` now detects test files and routes them to the new method instead of the generic `updateImportPaths`.
- Added `versions.yml` entry (3.62.1).
- Updated seed output for `ts-sdk/exhaustive/package-path` fixture — all 20 test files now have correct import paths.

## Testing

- Ran `seed test --generator ts-sdk --fixture exhaustive --outputFolder package-path --local` — 1/1 passed.
- Seed output confirms all 20 test files in the `package-path` fixture were corrected:
  - `from "../../../../../src/test-packagePath/core/..."` → `from "../../../core/..."`
  - `from "../../../../src/test-packagePath/core/..."` → `from "../../core/..."` (for shallower tests like `base64.test.ts`)
  - `makeRequest.test.ts` multi-line import with wrong depth (`../../../src/test-packagePath/...`) → correct single-line import (`../../../core/...`)

## Review Checklist

- [ ] Verify the `isTestFile` check (`destinationFile.includes(this.relativeTestPath)`) won't false-positive on source files whose path happens to contain the test directory name
- [ ] Verify the regex `/from "([^"]*\/)src\/([^"]*)"/g` won't unintentionally match non-import uses of `from` in test file string literals (e.g. a test assertion containing `from "foo/src/bar"`)
- [ ] Consider whether the old `updateImportPaths` has the same multi-line import bug for non-test source files (it does, but source files don't typically have cross-directory relative imports with the `src/` prefix, so it may be moot)

Link to Devin session: https://app.devin.ai/sessions/8cde81eb3b624d6ca699414ab0323866
Requested by: @Swimburger
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/14538" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
