### PR TITLE
fix(csharp): omit null values and fix pagination test generation in mock server tests

### DIFF
--- a/generators/csharp/sdk/src/test-generation/mock-server/MockEndpointGenerator.ts
+++ b/generators/csharp/sdk/src/test-generation/mock-server/MockEndpointGenerator.ts
@@ -343,8 +343,13 @@ export class MockEndpointGenerator extends WithGeneration {
      */
     private filterInlinedRequestBody(
         exampleRequest: FernIr.ExampleRequestBody.InlinedRequestBody,
-        _endpoint: HttpEndpoint
+        endpoint: HttpEndpoint
     ): Record<string, unknown> {
+        // Build the set of nullable property wire names so we can distinguish
+        // optional-but-not-nullable (null is omitted by WhenWritingNull) from
+        // nullable (null is explicitly serialized via [Nullable] attribute).
+        const nullableNames = this.getNullablePropertyNamesFromEndpoint(endpoint);
+
         // Build the result with filtering and datetime normalization
         const result: Record<string, unknown> = {};
 
@@ -354,7 +359,14 @@ export class MockEndpointGenerator extends WithGeneration {
                 continue;
             }
             // Recursively filter the property value (also normalizes datetime values)
-            result[prop.name.wireValue] = this.filterExampleTypeReference(prop.value);
+            const filteredValue = this.filterExampleTypeReference(prop.value);
+
+            // Omit null values for properties that are optional-but-not-nullable
+            // since the SDK won't serialize those nulls (JsonIgnoreCondition.WhenWritingNull)
+            if (filteredValue === null && !nullableNames.has(prop.name.wireValue)) {
+                continue;
+            }
+            result[prop.name.wireValue] = filteredValue;
         }
 
         // Also include extra properties if present
@@ -771,6 +783,32 @@ export class MockEndpointGenerator extends WithGeneration {
      * Converts a JSON object to form-urlencoded key=value pairs for use with FormUrlEncodedMatcher.
      * Returns a string like: "key1=value1", "key2=value2"
      */
+    /**
+     * Gets the set of nullable property wire names from an endpoint's inlined request body.
+     * Used to determine which null properties should be kept in the expected request JSON
+     * (nullable properties serialize null explicitly via [Nullable] attribute) vs omitted
+     * (optional-but-not-nullable properties are skipped by JsonIgnoreCondition.WhenWritingNull).
+     */
+    private getNullablePropertyNamesFromEndpoint(endpoint: HttpEndpoint): Set<string> {
+        const nullableNames = new Set<string>();
+        if (endpoint.requestBody?.type !== "inlinedRequestBody") {
+            return nullableNames;
+        }
+        for (const prop of endpoint.requestBody.properties) {
+            if (this.context.isNullable(prop.valueType)) {
+                nullableNames.add(prop.name.wireValue);
+            }
+        }
+        if (endpoint.requestBody.extendedProperties) {
+            for (const prop of endpoint.requestBody.extendedProperties) {
+                if (this.context.isNullable(prop.valueType)) {
+                    nullableNames.add(prop.name.wireValue);
+                }
+            }
+        }
+        return nullableNames;
+    }
+
     private convertToFormUrlEncodedPairs(json: unknown): string {
         if (typeof json !== "object" || json === null) {
             return "";

--- a/generators/csharp/sdk/src/test-generation/mock-server/MockEndpointGenerator.ts
+++ b/generators/csharp/sdk/src/test-generation/mock-server/MockEndpointGenerator.ts
@@ -780,10 +780,6 @@ export class MockEndpointGenerator extends WithGeneration {
     }
 
     /**
-     * Converts a JSON object to form-urlencoded key=value pairs for use with FormUrlEncodedMatcher.
-     * Returns a string like: "key1=value1", "key2=value2"
-     */
-    /**
      * Gets the set of nullable property wire names from an endpoint's inlined request body.
      * Used to determine which null properties should be kept in the expected request JSON
      * (nullable properties serialize null explicitly via [Nullable] attribute) vs omitted
@@ -809,6 +805,10 @@ export class MockEndpointGenerator extends WithGeneration {
         return nullableNames;
     }
 
+    /**
+     * Converts a JSON object to form-urlencoded key=value pairs for use with FormUrlEncodedMatcher.
+     * Returns a string like: "key1=value1", "key2=value2"
+     */
     private convertToFormUrlEncodedPairs(json: unknown): string {
         if (typeof json !== "object" || json === null) {
             return "";

--- a/generators/csharp/sdk/src/test-generation/mock-server/MockEndpointGenerator.ts
+++ b/generators/csharp/sdk/src/test-generation/mock-server/MockEndpointGenerator.ts
@@ -747,6 +747,9 @@ export class MockEndpointGenerator extends WithGeneration {
     /**
      * Gets the set of nullable property wire names for a type declaration.
      * A property is nullable if its type is a nullable container or optional<nullable<T>>.
+     *
+     * When enableExplicitNullableOptional is disabled (default), no [Nullable] attributes
+     * are generated and WhenWritingNull omits ALL nulls, so this returns an empty set.
      */
     private getNullablePropertyNamesForType(typeDeclaration: {
         shape: {
@@ -756,6 +759,13 @@ export class MockEndpointGenerator extends WithGeneration {
         };
     }): Set<string> {
         const nullableNames = new Set<string>();
+
+        // When the explicit nullable/optional flag is off, the generator does not emit
+        // [Nullable] attributes, so WhenWritingNull omits every null value.
+        if (!this.context.generation.settings.enableExplicitNullableOptional) {
+            return nullableNames;
+        }
+
         const shape = typeDeclaration.shape;
 
         if (shape.type !== "object" || !shape.properties) {
@@ -784,9 +794,19 @@ export class MockEndpointGenerator extends WithGeneration {
      * Used to determine which null properties should be kept in the expected request JSON
      * (nullable properties serialize null explicitly via [Nullable] attribute) vs omitted
      * (optional-but-not-nullable properties are skipped by JsonIgnoreCondition.WhenWritingNull).
+     *
+     * When enableExplicitNullableOptional is disabled (default), no [Nullable] attributes
+     * are generated and WhenWritingNull omits ALL nulls, so this returns an empty set.
      */
     private getNullablePropertyNamesFromEndpoint(endpoint: HttpEndpoint): Set<string> {
         const nullableNames = new Set<string>();
+
+        // When the explicit nullable/optional flag is off, the generator does not emit
+        // [Nullable] attributes, so WhenWritingNull omits every null value.
+        if (!this.context.generation.settings.enableExplicitNullableOptional) {
+            return nullableNames;
+        }
+
         if (endpoint.requestBody?.type !== "inlinedRequestBody") {
             return nullableNames;
         }

--- a/generators/csharp/sdk/src/test-generation/mock-server/MockServerTestGenerator.ts
+++ b/generators/csharp/sdk/src/test-generation/mock-server/MockServerTestGenerator.ts
@@ -54,6 +54,16 @@ export class MockServerTestGenerator extends FileGenerator<CSharpFile, SdkGenera
         return super.shouldGenerate();
     }
 
+    /**
+     * Returns true only when pagination clients are actually generated for this endpoint.
+     * The IR may have pagination info even when `generatePaginatedClients` is disabled,
+     * so we must check the config flag to avoid emitting `await foreach` against a
+     * non-IAsyncEnumerable return type.
+     */
+    private hasPaginationEnabled(): boolean {
+        return this.context.config.generatePaginatedClients === true && this.endpoint.pagination != null;
+    }
+
     private getServiceNamespaceSegments(): string[] {
         const subpackage = this.context.getSubpackageForServiceId(this.serviceId);
         if (!subpackage) {
@@ -90,7 +100,7 @@ export class MockServerTestGenerator extends FileGenerator<CSharpFile, SdkGenera
             const responseBodyType = this.endpoint.response?.body?.type;
 
             let isAsyncTest = false;
-            const isPaginationEndpoint = !!this.endpoint.pagination;
+            const isPaginationEndpoint = this.hasPaginationEnabled();
             if (isPaginationEndpoint) {
                 isAsyncTest = true;
             }
@@ -120,7 +130,7 @@ export class MockServerTestGenerator extends FileGenerator<CSharpFile, SdkGenera
                 if (endpointSnippet == null) {
                     throw new Error("Endpoint snippet is null");
                 }
-                if (this.endpoint.pagination) {
+                if (this.hasPaginationEnabled()) {
                     writer.write("var items = ");
                     writer.writeNode(endpointSnippet);
                     writer.write(";");

--- a/generators/csharp/sdk/versions.yml
+++ b/generators/csharp/sdk/versions.yml
@@ -1,4 +1,22 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 2.56.5
+  changelogEntry:
+    - summary: |
+        Fix mock server test generation to omit null values for non-nullable
+        properties in inlined request bodies, matching the SDK's
+        JsonIgnoreCondition.WhenWritingNull serialization behavior. When
+        enableExplicitNullableOptional is disabled (default), all nulls are
+        now unconditionally omitted from expected request JSON.
+      type: fix
+    - summary: |
+        Fix pagination test build errors (CS8411) when generatePaginatedClients
+        is disabled. The test generator now checks the config flag before emitting
+        `await foreach` code, preventing attempts to iterate over plain response
+        types that do not implement IAsyncEnumerable.
+      type: fix
+  createdAt: "2026-04-03"
+  irVersion: 65
+
 - version: 2.56.4
   changelogEntry:
     - summary: |


### PR DESCRIPTION
## Description

Two fixes for mock server test generation in the C# SDK generator, both surfaced by the [docusign-demo](https://github.com/fern-support/docusign-demo) generated C# SDK.

**1. Null value serialization mismatch** — Generated WireMock stubs included explicit `null` values for optional-but-not-nullable properties (e.g. `{"name": null, "brand_id": null}`), but the SDK serializes these as `{}` due to `DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull`, causing WireMock body matcher to return score 0.0 and tests to fail with 404. Affected 10 tests (CreateWorkspace, UpdateWorkspace, CreateUploadRequest, UpdateUploadRequest, CreateBulkJob, UpdateBrand, AddUser, UpdateUser, RevokeAccess, CreateEnvelope).

**2. Pagination test build errors** — The test generator checked `endpoint.pagination` from the IR to decide whether to emit `await foreach` code. However, when `generatePaginatedClients` is disabled (the default), no `IAsyncEnumerable` pager methods are generated on the client — the endpoint returns a plain response type. This caused `CS8411: Asynchronous foreach statement cannot operate on variables of type 'GetWorkspacesResponse'` build errors on 5 pagination endpoint tests.

## Changes Made

### MockEndpointGenerator.ts (null serialization fix)
- Updated `filterInlinedRequestBody` to skip null values for properties that are not explicitly nullable, matching the existing logic already present in `filterObjectExample`
- Added `getNullablePropertyNamesFromEndpoint` helper to extract nullable property wire names directly from an endpoint's inlined request body definition (checking both `properties` and `extendedProperties`)
- Gated both `getNullablePropertyNamesFromEndpoint` and `getNullablePropertyNamesForType` on the `enableExplicitNullableOptional` flag — when this flag is disabled (the default), no `[Nullable]` attributes are generated on properties, so `WhenWritingNull` omits **all** null values. The nullable name sets must be empty in this case to match.

### MockServerTestGenerator.ts (pagination test fix)
- Added `hasPaginationEnabled()` method that mirrors `AbstractEndpointGenerator.hasPagination()` — requires both `generatePaginatedClients === true` AND `endpoint.pagination != null` before treating an endpoint as paginated in test generation
- Replaced direct `this.endpoint.pagination` checks (lines 93 and 123) with `this.hasPaginationEnabled()` so that pagination test code (`await foreach`) is only emitted when pagination clients are actually generated

## Updates since last revision

**Pagination fix added**: When `generatePaginatedClients` is disabled (default for docusign-demo), the IR still has `pagination` info on endpoints. The endpoint generator correctly gates pager method generation on this config via `AbstractEndpointGenerator.hasPagination()`, but the test generator was checking `endpoint.pagination` directly — emitting `await foreach` against non-`IAsyncEnumerable` return types. Fixed by adding the same config check.

**Local verification against docusign-demo**: Generated C# SDK from IR, built it, and ran all tests — **276/276 passed** (up from 266/266 — the 5 previously-excluded pagination test files now compile and pass, plus 5 additional core tests).

## Testing

- [x] Local seed tests pass for `nullable-optional`, `nullable`, and `exhaustive` fixtures (no fixture changes expected — the affected pattern only appears in real-world specs like DocuSign, not in seed fixtures)
- [x] Lint (`pnpm run check`) passes
- [x] All CI checks green
- [x] Full end-to-end verification against docusign-demo: generated SDK via Docker, `dotnet build` succeeds (0 errors), 276/276 `dotnet test` pass

## Reviewer Checklist

- **`enableExplicitNullableOptional` gating**: When the flag is off (default), both `getNullablePropertyNamesForType` and `getNullablePropertyNamesFromEndpoint` return empty sets, so all nulls are unconditionally omitted. When on, the `isNullable()` check determines which properties retain null. Verify this matches the C# generator's `[Nullable]` attribute placement logic in `generateFields.ts`.
- **Pagination config gating**: `hasPaginationEnabled()` in `MockServerTestGenerator` mirrors `hasPagination()` in `AbstractEndpointGenerator`. When `generatePaginatedClients` is false, pagination endpoints fall through to the standard response assertion code paths (`isSupportedResponse` / `DoesNotThrowAsync`). Verify these fallback paths produce valid test code for paginated endpoints that return plain response types.
- **`extraProperties` not filtered**: The null-skipping logic applies to `properties` and `extendedProperties` (via the nullable set), but `extraProperties` in the filter loop do NOT get the same treatment. Verify this is intentional — extra properties may have different semantics.
- **`isNullable` does not resolve aliases**: `getNullablePropertyNamesFromEndpoint` uses `this.context.isNullable()` which does not dereference named aliases (unlike `isOptional` which does). This is a pre-existing limitation shared with the existing `getNullablePropertyNamesForType` method — fixing it would be a separate change affecting both methods equally.
- **No seed fixture diffs**: This change produces no diff in existing seed fixtures. The fix is only observable with real-world specs that have inlined request bodies with optional-but-not-nullable properties set to null in examples, or specs with pagination endpoints when `generatePaginatedClients` is disabled.

Link to Devin session: https://app.devin.ai/sessions/b09769ac33ba4a4085df1b9207921e48
Requested by: @jon-fern
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/14539" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
