### PR TITLE
fix(seed): clean up go-sdk allowedFailures for fixtures that now pass

### DIFF
--- a/packages/cli/ete-tests/src/tests/validate/__snapshots__/validate.test.ts.snap
+++ b/packages/cli/ete-tests/src/tests/validate/__snapshots__/validate.test.ts.snap
@@ -6,7 +6,7 @@ No API definition found. Expected one of the following:
   - An api section in generators.yml pointing to your API spec(s)
   - A definition/ directory with Fern Definition files
 For more information, see https://buildwithfern.com/learn/api-definition/introduction/what-is-the-fern-folder
-Found 0 errors and 1 warning in 0.000 seconds. Run fern check --warnings to print out the warnings not shown."
+All checks passed"
 `;
 
 exports[`validate > no-api 1`] = `"Missing file: api.yml"`;

--- a/packages/cli/ete-tests/src/tests/validate/__snapshots__/validate.test.ts.snap
+++ b/packages/cli/ete-tests/src/tests/validate/__snapshots__/validate.test.ts.snap
@@ -6,7 +6,7 @@ No API definition found. Expected one of the following:
   - An api section in generators.yml pointing to your API spec(s)
   - A definition/ directory with Fern Definition files
 For more information, see https://buildwithfern.com/learn/api-definition/introduction/what-is-the-fern-folder
-All checks passed"
+Found 0 errors and 1 warning in 0.000 seconds. Run fern check --warnings to print out the warnings not shown."
 `;
 
 exports[`validate > no-api 1`] = `"Missing file: api.yml"`;
@@ -29,5 +29,5 @@ exports[`validate > simple 1`] = `
         path: other.yml -> types -> MyType
         issue: Type MissingType is not defined.
 
-Found 2 errors and 0 warnings in"
+Found 2 errors and 0 warnings in 0.000 seconds."
 `;

--- a/packages/cli/ete-tests/src/tests/validate/validate.test.ts
+++ b/packages/cli/ete-tests/src/tests/validate/validate.test.ts
@@ -26,23 +26,12 @@ function itFixture(fixtureName: string) {
             signal
         });
 
-        if (fixtureName == "simple") {
-            expect(
-                stripAnsi(stdout)
-                    // for some reason, locally the output contains a newline that Circle doesn't
-                    .trim()
-                    // The expected stdout for the "simple" fixture includes
-                    // an elapsed time that can change on every test run.
-                    // So, we truncate the last 15 characters to remove the
-                    // variable part of the output.
-                    .slice(0, -15)
-            ).toMatchSnapshot();
-        } else {
-            expect(
-                stripAnsi(stdout)
-                    // for some reason, locally the output contains a newline that Circle doesn't
-                    .trim()
-            ).toMatchSnapshot();
-        }
+        expect(
+            stripAnsi(stdout)
+                // for some reason, locally the output contains a newline that Circle doesn't
+                .trim()
+                // The elapsed time can change on every test run, so normalize it.
+                .replace(/in \d+\.\d+ seconds/g, "in 0.000 seconds")
+        ).toMatchSnapshot();
     }, 90_000);
 }

--- a/seed/go-sdk/seed.yml
+++ b/seed/go-sdk/seed.yml
@@ -333,40 +333,11 @@ scripts:
           exit $TEST_EXIT_CODE
 allowedFailures:
   - alias-extends
-  - bytes-upload
   - bytes-download
-  - enum
-  - errors
-  - literal
-  - mixed-case:no-custom-config
-  - mixed-case:default-values
   - request-parameters
-  - reserved-keywords
   - streaming-parameter
-  - server-sent-event-examples:with-wire-tests # TODO: update wiretests geranation then remove it
-  - server-sent-events:with-wire-tests # TODO: update wiretests geranation then remove it
-  - server-url-templating
   - trace
-  - property-access
-  - oauth-client-credentials:.
-  - oauth-client-credentials-reference
 
   # TODO: Fix example generator to produce valid dynamic snippets.
   - pagination
-
-  # TODO: Update the dynamic snippet generator to handle these cases.
-  - examples:exported-client-name
-  - path-parameters:no-custom-config
-  - path-parameters:package-name
-
-  - oauth-client-credentials-with-variables
-  - variables
-
-  # Will include these back in once we fix dynamic snippets for inline file properties
-  - file-upload:no-custom-config
-  - file-upload:package-name
-  - file-upload-openapi
-
   - pagination-custom:.
-
-  # exhaustive fixtures now pass after fixing bytes endpoint wire test generation

--- a/seed/go-sdk/seed.yml
+++ b/seed/go-sdk/seed.yml
@@ -333,11 +333,21 @@ scripts:
           exit $TEST_EXIT_CODE
 allowedFailures:
   - alias-extends
+  - bytes-upload
   - bytes-download
+  - enum
+  - literal
+  - mixed-case:no-custom-config
+  - mixed-case:default-values
   - request-parameters
   - streaming-parameter
+  - server-sent-event-examples:with-wire-tests
   - trace
+  - property-access
 
   # TODO: Fix example generator to produce valid dynamic snippets.
   - pagination
   - pagination-custom:.
+
+  # TODO: Update the dynamic snippet generator to handle these cases.
+  - examples:exported-client-name


### PR DESCRIPTION
## Description

Refs FER-9441

Removes fixtures from the `allowedFailures` list in `seed/go-sdk/seed.yml` that now pass successfully. These were flagged as unexpected successes when running the full go-sdk seed test suite.

Also fixes a pre-existing flaky `test-ete` CI failure in the validate snapshot tests by improving elapsed-time normalization.

## Changes Made

- **Net removed 13 entries** from `allowedFailures` that are no longer failing: `errors`, `reserved-keywords`, `server-sent-events:with-wire-tests`, `server-url-templating`, `oauth-client-credentials:.`, `oauth-client-credentials-reference`, `path-parameters:no-custom-config`, `path-parameters:package-name`, `oauth-client-credentials-with-variables`, `variables`, `file-upload:no-custom-config`, `file-upload:package-name`, `file-upload-openapi`
- Removed stale TODO comments associated with now-passing fixtures
- Retained 15 entries that still fail: `alias-extends`, `bytes-upload`, `bytes-download`, `enum`, `literal`, `mixed-case:no-custom-config`, `mixed-case:default-values`, `request-parameters`, `streaming-parameter`, `server-sent-event-examples:with-wire-tests`, `trace`, `property-access`, `pagination`, `pagination-custom:.`, `examples:exported-client-name`

### Updates since last revision (ETE test fix)

- Simplified `validate.test.ts` to use a single regex-based time normalization (`.replace(/in \d+\.\d+ seconds/g, "in 0.000 seconds")`) for all fixtures, replacing the previous `slice(0, -15)` special-casing for the `simple` fixture
- Updated `simple` snapshot to include the full normalized suffix (`in 0.000 seconds.`) instead of being truncated at `in`
- The `docs` snapshot remains unchanged (`All checks passed`)

### Updates since last revision (re-add still-failing fixtures)

- Re-added 8 fixtures to `allowedFailures` that were removed initially but turned out to still be failing in CI: `bytes-upload`, `enum`, `literal`, `mixed-case:no-custom-config`, `mixed-case:default-values`, `server-sent-event-examples:with-wire-tests`, `property-access`, `examples:exported-client-name`
- Net removal is now 13 fixtures (down from 21)

## Testing

- [x] Ran `pnpm seed test --generator go-sdk --skip-scripts --parallel 8` — all 142 test cases pass (7 expected failures, 0 unexpected failures, 0 unexpected successes)
- [x] Ran `pnpm seed test --generator go-sdk --fixture imdb --skip-scripts` — 5/5 passed
- [x] Ran `pnpm seed test --generator go-sdk --fixture exhaustive --skip-scripts` — 2/2 passed
- [x] Ran `pnpm seed run --generator go-sdk --path test-definitions/fern/apis/imdb --skip-scripts` — succeeded
- [x] All CI checks passing (306 pass, 0 fail), including `test-ete` and `seed-test-results (go-sdk)`

## Reviewer Checklist

- [ ] Verify the 8 re-added `allowedFailures` entries (`bytes-upload`, `enum`, `literal`, `mixed-case:no-custom-config`, `mixed-case:default-values`, `server-sent-event-examples:with-wire-tests`, `property-access`, `examples:exported-client-name`) are genuinely still failing — these were originally removed but CI showed they haven't been fixed yet
- [ ] Confirm the 13 net-removed fixtures are truly passing consistently
- [ ] Confirm the regex time normalization in `validate.test.ts` doesn't inadvertently mask real output differences (it only targets `in X.XXX seconds` patterns)
- [ ] Verify the updated `simple` snapshot value (`Found 2 errors and 0 warnings in 0.000 seconds.`) matches the actual CLI output after normalization

Link to Devin session: https://app.devin.ai/sessions/19baccc97c7c4fdf9e5c3a5104a2eeca
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/14590" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
