### PR TITLE
fix(internal): make GitHub token optional for replay init

### DIFF
--- a/packages/cli/cli/src/cli.ts
+++ b/packages/cli/cli/src/cli.ts
@@ -2359,12 +2359,10 @@ function addReplayInitCommand(cli: Argv<GlobalCliOptions>, cliContext: CliContex
                 token = token ?? resolved.token;
             }
 
-            if (githubRepo == null || token == null) {
-                const hint =
-                    githubRepo != null
-                        ? "Repository found but no token. Pass --token or set GITHUB_TOKEN environment variable."
-                        : "Either use --group to read from generators.yml, or provide --github and --token directly.";
-                return cliContext.failAndThrow(`Missing required github config. ${hint}`);
+            if (githubRepo == null) {
+                return cliContext.failAndThrow(
+                    "Missing required github config. Either use --group to read from generators.yml, or provide --github directly."
+                );
             }
 
             cliContext.logger.info(`Initializing Replay for: ${githubRepo}`);

--- a/packages/cli/cli/src/cli.ts
+++ b/packages/cli/cli/src/cli.ts
@@ -2365,6 +2365,12 @@ function addReplayInitCommand(cli: Argv<GlobalCliOptions>, cliContext: CliContex
                 );
             }
 
+            if (token == null) {
+                cliContext.logger.warn(
+                    "No GitHub token found. Clone may fail for private repos. Set GITHUB_TOKEN or pass --token."
+                );
+            }
+
             cliContext.logger.info(`Initializing Replay for: ${githubRepo}`);
             if (argv.dryRun) {
                 cliContext.logger.info("(dry-run mode)");

--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -1,5 +1,13 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 
+- version: 4.62.3
+  changelogEntry:
+    - summary: |
+        Make GitHub token optional for replay init. Public repos no longer require a token.
+      type: fix
+  createdAt: "2026-04-06"
+  irVersion: 66
+
 - version: 4.62.2
   changelogEntry:
     - summary: |

--- a/packages/generator-cli/src/cli.ts
+++ b/packages/generator-cli/src/cli.ts
@@ -301,6 +301,12 @@ void yargs(hideBin(process.argv))
                             process.exit(1);
                         }
 
+                        if (argv.token == null) {
+                            process.stderr.write(
+                                "warning: no GitHub token provided. Clone may fail for private repos. Pass --token or set GITHUB_TOKEN.\n"
+                            );
+                        }
+
                         try {
                             const result = await replayInit({
                                 githubRepo: argv.github,

--- a/packages/generator-cli/src/cli.ts
+++ b/packages/generator-cli/src/cli.ts
@@ -296,10 +296,8 @@ void yargs(hideBin(process.argv))
                             });
                     },
                     async (argv) => {
-                        if (argv.github == null || argv.token == null) {
-                            process.stderr.write(
-                                "missing required arguments; please specify --github and --token flags\n"
-                            );
+                        if (argv.github == null) {
+                            process.stderr.write("missing required argument; please specify --github flag\n");
                             process.exit(1);
                         }
 

--- a/packages/generator-cli/src/replay/replay-init.ts
+++ b/packages/generator-cli/src/replay/replay-init.ts
@@ -8,8 +8,8 @@ import { ensureReplayFernignoreEntriesSync, REPLAY_FERNIGNORE_ENTRIES } from "./
 export interface ReplayInitParams {
     /** GitHub repo URI (e.g., "fern-demo/fern-replay-testbed-java-sdk") */
     githubRepo: string;
-    /** GitHub token for clone (read access) */
-    token: string;
+    /** GitHub token for clone (read access). Optional for public repos. */
+    token?: string;
     /** Report what would happen but don't create PR */
     dryRun?: boolean;
     /** Max commits to scan for generation history */

--- a/packages/generator-cli/versions.yml
+++ b/packages/generator-cli/versions.yml
@@ -1,6 +1,13 @@
 # yaml-language-server: $schema=../../versions-yml.schema.json
 - changelogEntry:
     - summary: |
+        Make GitHub token optional for replay init. Public repos no longer require a token.
+      type: fix
+  createdAt: "2026-04-06"
+  version: 0.8.1
+
+- changelogEntry:
+    - summary: |
         Upgrade replay to 0.8.0 with support for detecting git revert commits and cancelling matching patches.
       type: feat
   createdAt: "2026-03-30"

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -57,7 +57,7 @@ catalog:
   "@fern-api/docs-parsers": 0.0.65
   "@fern-api/fai-sdk": 0.0.6-2ee1b7e28
   "@fern-api/fdr-sdk": 1.1.13-c1ad12a2b8
-  "@fern-api/generator-cli": 0.8.0
+  "@fern-api/generator-cli": 0.8.1
   "@fern-api/ui-core-utils": 0.129.4-b6c699ad2
   "@fern-api/venus-api-sdk": 0.17.3-3-gf696595
   "@fern-fern/docs-config": 0.0.80

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -57,7 +57,7 @@ catalog:
   "@fern-api/docs-parsers": 0.0.65
   "@fern-api/fai-sdk": 0.0.6-2ee1b7e28
   "@fern-api/fdr-sdk": 1.1.13-c1ad12a2b8
-  "@fern-api/generator-cli": 0.8.1
+  "@fern-api/generator-cli": 0.8.0
   "@fern-api/ui-core-utils": 0.129.4-b6c699ad2
   "@fern-api/venus-api-sdk": 0.17.3-3-gf696595
   "@fern-fern/docs-config": 0.0.80


### PR DESCRIPTION
## Summary
- Makes the GitHub token optional for `fern replay init` — it was previously hard-required even for public repos
- The token is only used for the local `git clone` step; public repos can be cloned without authentication
- Private repos still work when `--token` or `GITHUB_TOKEN` is provided
- Removes confusing "Missing required github config" error when repo is resolved but no token is set

## Changes
- `packages/generator-cli/src/replay/replay-init.ts` — `token` field in `ReplayInitParams` is now optional
- `packages/cli/cli/src/cli.ts` — Removed hard `token == null` check from validation
- `packages/generator-cli/src/cli.ts` — Same validation fix for standalone CLI entry point

## Test plan
- [ ] Run `fern replay init --group <group> --api <api>` against a public repo without `GITHUB_TOKEN` set — should succeed
- [ ] Run `fern replay init --group <group> --api <api> --token <token>` against a private repo — should still work
- [ ] Run `fern replay init` without `--group` or `--github` — should fail with clear error about missing github config

🤖 Generated with [Claude Code](https://claude.com/claude-code)