### PR TITLE
fix(rust): ensure extraDependencies overrides take precedence over bundled deps

### DIFF
--- a/generators/rust/base/src/context/AbstractRustGeneratorContext.ts
+++ b/generators/rust/base/src/context/AbstractRustGeneratorContext.ts
@@ -50,6 +50,7 @@ export abstract class AbstractRustGeneratorContext<
         this.dependencyManager = new RustDependencyManager();
         this.addBaseDependencies();
         this.detectAndAddFeatureDependencies();
+        this.applyExtraDependencies();
 
         this.project = new RustProject({
             context: this,
@@ -104,7 +105,14 @@ export abstract class AbstractRustGeneratorContext<
         }
 
         this.dependencyManager.add("tokio-test", "0.4", RustDependencyType.DEV);
+    }
 
+    /**
+     * Apply extra dependencies from config, overriding any bundled versions.
+     * Called after all bundled deps (base + conditional) are registered so
+     * user-specified versions always take precedence.
+     */
+    private applyExtraDependencies(): void {
         const extraDeps = this.customConfig.extraDependencies ?? {};
         for (const [name, versionOrSpec] of Object.entries(extraDeps)) {
             if (typeof versionOrSpec === "string") {

--- a/generators/rust/base/src/project/RustProject.ts
+++ b/generators/rust/base/src/project/RustProject.ts
@@ -634,36 +634,6 @@ export class RustProject extends AbstractProject<AbstractRustGeneratorContext<Ba
         return content;
     }
 
-    private generateExtraDependencies(): string {
-        const extraDeps = this.context.customConfig.extraDependencies || {};
-        if (Object.keys(extraDeps).length === 0) {
-            return "";
-        }
-
-        let result = "";
-        for (const [name, config] of Object.entries(extraDeps)) {
-            if (typeof config === "string") {
-                result += `${name} = "${config}"\n`;
-            } else {
-                result += `${name} = ${this.objectToToml(config)}\n`;
-            }
-        }
-        return result;
-    }
-
-    private generateExtraDevDependencies(): string {
-        const extraDevDeps = this.context.customConfig.extraDevDependencies || {};
-        if (Object.keys(extraDevDeps).length === 0) {
-            return "";
-        }
-
-        let result = "";
-        for (const [name, version] of Object.entries(extraDevDeps)) {
-            result += `${name} = "${version}"\n`;
-        }
-        return result;
-    }
-
     private generatePublishWorkflow(): string {
         // Only include publish workflow when publishConfig is set
         if (this.context.publishConfig == null) {

--- a/generators/rust/sdk/versions.yml
+++ b/generators/rust/sdk/versions.yml
@@ -1,5 +1,16 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 
+- version: 0.31.1
+  changelogEntry:
+    - summary: |
+        Ensure extraDependencies overrides take precedence over bundled dependency
+        versions. Previously, conditional bundled deps (e.g., tokio-tungstenite,
+        reqwest-sse) were added after user overrides, reverting pinned versions.
+        Extra deps are now applied last so user-specified versions always win.
+      type: fix
+  createdAt: "2026-04-03"
+  irVersion: 65
+
 - version: 0.31.0
   changelogEntry:
     - summary: |
@@ -9,7 +20,6 @@
       type: feat
   createdAt: "2026-04-02"
   irVersion: 65
-
 - version: 0.30.2
   changelogEntry:
     - summary: |

--- a/scripts/validate-all-changelogs.sh
+++ b/scripts/validate-all-changelogs.sh
@@ -7,7 +7,6 @@ set -e
 
 # Run all validations in parallel and collect errors
 generators=(
-    ruby-sdk
     ruby-sdk-v2
     pydantic
     python-sdk


### PR DESCRIPTION
## Description
Refs [FER-9454](https://linear.app/buildwithfern/issue/FER-9454)

`extraDependencies` specified in `generators.yml` could not override **conditional** bundled dependency versions (e.g., `tokio-tungstenite`, `reqwest-sse`, `pin-project`). User overrides were applied inside `addBaseDependencies()`, but `detectAndAddFeatureDependencies()` ran afterward and re-added the bundled versions, reverting any user pins via the `mergeDependencySpecs` spread (`{...existing, ...newSpec}` — later call wins).

Base deps like `serde`, `reqwest`, and `tokio` were already correctly overridable since extras were added after them within the same method.

## Changes Made
- Extracted extra dependency processing from `addBaseDependencies()` into a new `applyExtraDependencies()` method
- `applyExtraDependencies()` is called **after** both `addBaseDependencies()` and `detectAndAddFeatureDependencies()` in the constructor, ensuring user-specified versions always take precedence
- Removed dead code: `generateExtraDependencies()` and `generateExtraDevDependencies()` in `RustProject.ts` (private methods, never called anywhere — actual Cargo.toml rendering uses `dependencyManager.toTomlSections()`)
- Added changelog entry (v0.31.1, rebased on top of v0.31.0 `maxRetries` feature)
- Removed stale `ruby-sdk` entry from `scripts/validate-all-changelogs.sh` (folder was renamed to `ruby-sdk-v2`, causing `Validate Changelogs` CI to fail on every PR)

## Human Review Checklist
- [ ] Verify no other code path adds bundled deps after `applyExtraDependencies()` in the constructor — currently the order is: `addBaseDependencies()` → `detectAndAddFeatureDependencies()` → `applyExtraDependencies()` → `new RustProject()`
- [ ] Confirm `generateExtraDependencies()` / `generateExtraDevDependencies()` in `RustProject.ts` were truly dead code (private, no callers)
- [ ] Confirm removing `ruby-sdk` from `validate-all-changelogs.sh` is correct (`seed/ruby-sdk` no longer exists; `ruby-sdk-v2` is already listed)
- Feature arrays are **merged** (unioned), not replaced, by `mergeDependencySpecs`. This is unchanged behavior — users can add features but not remove bundled ones. Only scalar properties (version, optional, etc.) are overridden.
- The extra deps logic itself is unchanged — only its call site moved. No new branching or type handling was introduced.

## Testing
- [ ] Unit tests added/updated — no unit tests added; the Rust generator relies on seed snapshot tests for regression coverage
- [ ] Manual testing completed — not tested locally; relies on CI
- All seed tests pass (rust-sdk, rust-model, and all other generators)
- All CI checks pass (62/62), including `Validate Changelogs`

Link to Devin session: https://app.devin.ai/sessions/dd09dc3fc802408fa0d1bbe6e2e4cd19
Requested by: @jsklan
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/14588" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
