### PR TITLE
chore(generator-cli): upgrade @fern-api/replay to 0.9.1

### DIFF
--- a/packages/generator-cli/package.json
+++ b/packages/generator-cli/package.json
@@ -24,7 +24,7 @@
   "files": ["bin", "dist", "lib"],
   "dependencies": {
     "@fern-api/core-utils": "workspace:*",
-    "@fern-api/replay": "^0.9.0",
+    "@fern-api/replay": "^0.9.1",
     "@octokit/rest": "catalog:",
     "es-toolkit": "catalog:",
     "tmp-promise": "catalog:"

--- a/packages/generator-cli/versions.yml
+++ b/packages/generator-cli/versions.yml
@@ -1,6 +1,13 @@
 # yaml-language-server: $schema=../../versions-yml.schema.json
 - changelogEntry:
     - summary: |
+        Upgrade @fern-api/replay to 0.9.1.
+      type: chore
+  createdAt: "2026-04-06"
+  version: 0.9.1
+
+- changelogEntry:
+    - summary: |
         Internal CLI improvements and dependency updates.
       type: feat
   createdAt: "2026-04-06"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7857,7 +7857,7 @@ importers:
         specifier: workspace:*
         version: link:../commons/core-utils
       '@fern-api/replay':
-        specifier: ^0.9.0
+        specifier: ^0.9.1
         version: 0.9.1
       '@octokit/rest':
         specifier: 'catalog:'


### PR DESCRIPTION
## Description

Bumps the minimum `@fern-api/replay` version from `^0.9.0` to `^0.9.1` in the generator-cli package.

## Changes Made

- Updated `@fern-api/replay` specifier to `^0.9.1` in `packages/generator-cli/package.json`
- Added `0.9.1` changelog entry in `packages/generator-cli/versions.yml`
- Updated `pnpm-lock.yaml` specifier (resolved version was already `0.9.1`)

## Testing

- [ ] No functional code changes — dependency version bump only

Link to Devin session: https://app.devin.ai/sessions/4231db5ba4a44c5d9192fed5352f4bc9
Requested by: @tstanmay13