### PR TITLE
fix(seed): fix --local parity for ruby-sdk-v2

### DIFF
--- a/generators/ruby-v2/sdk/src/SdkGeneratorCli.ts
+++ b/generators/ruby-v2/sdk/src/SdkGeneratorCli.ts
@@ -132,19 +132,31 @@ export class SdkGeneratorCLI extends AbstractRubyGeneratorCli<SdkCustomConfigSch
 
         await context.project.persist();
 
+        // Clear nix/devbox Ruby environment variables that may conflict with the
+        // project's bundled gems (e.g. RUBYLIB and GEM_PATH pointing to Ruby 3.4
+        // paths while running Ruby 3.3).
+        const rubyEnv = {
+            ...process.env,
+            RUBYLIB: undefined,
+            GEM_PATH: undefined,
+            GEM_HOME: undefined
+        };
+
+        await loggingExeca(context.logger, "bundle", ["install"], {
+            cwd: context.project.absolutePathToOutputDirectory,
+            doNotPipeOutput: true,
+            env: rubyEnv
+        });
+
         try {
-            await loggingExeca(context.logger, "rubocop", ["-A"], {
+            await loggingExeca(context.logger, "bundle", ["exec", "rubocop", "-A"], {
                 cwd: context.project.absolutePathToOutputDirectory,
-                doNotPipeOutput: true
+                doNotPipeOutput: true,
+                env: rubyEnv
             });
         } catch (_) {
             // It's okay if rubocop fails to run.
         }
-
-        await loggingExeca(context.logger, "bundle", ["install"], {
-            cwd: context.project.absolutePathToOutputDirectory,
-            doNotPipeOutput: true
-        });
     }
 
     private generateRequests(context: SdkGeneratorContext, service: FernIr.HttpService, serviceId: string) {

--- a/generators/ruby-v2/sdk/versions.yml
+++ b/generators/ruby-v2/sdk/versions.yml
@@ -1,5 +1,17 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 
+- version: 1.2.1
+  changelogEntry:
+    - summary: |
+        Fix rubocop not running in local mode by running `bundle install`
+        before `bundle exec rubocop -A` and clearing conflicting nix/devbox
+        Ruby environment variables. Previously, rubocop ran before dependencies
+        were installed and relied on a system-level rubocop that could be
+        broken or absent outside Docker.
+      type: fix
+  createdAt: "2026-04-04"
+  irVersion: 61
+
 - version: 1.2.0
   changelogEntry:
     - summary: |

--- a/scripts/validate-all-changelogs.sh
+++ b/scripts/validate-all-changelogs.sh
@@ -7,7 +7,6 @@ set -e
 
 # Run all validations in parallel and collect errors
 generators=(
-    ruby-sdk
     ruby-sdk-v2
     pydantic
     python-sdk

--- a/seed/ruby-sdk-v2/seed.yml
+++ b/seed/ruby-sdk-v2/seed.yml
@@ -22,6 +22,11 @@ test:
   podman:
     image: fernapi/fern-ruby-sdk-v2:latest
     command: pnpm turbo run podmanTagLatest --filter @fern-api/ruby-sdk
+  local:
+    workingDirectory: generators/ruby-v2
+    buildCommand:
+      - pnpm turbo run dist:cli --filter @fern-api/ruby-sdk
+    runCommand: node --enable-source-maps sdk/dist/cli.cjs {CONFIG_PATH}
 
 publish:
   preBuildCommands:


### PR DESCRIPTION
## Description

Refs FER-9446

Fixes `seed test --local` and `seed run --local` producing different output from Docker mode for the `ruby-sdk-v2` generator. The root cause was that rubocop formatting never ran in local mode, producing unformatted output while Docker produced formatted output.

## Changes Made

- **`seed/ruby-sdk-v2/seed.yml`**: Add missing `test.local` configuration (was required to enable `--local` mode at all)
- **`generators/ruby-v2/sdk/src/SdkGeneratorCli.ts`**: Three fixes to post-generation steps:
  1. Run `bundle install` **before** rubocop (was reversed — rubocop ran first and silently failed since gems weren't installed yet)
  2. Use `bundle exec rubocop -A` instead of bare `rubocop` (uses the project's bundled rubocop instead of relying on a system-level install)
  3. Clear `RUBYLIB`, `GEM_PATH`, `GEM_HOME` env vars when spawning Ruby processes to avoid nix/devbox library conflicts (devbox provides Ruby 3.3 but `RUBYLIB`/`GEM_PATH` point to Ruby 3.4 nix store paths, causing `LoadError` on native extensions)
- **`generators/ruby-v2/sdk/versions.yml`**: Add v1.2.1 changelog entry
- **`scripts/validate-all-changelogs.sh`**: Remove `ruby-sdk` from the changelog validation generators list (no `seed/ruby-sdk` directory exists, causing the "Validate Changelogs" CI check to crash)

## ⚠️ Review Notes

- **These changes affect Docker mode too**, not just local mode. In Docker, rubocop was previously installed globally (`gem install 'rubocop:~> 1.21'`) and ran before `bundle install`. Now it runs via `bundle exec` after `bundle install`, so it uses the Gemfile-pinned version. Verified that Docker output remains identical after the change.
- The env var clearing (`RUBYLIB`, `GEM_PATH`, `GEM_HOME` → `undefined`) is safe in Docker since those vars aren't set in the container, but worth confirming.
- The `ruby-sdk` removal from `validate-all-changelogs.sh` fixes a pre-existing issue on `main` — there is no `seed/ruby-sdk` directory, so the validation was always going to fail for that entry.

### Human Review Checklist
- [ ] Confirm `ruby-sdk` (v1) genuinely has no seed directory or versions.yml requiring changelog validation
- [ ] Verify Docker output parity is maintained with the rubocop execution order change
- [ ] Check that clearing `RUBYLIB`/`GEM_PATH`/`GEM_HOME` doesn't break Docker builds

## Testing

- [x] Ran `seed test --generator ruby-sdk-v2 --fixture exhaustive --skip-scripts` in Docker mode (baseline)
- [x] Ran `seed test --generator ruby-sdk-v2 --fixture exhaustive --skip-scripts --local` — **zero diff** vs Docker
- [x] Ran `seed run --generator ruby-sdk-v2 --local` and `seed run` (Docker) — **identical output** (only `Gemfile.lock` platform line differs: `x86_64-linux-musl` vs `x86_64-linux`, expected)
- [x] `pnpm format` and `pnpm run check` pass
- [x] All CI checks passing (including "Validate Changelogs")
- [ ] Unit tests added/updated

Link to Devin session: https://app.devin.ai/sessions/54696844eb9247c0871aa49f1fa288e7
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/14599" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
