### PR TITLE
chore(internal): add worktree scripts with automatic sparse checkout

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -46,7 +46,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash ./scripts/worktree-create-hook.sh"
+            "command": "bash \"$(git rev-parse --show-toplevel)/scripts/worktree-create-hook.sh\""
           }
         ]
       }

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -41,6 +41,16 @@
     ]
   },
   "hooks": {
+    "WorktreeCreate": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash ./scripts/worktree-create-hook.sh"
+          }
+        ]
+      }
+    ],
     "PostToolUse": [
       {
         "matcher": "Edit|MultiEdit|Write",

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,7 +37,7 @@ git clone --filter=blob:none --sparse https://github.com/fern-api/fern.git
 cd fern
 
 # Configure sparse checkout to exclude large directories
-bash ./sparse-checkout.sh
+bash ./scripts/sparse-checkout.sh
 ```
 
 This configuration:

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   },
   "scripts": {
     "sparse-checkout": "./scripts/sparse-checkout.sh",
+    "worktree:add": "./scripts/worktree-add.sh",
     "clean": "turbo run clean",
     "compile": "turbo run compile",
     "compile:debug": "turbo run compile:debug",

--- a/scripts/sparse-checkout.sh
+++ b/scripts/sparse-checkout.sh
@@ -1,9 +1,13 @@
 #!/bin/bash
 #
-#
+# Configures sparse checkout to exclude large test fixture directories.
+# Can be run from the repo root or from a worktree.
 #
 
 set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 
 RED='\033[0;31m'
 GREEN='\033[0;32m'
@@ -22,8 +26,12 @@ print_info() {
     echo "→ $1"
 }
 
-if [ ! -f "package.json" ] || [ ! -d ".git" ]; then
-    print_error "This script must be run from the root of the fern repository"
+# Allow running from a worktree path passed as $1, or default to repo root
+TARGET_DIR="${1:-$REPO_ROOT}"
+cd "$TARGET_DIR"
+
+if [ ! -f "package.json" ]; then
+    print_error "Target directory does not appear to be a fern checkout: $TARGET_DIR"
     exit 1
 fi
 

--- a/scripts/worktree-add.sh
+++ b/scripts/worktree-add.sh
@@ -31,8 +31,12 @@ if [ -z "$path" ]; then
     path="$WORKTREE_BASE/$branch"
 fi
 
-# Create worktree
-git worktree add "$path" "$branch"
+# Create worktree — use -b if the branch doesn't exist yet
+if git show-ref --verify --quiet "refs/heads/$branch"; then
+    git worktree add "$path" "$branch"
+else
+    git worktree add -b "$branch" "$path"
+fi
 
 # Apply sparse checkout in the new worktree
 bash "$SCRIPT_DIR/sparse-checkout.sh" "$path"

--- a/scripts/worktree-add.sh
+++ b/scripts/worktree-add.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+#
+# Creates a git worktree with sparse checkout pre-configured.
+#
+# Usage:
+#   bash scripts/worktree-add.sh <branch>          # creates at ../.fern-worktrees/<branch>
+#   bash scripts/worktree-add.sh <branch> <path>    # creates at <path>
+#
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+WORKTREE_BASE="$REPO_ROOT/../.fern-worktrees"
+
+branch="$1"
+path="$2"
+
+if [ -z "$branch" ]; then
+    echo "Usage: $0 <branch> [path]"
+    echo ""
+    echo "Creates a git worktree with sparse checkout configured."
+    echo "If [path] is omitted, the worktree is created at:"
+    echo "  ../.fern-worktrees/<branch>"
+    exit 1
+fi
+
+# Default path: ../.fern-worktrees/<branch>
+if [ -z "$path" ]; then
+    mkdir -p "$WORKTREE_BASE"
+    path="$WORKTREE_BASE/$branch"
+fi
+
+# Create worktree
+git worktree add "$path" "$branch"
+
+# Apply sparse checkout in the new worktree
+bash "$SCRIPT_DIR/sparse-checkout.sh" "$path"
+
+echo ""
+echo "Worktree created at $path with sparse checkout"

--- a/scripts/worktree-create-hook.sh
+++ b/scripts/worktree-create-hook.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+#
+# Claude Code WorktreeCreate hook.
+# Creates a worktree with sparse checkout in ../.fern-worktrees/.
+#
+# Stdin: JSON with session_id, cwd, etc.
+# Stdout: Must be ONLY the absolute worktree path (nothing else).
+#
+
+set -e
+
+INPUT=$(cat)
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+WORKTREE_BASE="$REPO_ROOT/../.fern-worktrees"
+
+# Generate a worktree name from timestamp + random suffix
+WORKTREE_NAME="wt-$(date +%s)-$$"
+WORKTREE_PATH="$WORKTREE_BASE/$WORKTREE_NAME"
+
+mkdir -p "$WORKTREE_BASE"
+
+# Create the worktree (suppress all output)
+git worktree add "$WORKTREE_PATH" >/dev/null 2>&1
+
+# Apply sparse checkout (suppress all output)
+bash "$SCRIPT_DIR/sparse-checkout.sh" "$WORKTREE_PATH" >/dev/null 2>&1
+
+# Print ONLY the absolute path — Claude Code parses this
+echo "$WORKTREE_PATH"


### PR DESCRIPTION
## Description
Add scripts and a Claude Code hook so that git worktrees in this repo automatically get sparse checkout configured, avoiding multi-GB checkouts of seed fixtures.

## Changes Made
- **Moved `sparse-checkout.sh` to `scripts/`**: Updated to accept an optional target directory argument so it can be run against worktrees (not just repo root). Fixed a mismatch where `package.json` already pointed to `scripts/` but the file was at root.
- **Added `scripts/worktree-add.sh`**: Human-facing script for creating worktrees with sparse checkout. Defaults to `../.fern-worktrees/<branch>`. Available via `pnpm worktree:add`.
- **Added `scripts/worktree-create-hook.sh`**: Claude Code `WorktreeCreate` hook that runs automatically when using `claude --worktree`. Outputs only the worktree path to stdout per the hook spec.
- **Configured `WorktreeCreate` hook** in `.claude/settings.json` so all Claude Code users in this repo get sparse worktrees by default.

## Testing
- [x] Ran `claude --worktree` twice, confirmed worktrees created in `../.fern-worktrees/` with sparse checkout active
- [x] Verified sparse checkout excludes `seed/` directory in worktrees
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/14582" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
