### PR TITLE
fix(seed): fix --local parity for java-sdk

### DIFF
--- a/packages/cli/generation/local-generation/local-workspace-runner/src/NativeExecutionEnvironment.ts
+++ b/packages/cli/generation/local-generation/local-workspace-runner/src/NativeExecutionEnvironment.ts
@@ -56,67 +56,69 @@ export class NativeExecutionEnvironment implements ExecutionEnvironment {
             }
         }
 
-        for (const command of this.commands) {
-            const processedCommand = command
-                .replace("{IR_PATH}", irPath)
-                .replace("{CONFIG_PATH}", configPath)
-                .replace("{OUTPUT_PATH}", outputPath)
-                .replace("{SNIPPET_PATH}", snippetPath || "")
-                .replace("{SNIPPET_TEMPLATE_PATH}", snippetTemplatePath || "")
-                .replace("{GENERATOR_NAME}", generatorName);
+        try {
+            for (const command of this.commands) {
+                const processedCommand = command
+                    .replace("{IR_PATH}", irPath)
+                    .replace("{CONFIG_PATH}", configPath)
+                    .replace("{OUTPUT_PATH}", outputPath)
+                    .replace("{SNIPPET_PATH}", snippetPath || "")
+                    .replace("{SNIPPET_TEMPLATE_PATH}", snippetTemplatePath || "")
+                    .replace("{GENERATOR_NAME}", generatorName);
 
-            context.logger.debug(`Executing command: ${processedCommand}`);
+                context.logger.debug(`Executing command: ${processedCommand}`);
 
-            // Check if command contains shell operators that require shell mode
-            const shellOperators = ["&&", "||", "|", ";", ">", "<", ">>", "<<"];
-            const needsShell = shellOperators.some((op) => processedCommand.includes(op));
+                // Check if command contains shell operators that require shell mode
+                const shellOperators = ["&&", "||", "|", ";", ">", "<", ">>", "<<"];
+                const needsShell = shellOperators.some((op) => processedCommand.includes(op));
 
-            const execOptions = {
-                doNotPipeOutput: false,
-                reject: false,
-                cwd: this.workingDirectory,
-                env: {
-                    ...process.env,
-                    ...this.env,
-                    IR_PATH: irPath,
-                    CONFIG_PATH: configPath,
-                    OUTPUT_PATH: outputPath,
-                    SNIPPET_PATH: snippetPath || "",
-                    SNIPPET_TEMPLATE_PATH: snippetTemplatePath || "",
-                    GENERATOR_NAME: generatorName,
-                    ...(inspect ? { NODE_OPTIONS: "--inspect-brk=0.0.0.0:9229" } : {})
-                },
-                shell: needsShell
-            };
+                const execOptions = {
+                    doNotPipeOutput: false,
+                    reject: false,
+                    cwd: this.workingDirectory,
+                    env: {
+                        ...process.env,
+                        ...this.env,
+                        IR_PATH: irPath,
+                        CONFIG_PATH: configPath,
+                        OUTPUT_PATH: outputPath,
+                        SNIPPET_PATH: snippetPath || "",
+                        SNIPPET_TEMPLATE_PATH: snippetTemplatePath || "",
+                        GENERATOR_NAME: generatorName,
+                        ...(inspect ? { NODE_OPTIONS: "--inspect-brk=0.0.0.0:9229" } : {})
+                    },
+                    shell: needsShell
+                };
 
-            let result;
-            if (needsShell) {
-                // For shell commands, pass the entire command as a single string
-                result = await loggingExeca(context.logger, processedCommand, [], execOptions);
-            } else {
-                // For simple commands, split by space
-                const parts = processedCommand.split(" ");
-                const program = parts[0];
-                const args = parts.slice(1);
+                let result;
+                if (needsShell) {
+                    // For shell commands, pass the entire command as a single string
+                    result = await loggingExeca(context.logger, processedCommand, [], execOptions);
+                } else {
+                    // For simple commands, split by space
+                    const parts = processedCommand.split(" ");
+                    const program = parts[0];
+                    const args = parts.slice(1);
 
-                if (!program) {
-                    throw new Error(`Invalid command: ${processedCommand}`);
+                    if (!program) {
+                        throw new Error(`Invalid command: ${processedCommand}`);
+                    }
+
+                    result = await loggingExeca(context.logger, program, args, execOptions);
                 }
 
-                result = await loggingExeca(context.logger, program, args, execOptions);
+                if (result.failed) {
+                    throw new Error(`Command failed: ${processedCommand}\n${result.stderr || result.stdout}`);
+                }
             }
-
-            if (result.failed) {
-                throw new Error(`Command failed: ${processedCommand}\n${result.stderr || result.stdout}`);
-            }
-        }
-
-        // Clean up the copied license file
-        if (copiedLicense) {
-            try {
-                await rm(LICENSE_MOUNT_PATH, { force: true });
-            } catch {
-                // Best-effort cleanup
+        } finally {
+            // Clean up the copied license file
+            if (copiedLicense) {
+                try {
+                    await rm(LICENSE_MOUNT_PATH, { force: true });
+                } catch (e) {
+                    context.logger.debug(`Best-effort cleanup of ${LICENSE_MOUNT_PATH} failed: ${e}`);
+                }
             }
         }
 

--- a/packages/cli/generation/local-generation/local-workspace-runner/src/NativeExecutionEnvironment.ts
+++ b/packages/cli/generation/local-generation/local-workspace-runner/src/NativeExecutionEnvironment.ts
@@ -1,6 +1,9 @@
 import { loggingExeca } from "@fern-api/logging-execa";
+import { copyFile, rm } from "fs/promises";
 
 import { ExecutionEnvironment } from "./ExecutionEnvironment.js";
+
+const LICENSE_MOUNT_PATH = "/tmp/LICENSE";
 
 /**
  * Executes generators natively on the host system using provided commands.
@@ -31,12 +34,27 @@ export class NativeExecutionEnvironment implements ExecutionEnvironment {
         outputPath,
         snippetPath,
         snippetTemplatePath,
+        licenseFilePath,
         context,
         inspect
     }: ExecutionEnvironment.ExecuteArgs): Promise<void> {
         context.logger.info(
             `Executing generator ${generatorName} natively with commands: ${this.commands.join(" && ")}`
         );
+
+        // Copy license file to /tmp/LICENSE to match the Docker mount path that generators expect
+        let copiedLicense = false;
+        if (licenseFilePath != null) {
+            try {
+                await copyFile(licenseFilePath, LICENSE_MOUNT_PATH);
+                copiedLicense = true;
+                context.logger.debug(`Copied license file from ${licenseFilePath} to ${LICENSE_MOUNT_PATH}`);
+            } catch (e) {
+                context.logger.warn(
+                    `Failed to copy license file from ${licenseFilePath} to ${LICENSE_MOUNT_PATH}: ${e}`
+                );
+            }
+        }
 
         for (const command of this.commands) {
             const processedCommand = command
@@ -90,6 +108,15 @@ export class NativeExecutionEnvironment implements ExecutionEnvironment {
 
             if (result.failed) {
                 throw new Error(`Command failed: ${processedCommand}\n${result.stderr || result.stdout}`);
+            }
+        }
+
+        // Clean up the copied license file
+        if (copiedLicense) {
+            try {
+                await rm(LICENSE_MOUNT_PATH, { force: true });
+            } catch {
+                // Best-effort cleanup
             }
         }
 


### PR DESCRIPTION
## Description

Refs FER-9442

Fixes a discrepancy between Docker and `--local` mode output for `java-sdk` generators that use custom licenses. In Docker mode, the license file is bind-mounted at `/tmp/LICENSE`; the Java generator reads it to extract the license name and copies it into the output directory. In native/local mode, `NativeExecutionEnvironment` ignored the `licenseFilePath` parameter entirely, so the license file was never placed where the generator expects it.

This caused two differences in the `custom-license` fixture output:
1. The `LICENSE` file was missing from the generated output
2. `build.gradle` contained a generic `"Custom License (LICENSE)"` instead of the actual license name extracted from the file

## Changes Made

- Destructure `licenseFilePath` from `ExecuteArgs` in `NativeExecutionEnvironment.execute()`
- Before running generator commands, copy the license file to `/tmp/LICENSE` (matching the Docker mount path)
- Wrap the command execution loop in `try/finally` so the copied license file is always cleaned up, even when a command throws
- Log errors in catch blocks instead of swallowing silently

## Testing

- [x] Manual testing: ran `seed test --generator java-sdk --fixture exhaustive --outputFolder custom-license` in both Docker and `--local` modes — output is now byte-for-byte identical
- [x] Manual testing: ran `seed run --generator java-sdk --path test-definitions/fern/apis/simple-api` in both modes — output identical
- [x] Lint passes (`pnpm run check`)
- [ ] Unit tests added/updated

## ⚠️ Review Notes

- **Concurrent execution**: The copy targets a fixed path (`/tmp/LICENSE`). Docker isolates this via container namespacing, but native mode writes directly to the host filesystem. If two native generators run in parallel, they could clobber each other's license file. Worth considering whether this needs a unique temp path instead.

### Human Review Checklist
- [ ] Verify that `/tmp/LICENSE` as a fixed path is acceptable given the generator execution model (are native generators ever run in parallel for the same project?)
- [ ] Consider whether the `warn`-level log on copy failure (line 53) is appropriate vs. throwing — a missing license file will silently produce different output

Link to Devin session: https://app.devin.ai/sessions/8e626c016c1c4334957b608c7ca40c41
Requested by: @jsklan
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/14598" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
