### PR TITLE
fix(internal): replace concurrent test execution with sequential for stability

### DIFF
--- a/packages/cli/ete-tests/src/tests/generate/fernignore.test.ts
+++ b/packages/cli/ete-tests/src/tests/generate/fernignore.test.ts
@@ -28,7 +28,7 @@ Practice schema-first API design with Fern
 
 describe("fern generate --local", () => {
     // eslint-disable-next-line jest/expect-expect
-    it.concurrent("Keep files listed in .fernignore from unmodified", async ({ signal }) => {
+    it("Keep files listed in .fernignore from unmodified", async ({ signal }) => {
         const pathOfDirectory = await init({ signal });
         await runFernCli(["generate", "--local", "--keepDocker"], { cwd: pathOfDirectory, signal });
 
@@ -55,7 +55,7 @@ describe("fern generate --local", () => {
     }, 360_000);
 
     // eslint-disable-next-line jest/expect-expect
-    it.concurrent("Prevent initial generation of files listed in .fernignore", async ({ signal }) => {
+    it("Prevent initial generation of files listed in .fernignore", async ({ signal }) => {
         const pathOfDirectory = await init({ signal });
 
         // Create output directory with .fernignore BEFORE first generation

--- a/packages/cli/ete-tests/src/tests/generate/generate-with-settings.test.ts
+++ b/packages/cli/ete-tests/src/tests/generate/generate-with-settings.test.ts
@@ -5,7 +5,7 @@ import tmp from "tmp-promise";
 import { runFernCli } from "../../utils/runFernCli.js";
 
 describe("fern generate with settings", () => {
-    it.concurrent("single api", async ({ expect, signal }) => {
+    it("single api", async ({ expect, signal }) => {
         const fixturesDir = join(AbsoluteFilePath.of(__dirname), RelativeFilePath.of("fixtures/api-settings"));
 
         const tmpDir = await tmp.dir();
@@ -20,7 +20,7 @@ describe("fern generate with settings", () => {
         ).toMatchSnapshot();
     }, 180_000);
 
-    it.concurrent("dependencies-based api", async ({ expect, signal }) => {
+    it("dependencies-based api", async ({ expect, signal }) => {
         const fixturesDir = join(AbsoluteFilePath.of(__dirname), RelativeFilePath.of("fixtures/api-settings-unioned"));
         const tmpDir = await tmp.dir();
         const directory = AbsoluteFilePath.of(tmpDir.path);

--- a/packages/cli/ete-tests/src/tests/generate/generate.test.ts
+++ b/packages/cli/ete-tests/src/tests/generate/generate.test.ts
@@ -8,7 +8,7 @@ import { init } from "../init/init.js";
 const fixturesDir = join(AbsoluteFilePath.of(__dirname), RelativeFilePath.of("fixtures"));
 
 describe("fern generate", () => {
-    it.concurrent("default api (fern init)", async ({ signal }) => {
+    it("default api (fern init)", async ({ signal }) => {
         const pathOfDirectory = await init({ signal });
 
         await runFernCli(["generate", "--local", "--keepDocker"], {
@@ -19,7 +19,7 @@ describe("fern generate", () => {
         expect(await doesPathExist(join(pathOfDirectory, RelativeFilePath.of("sdks/typescript")))).toBe(true);
     }, 180_000);
 
-    it.concurrent("ir contains fdr definitionid", async ({ signal }) => {
+    it("ir contains fdr definitionid", async ({ signal }) => {
         if (globalThis.process.env.FERN_ORG_TOKEN_DEV == null) {
             throw new Error("FERN_ORG_TOKEN_DEV is not set");
         }
@@ -68,7 +68,7 @@ describe("fern generate", () => {
         ).toMatchSnapshot();
     }, 180_000);
 
-    it.concurrent("generate docs with no auth requires login", async ({ signal }) => {
+    it("generate docs with no auth requires login", async ({ signal }) => {
         const { stdout, stderr } = await runFernCli(["generate", "--docs", "--no-prompt"], {
             cwd: join(fixturesDir, RelativeFilePath.of("docs")),
             reject: false,
@@ -84,7 +84,7 @@ describe("fern generate", () => {
         );
     }, 180_000);
 
-    it.concurrent("generate docs with FDR origin override and token succeeds", async ({ signal }) => {
+    it("generate docs with FDR origin override and token succeeds", async ({ signal }) => {
         const { stdout } = await runFernCli(["generate", "--docs", "--no-prompt"], {
             cwd: join(fixturesDir, RelativeFilePath.of("docs")),
             reject: false,
@@ -98,7 +98,7 @@ describe("fern generate", () => {
         expect(stdout).toContain("ferndevtest.docs.dev.buildwithfern.com Started.");
     }, 180_000);
 
-    it.concurrent("generate docs with no docs.yml file fails", async ({ signal }) => {
+    it("generate docs with no docs.yml file fails", async ({ signal }) => {
         const { stdout } = await runFernCli(["generate", "--docs"], {
             cwd: join(fixturesDir, RelativeFilePath.of("basic")),
             reject: false,
@@ -107,7 +107,7 @@ describe("fern generate", () => {
         expect(stdout).toContain("No docs.yml file found. Please make sure your project has one.");
     }, 180_000);
 
-    it.concurrent("lists available groups when no group specified", async ({ signal }) => {
+    it("lists available groups when no group specified", async ({ signal }) => {
         const { stdout, failed } = await runFernCli(["generate", "--local"], {
             cwd: join(fixturesDir, RelativeFilePath.of("no-default-group")),
             reject: false,

--- a/packages/cli/ete-tests/src/tests/upgrade-generator/upgrade-generator.test.ts
+++ b/packages/cli/ete-tests/src/tests/upgrade-generator/upgrade-generator.test.ts
@@ -10,7 +10,7 @@ import { runFernCli } from "../../utils/runFernCli.js";
 const FIXTURES_DIR = path.join(__dirname, "fixtures");
 
 describe("fern generator upgrade", () => {
-    it.concurrent("fern generator upgrade", async ({ signal }) => {
+    it("fern generator upgrade", async ({ signal }) => {
         // Create tmpdir and copy contents
         const tmpDir = await tmp.dir();
         const directory = AbsoluteFilePath.of(tmpDir.path);
@@ -38,7 +38,7 @@ describe("fern generator upgrade", () => {
         expect(JSON.parse((await readFile(outputFile)).toString()).version).not.toEqual("2.0.0");
     }, 180_000);
 
-    it.concurrent("fern generator upgrade with filters", async ({ signal }) => {
+    it("fern generator upgrade with filters", async ({ signal }) => {
         // Create tmpdir and copy contents
         const tmpDir = await tmp.dir();
         const directory = AbsoluteFilePath.of(tmpDir.path);
@@ -93,7 +93,7 @@ describe("fern generator upgrade", () => {
         ).toMatchSnapshot();
     }, 180_000);
 
-    it.concurrent("fern generator upgrade majors", async ({ signal }) => {
+    it("fern generator upgrade majors", async ({ signal }) => {
         // Create tmpdir and copy contents
         const tmpDir = await tmp.dir();
         const directory = AbsoluteFilePath.of(tmpDir.path);
@@ -183,9 +183,7 @@ describe("fern generator upgrade", () => {
         ).toMatchSnapshot();
     }, 180_000);
 
-    it.concurrent("fern generator upgrade --skip-autorelease-disabled skips autorelease false generators", async ({
-        signal
-    }) => {
+    it("fern generator upgrade --skip-autorelease-disabled skips autorelease false generators", async ({ signal }) => {
         const tmpDir = await tmp.dir();
         const directory = AbsoluteFilePath.of(tmpDir.path);
 
@@ -244,9 +242,7 @@ describe("fern generator upgrade", () => {
         expect(JSON.parse((await readFile(outputFileJava)).toString()).version).not.toEqual("0.0.1");
     }, 180_000);
 
-    it.concurrent("fern generator upgrade without --skip-autorelease-disabled upgrades all generators", async ({
-        signal
-    }) => {
+    it("fern generator upgrade without --skip-autorelease-disabled upgrades all generators", async ({ signal }) => {
         const tmpDir = await tmp.dir();
         const directory = AbsoluteFilePath.of(tmpDir.path);
 
@@ -276,7 +272,7 @@ describe("fern generator upgrade", () => {
         expect(JSON.parse((await readFile(outputFile)).toString()).version).not.toEqual("2.0.0");
     }, 180_000);
 
-    it.concurrent("fern generator upgrade shows major version message", async ({ signal }) => {
+    it("fern generator upgrade shows major version message", async ({ signal }) => {
         const tmpDir = await tmp.dir();
         const directory = AbsoluteFilePath.of(tmpDir.path);
 


### PR DESCRIPTION

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/14673" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
