### PR TITLE
fix(internal): use --worktree branch name instead of random suffix

### DIFF
--- a/scripts/worktree-create-hook.sh
+++ b/scripts/worktree-create-hook.sh
@@ -3,7 +3,7 @@
 # Claude Code WorktreeCreate hook.
 # Creates a worktree with sparse checkout in ../.fern-worktrees/.
 #
-# Stdin: JSON with session_id, cwd, etc.
+# Stdin: JSON with session_id, cwd, worktreeInput.branch, etc.
 # Stdout: Must be ONLY the absolute worktree path (nothing else).
 #
 
@@ -15,14 +15,31 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 WORKTREE_BASE="$REPO_ROOT/../.fern-worktrees"
 
-# Generate a worktree name from timestamp + random suffix
-WORKTREE_NAME="wt-$(date +%s)-$$"
+# Extract branch from worktreeInput if provided (e.g. claude --worktree username/my-branch)
+BRANCH=$(echo "$INPUT" | jq -r '.worktreeInput.branch // empty')
+
+if [ -n "$BRANCH" ]; then
+    # Use the branch name as the worktree directory name (slashes become directory separators)
+    WORKTREE_NAME="$BRANCH"
+else
+    # Fallback: generate a worktree name from timestamp + random suffix
+    WORKTREE_NAME="wt-$(date +%s)-$$"
+fi
+
 WORKTREE_PATH="$WORKTREE_BASE/$WORKTREE_NAME"
 
 mkdir -p "$WORKTREE_BASE"
 
-# Create the worktree (suppress all output)
-git worktree add "$WORKTREE_PATH" >/dev/null 2>&1
+# Create worktree — use -b if the branch doesn't exist yet
+if [ -n "$BRANCH" ]; then
+    if git show-ref --verify --quiet "refs/heads/$BRANCH"; then
+        git worktree add "$WORKTREE_PATH" "$BRANCH" >/dev/null 2>&1
+    else
+        git worktree add -b "$BRANCH" "$WORKTREE_PATH" >/dev/null 2>&1
+    fi
+else
+    git worktree add "$WORKTREE_PATH" >/dev/null 2>&1
+fi
 
 # Apply sparse checkout (suppress all output)
 bash "$SCRIPT_DIR/sparse-checkout.sh" "$WORKTREE_PATH" >/dev/null 2>&1

--- a/scripts/worktree-create-hook.sh
+++ b/scripts/worktree-create-hook.sh
@@ -3,7 +3,7 @@
 # Claude Code WorktreeCreate hook.
 # Creates a worktree with sparse checkout in ../.fern-worktrees/.
 #
-# Stdin: JSON with session_id, cwd, worktreeInput.branch, etc.
+# Stdin: JSON with session_id, cwd, name, etc.
 # Stdout: Must be ONLY the absolute worktree path (nothing else).
 #
 
@@ -15,12 +15,11 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 WORKTREE_BASE="$REPO_ROOT/../.fern-worktrees"
 
-# Extract branch from worktreeInput if provided (e.g. claude --worktree username/my-branch)
-BRANCH=$(echo "$INPUT" | jq -r '.worktreeInput.branch // empty')
+# Extract the worktree name (e.g. claude --worktree my-special-worktree)
+NAME=$(echo "$INPUT" | jq -r '.name // empty')
 
-if [ -n "$BRANCH" ]; then
-    # Use the branch name as the worktree directory name (slashes become directory separators)
-    WORKTREE_NAME="$BRANCH"
+if [ -n "$NAME" ]; then
+    WORKTREE_NAME="$NAME"
 else
     # Fallback: generate a worktree name from timestamp + random suffix
     WORKTREE_NAME="wt-$(date +%s)-$$"
@@ -30,16 +29,8 @@ WORKTREE_PATH="$WORKTREE_BASE/$WORKTREE_NAME"
 
 mkdir -p "$WORKTREE_BASE"
 
-# Create worktree — use -b if the branch doesn't exist yet
-if [ -n "$BRANCH" ]; then
-    if git show-ref --verify --quiet "refs/heads/$BRANCH"; then
-        git worktree add "$WORKTREE_PATH" "$BRANCH" >/dev/null 2>&1
-    else
-        git worktree add -b "$BRANCH" "$WORKTREE_PATH" >/dev/null 2>&1
-    fi
-else
-    git worktree add "$WORKTREE_PATH" >/dev/null 2>&1
-fi
+# Create the worktree (suppress all output)
+git worktree add "$WORKTREE_PATH" >/dev/null 2>&1
 
 # Apply sparse checkout (suppress all output)
 bash "$SCRIPT_DIR/sparse-checkout.sh" "$WORKTREE_PATH" >/dev/null 2>&1


### PR DESCRIPTION
## Summary
- Reads `worktreeInput.branch` from the WorktreeCreate hook stdin so that `claude --worktree username/my-branch` creates a worktree and branch with that name
- Creates the branch if it doesn't exist yet (via `git worktree add -b`), checks it out if it does
- Falls back to the random `wt-<timestamp>-<pid>` naming when no branch is provided (e.g. subagent `isolation: "worktree"`)

## Test plan
- [ ] Run `claude --worktree jsklan/test-branch` and verify the worktree is created at `../.fern-worktrees/jsklan/test-branch` on branch `jsklan/test-branch`
- [ ] Run `claude --worktree` without a branch name and verify fallback to random naming still works
- [ ] Run `claude --worktree existing-branch` with a pre-existing branch and verify it checks out correctly
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/14594" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
