### PR TITLE
fix(generator-cli): upgrade fern-go-sdk from 0.22.0 to 1.33.2

### DIFF
--- a/fern/apis/generator-cli/generators.yml
+++ b/fern/apis/generator-cli/generators.yml
@@ -37,7 +37,7 @@ groups:
           package_name: generatorcli
         smart-casing: false
       - name: fernapi/fern-go-sdk
-        version: 0.22.0
+        version: 1.33.2
         github:
           repository: fern-api/generator-cli-go
         config:


### PR DESCRIPTION
## Description

Upgrades the Go SDK generator version for the `generator-cli` API to fix the failed `publish-sdks` CI job.

## Changes Made

- Bumped `fernapi/fern-go-sdk` from `0.22.0` to `1.33.2` in `fern/apis/generator-cli/generators.yml`

## Context

The `publish-sdks` workflow ([failed run](https://github.com/fern-api/fern/actions/runs/24057267682/job/70166333299)) failed because `fernapi/fern-go-sdk@0.22.0` is not compatible with CLI v4.x.x+. The Python and TypeScript SDKs published successfully (v0.9.1), but the Go SDK generation failed with:

> `fernapi/fern-go-sdk@0.22.0 is not compatible with CLI v4.x.x+. Please upgrade to fernapi/fern-go-sdk@0.28.3 or later`

Upgraded to `1.33.2` (latest stable) rather than the minimum `0.28.3`.

## Human Review Checklist

- [ ] Verify that the Go SDK generator config options (`union: v1`, `packageName: generatorcli`) are still valid/supported in v1.33.2
- [ ] Confirm the major version jump (0.x → 1.x) won't produce unexpected breaking changes in the generated `fern-api/generator-cli-go` output

## Testing

- [ ] Re-run `publish-sdks` workflow after merge to generate and publish the Go SDK

Link to Devin session: https://app.devin.ai/sessions/3e320ce36da846dfa41f7bb991f3f840
Requested by: @tstanmay13