### PR TITLE
feat(seed): namespace Docker image tags per worktree for parallel test isolation

### DIFF
--- a/packages/seed/src/commands/test/test-runner/ContainerTestRunner.ts
+++ b/packages/seed/src/commands/test/test-runner/ContainerTestRunner.ts
@@ -56,7 +56,8 @@ export class ContainerTestRunner extends TestRunner {
             throw new Error(`Failed. No ${this.runner} command for ${this.generator.workspaceName}`);
         }
 
-        // Rewrite -t flags in build commands to use :local (or :local-wt-<suffix>) tags
+        // Rewrite -t flags in build commands to use :local (or :local-wt-<suffix>) tags.
+        // This handles direct `docker build` / `podman build` commands.
         const namespacedCommands = containerCommands.map((cmd) => this.rewriteDockerBuildTag(cmd));
 
         if (!this.shouldPipeOutput()) {
@@ -70,6 +71,21 @@ export class ContainerTestRunner extends TestRunner {
         });
         if (containerBuildReturn.exitCode !== 0) {
             throw new Error(`Failed to build the container for ${this.generator.workspaceName}.`);
+        }
+
+        // For turbo-wrapped or other indirect build commands that may have built
+        // the image under its original tag (e.g. :latest), create a :local alias
+        // so downstream consumers can find the image.
+        const originalImage = this.getOriginalImageFromConfig();
+        const localImage = this.getContainerImageName();
+        if (originalImage !== localImage) {
+            try {
+                await loggingExeca(undefined, this.runner, ["tag", originalImage, localImage], {
+                    doNotPipeOutput: !this.shouldPipeOutput()
+                });
+            } catch {
+                // tag may fail if the rewrite already produced the :local image directly
+            }
         }
 
         // Start a reusable long-lived container for generation (guard against double build() calls)
@@ -95,9 +111,9 @@ export class ContainerTestRunner extends TestRunner {
 
         // Remove the local Docker image unless the user passed --keep-docker
         if (!this.keepContainer) {
-            const namespacedImage = this.getContainerImageName();
+            const localImage = this.getContainerImageName();
             try {
-                await loggingExeca(undefined, "docker", ["rmi", namespacedImage], {
+                await loggingExeca(undefined, this.runner, ["rmi", localImage], {
                     doNotPipeOutput: !this.shouldPipeOutput()
                 });
             } catch {
@@ -172,7 +188,11 @@ export class ContainerTestRunner extends TestRunner {
     }
 
     protected override getParsedDockerImageName(): ParsedDockerName {
-        const parsed = parseDockerOrThrow(this.generator.workspaceConfig.test.docker.image);
+        const testConfig =
+            this.runner === "podman" && this.generator.workspaceConfig.test.podman != null
+                ? this.generator.workspaceConfig.test.podman
+                : this.generator.workspaceConfig.test.docker;
+        const parsed = parseDockerOrThrow(testConfig.image);
         return {
             name: parsed.name,
             version: this.getLocalTag()
@@ -192,12 +212,12 @@ export class ContainerTestRunner extends TestRunner {
     }
 
     /**
-     * Rewrites `-t <image>` flags in a docker build command to use
+     * Rewrites `-t <image>` flags in a docker/podman build command to use
      * `:local` (or `:local-wt-<suffix>` in worktrees) instead of `:latest`.
-     * Non-docker-build commands are returned unchanged.
+     * Non-build commands (including turbo-wrapped builds) are returned unchanged.
      */
     private rewriteDockerBuildTag(command: string): string {
-        if (!command.includes("docker build")) {
+        if (!command.includes("docker build") && !command.includes("podman build")) {
             return command;
         }
 
@@ -210,13 +230,18 @@ export class ContainerTestRunner extends TestRunner {
         });
     }
 
-    /** Returns the base image name from the test config without any tag. */
-    private getBaseImageName(): string {
+    /** Returns the original image string from the test config (e.g. `fernapi/fern-python-sdk:latest`). */
+    private getOriginalImageFromConfig(): string {
         const testConfig =
             this.runner === "podman" && this.generator.workspaceConfig.test.podman != null
                 ? this.generator.workspaceConfig.test.podman
                 : this.generator.workspaceConfig.test.docker;
-        const image = testConfig.image;
+        return testConfig.image;
+    }
+
+    /** Returns the base image name from the test config without any tag. */
+    private getBaseImageName(): string {
+        const image = this.getOriginalImageFromConfig();
         const colonIndex = image.indexOf(":");
         return colonIndex >= 0 ? image.substring(0, colonIndex) : image;
     }

--- a/packages/seed/src/commands/test/test-runner/ContainerTestRunner.ts
+++ b/packages/seed/src/commands/test/test-runner/ContainerTestRunner.ts
@@ -5,21 +5,26 @@ import {
     runContainerizedGenerationForSeed
 } from "@fern-api/local-workspace-runner";
 import { CONSOLE_LOGGER, LogLevel } from "@fern-api/logger";
+import { loggingExeca } from "@fern-api/logging-execa";
 import path from "path";
 
 import { runScript } from "../../../runScript.js";
 import { ALL_AUDIENCES, DUMMY_ORGANIZATION } from "../../../utils/constants.js";
 import { getGeneratorInvocation } from "../../../utils/getGeneratorInvocation.js";
+import { getWorktreeSuffix } from "../../../utils/getWorktreeSuffix.js";
+import { ParsedDockerName, parseDockerOrThrow } from "../../../utils/parseDockerOrThrow.js";
 import { TestRunner } from "./TestRunner.js";
 
 export class ContainerTestRunner extends TestRunner {
     private readonly runner: ContainerRunner;
     private readonly parallelism: number;
     private reusableContainer: ReusableContainerExecutionEnvironment | undefined;
+    private readonly worktreeSuffix: string | undefined;
 
     constructor(args: TestRunner.Args & { runner?: ContainerRunner; parallelism?: number }) {
         super(args);
         this.parallelism = args.parallelism ?? 4;
+        this.worktreeSuffix = getWorktreeSuffix();
 
         if (args.runner != null) {
             this.runner = args.runner;
@@ -50,11 +55,18 @@ export class ContainerTestRunner extends TestRunner {
         if (containerCommands == null) {
             throw new Error(`Failed. No ${this.runner} command for ${this.generator.workspaceName}`);
         }
+
+        // Rewrite -t flags in build commands to use worktree-namespaced tags
+        const namespacedCommands =
+            this.worktreeSuffix != null
+                ? containerCommands.map((cmd) => this.rewriteDockerBuildTag(cmd))
+                : containerCommands;
+
         if (!this.shouldPipeOutput()) {
             CONSOLE_LOGGER.info(`Building container for ${this.generator.workspaceName}...`);
         }
         const containerBuildReturn = await runScript({
-            commands: containerCommands,
+            commands: namespacedCommands,
             logger: this.shouldPipeOutput() ? CONSOLE_LOGGER : undefined,
             workingDir: path.dirname(path.dirname(this.generator.absolutePathToWorkspace)),
             doNotPipeOutput: !this.shouldPipeOutput()
@@ -82,6 +94,19 @@ export class ContainerTestRunner extends TestRunner {
         if (this.reusableContainer != null) {
             await this.reusableContainer.stop(CONSOLE_LOGGER, this.logLevel);
             this.reusableContainer = undefined;
+        }
+
+        // Remove the namespaced Docker image when a worktree suffix was applied,
+        // unless the user passed --keep-docker
+        if (this.worktreeSuffix != null && !this.keepContainer) {
+            const namespacedImage = this.getContainerImageName();
+            try {
+                await loggingExeca(undefined, "docker", ["rmi", namespacedImage], {
+                    doNotPipeOutput: !this.shouldPipeOutput()
+                });
+            } catch {
+                // Best-effort cleanup; image may already have been removed
+            }
         }
     }
 
@@ -150,11 +175,62 @@ export class ContainerTestRunner extends TestRunner {
         });
     }
 
+    protected override getParsedDockerImageName(): ParsedDockerName {
+        const parsed = parseDockerOrThrow(this.generator.workspaceConfig.test.docker.image);
+        if (this.worktreeSuffix == null) {
+            return parsed;
+        }
+        return {
+            name: parsed.name,
+            version: `${parsed.version}-${this.worktreeSuffix}`
+        };
+    }
+
     protected getContainerImageName(): string {
         const testConfig =
             this.runner === "podman" && this.generator.workspaceConfig.test.podman != null
                 ? this.generator.workspaceConfig.test.podman
                 : this.generator.workspaceConfig.test.docker;
-        return testConfig.image;
+        return this.appendWorktreeSuffix(testConfig.image);
+    }
+
+    /**
+     * Appends the worktree suffix to a Docker image reference.
+     * e.g. `fernapi/fern-python-sdk:latest` → `fernapi/fern-python-sdk:latest-wt-abc123`
+     */
+    private appendWorktreeSuffix(image: string): string {
+        if (this.worktreeSuffix == null) {
+            return image;
+        }
+        return `${image}-${this.worktreeSuffix}`;
+    }
+
+    /**
+     * Rewrites `-t <image>` flags in a docker build command to use the
+     * worktree-namespaced tag. Non-docker-build commands are returned unchanged.
+     */
+    private rewriteDockerBuildTag(command: string): string {
+        if (!command.includes("docker build") || this.worktreeSuffix == null) {
+            return command;
+        }
+
+        const baseImage = this.getBaseImageName();
+        const escapedBase = baseImage.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+        const imagePattern = new RegExp(`(${escapedBase})(:[\\w.-]+)?`, "g");
+        return command.replace(imagePattern, (_match: string, name: string, tag?: string) => {
+            const fullTag = tag != null ? `${tag}-${this.worktreeSuffix}` : `-${this.worktreeSuffix}`;
+            return `${name}${fullTag}`;
+        });
+    }
+
+    /** Returns the base image name from the test config without any tag. */
+    private getBaseImageName(): string {
+        const testConfig =
+            this.runner === "podman" && this.generator.workspaceConfig.test.podman != null
+                ? this.generator.workspaceConfig.test.podman
+                : this.generator.workspaceConfig.test.docker;
+        const image = testConfig.image;
+        const colonIndex = image.indexOf(":");
+        return colonIndex >= 0 ? image.substring(0, colonIndex) : image;
     }
 }

--- a/packages/seed/src/commands/test/test-runner/ContainerTestRunner.ts
+++ b/packages/seed/src/commands/test/test-runner/ContainerTestRunner.ts
@@ -83,8 +83,11 @@ export class ContainerTestRunner extends TestRunner {
                 await loggingExeca(undefined, this.runner, ["tag", originalImage, localImage], {
                     doNotPipeOutput: !this.shouldPipeOutput()
                 });
-            } catch {
+            } catch (error) {
                 // tag may fail if the rewrite already produced the :local image directly
+                CONSOLE_LOGGER.debug(
+                    `docker tag failed (expected if image was built with local tag directly): ${error}`
+                );
             }
         }
 
@@ -116,8 +119,9 @@ export class ContainerTestRunner extends TestRunner {
                 await loggingExeca(undefined, this.runner, ["rmi", localImage], {
                     doNotPipeOutput: !this.shouldPipeOutput()
                 });
-            } catch {
+            } catch (error) {
                 // Best-effort cleanup; image may already have been removed
+                CONSOLE_LOGGER.debug(`Failed to remove image ${localImage}: ${error}`);
             }
         }
     }

--- a/packages/seed/src/commands/test/test-runner/ContainerTestRunner.ts
+++ b/packages/seed/src/commands/test/test-runner/ContainerTestRunner.ts
@@ -56,11 +56,8 @@ export class ContainerTestRunner extends TestRunner {
             throw new Error(`Failed. No ${this.runner} command for ${this.generator.workspaceName}`);
         }
 
-        // Rewrite -t flags in build commands to use worktree-namespaced tags
-        const namespacedCommands =
-            this.worktreeSuffix != null
-                ? containerCommands.map((cmd) => this.rewriteDockerBuildTag(cmd))
-                : containerCommands;
+        // Rewrite -t flags in build commands to use :local (or :local-wt-<suffix>) tags
+        const namespacedCommands = containerCommands.map((cmd) => this.rewriteDockerBuildTag(cmd));
 
         if (!this.shouldPipeOutput()) {
             CONSOLE_LOGGER.info(`Building container for ${this.generator.workspaceName}...`);
@@ -96,9 +93,8 @@ export class ContainerTestRunner extends TestRunner {
             this.reusableContainer = undefined;
         }
 
-        // Remove the namespaced Docker image when a worktree suffix was applied,
-        // unless the user passed --keep-docker
-        if (this.worktreeSuffix != null && !this.keepContainer) {
+        // Remove the local Docker image unless the user passed --keep-docker
+        if (!this.keepContainer) {
             const namespacedImage = this.getContainerImageName();
             try {
                 await loggingExeca(undefined, "docker", ["rmi", namespacedImage], {
@@ -177,49 +173,40 @@ export class ContainerTestRunner extends TestRunner {
 
     protected override getParsedDockerImageName(): ParsedDockerName {
         const parsed = parseDockerOrThrow(this.generator.workspaceConfig.test.docker.image);
-        if (this.worktreeSuffix == null) {
-            return parsed;
-        }
         return {
             name: parsed.name,
-            version: `${parsed.version}-${this.worktreeSuffix}`
+            version: this.getLocalTag()
         };
     }
 
     protected getContainerImageName(): string {
-        const testConfig =
-            this.runner === "podman" && this.generator.workspaceConfig.test.podman != null
-                ? this.generator.workspaceConfig.test.podman
-                : this.generator.workspaceConfig.test.docker;
-        return this.appendWorktreeSuffix(testConfig.image);
+        return `${this.getBaseImageName()}:${this.getLocalTag()}`;
     }
 
     /**
-     * Appends the worktree suffix to a Docker image reference.
-     * e.g. `fernapi/fern-python-sdk:latest` → `fernapi/fern-python-sdk:latest-wt-abc123`
+     * Returns the tag to use for local seed test builds.
+     * `local` in a normal checkout, `local-wt-<suffix>` in a worktree.
      */
-    private appendWorktreeSuffix(image: string): string {
-        if (this.worktreeSuffix == null) {
-            return image;
-        }
-        return `${image}-${this.worktreeSuffix}`;
+    private getLocalTag(): string {
+        return this.worktreeSuffix != null ? `local-${this.worktreeSuffix}` : "local";
     }
 
     /**
-     * Rewrites `-t <image>` flags in a docker build command to use the
-     * worktree-namespaced tag. Non-docker-build commands are returned unchanged.
+     * Rewrites `-t <image>` flags in a docker build command to use
+     * `:local` (or `:local-wt-<suffix>` in worktrees) instead of `:latest`.
+     * Non-docker-build commands are returned unchanged.
      */
     private rewriteDockerBuildTag(command: string): string {
-        if (!command.includes("docker build") || this.worktreeSuffix == null) {
+        if (!command.includes("docker build")) {
             return command;
         }
 
         const baseImage = this.getBaseImageName();
         const escapedBase = baseImage.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
         const imagePattern = new RegExp(`(${escapedBase})(:[\\w.-]+)?`, "g");
-        return command.replace(imagePattern, (_match: string, name: string, tag?: string) => {
-            const fullTag = tag != null ? `${tag}-${this.worktreeSuffix}` : `-${this.worktreeSuffix}`;
-            return `${name}${fullTag}`;
+        const localTag = this.getLocalTag();
+        return command.replace(imagePattern, (_match: string, name: string, _tag?: string) => {
+            return `${name}:${localTag}`;
         });
     }
 

--- a/packages/seed/src/commands/test/test-runner/TestRunner.ts
+++ b/packages/seed/src/commands/test/test-runner/TestRunner.ts
@@ -129,7 +129,7 @@ export abstract class TestRunner {
     protected readonly lock: Semaphore;
     protected readonly taskContextFactory: TaskContextFactory;
     private readonly skipScripts: boolean;
-    private readonly keepContainer: boolean;
+    protected readonly keepContainer: boolean;
     private scriptRunner: ScriptRunner | undefined;
     private readonly workspaceCache: WorkspaceCache | undefined;
     protected readonly logLevel: LogLevel;

--- a/packages/seed/src/utils/getWorktreeSuffix.ts
+++ b/packages/seed/src/utils/getWorktreeSuffix.ts
@@ -20,6 +20,7 @@ export function getWorktreeSuffix(): string | undefined {
     try {
         stat = fs.statSync(gitPath);
     } catch {
+        // stat may fail for dangling symlinks or permission errors; safe to ignore
         return undefined;
     }
 

--- a/packages/seed/src/utils/getWorktreeSuffix.ts
+++ b/packages/seed/src/utils/getWorktreeSuffix.ts
@@ -1,0 +1,55 @@
+import { createHash } from "crypto";
+import fs from "fs";
+import path from "path";
+
+/**
+ * Detects if the current working directory is inside a git worktree and returns
+ * a short deterministic suffix derived from the worktree path. In a worktree,
+ * `.git` is a **file** (containing `gitdir: <path>`) rather than a directory.
+ *
+ * Returns `undefined` when running from the main repo checkout (`.git` is a directory)
+ * or when `.git` cannot be found.
+ */
+export function getWorktreeSuffix(): string | undefined {
+    const gitPath = findDotGit(process.cwd());
+    if (gitPath == null) {
+        return undefined;
+    }
+
+    let stat: fs.Stats;
+    try {
+        stat = fs.statSync(gitPath);
+    } catch {
+        return undefined;
+    }
+
+    // In a normal checkout .git is a directory — no suffix needed
+    if (stat.isDirectory()) {
+        return undefined;
+    }
+
+    // In a worktree .git is a file; derive suffix from the worktree root directory
+    const worktreeRoot = path.dirname(gitPath);
+    const hash = createHash("sha256").update(worktreeRoot).digest("hex").slice(0, 8);
+    return `wt-${hash}`;
+}
+
+/**
+ * Walks up from `startDir` looking for a `.git` entry (file or directory).
+ * Returns the absolute path to it, or `undefined` if the filesystem root is reached.
+ */
+function findDotGit(startDir: string): string | undefined {
+    let dir = path.resolve(startDir);
+    // eslint-disable-next-line no-constant-condition
+    while (true) {
+        const candidate = path.join(dir, ".git");
+        if (fs.existsSync(candidate)) {
+            return candidate;
+        }
+        const parent = path.dirname(dir);
+        if (parent === dir) {
+            return undefined;
+        }
+        dir = parent;
+    }
+}


### PR DESCRIPTION
## Description

Refs #14582

When multiple git worktrees run `pnpm seed test --generator python-sdk` simultaneously against the same Docker daemon, they collide because they all build and reference the same image tag (e.g., `fernapi/fern-python-sdk:latest`). One worktree can overwrite another's image mid-test.

This PR replaces `:latest` with a dedicated `:local` tag for all seed test builds, and further namespaces with a worktree-derived suffix when running inside a git worktree:

- **Not in a worktree**: `fernapi/fern-python-sdk:local`
- **In a worktree**: `fernapi/fern-python-sdk:local-wt-abc12345`

## Changes Made

- **New utility `packages/seed/src/utils/getWorktreeSuffix.ts`**: Detects if CWD is inside a git worktree (`.git` is a file, not a directory) and derives a deterministic 8-char hash suffix from the worktree root path (e.g., `wt-abc12345`). Returns `undefined` in normal checkouts.
- **`ContainerTestRunner.build()`**: Rewrites `-t <image>` flags in docker/podman build commands to replace any existing tag with `:local` or `:local-wt-<suffix>`. After the build completes, also runs `docker tag <original> <local>` as a fallback to handle turbo-wrapped builds (e.g., `pnpm turbo run dockerTagLatest`) where the actual `docker build` happens inside a turbo script and the `-t` rewriting cannot reach it.
- **`ContainerTestRunner.getContainerImageName()`**: Returns the image with the `:local` / `:local-wt-<suffix>` tag so `ReusableContainerExecutionEnvironment` and `runContainerizedGenerationForSeed` use the correct image.
- **`ContainerTestRunner.getParsedDockerImageName()` (new override)**: Ensures `getGeneratorInvocation` also receives the `:local`-tagged version. Respects podman config when present.
- **`ContainerTestRunner.cleanup()`**: Removes the `:local` Docker image after tests complete (best-effort, with debug logging on failure). Uses `this.runner` (not hardcoded `"docker"`) so podman cleanup works. Skipped when `--keep-docker` is passed.
- **`TestRunner.keepContainer`**: Changed from `private` to `protected` so the subclass can check it during cleanup.

### Updates since last revision (addressing Devin Review feedback)

- **Turbo-wrapped build fallback**: Added `docker tag <originalImage> <localImage>` step after `runScript` to handle generators that use `pnpm turbo run dockerTagLatest` — these build `:latest` internally, so the tag command creates the `:local` alias.
- **Podman support**: `rewriteDockerBuildTag` now handles both `docker build` and `podman build` commands; `getParsedDockerImageName()` reads from podman config when `this.runner === "podman"`.
- **`this.runner` in cleanup**: `cleanup()` now uses `this.runner` instead of hardcoded `"docker"`.
- **Debug logging in catch blocks**: All catch blocks now log via `CONSOLE_LOGGER.debug(...)` per REVIEW.md rules.

## Human Review Checklist

- [ ] **Regex in `rewriteDockerBuildTag`**: The regex matches base image name occurrences globally in the command string, not just after `-t` flags. Verify this is safe given real `seed.yml` `test.docker.command` values — could the base image name appear in non-tag positions (e.g., `--from`, comments)?
- [ ] **Cleanup always removes image**: In non-worktree mode, `cleanup()` now removes the `:local` image after every test run (unless `--keep-docker`). Previously no image was removed. Confirm this is acceptable — it means a full rebuild on each `pnpm seed test` invocation unless `--keep-docker` is passed.
- [ ] **`docker tag` fallback when original has no tag**: If the config has `image: fernapi/fern-python-sdk` (no explicit tag), `getOriginalImageFromConfig()` returns it as-is. Docker will resolve this to `:latest` for the `docker tag` command, which is the intended behavior but worth verifying.
- [ ] **Visibility change**: `TestRunner.keepContainer` from `private` → `protected`. Verify no unintended access from other subclasses.

## Testing

- [ ] Unit tests added/updated — *not included; the worktree detection and tag rewriting are pure-ish functions that could benefit from unit tests*
- [x] Lint (`pnpm run check`) and format (`pnpm format`) pass locally
- [x] CI: All 304 checks pass (rebased onto latest main)
- [ ] Manual testing completed — this change is transparent in non-worktree environments and requires a real git worktree setup to exercise the namespacing path

Link to Devin session: https://app.devin.ai/sessions/7773e4ab3502411ab81a90cafa6b7cc2
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/14584" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
