### PR TITLE
chore(ci): remove fiber from allowed scopes and references

### DIFF
--- a/.devin/settings.md
+++ b/.devin/settings.md
@@ -8,7 +8,7 @@ PR titles are validated by CI (`.github/workflows/lint-pr-title.yml`) using [sem
 
 **Allowed types**: `fix`, `feat`, `revert`, `break`, `chore`
 
-**Allowed scopes**: `docs`, `changelog`, `internal`, `cli`, `typescript`, `python`, `java`, `csharp`, `go`, `php`, `ruby`, `seed`, `ci`, `lint`, `fastapi`, `spring`, `openapi`, `deps`, `deps-dev`, `fiber`, `pydantic`, `ai-search`, `swift`, `rust`
+**Allowed scopes**: `docs`, `changelog`, `internal`, `cli`, `typescript`, `python`, `java`, `csharp`, `go`, `php`, `ruby`, `seed`, `ci`, `lint`, `fastapi`, `spring`, `openapi`, `deps`, `deps-dev`, `pydantic`, `ai-search`, `swift`, `rust`
 
 **Examples**:
 - `chore(docs): update guidelines`

--- a/.github/workflows/lint-pr-title.yml
+++ b/.github/workflows/lint-pr-title.yml
@@ -47,7 +47,6 @@ jobs:
             openapi
             deps
             deps-dev
-            fiber
             pydantic
             ai-search
             swift

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -318,7 +318,7 @@ When creating pull requests in this repository:
 
    **Allowed types**: `fix`, `feat`, `revert`, `break`, `chore`
 
-   **Allowed scopes**: `docs`, `changelog`, `internal`, `cli`, `typescript`, `python`, `java`, `csharp`, `go`, `php`, `ruby`, `seed`, `ci`, `lint`, `fastapi`, `spring`, `openapi`, `deps`, `deps-dev`, `fiber`, `pydantic`, `ai-search`, `swift`, `rust`
+   **Allowed scopes**: `docs`, `changelog`, `internal`, `cli`, `typescript`, `python`, `java`, `csharp`, `go`, `php`, `ruby`, `seed`, `ci`, `lint`, `fastapi`, `spring`, `openapi`, `deps`, `deps-dev`, `pydantic`, `ai-search`, `swift`, `rust`
 
    **Examples**: `chore(docs): update guidelines`, `feat(python): add new feature`, `fix(cli): resolve config loading bug`
 

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -38,7 +38,7 @@ This file provides guidance to [Devin Review](https://docs.devin.ai/work-with-de
 ### PR Structure
 - PR titles must follow semantic commit format: `<type>(<scope>): <description>` where both type and scope are required.
 - Allowed types: `fix`, `feat`, `revert`, `break`, `chore`.
-- Allowed scopes: `docs`, `changelog`, `internal`, `cli`, `typescript`, `python`, `java`, `csharp`, `go`, `php`, `ruby`, `seed`, `ci`, `lint`, `fastapi`, `spring`, `openapi`, `deps`, `deps-dev`, `fiber`, `pydantic`, `ai-search`, `swift`, `rust`, `generator-cli`.
+- Allowed scopes: `docs`, `changelog`, `internal`, `cli`, `typescript`, `python`, `java`, `csharp`, `go`, `php`, `ruby`, `seed`, `ci`, `lint`, `fastapi`, `spring`, `openapi`, `deps`, `deps-dev`, `pydantic`, `ai-search`, `swift`, `rust`, `generator-cli`.
 
 ### Cross-Package Type Safety
 - When importing types across packages, watch for name collisions -- use namespace imports (`import * as X`) rather than direct imports when multiple packages export types with the same name.


### PR DESCRIPTION
## Description

Refs #14669

Removes `fiber` from allowed PR title scopes and related documentation, following the same safe removal pattern used for Postman in #14669.

## Changes Made

- Removed `fiber` from the allowed scopes list in `.github/workflows/lint-pr-title.yml`
- Removed `fiber` from the allowed scopes documentation in `.devin/settings.md`, `CLAUDE.md`, and `REVIEW.md`

Historical changelog entries referencing `go-fiber` in `packages/cli/cli/versions.yml` are intentionally preserved — they are just recording history.

## Human Review Checklist

- [ ] Confirm there are no open PRs using the `fiber` scope that would be blocked by this change
- [ ] Verify no other files reference `fiber` as a generator scope (search confirmed only these 4 files + historical changelogs)

## Testing

- No unit tests needed — this is a config/documentation-only change
- The PR title lint workflow is the only functional change; it will simply reject `fiber` as a scope going forward

Link to Devin session: https://app.devin.ai/sessions/a484f315a5fc49f29822387882792908
Requested by: @Swimburger
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/14677" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
