### PR TITLE
chore(ci): reduce ETE test concurrency to fix timeouts

### DIFF
--- a/packages/cli/ete-tests/vitest.config.ts
+++ b/packages/cli/ete-tests/vitest.config.ts
@@ -6,12 +6,14 @@ export default defineConfig(
             // ETE tests spawn heavy child processes (Node CLI, Docker containers).
             // Running too many test files in parallel causes resource contention
             // and widespread timeouts on CI runners.
+            fileParallelism: false,
+            maxConcurrency: 3,
             poolOptions: {
                 threads: {
-                    maxThreads: 4
+                    maxThreads: 2
                 },
                 forks: {
-                    maxForks: 4
+                    maxForks: 2
                 }
             }
         }


### PR DESCRIPTION
## Description

Reduces concurrency in ETE tests to address widespread timeout failures on CI runners.

## Changes Made

- Disabled file-level parallelism (`fileParallelism: false`) so test files run sequentially instead of concurrently
- Reduced `maxConcurrency` from 10 (base default) to 3 to limit concurrent tests within each file
- Halved `maxThreads` and `maxForks` from 4 to 2

ETE tests spawn heavy child processes (Node CLI, Docker containers), and running multiple test files in parallel causes resource contention that leads to timeouts.

## Testing

- [ ] Manual testing not applicable — change is a CI config tuning
- Validation will come from observing fewer timeout failures in subsequent CI runs

## Review Checklist

- **Is `fileParallelism: false` too aggressive?** With ~35 test files running fully sequentially, verify the total runtime still fits within the 20-minute CI timeout for the ETE step. If sequential is too slow, an alternative would be to keep file parallelism on but with a lower worker count (e.g., `maxThreads: 2` alone without `fileParallelism: false`).

Link to Devin session: https://app.devin.ai/sessions/e0f4707b3a554b7fb91f514eec897a23
Requested by: @Swimburger
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/14601" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
