### PR TITLE
chore(ci): amend publish workflow for browser-compatible fern workspace 

### DIFF
--- a/.github/workflows/publish-browser-compatible-fern-workspace.yml
+++ b/.github/workflows/publish-browser-compatible-fern-workspace.yml
@@ -62,6 +62,9 @@ jobs:
             exit 1
           fi
 
+      - name: Compile dependencies
+        run: pnpm turbo run compile --filter="${PACKAGE_NAME}..."
+
       - name: Build and publish
         env:
           VERSION: ${{ inputs.version }}


### PR DESCRIPTION
## Description                                                                                                                                   
                                                                                                                                                   
  Refs [FER-9460](https://linear.app/buildwithfern/issue/FER-9460/phase-1-create-publish-workflow-for-browser-compatible-fern-workspace)           
                                                                                                                                                   
  Amends a GitHub Actions workflow to publish a browser-compatible version of the `@fern-api/fern-workspace` package to npm.                         
                             
  ## Changes Made                                                                                                                                  
                                                                                                                                                   
  - Amended `.github/workflows/publish-browser-compatible-fern-workspace.yml` workflow                                                                                                                                                         
                                                                                                                                                   
  ## Testing                 
  - [x] Manual testing completed — verified workflow triggers and publishes correctly  ```gh workflow run publish-browser-compatible-fern-workspace.yml --ref publish-workflow-bcfw-2 -f version="0.0.2" ``` => https://github.com/fern-api/fern/actions/runs/24048764571/job/70138767568
  => https://www.npmjs.com/package/@fern-api/browser-compatible-fern-workspace/access