### PR TITLE
fix(go): fix operator precedence and dead pointer comparison in moduleConfigFromCustomConfig

### DIFF
--- a/generators/go/internal/cmd/cmd.go
+++ b/generators/go/internal/cmd/cmd.go
@@ -388,7 +388,7 @@ func customConfigFromConfig(c *generatorexec.GeneratorConfig) (*customConfig, er
 
 func moduleConfigFromCustomConfig(customConfig *customConfig, outputMode writer.OutputMode) (*generator.ModuleConfig, error) {
 	githubConfig, ok := outputMode.(*writer.GithubConfig)
-	if !ok && customConfig.Module == nil || customConfig.Module == (&moduleConfig{}) {
+	if !ok && isEmptyModuleConfig(customConfig.Module) {
 		// Neither a GitHub configuration nor a module configuration were provided.
 		return nil, nil
 	}
@@ -396,7 +396,7 @@ func moduleConfigFromCustomConfig(customConfig *customConfig, outputMode writer.
 	if ok {
 		modulePath = strings.TrimPrefix(githubConfig.RepoURL, "https://")
 	}
-	if customConfig.Module == nil || customConfig.Module == (&moduleConfig{}) {
+	if isEmptyModuleConfig(customConfig.Module) {
 		// A GitHub configuration was provided, so the module config should use
 		// the GitHub configuration's repository url.
 		return &generator.ModuleConfig{
@@ -421,6 +421,12 @@ func moduleConfigFromCustomConfig(customConfig *customConfig, outputMode writer.
 		Version: customConfig.Module.Version, // If not specified, defaults to the Go command's current version.
 		Imports: imports,
 	}, nil
+}
+
+// isEmptyModuleConfig returns true if the given module config is nil
+// or contains only zero-value fields.
+func isEmptyModuleConfig(m *moduleConfig) bool {
+	return m == nil || (m.Path == "" && m.Version == "" && len(m.Imports) == 0)
 }
 
 func outputModeFromConfig(c *generatorexec.GeneratorConfig) (writer.OutputMode, error) {

--- a/generators/go/sdk/versions.yml
+++ b/generators/go/sdk/versions.yml
@@ -1,4 +1,17 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 1.33.2
+  changelogEntry:
+    - summary: |
+        Fix operator precedence bug in `moduleConfigFromCustomConfig` guard
+        conditions. The `&&`/`||` precedence caused the `(&moduleConfig{})`
+        pointer-equality check to be evaluated as a separate disjunct, which
+        was always false (comparing distinct pointer addresses). Replaced with
+        a value-equality helper `isEmptyModuleConfig` that correctly detects
+        nil or zero-value module configs.
+      type: fix
+  createdAt: "2026-04-06"
+  irVersion: 61
+
 - version: 1.33.1
   changelogEntry:
     - summary: |
@@ -10,7 +23,6 @@
       type: fix
   createdAt: "2026-04-03"
   irVersion: 61
-
 - version: 1.33.0
   changelogEntry:
     - summary: |


### PR DESCRIPTION
## Description

Fixes a pre-existing operator precedence bug and dead pointer-equality checks in `moduleConfigFromCustomConfig`. Found by [Devin Review](https://app.devin.ai/review/fern-api/fern/pull/14587#analysis-ANALYSIS_pr-review-job-3d2bc450011643cfab2f254e9fac6e0a_0001) on PR #14587.

## Changes Made

- **Fixed operator precedence on line 391**: `!ok && customConfig.Module == nil || customConfig.Module == (&moduleConfig{})` was parsed as `(!ok && Module == nil) || (Module == &moduleConfig{})` due to `&&` binding tighter than `||`. The second disjunct compared two different pointer addresses, so it was always `false` — making it dead code.
- **Fixed same dead pointer comparison on line 399**: `customConfig.Module == nil || customConfig.Module == (&moduleConfig{})` had the same issue; the `&moduleConfig{}` branch never matched.
- **Introduced `isEmptyModuleConfig` helper**: Performs value-level field checks (`Path`, `Version`, `Imports`) instead of pointer equality, correctly detecting both `nil` and zero-value `*moduleConfig` pointers.

## Review Checklist

- [ ] Verify `isEmptyModuleConfig` covers all three fields of `moduleConfig` (`Path`, `Version`, `Imports`) — if the struct gains fields later, this helper must be updated
- [ ] Confirm the subtle behavioral change is acceptable: a non-nil `*moduleConfig` with all zero-value fields (e.g. from JSON deserializing `"module": {}`) is now treated as empty. Previously it would fall through to the merge path, which would produce the same defaults anyway, so this should be safe.

## Testing

- [x] Go build passes (`go build ./...`)
- [x] All CI checks passing (38/38)
- [ ] No new unit tests — this is a correctness fix for dead code with no practical behavioral change

Link to Devin session: https://app.devin.ai/sessions/9cd4c6d6666d469b84ed9c0b19a58e36
Requested by: @jsklan
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/14667" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
