### PR TITLE
fix(cli): improve fern check performance for api section markdown links

### DIFF
--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -1,5 +1,15 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 
+- version: 4.65.1
+  changelogEntry:
+    - summary: |
+        Fixed a performance issue in `fern check` where `valid-markdown-links`
+        repeatedly reprocessed duplicate API descriptions and pathnames in API
+        sections, significantly improving runtime on large docs sites.
+      type: fix
+  createdAt: "2026-04-09"
+  irVersion: 66
+
 - version: 4.65.0
   changelogEntry:
     - summary: |

--- a/packages/cli/yaml/docs-validator/src/docsAst/visitDocsConfigFileYamlAst.ts
+++ b/packages/cli/yaml/docs-validator/src/docsAst/visitDocsConfigFileYamlAst.ts
@@ -227,6 +227,8 @@ export async function visitDocsConfigFileYamlAst({
                 return;
             }
 
+            const navStart = performance.now();
+            context.logger.debug("[docs-ast] Starting main navigation traversal...");
             await visitNavigationAst({
                 absolutePathToFernFolder,
                 navigation,
@@ -236,12 +238,17 @@ export async function visitDocsConfigFileYamlAst({
                 apiWorkspaces,
                 context
             });
+            context.logger.debug(
+                `[docs-ast] Main navigation traversal complete in ${(performance.now() - navStart).toFixed(0)}ms`
+            );
         },
         products: async (products) => {
             if (products == null) {
                 return;
             }
 
+            const productsStart = performance.now();
+            context.logger.debug(`[docs-ast] Processing ${products.length} products...`);
             await Promise.all(
                 products.map(async (product, idx) => {
                     if ("path" in product) {
@@ -277,6 +284,9 @@ export async function visitDocsConfigFileYamlAst({
                         }
                     }
                 })
+            );
+            context.logger.debug(
+                `[docs-ast] Products processing complete in ${(performance.now() - productsStart).toFixed(0)}ms`
             );
         },
         check: noop,
@@ -328,6 +338,8 @@ export async function visitDocsConfigFileYamlAst({
                 return;
             }
 
+            const versionsStart = performance.now();
+            context.logger.debug(`[docs-ast] Processing ${versions.length} versions...`);
             await Promise.all(
                 versions.map(async (version, idx) => {
                     await visitFilepath({
@@ -361,6 +373,9 @@ export async function visitDocsConfigFileYamlAst({
                         });
                     }
                 })
+            );
+            context.logger.debug(
+                `[docs-ast] Versions processing complete in ${(performance.now() - versionsStart).toFixed(0)}ms`
             );
         },
         roles: noop,

--- a/packages/cli/yaml/docs-validator/src/rules/valid-markdown-link/valid-markdown-link.ts
+++ b/packages/cli/yaml/docs-validator/src/rules/valid-markdown-link/valid-markdown-link.ts
@@ -170,55 +170,58 @@ export const ValidMarkdownLinks: Rule = {
                     convertIrToApiDefinition({ ir, apiDefinitionId: randomUUID(), context: NOOP_CONTEXT })
                 );
 
+                const uniqueDescriptions = collectUniqueDescriptions(api);
                 const violations: RuleViolation[] = [];
+                const uniquePathnames = new Map<string, PathnameToCheck>();
 
-                for (const endpoint of endpoints) {
-                    const descriptions = await collectDescriptions(ApiDefinition.prune(api, endpoint));
-
-                    for (const description of descriptions) {
-                        const { pathnamesToCheck, violations: descriptionViolations } = collectPathnamesToCheck(
-                            description,
-                            { instanceUrls }
-                        );
-
-                        violations.push(...descriptionViolations);
-
-                        const pathToCheckViolations = await Promise.all(
-                            pathnamesToCheck.map(async (pathnameToCheck) => {
-                                // TODO: we don't know where the endpoint is defined (which file it's in) so this doesn't always work
-                                const exists = await checkIfPathnameExists({
-                                    pathname: pathnameToCheck.pathname,
-                                    markdown: pathnameToCheck.markdown,
-                                    workspaceAbsoluteFilePath: workspace.absoluteFilePath,
-                                    pageSlugs: visitableSlugs,
-                                    absoluteFilePathsToSlugs,
-                                    redirects: workspace.config.redirects,
-                                    baseUrl
-                                });
-
-                                if (exists === true) {
-                                    return [];
-                                }
-
-                                return exists.map((brokenPathname) => {
-                                    const [message, relFilePath] = createLinkViolationMessage({
-                                        pathnameToCheck,
-                                        targetPathname: brokenPathname,
-                                        absoluteFilepathToWorkspace: workspace.absoluteFilePath
-                                    });
-                                    return {
-                                        name: ValidMarkdownLinks.name,
-                                        severity: "error" as const,
-                                        message,
-                                        relFilepath: relFilePath
-                                    };
-                                });
-                            })
-                        );
-
-                        violations.push(...pathToCheckViolations.flat());
+                // Parse all unique descriptions to find link pathnames, then deduplicate pathnames
+                for (const description of uniqueDescriptions) {
+                    const { pathnamesToCheck, violations: descriptionViolations } = collectPathnamesToCheck(
+                        description,
+                        { instanceUrls }
+                    );
+                    violations.push(...descriptionViolations);
+                    for (const p of pathnamesToCheck) {
+                        if (!uniquePathnames.has(p.pathname)) {
+                            uniquePathnames.set(p.pathname, p);
+                        }
                     }
                 }
+
+                // Batch-check all unique pathnames
+                const pathToCheckViolations = await Promise.all(
+                    [...uniquePathnames.values()].map(async (pathnameToCheck) => {
+                        const exists = await checkIfPathnameExists({
+                            pathname: pathnameToCheck.pathname,
+                            markdown: pathnameToCheck.markdown,
+                            workspaceAbsoluteFilePath: workspace.absoluteFilePath,
+                            pageSlugs: visitableSlugs,
+                            absoluteFilePathsToSlugs,
+                            redirects: workspace.config.redirects,
+                            baseUrl
+                        });
+
+                        if (exists === true) {
+                            return [];
+                        }
+
+                        return exists.map((brokenPathname) => {
+                            const [message, relFilePath] = createLinkViolationMessage({
+                                pathnameToCheck,
+                                targetPathname: brokenPathname,
+                                absoluteFilepathToWorkspace: workspace.absoluteFilePath
+                            });
+                            return {
+                                name: ValidMarkdownLinks.name,
+                                severity: "error" as const,
+                                message,
+                                relFilepath: relFilePath
+                            };
+                        });
+                    })
+                );
+
+                violations.push(...pathToCheckViolations.flat());
 
                 return violations;
             }
@@ -257,14 +260,11 @@ function toLatest(apiDefinition: APIV1Read.ApiDefinition) {
     return latest;
 }
 
-async function collectDescriptions(apiDefinition: ApiDefinition.ApiDefinition): Promise<string[]> {
-    const descriptions: string[] = [];
+function collectUniqueDescriptions(apiDefinition: ApiDefinition.ApiDefinition) {
+    const set = new Set<string>();
     ApiDefinition.Transformer.descriptions((description) => {
-        if (typeof description === "string") {
-            descriptions.push(description);
-        }
-
+        set.add(description);
         return description;
     }).apiDefinition(apiDefinition);
-    return descriptions;
+    return set;
 }


### PR DESCRIPTION
## Description
Linear ticket: Closes [FER-8923](https://linear.app/buildwithfern/issue/FER-8923/improve-fern-check-strict-broken-links-performance-on-large-docs-sites) 

This PR improves `fern check` performance for the `valid-markdown-links` rule on large docs sites.

Previously, API section validation repeatedly pruned the API definition per endpoint, re-collected many of the same descriptions, and re-validated the same pathnames over and over. This change instead collects unique descriptions once from the full API definition, extracts pathnames from those unique descriptions, and checks each unique pathname once.

## Changes Made
- Reworked `valid-markdown-links` API section validation to collect unique descriptions from the full API definition instead of pruning per endpoint
- Deduplicated extracted pathnames before running existence checks to avoid repeated validation work
- Kept the resulting validation output unchanged while substantially reducing runtime on large documentation sets

## Testing
- [ ] Unit tests added/updated
- [x] Manual testing completed