### PR TITLE
fix(seed): fix --local parity for python-sdk

### DIFF
--- a/generators/python-v2/sdk/build.mjs
+++ b/generators/python-v2/sdk/build.mjs
@@ -1,3 +1,5 @@
 import { buildGenerator, getDirname } from "@fern-api/configs/build-utils.mjs";
 
-await buildGenerator(getDirname(import.meta.url));
+await buildGenerator(getDirname(import.meta.url), {
+    copy: [{ from: "../../python/sdk/features.yml", to: "./dist/assets/features.yml" }]
+});

--- a/generators/python/src/fern_python/generators/sdk/as_is_copier.py
+++ b/generators/python/src/fern_python/generators/sdk/as_is_copier.py
@@ -95,6 +95,15 @@ def copy_to_project(*, project: Project) -> None:
         )
 
 
+def _get_local_assets_root() -> str:
+    """Return the local equivalent of /assets for non-Docker runs.
+
+    In Docker the layout is /assets/{tests,core_utilities,...} which maps to
+    generators/python/{tests,core_utilities,...} on disk.
+    """
+    return os.path.join(os.path.dirname(__file__), "../../../../")
+
+
 def _copy_directory_to_project(
     *,
     project: Project,
@@ -102,9 +111,7 @@ def _copy_directory_to_project(
     path_in_project: str,
     replacements: Optional[Dict[str, str]] = None,
 ) -> None:
-    source = (
-        os.path.join(os.path.dirname(__file__), "../../../../../") if "PYTEST_CURRENT_TEST" in os.environ else "/assets"
-    )
+    source = _get_local_assets_root() if "PYTEST_CURRENT_TEST" in os.environ else "/assets"
 
     for _, _, files in os.walk(os.path.join(source, relative_path_on_disk)):
         for f in files:
@@ -129,10 +136,7 @@ def _copy_file_to_project(
     filepath_in_project: Filepath,
     replacements: Optional[Dict[str, str]] = None,
 ) -> None:
-    # Project root source, so all from_ requests should be relative to that
-    source = (
-        os.path.join(os.path.dirname(__file__), "../../../../../") if "PYTEST_CURRENT_TEST" in os.environ else "/assets"
-    )
+    source = _get_local_assets_root() if "PYTEST_CURRENT_TEST" in os.environ else "/assets"
     SourceFileFactory.add_source_file_from_disk(
         project=project,
         path_on_disk=os.path.join(source, relative_filepath_on_disk),

--- a/generators/python/src/fern_python/generators/sdk/core_utilities/core_utilities.py
+++ b/generators/python/src/fern_python/generators/sdk/core_utilities/core_utilities.py
@@ -328,6 +328,20 @@ class CoreUtilities:
         else:
             project.add_dependency(PYDANTIC_DEPENDENCY)
 
+    @staticmethod
+    def _resolve_local_core_utilities_path(relative_filepath_on_disk: str) -> str:
+        """Resolve a core utilities file path for local (non-Docker) runs.
+
+        In Docker, both core_utilities/sdk and core_utilities/shared are merged
+        into /assets/core_utilities. In local mode we need to search both directories.
+        """
+        base = os.path.join(os.path.dirname(__file__), "../../../../../core_utilities")
+        for subdir in ("sdk", "shared"):
+            candidate = os.path.join(base, subdir, relative_filepath_on_disk)
+            if os.path.exists(candidate):
+                return os.path.join(base, subdir)
+        return os.path.join(base, "sdk")
+
     def _copy_file_to_project(
         self,
         *,
@@ -337,11 +351,10 @@ class CoreUtilities:
         exports: Set[str],
         string_replacements: Optional[dict[str, str]] = None,
     ) -> None:
-        source = (
-            os.path.join(os.path.dirname(__file__), "../../../../../core_utilities/sdk")
-            if "PYTEST_CURRENT_TEST" in os.environ
-            else "/assets/core_utilities"
-        )
+        if "PYTEST_CURRENT_TEST" in os.environ:
+            source = self._resolve_local_core_utilities_path(relative_filepath_on_disk)
+        else:
+            source = "/assets/core_utilities"
         SourceFileFactory.add_source_file_from_disk(
             project=project,
             path_on_disk=os.path.join(source, relative_filepath_on_disk),
@@ -352,11 +365,10 @@ class CoreUtilities:
 
     def _copy_http_sse_folder_to_project(self, *, project: Project) -> None:
         """Copy the http_sse folder using the same approach as individual file copying"""
-        source = (
-            os.path.join(os.path.dirname(__file__), "../../../../../core_utilities/sdk")
-            if "PYTEST_CURRENT_TEST" in os.environ
-            else "/assets/core_utilities"
-        )
+        if "PYTEST_CURRENT_TEST" in os.environ:
+            source = self._resolve_local_core_utilities_path("http_sse")
+        else:
+            source = "/assets/core_utilities"
         folder_path_on_disk = os.path.join(source, "http_sse")
 
         # Define exports for each file

--- a/generators/python/src/fern_python/generators/sdk/v2/generator.py
+++ b/generators/python/src/fern_python/generators/sdk/v2/generator.py
@@ -1,3 +1,4 @@
+import os
 import subprocess
 import sys
 from pathlib import Path
@@ -11,6 +12,23 @@ import fern.generator_exec as generator_exec
 V2_BIN_PATH = "/bin/python-v2"
 
 
+def _resolve_v2_bin_path() -> str:
+    """Resolve the python-v2 binary path.
+
+    In Docker the binary is at /bin/python-v2. In local mode it lives at
+    generators/python-v2/sdk/dist/cli.cjs relative to the repo root.
+    """
+    if Path(V2_BIN_PATH).exists():
+        return V2_BIN_PATH
+    # Local mode: walk up from this file to find the repo-relative path
+    local_path = os.path.normpath(
+        os.path.join(os.path.dirname(__file__), "../../../../../../python-v2/sdk/dist/cli.cjs")
+    )
+    if Path(local_path).exists():
+        return local_path
+    return V2_BIN_PATH
+
+
 class PythonV2Generator:
     """Generator represents a shim used to run the python-v2 SDK generator."""
 
@@ -21,8 +39,9 @@ class PythonV2Generator:
         if len(sys.argv) < 2:
             raise RuntimeError("Internal error; failed to resolve configuration file path")
 
-        if not Path(V2_BIN_PATH).exists():
-            raise RuntimeError(f"python-v2 binary not found at {V2_BIN_PATH}")
+        v2_bin = _resolve_v2_bin_path()
+        if not Path(v2_bin).exists():
+            raise RuntimeError(f"python-v2 binary not found at {v2_bin}")
 
         config_filepath = sys.argv[1]
         if not Path(config_filepath).exists():
@@ -39,7 +58,7 @@ class PythonV2Generator:
 
         try:
             subprocess.run(
-                ["node", "--enable-source-maps", V2_BIN_PATH, config_filepath],
+                ["node", "--enable-source-maps", v2_bin, config_filepath],
                 capture_output=True,
                 text=True,
                 check=True,


### PR DESCRIPTION
## Description

Refs FER-9444

Running `seed test` or `seed run` with `--local` for the `python-sdk` generator crashed with `FileNotFoundError` due to three path resolution issues where local mode didn't match the Docker filesystem layout. After these fixes, both modes produce byte-for-byte identical output.

## Changes Made

### 1. `core_utilities.py` — search both `sdk/` and `shared/` directories
In Docker, the Dockerfile merges `core_utilities/sdk` and `core_utilities/shared` into a single `/assets/core_utilities` directory. Local mode only searched `core_utilities/sdk`, so files like `datetime_utils.py` (which live in `shared/`) were not found. Added `_resolve_local_core_utilities_path()` to search both subdirectories.

### 2. `as_is_copier.py` — fix path traversal depth
The relative path `../../../../../` went up 5 levels from `sdk/` to `generators/`, but `tests/` and other assets live under `generators/python/` (4 levels up). Extracted `_get_local_assets_root()` with the correct depth.

### 3. `v2/generator.py` — resolve python-v2 binary locally
The v2 binary is at `/bin/python-v2` in Docker but at `generators/python-v2/sdk/dist/cli.cjs` locally. Added `_resolve_v2_bin_path()` fallback.

### 4. `python-v2/sdk/build.mjs` — bundle `features.yml` into dist
The python-v2 generator's `AbstractGeneratorAgent` searches for `features.yml` relative to `__dirname`, but it was never copied into the dist. Added a `copy` step matching the pattern used by other generators (e.g. TypeScript SDK).

## Reviewer Checklist
- [ ] Verify relative path depths: `../../../../` in `as_is_copier.py` (4 levels: `sdk → generators → fern_python → src` = `generators/python/`) and `../../../../../../` in `v2/generator.py` (6 levels to `generators/` then `python-v2/sdk/dist/cli.cjs`)
- [ ] `_resolve_local_core_utilities_path` searches `sdk` before `shared` — confirm no files exist in both with different content
- [ ] `build.mjs` copy path `../../python/sdk/features.yml` is relative to `generators/python-v2/sdk/`

## Testing
- [x] `seed test --generator python-sdk --fixture enum --skip-scripts --local` — all 4 variants pass
- [x] `git diff` confirms zero diff between Docker and local output for `seed test`
- [x] `seed run --generator python-sdk --path test-definitions/fern/apis/x-fern-default --skip-scripts` — Docker and local output are byte-for-byte identical

Link to Devin session: https://app.devin.ai/sessions/b908d97e8ba7440a93fd2a9b166b586d
Requested by: @jsklan
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/14600" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
