### PR TITLE
fix(seed): remove stale allowedFailures for python-sdk

### DIFF
--- a/seed/python-sdk/seed.yml
+++ b/seed/python-sdk/seed.yml
@@ -441,9 +441,14 @@ scripts:
         - poetry install --extras aiohttp
         - poetry run pytest -rP -n auto -m aiohttp .
 allowedFailures:
+  - any-auth
+  - endpoint-security-auth
+  - examples:legacy-wire-tests
   - exhaustive:additional_init_exports
+  - exhaustive:deps_with_min_python_version
   - exhaustive:pydantic-v1-with-utils
   - oauth-client-credentials-custom
   - oauth-client-credentials-openapi
+  - response-property
   - streaming-parameter
   - trace

--- a/seed/python-sdk/seed.yml
+++ b/seed/python-sdk/seed.yml
@@ -441,16 +441,9 @@ scripts:
         - poetry install --extras aiohttp
         - poetry run pytest -rP -n auto -m aiohttp .
 allowedFailures:
-  - any-auth
-  - endpoint-security-auth
-  - examples:legacy-wire-tests
   - exhaustive:additional_init_exports
-  - exhaustive:deps_with_min_python_version
   - exhaustive:pydantic-v1-with-utils
   - oauth-client-credentials-custom
   - oauth-client-credentials-openapi
-  - pagination-custom
-  - response-property
   - streaming-parameter
-  - server-sent-event-examples:with-wire-tests # TODO: update wiretests geranation then remove it
   - trace


### PR DESCRIPTION
## Description

Refs FER-9444

Removes 2 stale `allowedFailures` entries from the `python-sdk` seed config that now pass the full test suite (including the script phase — mypy/pytest).

## Updates since last revision

The original version of this PR attempted to remove all 13 `allowedFailures`, but CI revealed most fixtures still fail during the **script phase** (mypy/pytest). After iterating:

- **Rebased** onto latest `main` (includes PR #14584 — Docker image tag namespacing)
- **Removed 2 entries** that now pass: `pagination-custom`, `server-sent-event-examples:with-wire-tests`
- **Kept 11 entries** that still have genuine failures (mypy type errors, pytest collection errors, etc.)

## Changes Made

- Removed `pagination-custom` from `allowedFailures` in `seed/python-sdk/seed.yml`
- Removed `server-sent-event-examples:with-wire-tests` from `allowedFailures` (this also had a stale TODO comment)

## Testing

- [x] Verified remaining 11 fixtures still fail by analyzing CI job logs across multiple shard runs
- [x] Confirmed `pagination-custom` and `server-sent-event-examples:with-wire-tests` were NOT listed as unexpected failures in any CI shard
- [ ] CI seed tests pass for `python-sdk` on this branch

## ⚠️ Reviewer Checklist

- [ ] Confirm CI `seed-test-results (python-sdk)` passes — the 2 removed fixtures should no longer appear as failures
- [ ] Verify `pagination-custom` and `server-sent-event-examples:with-wire-tests` are not flaky (i.e., they pass consistently, not just on one run)

Link to Devin session: https://app.devin.ai/sessions/966805098ac04547b1020e870eb1701b
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/14592" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
