### PR TITLE
chore(cli): batch docker cp calls for reusable container input files

### DIFF
--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -1,5 +1,15 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 
+- version: 4.59.1
+  changelogEntry:
+    - summary: |
+        Batch multiple `docker cp` calls into a single invocation when copying
+        input files (IR, config, snippets) into reusable generator containers,
+        reducing the number of Docker CLI round-trips during local generation.
+      type: chore
+  createdAt: "2026-04-03"
+  irVersion: 66
+
 - version: 4.59.0
   changelogEntry:
     - summary: |

--- a/packages/cli/generation/local-generation/docker-utils/src/index.ts
+++ b/packages/cli/generation/local-generation/docker-utils/src/index.ts
@@ -1,4 +1,5 @@
 export {
+    batchCopyToContainer,
     copyFromContainer,
     copyToContainer,
     execInContainer,

--- a/packages/cli/generation/local-generation/docker-utils/src/runDocker.ts
+++ b/packages/cli/generation/local-generation/docker-utils/src/runDocker.ts
@@ -1,7 +1,8 @@
 import { ContainerRunner } from "@fern-api/core-utils";
 import { Logger } from "@fern-api/logger";
 import { loggingExeca } from "@fern-api/logging-execa";
-import { writeFile } from "fs/promises";
+import { copyFile, writeFile } from "fs/promises";
+import path from "path";
 import tmp from "tmp-promise";
 
 export declare namespace runContainer {
@@ -288,6 +289,67 @@ export async function copyToContainer({
         throw new Error(
             `Failed to copy ${hostPath} to container ${containerId}:${containerPath}.\n${stdout}\n${stderr}`
         );
+    }
+}
+
+/**
+ * Copies multiple files into a single container directory using one `docker cp` call.
+ * Files are staged in a temporary directory and copied as a batch, reducing the number
+ * of Docker CLI invocations.
+ */
+export async function batchCopyToContainer({
+    logger,
+    containerId,
+    files,
+    containerDir,
+    runner
+}: {
+    logger: Logger;
+    containerId: string;
+    files: Array<{ hostPath: string; containerFilename: string }>;
+    containerDir: string;
+    runner?: ContainerRunner;
+}): Promise<void> {
+    if (files.length === 0) {
+        return;
+    }
+    if (files.length === 1) {
+        const [file] = files;
+        if (file != null) {
+            return copyToContainer({
+                logger,
+                containerId,
+                hostPath: file.hostPath,
+                containerPath: `${containerDir}/${file.containerFilename}`,
+                runner
+            });
+        }
+    }
+
+    const containerRunner = runner ?? "docker";
+    const tmpDir = await tmp.dir({ unsafeCleanup: true });
+    try {
+        await Promise.all(
+            files.map(({ hostPath, containerFilename }) =>
+                copyFile(hostPath, path.join(tmpDir.path, containerFilename))
+            )
+        );
+        const { exitCode, stdout, stderr } = await loggingExeca(
+            logger,
+            containerRunner,
+            ["cp", `${tmpDir.path}/.`, `${containerId}:${containerDir}/`],
+            {
+                reject: false,
+                doNotPipeOutput: true
+            }
+        );
+        if (exitCode !== 0) {
+            throw new Error(
+                `Failed to batch copy files to container ${containerId}:${containerDir}.\n${stdout}\n${stderr}`
+            );
+        }
+    } finally {
+        await tmpDir.cleanup();
     }
 }
 

--- a/packages/cli/generation/local-generation/local-workspace-runner/src/ReusableContainerExecutionEnvironment.ts
+++ b/packages/cli/generation/local-generation/local-workspace-runner/src/ReusableContainerExecutionEnvironment.ts
@@ -1,5 +1,6 @@
 import { ContainerRunner, extractErrorMessage } from "@fern-api/core-utils";
 import {
+    batchCopyToContainer,
     copyFromContainer,
     copyToContainer,
     execInContainer,
@@ -11,11 +12,13 @@ import { loggingExeca } from "@fern-api/logging-execa";
 import {
     CONTAINER_CODEGEN_OUTPUT_DIRECTORY,
     CONTAINER_FERN_DIRECTORY,
-    CONTAINER_GENERATOR_CONFIG_PATH,
-    CONTAINER_PATH_TO_IR,
     CONTAINER_PATH_TO_SNIPPET,
     CONTAINER_PATH_TO_SNIPPET_TEMPLATES,
-    CONTAINER_SOURCES_DIRECTORY
+    CONTAINER_SOURCES_DIRECTORY,
+    GENERATOR_CONFIG_FILENAME,
+    IR_FILENAME,
+    SNIPPET_FILENAME,
+    SNIPPET_TEMPLATES_FILENAME
 } from "./constants.js";
 import { ExecutionEnvironment } from "./ExecutionEnvironment.js";
 
@@ -180,42 +183,24 @@ export class ReusableContainerExecutionEnvironment implements ExecutionEnvironme
             writeLogsToFile: false
         });
 
-        // Copy input files into the container
-        await copyToContainer({
-            logger,
-            containerId,
-            hostPath: irPath,
-            containerPath: CONTAINER_PATH_TO_IR,
-            runner: this.runner
-        });
-
-        await copyToContainer({
-            logger,
-            containerId,
-            hostPath: configPath,
-            containerPath: CONTAINER_GENERATOR_CONFIG_PATH,
-            runner: this.runner
-        });
-
+        // Batch copy input files that all go to /fern/ in a single docker cp
+        const fernFiles: Array<{ hostPath: string; containerFilename: string }> = [
+            { hostPath: irPath, containerFilename: IR_FILENAME },
+            { hostPath: configPath, containerFilename: GENERATOR_CONFIG_FILENAME }
+        ];
         if (snippetPath != null) {
-            await copyToContainer({
-                logger,
-                containerId,
-                hostPath: snippetPath,
-                containerPath: CONTAINER_PATH_TO_SNIPPET,
-                runner: this.runner
-            });
+            fernFiles.push({ hostPath: snippetPath, containerFilename: SNIPPET_FILENAME });
         }
-
         if (snippetTemplatePath != null) {
-            await copyToContainer({
-                logger,
-                containerId,
-                hostPath: snippetTemplatePath,
-                containerPath: CONTAINER_PATH_TO_SNIPPET_TEMPLATES,
-                runner: this.runner
-            });
+            fernFiles.push({ hostPath: snippetTemplatePath, containerFilename: SNIPPET_TEMPLATES_FILENAME });
         }
+        await batchCopyToContainer({
+            logger,
+            containerId,
+            files: fernFiles,
+            containerDir: CONTAINER_FERN_DIRECTORY,
+            runner: this.runner
+        });
 
         if (licenseFilePath != null) {
             await copyToContainer({
@@ -241,7 +226,7 @@ export class ReusableContainerExecutionEnvironment implements ExecutionEnvironme
         await execInContainer({
             logger,
             containerId,
-            command: [...entrypoint, CONTAINER_GENERATOR_CONFIG_PATH],
+            command: [...entrypoint, `${CONTAINER_FERN_DIRECTORY}/${GENERATOR_CONFIG_FILENAME}`],
             runner: this.runner,
             writeLogsToFile: true
         });


### PR DESCRIPTION
## Description

Consolidates multiple sequential `docker cp` invocations into a single call when copying input files (IR, config, snippets) into reusable generator containers during `fern generate --local`.

Previously, each file was copied with its own `docker cp` command (2–4 calls depending on whether snippets are present). Now files destined for the same container directory (`/fern/`) are staged in a temporary host directory and copied in one `docker cp` invocation.

## Changes Made

- Added `batchCopyToContainer` to `@fern-api/docker-utils` — stages files in a temp directory and copies them with a single `docker cp tmpdir/. container:/dir/` call
- Updated `ReusableContainerExecutionEnvironment.doExecute` to collect `/fern/`-bound files into an array and use the new batch function
- License file and source mounts still use individual `copyToContainer` (they target different container directories)
- Added CLI changelog entry (v4.59.1)

## Review Checklist

- [ ] Verify `docker cp dir/. container:/dir/` syntax is compatible with both Docker and Podman (the `runner` param supports both)
- [ ] In the `files.length === 1` early-return path, `file` is guarded with `!= null` — if somehow null, the function returns silently without copying. This is unreachable in practice but worth noting.
- [ ] `CONTAINER_GENERATOR_CONFIG_PATH` was replaced with `` `${CONTAINER_FERN_DIRECTORY}/${GENERATOR_CONFIG_FILENAME}` `` (string template instead of `path.join`). These are Linux container paths so `/` is always correct.

## Testing

- [ ] Unit tests added/updated
- [x] Lint passes (`pnpm run check`)

Link to Devin session: https://app.devin.ai/sessions/d5609f5c83e64866a80c5a48912247a4
Requested by: @Swimburger
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/14542" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
