### PR TITLE
chore(ci): create publish workflow for browser-compatible fern workspace                                                                         

### DIFF
--- a/.github/workflows/publish-browser-compatible-fern-workspace.yml
+++ b/.github/workflows/publish-browser-compatible-fern-workspace.yml
@@ -27,8 +27,6 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
 
       - name: Install
         uses: ./.github/actions/install
@@ -48,8 +46,15 @@ jobs:
 
       - name: Validate version
         run: |
-          if [[ ! "${{ inputs.version }}" =~ ^[0-9]+\.[0-9]+\.[0-9]+ ]]; then
+          if [[ ! "${{ inputs.version }}" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?$ ]]; then
             echo "::error::Invalid version format: ${{ inputs.version }}"
+            exit 1
+          fi
+
+      - name: Check version not already published
+        run: |
+          if npm view "${{ env.PACKAGE_NAME }}@${{ inputs.version }}" version 2>/dev/null; then
+            echo "::error::Version ${{ inputs.version }} is already published"
             exit 1
           fi
 

--- a/.github/workflows/publish-browser-compatible-fern-workspace.yml
+++ b/.github/workflows/publish-browser-compatible-fern-workspace.yml
@@ -1,0 +1,55 @@
+name: Publish Browser Compatible Fern Workspace
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "The version to publish (e.g., 0.0.1)"
+        required: true
+        type: string
+
+env:
+  DO_NOT_TRACK: "1"
+  PACKAGE_NAME: "@fern-api/browser-compatible-fern-workspace"
+  TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+  TURBO_TEAM: "buildwithfern"
+  TURBO_REMOTE_CACHE_TIMEOUT: 10
+  TURBO_NO_UPDATE_NOTIFIER: "1"
+  TURBO_DAEMON: "false"
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  publish-package:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v6
+
+      - name: Install
+        uses: ./.github/actions/install
+
+      - name: Setup Node for npm publish
+        uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          registry-url: https://registry.npmjs.org
+          scope: "@fern-api"
+
+      # npm >= 11.5.1 is required for OIDC trusted publishing.
+      # Node 22 ships with npm 10.x which does not support OIDC.
+      # Two-step upgrade works around Node 22.22.2 regression (npm/cli#9151).
+      - name: Update npm for OIDC publishing
+        run: npm install -g npm@10.9.8 && npm install -g npm@11
+
+      - name: Build and publish
+        run: |
+          pnpm turbo run dist --filter=${{ env.PACKAGE_NAME }} -- ${{ inputs.version }}
+
+          cd packages/cli/workspace/browser-compatible-fern-workspace/dist
+          echo "Publishing ${PACKAGE_NAME}@${{ inputs.version }}"
+          cat package.json
+          npm publish --access public --tag latest
+          echo "✓ Successfully published ${PACKAGE_NAME}@${{ inputs.version }}"

--- a/.github/workflows/publish-browser-compatible-fern-workspace.yml
+++ b/.github/workflows/publish-browser-compatible-fern-workspace.yml
@@ -27,6 +27,8 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
 
       - name: Install
         uses: ./.github/actions/install
@@ -44,12 +46,19 @@ jobs:
       - name: Update npm for OIDC publishing
         run: npm install -g npm@10.9.8 && npm install -g npm@11
 
+      - name: Validate version
+        run: |
+          if [[ ! "${{ inputs.version }}" =~ ^[0-9]+\.[0-9]+\.[0-9]+ ]]; then
+            echo "::error::Invalid version format: ${{ inputs.version }}"
+            exit 1
+          fi
+
       - name: Build and publish
         run: |
           pnpm turbo run dist --filter=${{ env.PACKAGE_NAME }} -- ${{ inputs.version }}
 
           cd packages/cli/workspace/browser-compatible-fern-workspace/dist
-          echo "Publishing ${PACKAGE_NAME}@${{ inputs.version }}"
+          echo "Publishing ${{ env.PACKAGE_NAME }}@${{ inputs.version }}"
           cat package.json
-          npm publish --access public --tag latest
-          echo "✓ Successfully published ${PACKAGE_NAME}@${{ inputs.version }}"
+          npm publish --provenance --access public --tag latest
+          echo "✓ Successfully published ${{ env.PACKAGE_NAME }}@${{ inputs.version }}"

--- a/.github/workflows/publish-browser-compatible-fern-workspace.yml
+++ b/.github/workflows/publish-browser-compatible-fern-workspace.yml
@@ -45,25 +45,31 @@ jobs:
         run: npm install -g npm@10.9.8 && npm install -g npm@11
 
       - name: Validate version
+        env:
+          VERSION: ${{ inputs.version }}
         run: |
-          if [[ ! "${{ inputs.version }}" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?$ ]]; then
-            echo "::error::Invalid version format: ${{ inputs.version }}"
+          if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?$ ]]; then
+            echo "::error::Invalid version format: $VERSION"
             exit 1
           fi
 
       - name: Check version not already published
+        env:
+          VERSION: ${{ inputs.version }}
         run: |
-          if npm view "${{ env.PACKAGE_NAME }}@${{ inputs.version }}" version 2>/dev/null; then
-            echo "::error::Version ${{ inputs.version }} is already published"
+          if npm view "${PACKAGE_NAME}@${VERSION}" version 2>/dev/null; then
+            echo "::error::Version ${VERSION} is already published"
             exit 1
           fi
 
       - name: Build and publish
+        env:
+          VERSION: ${{ inputs.version }}
         run: |
-          pnpm turbo run dist --filter=${{ env.PACKAGE_NAME }} -- ${{ inputs.version }}
+          pnpm turbo run dist --filter="${PACKAGE_NAME}" -- "${VERSION}"
 
           cd packages/cli/workspace/browser-compatible-fern-workspace/dist
-          echo "Publishing ${{ env.PACKAGE_NAME }}@${{ inputs.version }}"
+          echo "Publishing ${PACKAGE_NAME}@${VERSION}"
           cat package.json
           npm publish --provenance --access public --tag latest
-          echo "✓ Successfully published ${{ env.PACKAGE_NAME }}@${{ inputs.version }}"
+          echo "✓ Successfully published ${PACKAGE_NAME}@${VERSION}"


### PR DESCRIPTION
## Description                                                                                                                                   
                                                                                                                                                   
  Refs [FER-9460](https://linear.app/buildwithfern/issue/FER-9460/phase-1-create-publish-workflow-for-browser-compatible-fern-workspace)           
                                                                                                                                                   
  Adds a GitHub Actions workflow to publish a browser-compatible version of the `@fern-api/fern-workspace` package to npm.                         
                             
  ## Changes Made                                                                                                                                  
                                                                                                                                                   
  - Added `.github/workflows/publish-browser-compatible-fern-workspace.yml` workflow                                                                                                                                                         
                                                                                                                                                   
  ## Testing                 
  - [ ] Manual testing completed — verified workflow triggers and publishes correctly  
Ran ```gh workflow run publish-browser-compatible-fern-workspace.yml --ref create-publish-workflow-for-browser-compatible-fern-workspace -f version="0.0.1" ``` => [gh run view 24046555324 ](https://github.com/fern-api/fern/actions/runs/24046555324)