### PR TITLE
fix(ts-sdk): remove dist/ from published package in legacy exports mode

### DIFF
--- a/generators/typescript/sdk/versions.yml
+++ b/generators/typescript/sdk/versions.yml
@@ -1,4 +1,15 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 3.63.1
+  changelogEntry:
+    - summary: |
+        Fix legacy publishing including duplicate files in the published npm package.
+        The `prepack` script now removes the `dist/` directory after copying its
+        contents to the project root, preventing the tarball from containing both
+        `dist/` and root-level copies of the same files.
+      type: fix
+  createdAt: "2026-04-07"
+  irVersion: 66
+
 - version: 3.63.0
   changelogEntry:
     - summary: |

--- a/generators/typescript/utils/commons/src/typescript-project/SimpleTypescriptProject.ts
+++ b/generators/typescript/utils/commons/src/typescript-project/SimpleTypescriptProject.ts
@@ -207,7 +207,7 @@ export class SimpleTypescriptProject extends TypescriptProject {
                 scripts: {
                     ...this.getCommonScripts(),
                     [SimpleTypescriptProject.BUILD_SCRIPT_NAME]: "tsc",
-                    prepack: `cp -rv ${SimpleTypescriptProject.DIST_DIRECTORY}/. .`,
+                    prepack: `cp -rv ${SimpleTypescriptProject.DIST_DIRECTORY}/. . && rm -rf ${SimpleTypescriptProject.DIST_DIRECTORY}`,
                     ...packageJson.scripts,
                     ...this.extraScripts
                 }

--- a/seed/ts-sdk/simple-api/legacy-exports/package.json
+++ b/seed/ts-sdk/simple-api/legacy-exports/package.json
@@ -16,7 +16,7 @@
         "check": "biome check --skip-parse-errors --no-errors-on-unmatched --max-diagnostics=none",
         "check:fix": "biome check --fix --unsafe --skip-parse-errors --no-errors-on-unmatched --max-diagnostics=none",
         "build": "tsc",
-        "prepack": "cp -rv dist/. .",
+        "prepack": "cp -rv dist/. . && rm -rf dist",
         "test": "vitest",
         "test:unit": "vitest --project unit",
         "test:wire": "vitest --project wire"


### PR DESCRIPTION
## Description

With legacy publishing (`useLegacyExports: true`), the generated `prepack` script copies compiled output from `dist/` to the project root so that `main: "./index.js"` resolves correctly. However, the `dist/` directory itself was left in place, causing it to be included in the published npm tarball alongside the root-level copies — effectively doubling the package size.

For example, the published `cohere-ai@8.0.0` package contains **3,106 files**: ~1,512 under `dist/` and ~1,594 at root, with nearly all `dist/` files being duplicates.

While the generated `.npmignore` already lists `dist`, repos with stale `.npmignore` files (e.g. preserved via `.fernignore`) don't benefit from that exclusion.

## Changes Made

- Append `&& rm -rf dist` to the legacy `prepack` script so the `dist/` directory is removed after its contents are copied to root, before npm creates the tarball
- Update the `legacy-exports` seed snapshot to reflect the new prepack command

## Testing

- [ ] Unit tests added/updated
- [x] Verified the published `cohere-ai@8.0.0` tarball contains duplicate files via `npm pack` + `tar tf`
- [x] Seed snapshot updated for `simple-api/legacy-exports`

## Review checklist

- Confirm that removing `dist/` during `prepack` is safe — `prepack` runs only during `npm pack`/`npm publish`, typically in CI where post-publish directory state doesn't matter
- The `.npmignore` still lists `dist` as a secondary safeguard for the non-stale case

Link to Devin session: https://app.devin.ai/sessions/f5b65432734b4a78b329d0823e852db7
Requested by: @Swimburger
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/14710" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
