### PR TITLE
fix(seed): fix --local parity for php-sdk

### DIFF
--- a/generators/php/base/src/project/PhpProject.ts
+++ b/generators/php/base/src/project/PhpProject.ts
@@ -4,7 +4,8 @@ import { loggingExeca } from "@fern-api/logging-execa";
 import { BasePhpCustomConfigSchema } from "@fern-api/php-codegen";
 import { Eta } from "eta";
 import { createWriteStream, existsSync } from "fs";
-import { chmod, mkdir, readFile, writeFile } from "fs/promises";
+import { chmod, mkdir, readFile, rename, unlink, writeFile } from "fs/promises";
+import type { IncomingMessage } from "http";
 import https from "https";
 import { cloneDeep, isArray, mergeWith } from "lodash-es";
 import os from "os";
@@ -33,7 +34,7 @@ const PHP_CS_FIXER_DOWNLOAD_URL = `https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/
 
 let resolvedPhpCsFixerPath: string | undefined;
 
-async function resolvePhpCsFixer(): Promise<{ command: string; args: string[] }> {
+async function resolvePhpCsFixer(logger?: { debug: (msg: string) => void }): Promise<{ command: string; args: string[] }> {
     if (resolvedPhpCsFixerPath != null) {
         if (resolvedPhpCsFixerPath === "php-cs-fixer") {
             return { command: "php-cs-fixer", args: [] };
@@ -51,8 +52,8 @@ async function resolvePhpCsFixer(): Promise<{ command: string; args: string[] }>
             resolvedPhpCsFixerPath = "php-cs-fixer";
             return { command: "php-cs-fixer", args: [] };
         }
-    } catch {
-        // Not on PATH, fall through to download
+    } catch (error) {
+        logger?.debug(`php-cs-fixer not found on PATH, falling back to download: ${error}`);
     }
 
     // Download the phar to a cache directory
@@ -61,39 +62,46 @@ async function resolvePhpCsFixer(): Promise<{ command: string; args: string[] }>
 
     if (!existsSync(pharPath)) {
         await mkdir(cacheDir, { recursive: true });
-        await downloadFile(PHP_CS_FIXER_DOWNLOAD_URL, pharPath);
-        await chmod(pharPath, 0o755);
+        const tmpPath = pharPath + ".tmp";
+        try {
+            await downloadFile(PHP_CS_FIXER_DOWNLOAD_URL, tmpPath);
+            await chmod(tmpPath, 0o755);
+            await rename(tmpPath, pharPath);
+        } catch (error) {
+            // Clean up partial download so next attempt re-downloads
+            await unlink(tmpPath).catch(() => {});
+            throw error;
+        }
     }
 
     resolvedPhpCsFixerPath = pharPath;
     return { command: "php", args: [pharPath] };
 }
 
-function downloadFile(url: string, destPath: string): Promise<void> {
-    return new Promise((resolve, reject) => {
-        const makeRequest = (requestUrl: string) => {
-            https
-                .get(requestUrl, (response) => {
-                    if (
-                        response.statusCode != null &&
-                        response.statusCode >= 300 &&
-                        response.statusCode < 400 &&
-                        response.headers.location
-                    ) {
-                        makeRequest(response.headers.location);
-                        return;
-                    }
-                    if (response.statusCode != null && response.statusCode !== 200) {
-                        reject(new Error(`Failed to download ${requestUrl}: HTTP ${response.statusCode}`));
-                        return;
-                    }
-                    const fileStream = createWriteStream(destPath);
-                    pipeline(response, fileStream).then(resolve).catch(reject);
-                })
-                .on("error", reject);
-        };
-        makeRequest(url);
-    });
+async function downloadFile(url: string, destPath: string): Promise<void> {
+    let requestUrl = url;
+    for (;;) {
+        const response = await new Promise<IncomingMessage>((resolve, reject) => {
+            https.get(requestUrl, resolve).on("error", reject);
+        });
+        if (
+            response.statusCode != null &&
+            response.statusCode >= 300 &&
+            response.statusCode < 400 &&
+            response.headers.location
+        ) {
+            response.resume();
+            requestUrl = response.headers.location;
+            continue;
+        }
+        if (response.statusCode != null && response.statusCode !== 200) {
+            response.resume();
+            throw new Error(`Failed to download ${requestUrl}: HTTP ${response.statusCode}`);
+        }
+        const fileStream = createWriteStream(destPath);
+        await pipeline(response, fileStream);
+        return;
+    }
 }
 
 /**
@@ -300,7 +308,7 @@ export class PhpProject extends AbstractProject<AbstractPhpGeneratorContext<Base
         await this.mkdir(absolutePathToDirectory);
         await Promise.all(files.map(async (file) => await file.write(absolutePathToDirectory)));
         if (files.length > 0) {
-            const { command, args } = await resolvePhpCsFixer();
+            const { command, args } = await resolvePhpCsFixer(this.context.logger);
             await loggingExeca(this.context.logger, command, [...args, "fix", ".", "--no-interaction"], {
                 doNotPipeOutput: true,
                 cwd: absolutePathToDirectory

--- a/generators/php/base/src/project/PhpProject.ts
+++ b/generators/php/base/src/project/PhpProject.ts
@@ -83,8 +83,12 @@ async function resolvePhpCsFixer(logger?: {
 }
 
 async function downloadFile(url: string, destPath: string): Promise<void> {
+    const MAX_REDIRECTS = 10;
     let requestUrl = url;
-    for (;;) {
+    for (let redirectCount = 0; ; redirectCount++) {
+        if (redirectCount > MAX_REDIRECTS) {
+            throw new Error(`Too many redirects (>${MAX_REDIRECTS}) while downloading ${url}`);
+        }
         const response = await new Promise<IncomingMessage>((resolve, reject) => {
             https.get(requestUrl, resolve).on("error", reject);
         });

--- a/generators/php/base/src/project/PhpProject.ts
+++ b/generators/php/base/src/project/PhpProject.ts
@@ -3,9 +3,13 @@ import { AbsoluteFilePath, join, RelativeFilePath } from "@fern-api/fs-utils";
 import { loggingExeca } from "@fern-api/logging-execa";
 import { BasePhpCustomConfigSchema } from "@fern-api/php-codegen";
 import { Eta } from "eta";
-import { mkdir, readFile, writeFile } from "fs/promises";
+import { createWriteStream, existsSync } from "fs";
+import { chmod, mkdir, readFile, writeFile } from "fs/promises";
+import https from "https";
 import { cloneDeep, isArray, mergeWith } from "lodash-es";
+import os from "os";
 import path from "path";
+import { pipeline } from "stream/promises";
 
 import { AsIsFiles } from "../AsIs.js";
 import { AbstractPhpGeneratorContext } from "../context/AbstractPhpGeneratorContext.js";
@@ -23,6 +27,74 @@ const TESTS_DIRECTORY_NAME = "tests";
 const CUSTOM_LICENSE_NAME = "LicenseRef-LICENSE";
 
 const COMPOSER_JSON_FILENAME = "composer.json";
+
+const PHP_CS_FIXER_VERSION = "v3.94.2";
+const PHP_CS_FIXER_DOWNLOAD_URL = `https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/releases/download/${PHP_CS_FIXER_VERSION}/php-cs-fixer.phar`;
+
+let resolvedPhpCsFixerPath: string | undefined;
+
+async function resolvePhpCsFixer(): Promise<{ command: string; args: string[] }> {
+    if (resolvedPhpCsFixerPath != null) {
+        if (resolvedPhpCsFixerPath === "php-cs-fixer") {
+            return { command: "php-cs-fixer", args: [] };
+        }
+        return { command: "php", args: [resolvedPhpCsFixerPath] };
+    }
+
+    // Check if php-cs-fixer is on PATH
+    try {
+        const { exitCode } = await loggingExeca(undefined, "php-cs-fixer", ["--version"], {
+            doNotPipeOutput: true,
+            reject: false
+        });
+        if (exitCode === 0) {
+            resolvedPhpCsFixerPath = "php-cs-fixer";
+            return { command: "php-cs-fixer", args: [] };
+        }
+    } catch {
+        // Not on PATH, fall through to download
+    }
+
+    // Download the phar to a cache directory
+    const cacheDir = path.join(os.tmpdir(), "fern-php-cs-fixer");
+    const pharPath = path.join(cacheDir, `php-cs-fixer-${PHP_CS_FIXER_VERSION}.phar`);
+
+    if (!existsSync(pharPath)) {
+        await mkdir(cacheDir, { recursive: true });
+        await downloadFile(PHP_CS_FIXER_DOWNLOAD_URL, pharPath);
+        await chmod(pharPath, 0o755);
+    }
+
+    resolvedPhpCsFixerPath = pharPath;
+    return { command: "php", args: [pharPath] };
+}
+
+function downloadFile(url: string, destPath: string): Promise<void> {
+    return new Promise((resolve, reject) => {
+        const makeRequest = (requestUrl: string) => {
+            https
+                .get(requestUrl, (response) => {
+                    if (
+                        response.statusCode != null &&
+                        response.statusCode >= 300 &&
+                        response.statusCode < 400 &&
+                        response.headers.location
+                    ) {
+                        makeRequest(response.headers.location);
+                        return;
+                    }
+                    if (response.statusCode != null && response.statusCode !== 200) {
+                        reject(new Error(`Failed to download ${requestUrl}: HTTP ${response.statusCode}`));
+                        return;
+                    }
+                    const fileStream = createWriteStream(destPath);
+                    pipeline(response, fileStream).then(resolve).catch(reject);
+                })
+                .on("error", reject);
+        };
+        makeRequest(url);
+    });
+}
 
 /**
  * In memory representation of a PHP project.
@@ -228,7 +300,8 @@ export class PhpProject extends AbstractProject<AbstractPhpGeneratorContext<Base
         await this.mkdir(absolutePathToDirectory);
         await Promise.all(files.map(async (file) => await file.write(absolutePathToDirectory)));
         if (files.length > 0) {
-            await loggingExeca(this.context.logger, "php-cs-fixer", ["fix", ".", "--no-interaction"], {
+            const { command, args } = await resolvePhpCsFixer();
+            await loggingExeca(this.context.logger, command, [...args, "fix", ".", "--no-interaction"], {
                 doNotPipeOutput: true,
                 cwd: absolutePathToDirectory
             });

--- a/generators/php/base/src/project/PhpProject.ts
+++ b/generators/php/base/src/project/PhpProject.ts
@@ -34,7 +34,9 @@ const PHP_CS_FIXER_DOWNLOAD_URL = `https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/
 
 let resolvedPhpCsFixerPath: string | undefined;
 
-async function resolvePhpCsFixer(logger?: { debug: (msg: string) => void }): Promise<{ command: string; args: string[] }> {
+async function resolvePhpCsFixer(logger?: {
+    debug: (msg: string) => void;
+}): Promise<{ command: string; args: string[] }> {
     if (resolvedPhpCsFixerPath != null) {
         if (resolvedPhpCsFixerPath === "php-cs-fixer") {
             return { command: "php-cs-fixer", args: [] };
@@ -69,7 +71,9 @@ async function resolvePhpCsFixer(logger?: { debug: (msg: string) => void }): Pro
             await rename(tmpPath, pharPath);
         } catch (error) {
             // Clean up partial download so next attempt re-downloads
-            await unlink(tmpPath).catch(() => {});
+            await unlink(tmpPath).catch(() => {
+                // Ignore cleanup errors; the file may not exist
+            });
             throw error;
         }
     }


### PR DESCRIPTION
## Description

Linear ticket: Refs FER-9443

When running `seed test --local` or `seed run --local` for the `php-sdk` generator, all tests fail with `spawn php-cs-fixer ENOENT` because `php-cs-fixer` is only installed inside the Docker image and is not available on the host PATH.

This change makes the PHP generator auto-resolve `php-cs-fixer` at runtime: if the binary is on PATH (Docker mode), it uses it directly; otherwise, it downloads the matching `.phar` from GitHub releases to a temp cache directory and invokes it via `php <phar-path>`.

## Changes Made

- Added `resolvePhpCsFixer()` in `PhpProject.ts` that checks PATH first, then falls back to downloading `php-cs-fixer.phar` (v3.94.2, matching the Dockerfile) to `$TMPDIR/fern-php-cs-fixer/`
- Added a `downloadFile()` helper using async/await with a redirect-following loop (capped at 10 redirects)
- Updated `createPhpDirectory()` to use the resolved command instead of hardcoding `php-cs-fixer`
- Result is cached in a module-level variable so the download/check only happens once per process
- Download uses atomic write (tmp file + rename) to prevent corrupt partial files from persisting
- Response bodies are properly drained on redirect/error paths to avoid socket leaks
- Catch block in PATH check logs the error at debug level via optional `logger` parameter

## Testing

- [x] `seed test --generator php-sdk --fixture imdb --skip-scripts` (Docker): 7/7 passed ✅
- [x] `seed test --generator php-sdk --fixture imdb --skip-scripts --local`: 7/7 passed ✅ (was 0/7 before fix)
- [x] `git diff` between Docker and local output: **empty** (byte-for-byte identical)
- [x] `seed run --generator php-sdk --path test-definitions/fern/apis/imdb --skip-scripts` (Docker): success ✅
- [x] `seed run --generator php-sdk --path test-definitions/fern/apis/imdb --skip-scripts --local`: success ✅
- [x] `diff -rq` between Docker and local `seed run` output: identical (only `.php-cs-fixer.cache` files differ, which are ephemeral)
- [x] `pnpm check` passes

## Human Review Checklist

- The `php-cs-fixer` version (`v3.94.2`) is hardcoded in `PhpProject.ts` and must stay in sync with the version in `generators/php/sdk/Dockerfile`. If the Dockerfile version is bumped, this constant needs updating too.
- Module-level `let resolvedPhpCsFixerPath` caches the result for the process lifetime. Acceptable for seed CLI but worth noting.
- No timeout or retry on the phar download — acceptable for a dev tool?

Link to Devin session: https://app.devin.ai/sessions/553b1a740dc543b2bd2f44a5a18bea07
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/14596" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
