### PR TITLE
chore(internal): Update IR chagnelog

### DIFF
--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -35,7 +35,6 @@
   createdAt: "2026-04-02"
   irVersion: 66
 
-
 - version: 4.56.0
   changelogEntry:
     - summary: |

--- a/packages/ir-sdk/fern/apis/ir-types-latest/changelog/CHANGELOG.md
+++ b/packages/ir-sdk/fern/apis/ir-types-latest/changelog/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v66.0.0] - 2026-04-02
+- Feature: Add IR Name compression support via new `NameOrString` and `NameAndWireValueOrString` union types.
+  Throughout the IR, fields previously typed as `Name` or `NameAndWireValue` are now typed as `NameOrString` or
+  `NameAndWireValueOrString` respectively, allowing names to be stored as plain strings (compressed) instead of fully
+  expanded casing objects. Affected fields span `FernFilepath`, auth schemes, environments, errors, HTTP types,
+  webhooks, websockets, and type declarations.
+- Feature: Add `CasingsConfig` type to `IntermediateRepresentation`. Stores the casing generator configuration
+  (target language, reserved keywords, smart casing flag) so that IR migrations can reconstruct the correct
+  `CasingsGenerator` when inflating compressed `NameOrString` values back to full `Name` objects.
+- Feature: Add `NameOrString` and `NameAndWireValueOrString` union types to both the main IR and dynamic IR commons,
+  enabling forward-compatible parsing of either string or structured name objects.
+
 ## [v65.7.0] - 2026-03-31
 - Feature: Add optional `clientDefault` field to `HttpHeader`, `PathParameter`, and `QueryParameter`.
   When present, the parameter/header is optional in the generated SDK and the literal value is sent

--- a/packages/ir-sdk/fern/apis/ir-types-latest/generators.yml
+++ b/packages/ir-sdk/fern/apis/ir-types-latest/generators.yml
@@ -48,7 +48,7 @@ groups:
         output:
           location: maven
           url: maven.buildwithfern.com
-          coordinate: com.fern.fern:irV65
+          coordinate: com.fern.fern:irV66
         config:
           wrapped-aliases: true
           enable-forward-compatible-enums: true
@@ -60,7 +60,7 @@ groups:
         output:
           location: pypi
           url: pypi.buildwithfern.com
-          package-name: fern_fern_ir_v65
+          package-name: fern_fern_ir_v66
         config:
           include_union_utils: true
           frozen: true


### PR DESCRIPTION
## Description
  Updates the IR SDK changelog and version references for v66.0.0, which introduces IR Name compression and CasingsConfig features.                                                                                                                                                           
                                                                                                                                                                                                                                                                                            
  ## Changes Made                                                                                                                                                                                                                                                                             
  - Added \`[v66.0.0]\` changelog entry to \`packages/ir-sdk/fern/apis/ir-types-latest/changelog/CHANGELOG.md\` documenting:                                                                                                                                                                
    - IR Name compression support via new \`NameOrString\` and \`NameAndWireValueOrString\` union types                                                                                                                                                                                       
    - New \`CasingsConfig\` type added to \`IntermediateRepresentation\`                                                                                                                                                                                                                      
    - Forward-compatible parsing of either string or structured name objects in main IR and dynamic IR commons                                                                                                                                                                                
  - Updated \`packages/ir-sdk/fern/apis/ir-types-latest/generators.yml\` to reference \`irV66\` for Maven and PyPI output coordinates                                                                                                                                                         
  - Removed extra blank line in \`packages/cli/cli/versions.yml\`                                                                                                                                                                                                                             
                                                                                                                                                                                                                                                                                              
  ## Testing                                                                                                                                                                                                                                                                                  
  - [ ] Unit tests added/updated                                                                                                                                                                                                                                                              
  - [x] Manual testing completed — changelog and version references verified 