### PR TITLE
fix(go): ensure extraDependencies overrides take precedence over bundled deps

### DIFF
--- a/generators/go/internal/cmd/cmd.go
+++ b/generators/go/internal/cmd/cmd.go
@@ -408,9 +408,13 @@ func moduleConfigFromCustomConfig(customConfig *customConfig, outputMode writer.
 		// The user explicitly specified a module path, so we should use it.
 		modulePath = customConfig.Module.Path
 	}
-	imports := customConfig.Module.Imports
-	if imports == nil {
-		imports = defaultImports
+	// Merge user-specified imports with defaults, allowing user versions to override bundled ones.
+	imports := make(map[string]string)
+	for k, v := range defaultImports {
+		imports[k] = v
+	}
+	for k, v := range customConfig.Module.Imports {
+		imports[k] = v
 	}
 	return &generator.ModuleConfig{
 		Path:    modulePath,

--- a/generators/go/sdk/versions.yml
+++ b/generators/go/sdk/versions.yml
@@ -1,4 +1,16 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 1.33.1
+  changelogEntry:
+    - summary: |
+        Fix `module.imports` to merge with bundled default dependencies instead
+        of replacing them. Previously, specifying any custom module imports would
+        discard all default dependencies (uuid, testify, yaml). Now user-specified
+        versions correctly override individual bundled defaults while preserving
+        the rest, matching the v2 generator behavior.
+      type: fix
+  createdAt: "2026-04-03"
+  irVersion: 61
+
 - version: 1.33.0
   changelogEntry:
     - summary: |

--- a/scripts/validate-all-changelogs.sh
+++ b/scripts/validate-all-changelogs.sh
@@ -7,7 +7,6 @@ set -e
 
 # Run all validations in parallel and collect errors
 generators=(
-    ruby-sdk
     ruby-sdk-v2
     pydantic
     python-sdk


### PR DESCRIPTION
## Description

Refs [FER-9453](https://linear.app/buildwithfern/issue/FER-9453)

The Go v1 generator's `module.imports` config (the Go equivalent of `extraDependencies`) could not override bundled dependency versions. When a user specified `module.imports`, the entire default import set was **replaced** instead of **merged**, causing all unspecified defaults (uuid, testify, yaml) to be silently dropped.

The v2 generator (TypeScript) already handled this correctly via object spread (`{...defaults, ...userImports}`). This PR aligns v1 behavior with v2.

## Changes Made

- **`generators/go/internal/cmd/cmd.go`**: Changed `moduleConfigFromCustomConfig` to merge user-specified imports on top of `defaultImports` instead of replacing them. Default deps are copied first, then user entries are applied, so user versions override matching keys while preserving the rest.
- **`generators/go/sdk/versions.yml`**: Added changelog entry (v1.33.1).
- **`scripts/validate-all-changelogs.sh`**: Removed stale `ruby-sdk` entry that was causing the "Validate Changelogs" CI check to fail. `ruby-sdk` was replaced by `ruby-sdk-v2` in #14585 but this script was not updated, breaking changelog validation for all PRs touching `generators/**/versions.yml`.

## Key Review Points

- **Behavioral change**: Previously, specifying _any_ `module.imports` would discard all defaults. Now defaults are always included as a base. If any user relied on the old behavior to intentionally exclude a default dep, they would now get it back. This seems like the correct trade-off — and matches how v2 already works.
- Ranging over a nil `customConfig.Module.Imports` map in Go is a safe no-op, so no nil guard is needed.
- For SDK generation (client mode), v2 overwrites `go.mod` anyway, so this fix primarily impacts model-only generation in v1.

### Human Review Checklist

- [ ] Verify merge order in `cmd.go`: defaults are written first, then user imports overwrite — confirm this gives user values precedence (not the reverse)
- [ ] Confirm removing `ruby-sdk` from `validate-all-changelogs.sh` is correct given the `ruby-sdk` → `ruby-sdk-v2` migration in #14585
- [ ] Consider whether any existing user relies on the old replace-all behavior of `module.imports`

## Testing

- [x] `go build ./...` passes
- [x] `go test ./...` passes
- [x] All seed snapshot tests pass (go-sdk, go-model)
- [ ] No unit tests added — `internal/cmd` has no test infrastructure; relies on seed snapshot tests for regression coverage

Link to Devin session: https://app.devin.ai/sessions/0f8b8b4bcb8c4289828129dc6c59feb5
Requested by: @jsklan
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/14587" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
