### PR TITLE
fix(ci): update ruby-sdk changelog path to ruby-sdk-v2 in write-changelogs-to-docs workflow

### DIFF
--- a/.github/workflows/write-changelogs-to-docs.yml
+++ b/.github/workflows/write-changelogs-to-docs.yml
@@ -62,7 +62,7 @@ jobs:
         run: rsync -av --delete "changelogs/python-sdk/" "docs/fern/products/sdks/overview/python/changelog"
 
       - name: update ruby-sdk changelog
-        run: rsync -av --delete "changelogs/ruby-sdk/" "docs/fern/products/sdks/overview/ruby/changelog"
+        run: rsync -av --delete "changelogs/ruby-sdk-v2/" "docs/fern/products/sdks/overview/ruby/changelog"
 
       - name: update ts-sdk changelog
         run: rsync -av --delete "changelogs/ts-sdk/" "docs/fern/products/sdks/overview/typescript/changelog"


### PR DESCRIPTION
## Description

Refs https://github.com/fern-api/fern/pull/14585

Fixes the `copy-changelogs` job in the `write-changelogs-to-docs` workflow, which has been failing since PR #14585 renamed the seed directory from `ruby-sdk` to `ruby-sdk-v2`.

## Changes Made

- Updated the rsync source path in `write-changelogs-to-docs.yml` from `changelogs/ruby-sdk/` to `changelogs/ruby-sdk-v2/` to match the renamed seed workspace directory.

The changelog generation step (`pnpm seed:local generate changelog generator`) outputs to a directory named after each seed workspace. Since the workspace was renamed to `ruby-sdk-v2`, the output goes to `changelogs/ruby-sdk-v2/`, but the rsync step was still looking for `changelogs/ruby-sdk/`.

## Review Checklist

- [ ] Confirm `seed/ruby-sdk-v2/` is the current workspace name (it is — `seed/ruby-sdk/` no longer exists)
- [ ] Check if any other files reference the old `changelogs/ruby-sdk/` path

## Testing

- No unit tests applicable — this is a CI workflow path fix
- The failing job can be seen at: https://github.com/fern-api/fern/actions/runs/23979505642/job/69941594354

Link to Devin session: https://app.devin.ai/sessions/c0f2723e57cc4fd796f46d6c35457dc1
Requested by: @davidkonigsberg