### PR TITLE
chore(generator-cli): bump to 0.9.2 to re-trigger publish with Go SDK

### DIFF
--- a/packages/generator-cli/versions.yml
+++ b/packages/generator-cli/versions.yml
@@ -1,6 +1,13 @@
 # yaml-language-server: $schema=../../versions-yml.schema.json
 - changelogEntry:
     - summary: |
+        Re-publish to include Go SDK after upgrading fern-go-sdk from 0.22.0 to 1.33.2.
+      type: chore
+  createdAt: "2026-04-07"
+  version: 0.9.2
+
+- changelogEntry:
+    - summary: |
         Upgrade @fern-api/replay to 0.9.1.
       type: chore
   createdAt: "2026-04-06"


### PR DESCRIPTION
## Description

Refs https://github.com/fern-api/fern/actions/runs/24057267682

Bumps generator-cli to 0.9.2 to re-trigger the `publish-generator-cli` workflow. The 0.9.1 publish run failed for the Go SDK because `fernapi/fern-go-sdk@0.22.0` was incompatible with CLI v4.x.x+. The generator version was upgraded to 1.33.2 in #14690 (already merged), but a versions.yml bump is needed to re-trigger the publish workflow.

## Changes Made

- Added version 0.9.2 entry to `packages/generator-cli/versions.yml` with a chore changelog entry

## Testing

- No code changes; this is a version bump to re-trigger the publish workflow
- [ ] Verify after merge that the `publish-sdks` job succeeds and the Go SDK is published to `fern-api/generator-cli-go`

## Human Review Checklist

- [ ] Confirm it's acceptable that TS and Python SDKs will also be re-published at 0.9.2 (they already published 0.9.1 successfully with the same underlying code)
- [ ] Confirm the Go SDK generator config (`union: v1`, `packageName: generatorcli`) is compatible with `fern-go-sdk@1.33.2` (major version jump from 0.22.0)

Link to Devin session: https://app.devin.ai/sessions/3e320ce36da846dfa41f7bb991f3f840
Requested by: @tstanmay13