### PR TITLE
chore(ci): replace Go toolchain and buf-setup-action with fern install-dependencies

### DIFF
--- a/.github/workflows/ci-dynamic-snippets.yml
+++ b/.github/workflows/ci-dynamic-snippets.yml
@@ -34,10 +34,6 @@ jobs:
       - name: 📥 Install
         uses: ./.github/actions/install
 
-      - uses: bufbuild/buf-setup-action@v1.50.0
-        with:
-          github_token: ${{ github.token }}
-
       - name: Cache Fern bin dependencies
         uses: actions/cache@v4
         with:
@@ -69,10 +65,6 @@ jobs:
 
       - name: 📥 Install
         uses: ./.github/actions/install
-
-      - uses: bufbuild/buf-setup-action@v1.50.0
-        with:
-          github_token: ${{ github.token }}
 
       - name: Cache Fern bin dependencies
         uses: actions/cache@v4
@@ -106,10 +98,6 @@ jobs:
       - name: 📥 Install
         uses: ./.github/actions/install
 
-      - uses: bufbuild/buf-setup-action@v1.50.0
-        with:
-          github_token: ${{ github.token }}
-
       - name: Cache Fern bin dependencies
         uses: actions/cache@v4
         with:
@@ -141,10 +129,6 @@ jobs:
 
       - name: 📥 Install
         uses: ./.github/actions/install
-
-      - uses: bufbuild/buf-setup-action@v1.50.0
-        with:
-          github_token: ${{ github.token }}
 
       - name: Cache Fern bin dependencies
         uses: actions/cache@v4
@@ -178,10 +162,6 @@ jobs:
       - name: 📥 Install
         uses: ./.github/actions/install
 
-      - uses: bufbuild/buf-setup-action@v1.50.0
-        with:
-          github_token: ${{ github.token }}
-
       - name: Cache Fern bin dependencies
         uses: actions/cache@v4
         with:
@@ -213,10 +193,6 @@ jobs:
 
       - name: 📥 Install
         uses: ./.github/actions/install
-
-      - uses: bufbuild/buf-setup-action@v1.50.0
-        with:
-          github_token: ${{ github.token }}
 
       - name: Cache Fern bin dependencies
         uses: actions/cache@v4
@@ -250,10 +226,6 @@ jobs:
       - name: 📥 Install
         uses: ./.github/actions/install
 
-      - uses: bufbuild/buf-setup-action@v1.50.0
-        with:
-          github_token: ${{ github.token }}
-
       - name: Cache Fern bin dependencies
         uses: actions/cache@v4
         with:
@@ -285,10 +257,6 @@ jobs:
 
       - name: 📥 Install
         uses: ./.github/actions/install
-
-      - uses: bufbuild/buf-setup-action@v1.50.0
-        with:
-          github_token: ${{ github.token }}
 
       - name: Cache Fern bin dependencies
         uses: actions/cache@v4

--- a/.github/workflows/ci-dynamic-snippets.yml
+++ b/.github/workflows/ci-dynamic-snippets.yml
@@ -38,23 +38,21 @@ jobs:
         with:
           github_token: ${{ github.token }}
 
-      - uses: actions/setup-go@v6
-        with:
-          go-version: "stable"
-          cache: false
-
-      - name: Cache Go modules and binaries
+      - name: Cache protoc-gen-openapi binary
         uses: actions/cache@v4
         with:
-          path: |
-            ~/go/pkg/mod
-            ~/go/bin
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-
+          path: ~/.fern/bin/protoc-gen-openapi
+          key: protoc-gen-openapi-v0.1.13-${{ runner.os }}-${{ runner.arch }}
 
       - name: Install protoc-gen-openapi
-        run: go install github.com/fern-api/protoc-gen-openapi/cmd/protoc-gen-openapi@latest
+        run: |
+          mkdir -p "$HOME/.fern/bin"
+          if [ ! -x "$HOME/.fern/bin/protoc-gen-openapi" ]; then
+            curl -fsSL -o "$HOME/.fern/bin/protoc-gen-openapi" \
+              "https://github.com/fern-api/protoc-gen-openapi/releases/download/v0.1.13/protoc-gen-openapi-linux-amd64"
+            chmod +x "$HOME/.fern/bin/protoc-gen-openapi"
+          fi
+          echo "$HOME/.fern/bin" >> $GITHUB_PATH
 
       - name: 🧪 Build
         run: pnpm turbo run compile --filter=@fern-api/typescript-dynamic-snippets
@@ -76,23 +74,21 @@ jobs:
         with:
           github_token: ${{ github.token }}
 
-      - uses: actions/setup-go@v6
-        with:
-          go-version: "stable"
-          cache: false
-
-      - name: Cache Go modules and binaries
+      - name: Cache protoc-gen-openapi binary
         uses: actions/cache@v4
         with:
-          path: |
-            ~/go/pkg/mod
-            ~/go/bin
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-
+          path: ~/.fern/bin/protoc-gen-openapi
+          key: protoc-gen-openapi-v0.1.13-${{ runner.os }}-${{ runner.arch }}
 
       - name: Install protoc-gen-openapi
-        run: go install github.com/fern-api/protoc-gen-openapi/cmd/protoc-gen-openapi@latest
+        run: |
+          mkdir -p "$HOME/.fern/bin"
+          if [ ! -x "$HOME/.fern/bin/protoc-gen-openapi" ]; then
+            curl -fsSL -o "$HOME/.fern/bin/protoc-gen-openapi" \
+              "https://github.com/fern-api/protoc-gen-openapi/releases/download/v0.1.13/protoc-gen-openapi-linux-amd64"
+            chmod +x "$HOME/.fern/bin/protoc-gen-openapi"
+          fi
+          echo "$HOME/.fern/bin" >> $GITHUB_PATH
 
       - name: 🧪 Build
         run: pnpm turbo run compile --filter=@fern-api/python-dynamic-snippets
@@ -114,23 +110,21 @@ jobs:
         with:
           github_token: ${{ github.token }}
 
-      - uses: actions/setup-go@v6
-        with:
-          go-version: "stable"
-          cache: false
-
-      - name: Cache Go modules and binaries
+      - name: Cache protoc-gen-openapi binary
         uses: actions/cache@v4
         with:
-          path: |
-            ~/go/pkg/mod
-            ~/go/bin
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-
+          path: ~/.fern/bin/protoc-gen-openapi
+          key: protoc-gen-openapi-v0.1.13-${{ runner.os }}-${{ runner.arch }}
 
       - name: Install protoc-gen-openapi
-        run: go install github.com/fern-api/protoc-gen-openapi/cmd/protoc-gen-openapi@latest
+        run: |
+          mkdir -p "$HOME/.fern/bin"
+          if [ ! -x "$HOME/.fern/bin/protoc-gen-openapi" ]; then
+            curl -fsSL -o "$HOME/.fern/bin/protoc-gen-openapi" \
+              "https://github.com/fern-api/protoc-gen-openapi/releases/download/v0.1.13/protoc-gen-openapi-linux-amd64"
+            chmod +x "$HOME/.fern/bin/protoc-gen-openapi"
+          fi
+          echo "$HOME/.fern/bin" >> $GITHUB_PATH
 
       - name: 🧪 Build
         run: pnpm turbo run compile --filter=@fern-api/csharp-dynamic-snippets
@@ -152,23 +146,21 @@ jobs:
         with:
           github_token: ${{ github.token }}
 
-      - uses: actions/setup-go@v6
-        with:
-          go-version: "stable"
-          cache: false
-
-      - name: Cache Go modules and binaries
+      - name: Cache protoc-gen-openapi binary
         uses: actions/cache@v4
         with:
-          path: |
-            ~/go/pkg/mod
-            ~/go/bin
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-
+          path: ~/.fern/bin/protoc-gen-openapi
+          key: protoc-gen-openapi-v0.1.13-${{ runner.os }}-${{ runner.arch }}
 
       - name: Install protoc-gen-openapi
-        run: go install github.com/fern-api/protoc-gen-openapi/cmd/protoc-gen-openapi@latest
+        run: |
+          mkdir -p "$HOME/.fern/bin"
+          if [ ! -x "$HOME/.fern/bin/protoc-gen-openapi" ]; then
+            curl -fsSL -o "$HOME/.fern/bin/protoc-gen-openapi" \
+              "https://github.com/fern-api/protoc-gen-openapi/releases/download/v0.1.13/protoc-gen-openapi-linux-amd64"
+            chmod +x "$HOME/.fern/bin/protoc-gen-openapi"
+          fi
+          echo "$HOME/.fern/bin" >> $GITHUB_PATH
 
       - name: 🧪 Build
         run: pnpm turbo run compile --filter=@fern-api/go-dynamic-snippets
@@ -190,23 +182,21 @@ jobs:
         with:
           github_token: ${{ github.token }}
 
-      - uses: actions/setup-go@v6
-        with:
-          go-version: "stable"
-          cache: false
-
-      - name: Cache Go modules and binaries
+      - name: Cache protoc-gen-openapi binary
         uses: actions/cache@v4
         with:
-          path: |
-            ~/go/pkg/mod
-            ~/go/bin
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-
+          path: ~/.fern/bin/protoc-gen-openapi
+          key: protoc-gen-openapi-v0.1.13-${{ runner.os }}-${{ runner.arch }}
 
       - name: Install protoc-gen-openapi
-        run: go install github.com/fern-api/protoc-gen-openapi/cmd/protoc-gen-openapi@latest
+        run: |
+          mkdir -p "$HOME/.fern/bin"
+          if [ ! -x "$HOME/.fern/bin/protoc-gen-openapi" ]; then
+            curl -fsSL -o "$HOME/.fern/bin/protoc-gen-openapi" \
+              "https://github.com/fern-api/protoc-gen-openapi/releases/download/v0.1.13/protoc-gen-openapi-linux-amd64"
+            chmod +x "$HOME/.fern/bin/protoc-gen-openapi"
+          fi
+          echo "$HOME/.fern/bin" >> $GITHUB_PATH
 
       - name: 🧪 Build
         run: pnpm turbo run compile --filter=@fern-api/ruby-dynamic-snippets
@@ -228,23 +218,21 @@ jobs:
         with:
           github_token: ${{ github.token }}
 
-      - uses: actions/setup-go@v6
-        with:
-          go-version: "stable"
-          cache: false
-
-      - name: Cache Go modules and binaries
+      - name: Cache protoc-gen-openapi binary
         uses: actions/cache@v4
         with:
-          path: |
-            ~/go/pkg/mod
-            ~/go/bin
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-
+          path: ~/.fern/bin/protoc-gen-openapi
+          key: protoc-gen-openapi-v0.1.13-${{ runner.os }}-${{ runner.arch }}
 
       - name: Install protoc-gen-openapi
-        run: go install github.com/fern-api/protoc-gen-openapi/cmd/protoc-gen-openapi@latest
+        run: |
+          mkdir -p "$HOME/.fern/bin"
+          if [ ! -x "$HOME/.fern/bin/protoc-gen-openapi" ]; then
+            curl -fsSL -o "$HOME/.fern/bin/protoc-gen-openapi" \
+              "https://github.com/fern-api/protoc-gen-openapi/releases/download/v0.1.13/protoc-gen-openapi-linux-amd64"
+            chmod +x "$HOME/.fern/bin/protoc-gen-openapi"
+          fi
+          echo "$HOME/.fern/bin" >> $GITHUB_PATH
 
       - name: 🧪 Build
         run: pnpm turbo run compile --filter=@fern-api/php-dynamic-snippets
@@ -266,23 +254,21 @@ jobs:
         with:
           github_token: ${{ github.token }}
 
-      - uses: actions/setup-go@v6
-        with:
-          go-version: "stable"
-          cache: false
-
-      - name: Cache Go modules and binaries
+      - name: Cache protoc-gen-openapi binary
         uses: actions/cache@v4
         with:
-          path: |
-            ~/go/pkg/mod
-            ~/go/bin
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-
+          path: ~/.fern/bin/protoc-gen-openapi
+          key: protoc-gen-openapi-v0.1.13-${{ runner.os }}-${{ runner.arch }}
 
       - name: Install protoc-gen-openapi
-        run: go install github.com/fern-api/protoc-gen-openapi/cmd/protoc-gen-openapi@latest
+        run: |
+          mkdir -p "$HOME/.fern/bin"
+          if [ ! -x "$HOME/.fern/bin/protoc-gen-openapi" ]; then
+            curl -fsSL -o "$HOME/.fern/bin/protoc-gen-openapi" \
+              "https://github.com/fern-api/protoc-gen-openapi/releases/download/v0.1.13/protoc-gen-openapi-linux-amd64"
+            chmod +x "$HOME/.fern/bin/protoc-gen-openapi"
+          fi
+          echo "$HOME/.fern/bin" >> $GITHUB_PATH
 
       - name: 🧪 Build
         run: pnpm turbo run compile --filter=@fern-api/swift-dynamic-snippets
@@ -304,23 +290,21 @@ jobs:
         with:
           github_token: ${{ github.token }}
 
-      - uses: actions/setup-go@v6
-        with:
-          go-version: "stable"
-          cache: false
-
-      - name: Cache Go modules and binaries
+      - name: Cache protoc-gen-openapi binary
         uses: actions/cache@v4
         with:
-          path: |
-            ~/go/pkg/mod
-            ~/go/bin
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-
+          path: ~/.fern/bin/protoc-gen-openapi
+          key: protoc-gen-openapi-v0.1.13-${{ runner.os }}-${{ runner.arch }}
 
       - name: Install protoc-gen-openapi
-        run: go install github.com/fern-api/protoc-gen-openapi/cmd/protoc-gen-openapi@latest
+        run: |
+          mkdir -p "$HOME/.fern/bin"
+          if [ ! -x "$HOME/.fern/bin/protoc-gen-openapi" ]; then
+            curl -fsSL -o "$HOME/.fern/bin/protoc-gen-openapi" \
+              "https://github.com/fern-api/protoc-gen-openapi/releases/download/v0.1.13/protoc-gen-openapi-linux-amd64"
+            chmod +x "$HOME/.fern/bin/protoc-gen-openapi"
+          fi
+          echo "$HOME/.fern/bin" >> $GITHUB_PATH
 
       - name: 🧪 Build
         run: pnpm turbo run compile --filter=@fern-api/java-dynamic-snippets

--- a/.github/workflows/ci-dynamic-snippets.yml
+++ b/.github/workflows/ci-dynamic-snippets.yml
@@ -41,6 +41,17 @@ jobs:
       - uses: actions/setup-go@v6
         with:
           go-version: "stable"
+          cache: false
+
+      - name: Cache Go modules and binaries
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/go/pkg/mod
+            ~/go/bin
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
 
       - name: Install protoc-gen-openapi
         run: go install github.com/fern-api/protoc-gen-openapi/cmd/protoc-gen-openapi@latest
@@ -68,6 +79,17 @@ jobs:
       - uses: actions/setup-go@v6
         with:
           go-version: "stable"
+          cache: false
+
+      - name: Cache Go modules and binaries
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/go/pkg/mod
+            ~/go/bin
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
 
       - name: Install protoc-gen-openapi
         run: go install github.com/fern-api/protoc-gen-openapi/cmd/protoc-gen-openapi@latest
@@ -95,6 +117,17 @@ jobs:
       - uses: actions/setup-go@v6
         with:
           go-version: "stable"
+          cache: false
+
+      - name: Cache Go modules and binaries
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/go/pkg/mod
+            ~/go/bin
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
 
       - name: Install protoc-gen-openapi
         run: go install github.com/fern-api/protoc-gen-openapi/cmd/protoc-gen-openapi@latest
@@ -122,6 +155,17 @@ jobs:
       - uses: actions/setup-go@v6
         with:
           go-version: "stable"
+          cache: false
+
+      - name: Cache Go modules and binaries
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/go/pkg/mod
+            ~/go/bin
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
 
       - name: Install protoc-gen-openapi
         run: go install github.com/fern-api/protoc-gen-openapi/cmd/protoc-gen-openapi@latest
@@ -149,6 +193,17 @@ jobs:
       - uses: actions/setup-go@v6
         with:
           go-version: "stable"
+          cache: false
+
+      - name: Cache Go modules and binaries
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/go/pkg/mod
+            ~/go/bin
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
 
       - name: Install protoc-gen-openapi
         run: go install github.com/fern-api/protoc-gen-openapi/cmd/protoc-gen-openapi@latest
@@ -176,6 +231,17 @@ jobs:
       - uses: actions/setup-go@v6
         with:
           go-version: "stable"
+          cache: false
+
+      - name: Cache Go modules and binaries
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/go/pkg/mod
+            ~/go/bin
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
 
       - name: Install protoc-gen-openapi
         run: go install github.com/fern-api/protoc-gen-openapi/cmd/protoc-gen-openapi@latest
@@ -203,6 +269,17 @@ jobs:
       - uses: actions/setup-go@v6
         with:
           go-version: "stable"
+          cache: false
+
+      - name: Cache Go modules and binaries
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/go/pkg/mod
+            ~/go/bin
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
 
       - name: Install protoc-gen-openapi
         run: go install github.com/fern-api/protoc-gen-openapi/cmd/protoc-gen-openapi@latest
@@ -230,6 +307,17 @@ jobs:
       - uses: actions/setup-go@v6
         with:
           go-version: "stable"
+          cache: false
+
+      - name: Cache Go modules and binaries
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/go/pkg/mod
+            ~/go/bin
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
 
       - name: Install protoc-gen-openapi
         run: go install github.com/fern-api/protoc-gen-openapi/cmd/protoc-gen-openapi@latest

--- a/.github/workflows/ci-dynamic-snippets.yml
+++ b/.github/workflows/ci-dynamic-snippets.yml
@@ -38,20 +38,20 @@ jobs:
         with:
           github_token: ${{ github.token }}
 
-      - name: Cache protoc-gen-openapi binary
+      - name: Cache Fern bin dependencies
         uses: actions/cache@v4
         with:
-          path: ~/.fern/bin/protoc-gen-openapi
-          key: protoc-gen-openapi-v0.1.13-${{ runner.os }}-${{ runner.arch }}
+          path: ~/.fern/bin
+          key: ${{ runner.os }}-fern-bin-${{ hashFiles('packages/cli/workspace/lazy-fern-workspace/src/protobuf/BufDownloader.ts', 'packages/cli/workspace/lazy-fern-workspace/src/protobuf/ProtocGenOpenAPIDownloader.ts') }}
+          restore-keys: |
+            ${{ runner.os }}-fern-bin-
 
-      - name: Install protoc-gen-openapi
+      - name: Build CLI for install-dependencies
+        run: pnpm turbo run dist:cli:dev --filter=@fern-api/cli
+
+      - name: Install protobuf dependencies (buf + protoc-gen-openapi)
         run: |
-          mkdir -p "$HOME/.fern/bin"
-          if [ ! -x "$HOME/.fern/bin/protoc-gen-openapi" ]; then
-            curl -fsSL -o "$HOME/.fern/bin/protoc-gen-openapi" \
-              "https://github.com/fern-api/protoc-gen-openapi/releases/download/v0.1.13/protoc-gen-openapi-linux-amd64"
-            chmod +x "$HOME/.fern/bin/protoc-gen-openapi"
-          fi
+          FERN_NO_VERSION_REDIRECTION=true node packages/cli/cli/dist/dev/cli.cjs install-dependencies
           echo "$HOME/.fern/bin" >> $GITHUB_PATH
 
       - name: 🧪 Build
@@ -74,20 +74,20 @@ jobs:
         with:
           github_token: ${{ github.token }}
 
-      - name: Cache protoc-gen-openapi binary
+      - name: Cache Fern bin dependencies
         uses: actions/cache@v4
         with:
-          path: ~/.fern/bin/protoc-gen-openapi
-          key: protoc-gen-openapi-v0.1.13-${{ runner.os }}-${{ runner.arch }}
+          path: ~/.fern/bin
+          key: ${{ runner.os }}-fern-bin-${{ hashFiles('packages/cli/workspace/lazy-fern-workspace/src/protobuf/BufDownloader.ts', 'packages/cli/workspace/lazy-fern-workspace/src/protobuf/ProtocGenOpenAPIDownloader.ts') }}
+          restore-keys: |
+            ${{ runner.os }}-fern-bin-
 
-      - name: Install protoc-gen-openapi
+      - name: Build CLI for install-dependencies
+        run: pnpm turbo run dist:cli:dev --filter=@fern-api/cli
+
+      - name: Install protobuf dependencies (buf + protoc-gen-openapi)
         run: |
-          mkdir -p "$HOME/.fern/bin"
-          if [ ! -x "$HOME/.fern/bin/protoc-gen-openapi" ]; then
-            curl -fsSL -o "$HOME/.fern/bin/protoc-gen-openapi" \
-              "https://github.com/fern-api/protoc-gen-openapi/releases/download/v0.1.13/protoc-gen-openapi-linux-amd64"
-            chmod +x "$HOME/.fern/bin/protoc-gen-openapi"
-          fi
+          FERN_NO_VERSION_REDIRECTION=true node packages/cli/cli/dist/dev/cli.cjs install-dependencies
           echo "$HOME/.fern/bin" >> $GITHUB_PATH
 
       - name: 🧪 Build
@@ -110,20 +110,20 @@ jobs:
         with:
           github_token: ${{ github.token }}
 
-      - name: Cache protoc-gen-openapi binary
+      - name: Cache Fern bin dependencies
         uses: actions/cache@v4
         with:
-          path: ~/.fern/bin/protoc-gen-openapi
-          key: protoc-gen-openapi-v0.1.13-${{ runner.os }}-${{ runner.arch }}
+          path: ~/.fern/bin
+          key: ${{ runner.os }}-fern-bin-${{ hashFiles('packages/cli/workspace/lazy-fern-workspace/src/protobuf/BufDownloader.ts', 'packages/cli/workspace/lazy-fern-workspace/src/protobuf/ProtocGenOpenAPIDownloader.ts') }}
+          restore-keys: |
+            ${{ runner.os }}-fern-bin-
 
-      - name: Install protoc-gen-openapi
+      - name: Build CLI for install-dependencies
+        run: pnpm turbo run dist:cli:dev --filter=@fern-api/cli
+
+      - name: Install protobuf dependencies (buf + protoc-gen-openapi)
         run: |
-          mkdir -p "$HOME/.fern/bin"
-          if [ ! -x "$HOME/.fern/bin/protoc-gen-openapi" ]; then
-            curl -fsSL -o "$HOME/.fern/bin/protoc-gen-openapi" \
-              "https://github.com/fern-api/protoc-gen-openapi/releases/download/v0.1.13/protoc-gen-openapi-linux-amd64"
-            chmod +x "$HOME/.fern/bin/protoc-gen-openapi"
-          fi
+          FERN_NO_VERSION_REDIRECTION=true node packages/cli/cli/dist/dev/cli.cjs install-dependencies
           echo "$HOME/.fern/bin" >> $GITHUB_PATH
 
       - name: 🧪 Build
@@ -146,20 +146,20 @@ jobs:
         with:
           github_token: ${{ github.token }}
 
-      - name: Cache protoc-gen-openapi binary
+      - name: Cache Fern bin dependencies
         uses: actions/cache@v4
         with:
-          path: ~/.fern/bin/protoc-gen-openapi
-          key: protoc-gen-openapi-v0.1.13-${{ runner.os }}-${{ runner.arch }}
+          path: ~/.fern/bin
+          key: ${{ runner.os }}-fern-bin-${{ hashFiles('packages/cli/workspace/lazy-fern-workspace/src/protobuf/BufDownloader.ts', 'packages/cli/workspace/lazy-fern-workspace/src/protobuf/ProtocGenOpenAPIDownloader.ts') }}
+          restore-keys: |
+            ${{ runner.os }}-fern-bin-
 
-      - name: Install protoc-gen-openapi
+      - name: Build CLI for install-dependencies
+        run: pnpm turbo run dist:cli:dev --filter=@fern-api/cli
+
+      - name: Install protobuf dependencies (buf + protoc-gen-openapi)
         run: |
-          mkdir -p "$HOME/.fern/bin"
-          if [ ! -x "$HOME/.fern/bin/protoc-gen-openapi" ]; then
-            curl -fsSL -o "$HOME/.fern/bin/protoc-gen-openapi" \
-              "https://github.com/fern-api/protoc-gen-openapi/releases/download/v0.1.13/protoc-gen-openapi-linux-amd64"
-            chmod +x "$HOME/.fern/bin/protoc-gen-openapi"
-          fi
+          FERN_NO_VERSION_REDIRECTION=true node packages/cli/cli/dist/dev/cli.cjs install-dependencies
           echo "$HOME/.fern/bin" >> $GITHUB_PATH
 
       - name: 🧪 Build
@@ -182,20 +182,20 @@ jobs:
         with:
           github_token: ${{ github.token }}
 
-      - name: Cache protoc-gen-openapi binary
+      - name: Cache Fern bin dependencies
         uses: actions/cache@v4
         with:
-          path: ~/.fern/bin/protoc-gen-openapi
-          key: protoc-gen-openapi-v0.1.13-${{ runner.os }}-${{ runner.arch }}
+          path: ~/.fern/bin
+          key: ${{ runner.os }}-fern-bin-${{ hashFiles('packages/cli/workspace/lazy-fern-workspace/src/protobuf/BufDownloader.ts', 'packages/cli/workspace/lazy-fern-workspace/src/protobuf/ProtocGenOpenAPIDownloader.ts') }}
+          restore-keys: |
+            ${{ runner.os }}-fern-bin-
 
-      - name: Install protoc-gen-openapi
+      - name: Build CLI for install-dependencies
+        run: pnpm turbo run dist:cli:dev --filter=@fern-api/cli
+
+      - name: Install protobuf dependencies (buf + protoc-gen-openapi)
         run: |
-          mkdir -p "$HOME/.fern/bin"
-          if [ ! -x "$HOME/.fern/bin/protoc-gen-openapi" ]; then
-            curl -fsSL -o "$HOME/.fern/bin/protoc-gen-openapi" \
-              "https://github.com/fern-api/protoc-gen-openapi/releases/download/v0.1.13/protoc-gen-openapi-linux-amd64"
-            chmod +x "$HOME/.fern/bin/protoc-gen-openapi"
-          fi
+          FERN_NO_VERSION_REDIRECTION=true node packages/cli/cli/dist/dev/cli.cjs install-dependencies
           echo "$HOME/.fern/bin" >> $GITHUB_PATH
 
       - name: 🧪 Build
@@ -218,20 +218,20 @@ jobs:
         with:
           github_token: ${{ github.token }}
 
-      - name: Cache protoc-gen-openapi binary
+      - name: Cache Fern bin dependencies
         uses: actions/cache@v4
         with:
-          path: ~/.fern/bin/protoc-gen-openapi
-          key: protoc-gen-openapi-v0.1.13-${{ runner.os }}-${{ runner.arch }}
+          path: ~/.fern/bin
+          key: ${{ runner.os }}-fern-bin-${{ hashFiles('packages/cli/workspace/lazy-fern-workspace/src/protobuf/BufDownloader.ts', 'packages/cli/workspace/lazy-fern-workspace/src/protobuf/ProtocGenOpenAPIDownloader.ts') }}
+          restore-keys: |
+            ${{ runner.os }}-fern-bin-
 
-      - name: Install protoc-gen-openapi
+      - name: Build CLI for install-dependencies
+        run: pnpm turbo run dist:cli:dev --filter=@fern-api/cli
+
+      - name: Install protobuf dependencies (buf + protoc-gen-openapi)
         run: |
-          mkdir -p "$HOME/.fern/bin"
-          if [ ! -x "$HOME/.fern/bin/protoc-gen-openapi" ]; then
-            curl -fsSL -o "$HOME/.fern/bin/protoc-gen-openapi" \
-              "https://github.com/fern-api/protoc-gen-openapi/releases/download/v0.1.13/protoc-gen-openapi-linux-amd64"
-            chmod +x "$HOME/.fern/bin/protoc-gen-openapi"
-          fi
+          FERN_NO_VERSION_REDIRECTION=true node packages/cli/cli/dist/dev/cli.cjs install-dependencies
           echo "$HOME/.fern/bin" >> $GITHUB_PATH
 
       - name: 🧪 Build
@@ -254,20 +254,20 @@ jobs:
         with:
           github_token: ${{ github.token }}
 
-      - name: Cache protoc-gen-openapi binary
+      - name: Cache Fern bin dependencies
         uses: actions/cache@v4
         with:
-          path: ~/.fern/bin/protoc-gen-openapi
-          key: protoc-gen-openapi-v0.1.13-${{ runner.os }}-${{ runner.arch }}
+          path: ~/.fern/bin
+          key: ${{ runner.os }}-fern-bin-${{ hashFiles('packages/cli/workspace/lazy-fern-workspace/src/protobuf/BufDownloader.ts', 'packages/cli/workspace/lazy-fern-workspace/src/protobuf/ProtocGenOpenAPIDownloader.ts') }}
+          restore-keys: |
+            ${{ runner.os }}-fern-bin-
 
-      - name: Install protoc-gen-openapi
+      - name: Build CLI for install-dependencies
+        run: pnpm turbo run dist:cli:dev --filter=@fern-api/cli
+
+      - name: Install protobuf dependencies (buf + protoc-gen-openapi)
         run: |
-          mkdir -p "$HOME/.fern/bin"
-          if [ ! -x "$HOME/.fern/bin/protoc-gen-openapi" ]; then
-            curl -fsSL -o "$HOME/.fern/bin/protoc-gen-openapi" \
-              "https://github.com/fern-api/protoc-gen-openapi/releases/download/v0.1.13/protoc-gen-openapi-linux-amd64"
-            chmod +x "$HOME/.fern/bin/protoc-gen-openapi"
-          fi
+          FERN_NO_VERSION_REDIRECTION=true node packages/cli/cli/dist/dev/cli.cjs install-dependencies
           echo "$HOME/.fern/bin" >> $GITHUB_PATH
 
       - name: 🧪 Build
@@ -290,20 +290,20 @@ jobs:
         with:
           github_token: ${{ github.token }}
 
-      - name: Cache protoc-gen-openapi binary
+      - name: Cache Fern bin dependencies
         uses: actions/cache@v4
         with:
-          path: ~/.fern/bin/protoc-gen-openapi
-          key: protoc-gen-openapi-v0.1.13-${{ runner.os }}-${{ runner.arch }}
+          path: ~/.fern/bin
+          key: ${{ runner.os }}-fern-bin-${{ hashFiles('packages/cli/workspace/lazy-fern-workspace/src/protobuf/BufDownloader.ts', 'packages/cli/workspace/lazy-fern-workspace/src/protobuf/ProtocGenOpenAPIDownloader.ts') }}
+          restore-keys: |
+            ${{ runner.os }}-fern-bin-
 
-      - name: Install protoc-gen-openapi
+      - name: Build CLI for install-dependencies
+        run: pnpm turbo run dist:cli:dev --filter=@fern-api/cli
+
+      - name: Install protobuf dependencies (buf + protoc-gen-openapi)
         run: |
-          mkdir -p "$HOME/.fern/bin"
-          if [ ! -x "$HOME/.fern/bin/protoc-gen-openapi" ]; then
-            curl -fsSL -o "$HOME/.fern/bin/protoc-gen-openapi" \
-              "https://github.com/fern-api/protoc-gen-openapi/releases/download/v0.1.13/protoc-gen-openapi-linux-amd64"
-            chmod +x "$HOME/.fern/bin/protoc-gen-openapi"
-          fi
+          FERN_NO_VERSION_REDIRECTION=true node packages/cli/cli/dist/dev/cli.cjs install-dependencies
           echo "$HOME/.fern/bin" >> $GITHUB_PATH
 
       - name: 🧪 Build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,6 +123,14 @@ jobs:
       - name: Install
         uses: ./.github/actions/install
 
+      - name: Cache Fern bin dependencies
+        uses: actions/cache@v4
+        with:
+          path: ~/.fern/bin
+          key: ${{ runner.os }}-fern-bin-${{ hashFiles('packages/cli/workspace/lazy-fern-workspace/src/protobuf/BufDownloader.ts', 'packages/cli/workspace/lazy-fern-workspace/src/protobuf/ProtocGenOpenAPIDownloader.ts') }}
+          restore-keys: |
+            ${{ runner.os }}-fern-bin-
+
       - name: Build CLI for install-dependencies
         run: pnpm turbo run dist:cli:dev --filter=@fern-api/cli
 
@@ -171,6 +179,14 @@ jobs:
 
       - name: Install
         uses: ./.github/actions/install
+
+      - name: Cache Fern bin dependencies
+        uses: actions/cache@v4
+        with:
+          path: ~/.fern/bin
+          key: ${{ runner.os }}-fern-bin-${{ hashFiles('packages/cli/workspace/lazy-fern-workspace/src/protobuf/BufDownloader.ts', 'packages/cli/workspace/lazy-fern-workspace/src/protobuf/ProtocGenOpenAPIDownloader.ts') }}
+          restore-keys: |
+            ${{ runner.os }}-fern-bin-
 
       - name: Build CLI for install-dependencies
         run: pnpm turbo run dist:cli:dev --filter=@fern-api/cli

--- a/.github/workflows/publish-snippets-core.yml
+++ b/.github/workflows/publish-snippets-core.yml
@@ -34,23 +34,21 @@ jobs:
         with:
           github_token: ${{ github.token }}
 
-      - uses: actions/setup-go@v6
-        with:
-          go-version: "stable"
-          cache: false
-
-      - name: Cache Go modules and binaries
+      - name: Cache protoc-gen-openapi binary
         uses: actions/cache@v4
         with:
-          path: |
-            ~/go/pkg/mod
-            ~/go/bin
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-
+          path: ~/.fern/bin/protoc-gen-openapi
+          key: protoc-gen-openapi-v0.1.13-${{ runner.os }}-${{ runner.arch }}
 
       - name: Install protoc-gen-openapi
-        run: go install github.com/fern-api/protoc-gen-openapi/cmd/protoc-gen-openapi@latest
+        run: |
+          mkdir -p "$HOME/.fern/bin"
+          if [ ! -x "$HOME/.fern/bin/protoc-gen-openapi" ]; then
+            curl -fsSL -o "$HOME/.fern/bin/protoc-gen-openapi" \
+              "https://github.com/fern-api/protoc-gen-openapi/releases/download/v0.1.13/protoc-gen-openapi-linux-amd64"
+            chmod +x "$HOME/.fern/bin/protoc-gen-openapi"
+          fi
+          echo "$HOME/.fern/bin" >> $GITHUB_PATH
 
       - name: 🧪 Build
         run: pnpm turbo run compile --filter=${{ env.PACKAGE_NAME }}

--- a/.github/workflows/publish-snippets-core.yml
+++ b/.github/workflows/publish-snippets-core.yml
@@ -37,6 +37,17 @@ jobs:
       - uses: actions/setup-go@v6
         with:
           go-version: "stable"
+          cache: false
+
+      - name: Cache Go modules and binaries
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/go/pkg/mod
+            ~/go/bin
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
 
       - name: Install protoc-gen-openapi
         run: go install github.com/fern-api/protoc-gen-openapi/cmd/protoc-gen-openapi@latest

--- a/.github/workflows/publish-snippets-core.yml
+++ b/.github/workflows/publish-snippets-core.yml
@@ -30,10 +30,6 @@ jobs:
       - name: 📥 Install
         uses: ./.github/actions/install
 
-      - uses: bufbuild/buf-setup-action@v1.50.0
-        with:
-          github_token: ${{ github.token }}
-
       - name: Cache Fern bin dependencies
         uses: actions/cache@v4
         with:

--- a/.github/workflows/publish-snippets-core.yml
+++ b/.github/workflows/publish-snippets-core.yml
@@ -34,20 +34,20 @@ jobs:
         with:
           github_token: ${{ github.token }}
 
-      - name: Cache protoc-gen-openapi binary
+      - name: Cache Fern bin dependencies
         uses: actions/cache@v4
         with:
-          path: ~/.fern/bin/protoc-gen-openapi
-          key: protoc-gen-openapi-v0.1.13-${{ runner.os }}-${{ runner.arch }}
+          path: ~/.fern/bin
+          key: ${{ runner.os }}-fern-bin-${{ hashFiles('packages/cli/workspace/lazy-fern-workspace/src/protobuf/BufDownloader.ts', 'packages/cli/workspace/lazy-fern-workspace/src/protobuf/ProtocGenOpenAPIDownloader.ts') }}
+          restore-keys: |
+            ${{ runner.os }}-fern-bin-
 
-      - name: Install protoc-gen-openapi
+      - name: Build CLI for install-dependencies
+        run: pnpm turbo run dist:cli:dev --filter=@fern-api/cli
+
+      - name: Install protobuf dependencies (buf + protoc-gen-openapi)
         run: |
-          mkdir -p "$HOME/.fern/bin"
-          if [ ! -x "$HOME/.fern/bin/protoc-gen-openapi" ]; then
-            curl -fsSL -o "$HOME/.fern/bin/protoc-gen-openapi" \
-              "https://github.com/fern-api/protoc-gen-openapi/releases/download/v0.1.13/protoc-gen-openapi-linux-amd64"
-            chmod +x "$HOME/.fern/bin/protoc-gen-openapi"
-          fi
+          FERN_NO_VERSION_REDIRECTION=true node packages/cli/cli/dist/dev/cli.cjs install-dependencies
           echo "$HOME/.fern/bin" >> $GITHUB_PATH
 
       - name: 🧪 Build

--- a/.github/workflows/test-definitions.yml
+++ b/.github/workflows/test-definitions.yml
@@ -48,6 +48,16 @@ jobs:
           go-version: "stable"
           cache: false
 
+      - name: Cache Go modules and binaries
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/go/pkg/mod
+            ~/go/bin
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
+
       - name: Install protoc-gen-openapi
         run: go install github.com/fern-api/protoc-gen-openapi/cmd/protoc-gen-openapi@latest
 

--- a/.github/workflows/test-definitions.yml
+++ b/.github/workflows/test-definitions.yml
@@ -39,10 +39,6 @@ jobs:
       - name: Install
         uses: ./.github/actions/install
 
-      - uses: bufbuild/buf-setup-action@v1.50.0
-        with:
-          github_token: ${{ github.token }}
-
       - name: Cache Fern bin dependencies
         uses: actions/cache@v4
         with:

--- a/.github/workflows/test-definitions.yml
+++ b/.github/workflows/test-definitions.yml
@@ -43,20 +43,20 @@ jobs:
         with:
           github_token: ${{ github.token }}
 
-      - name: Cache protoc-gen-openapi binary
+      - name: Cache Fern bin dependencies
         uses: actions/cache@v4
         with:
-          path: ~/.fern/bin/protoc-gen-openapi
-          key: protoc-gen-openapi-v0.1.13-${{ runner.os }}-${{ runner.arch }}
+          path: ~/.fern/bin
+          key: ${{ runner.os }}-fern-bin-${{ hashFiles('packages/cli/workspace/lazy-fern-workspace/src/protobuf/BufDownloader.ts', 'packages/cli/workspace/lazy-fern-workspace/src/protobuf/ProtocGenOpenAPIDownloader.ts') }}
+          restore-keys: |
+            ${{ runner.os }}-fern-bin-
 
-      - name: Install protoc-gen-openapi
+      - name: Build CLI for install-dependencies
+        run: pnpm turbo run dist:cli:dev --filter=@fern-api/cli
+
+      - name: Install protobuf dependencies (buf + protoc-gen-openapi)
         run: |
-          mkdir -p "$HOME/.fern/bin"
-          if [ ! -x "$HOME/.fern/bin/protoc-gen-openapi" ]; then
-            curl -fsSL -o "$HOME/.fern/bin/protoc-gen-openapi" \
-              "https://github.com/fern-api/protoc-gen-openapi/releases/download/v0.1.13/protoc-gen-openapi-linux-amd64"
-            chmod +x "$HOME/.fern/bin/protoc-gen-openapi"
-          fi
+          FERN_NO_VERSION_REDIRECTION=true node packages/cli/cli/dist/dev/cli.cjs install-dependencies
           echo "$HOME/.fern/bin" >> $GITHUB_PATH
 
       - name: Fern check

--- a/.github/workflows/test-definitions.yml
+++ b/.github/workflows/test-definitions.yml
@@ -43,23 +43,21 @@ jobs:
         with:
           github_token: ${{ github.token }}
 
-      - uses: actions/setup-go@v6
-        with:
-          go-version: "stable"
-          cache: false
-
-      - name: Cache Go modules and binaries
+      - name: Cache protoc-gen-openapi binary
         uses: actions/cache@v4
         with:
-          path: |
-            ~/go/pkg/mod
-            ~/go/bin
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-
+          path: ~/.fern/bin/protoc-gen-openapi
+          key: protoc-gen-openapi-v0.1.13-${{ runner.os }}-${{ runner.arch }}
 
       - name: Install protoc-gen-openapi
-        run: go install github.com/fern-api/protoc-gen-openapi/cmd/protoc-gen-openapi@latest
+        run: |
+          mkdir -p "$HOME/.fern/bin"
+          if [ ! -x "$HOME/.fern/bin/protoc-gen-openapi" ]; then
+            curl -fsSL -o "$HOME/.fern/bin/protoc-gen-openapi" \
+              "https://github.com/fern-api/protoc-gen-openapi/releases/download/v0.1.13/protoc-gen-openapi-linux-amd64"
+            chmod +x "$HOME/.fern/bin/protoc-gen-openapi"
+          fi
+          echo "$HOME/.fern/bin" >> $GITHUB_PATH
 
       - name: Fern check
         env:

--- a/.github/workflows/update-test.yml
+++ b/.github/workflows/update-test.yml
@@ -37,23 +37,21 @@ jobs:
       - name: Verify buf
         run: buf --version
 
-      - uses: actions/setup-go@v6
-        with:
-          go-version: "stable"
-          cache: false
-
-      - name: Cache Go modules and binaries
+      - name: Cache protoc-gen-openapi binary
         uses: actions/cache@v4
         with:
-          path: |
-            ~/go/pkg/mod
-            ~/go/bin
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-
+          path: ~/.fern/bin/protoc-gen-openapi
+          key: protoc-gen-openapi-v0.1.13-${{ runner.os }}-${{ runner.arch }}
 
       - name: Install protoc-gen-openapi
-        run: go install github.com/fern-api/protoc-gen-openapi/cmd/protoc-gen-openapi@latest
+        run: |
+          mkdir -p "$HOME/.fern/bin"
+          if [ ! -x "$HOME/.fern/bin/protoc-gen-openapi" ]; then
+            curl -fsSL -o "$HOME/.fern/bin/protoc-gen-openapi" \
+              "https://github.com/fern-api/protoc-gen-openapi/releases/download/v0.1.13/protoc-gen-openapi-linux-amd64"
+            chmod +x "$HOME/.fern/bin/protoc-gen-openapi"
+          fi
+          echo "$HOME/.fern/bin" >> $GITHUB_PATH
 
       - name: Run test:update
         run: pnpm test:update

--- a/.github/workflows/update-test.yml
+++ b/.github/workflows/update-test.yml
@@ -40,7 +40,17 @@ jobs:
       - uses: actions/setup-go@v6
         with:
           go-version: "stable"
-          cache-dependency-path: generators/go/go.sum
+          cache: false
+
+      - name: Cache Go modules and binaries
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/go/pkg/mod
+            ~/go/bin
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
 
       - name: Install protoc-gen-openapi
         run: go install github.com/fern-api/protoc-gen-openapi/cmd/protoc-gen-openapi@latest

--- a/.github/workflows/update-test.yml
+++ b/.github/workflows/update-test.yml
@@ -30,13 +30,6 @@ jobs:
       - name: Install
         uses: ./.github/actions/install
 
-      - uses: bufbuild/buf-setup-action@v1.50.0
-        with:
-          github_token: ${{ github.token }}
-
-      - name: Verify buf
-        run: buf --version
-
       - name: Cache Fern bin dependencies
         uses: actions/cache@v4
         with:

--- a/.github/workflows/update-test.yml
+++ b/.github/workflows/update-test.yml
@@ -37,20 +37,20 @@ jobs:
       - name: Verify buf
         run: buf --version
 
-      - name: Cache protoc-gen-openapi binary
+      - name: Cache Fern bin dependencies
         uses: actions/cache@v4
         with:
-          path: ~/.fern/bin/protoc-gen-openapi
-          key: protoc-gen-openapi-v0.1.13-${{ runner.os }}-${{ runner.arch }}
+          path: ~/.fern/bin
+          key: ${{ runner.os }}-fern-bin-${{ hashFiles('packages/cli/workspace/lazy-fern-workspace/src/protobuf/BufDownloader.ts', 'packages/cli/workspace/lazy-fern-workspace/src/protobuf/ProtocGenOpenAPIDownloader.ts') }}
+          restore-keys: |
+            ${{ runner.os }}-fern-bin-
 
-      - name: Install protoc-gen-openapi
+      - name: Build CLI for install-dependencies
+        run: pnpm turbo run dist:cli:dev --filter=@fern-api/cli
+
+      - name: Install protobuf dependencies (buf + protoc-gen-openapi)
         run: |
-          mkdir -p "$HOME/.fern/bin"
-          if [ ! -x "$HOME/.fern/bin/protoc-gen-openapi" ]; then
-            curl -fsSL -o "$HOME/.fern/bin/protoc-gen-openapi" \
-              "https://github.com/fern-api/protoc-gen-openapi/releases/download/v0.1.13/protoc-gen-openapi-linux-amd64"
-            chmod +x "$HOME/.fern/bin/protoc-gen-openapi"
-          fi
+          FERN_NO_VERSION_REDIRECTION=true node packages/cli/cli/dist/dev/cli.cjs install-dependencies
           echo "$HOME/.fern/bin" >> $GITHUB_PATH
 
       - name: Run test:update


### PR DESCRIPTION
## Description

Removes the Go toolchain (`actions/setup-go` + `go install`) **and** `bufbuild/buf-setup-action` from 4 workflows, replacing both with the CLI's built-in `install-dependencies` command—the same approach already used in `ci.yml`. Also adds `~/.fern/bin` caching across all affected workflows to avoid redundant downloads.

## Changes Made

### Remove Go toolchain + buf-setup-action, use `fern install-dependencies` (4 workflows)
- Removes `actions/setup-go@v6`, `go install protoc-gen-openapi@latest`, `bufbuild/buf-setup-action@v1.50.0`, and the "Verify buf" step from:
  - `ci-dynamic-snippets.yml` (all 8 language jobs)
  - `test-definitions.yml`
  - `update-test.yml`
  - `publish-snippets-core.yml`
- Replaces with three steps matching the `ci.yml` pattern:
  1. **Cache** `~/.fern/bin` via `actions/cache@v4`, keyed on `BufDownloader.ts` + `ProtocGenOpenAPIDownloader.ts` with `restore-keys` fallback
  2. **Build CLI**: `pnpm turbo run dist:cli:dev --filter=@fern-api/cli` (turbo remote cache keeps this fast)
  3. **Install dependencies**: `node packages/cli/cli/dist/dev/cli.cjs install-dependencies` + add `~/.fern/bin` to `$GITHUB_PATH`
- Both buf and protoc-gen-openapi versions are now managed in a single source of truth (`BufDownloader.ts` / `ProtocGenOpenAPIDownloader.ts`) instead of being pinned in workflow files or via `go install @latest`

### `~/.fern/bin` caching (`ci.yml`)
- Caches `~/.fern/bin` (buf + protoc-gen-openapi binaries downloaded by `install-dependencies`) in both `test` and `test-ete` jobs
- Cache key is based on the source files containing hardcoded version constants, with `restore-keys` fallback

## Human Review Checklist
- [ ] `update-test.yml` previously set `cache-dependency-path: generators/go/go.sum` for `actions/setup-go`, suggesting Go may have been used beyond `protoc-gen-openapi`. Confirm the `Test` runner does not need Go for other purposes (e.g., Go generator tests run in separate seed jobs).
- [ ] buf is now installed by `install-dependencies` to `~/.fern/bin` (version `v1.50.0` from `BufDownloader.ts`) instead of by `bufbuild/buf-setup-action@v1.50.0`. Versions match today, but future buf upgrades must be done in `BufDownloader.ts` rather than updating the action version.
- [ ] The new `Build CLI for install-dependencies` step adds a dependency on turbo remote cache for acceptable build times. Confirm this is fine for `ci-dynamic-snippets.yml` jobs that previously didn't build the CLI at all.
- [ ] `publish-snippets-core.yml` does not set `TURBO_TOKEN`/`TURBO_TEAM` env vars, so the CLI build step won't benefit from turbo remote cache (pre-existing issue, now more impactful).
- [ ] `update-test.yml` and `publish-snippets-core.yml` are `workflow_dispatch`-only and were **not** exercised by this PR's CI run.

## Testing
- [ ] No unit tests — workflow-only changes; validated by reviewing YAML structure and observing CI run behavior
- [ ] CI `test` job (which uses `install-dependencies` + cache) passed

Link to Devin session: https://app.devin.ai/sessions/00567704b38245538865f0ce88464ab6
Requested by: @Swimburger
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/14675" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
