### PR TITLE
fix(ci): use env vars instead of secrets in step if conditions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -180,8 +180,10 @@ jobs:
         uses: ./.github/actions/install
 
       - name: Log in to Docker Hub
-        if: ${{ secrets.DOCKER_USERNAME_PUBLIC_READONLY != '' }}
+        if: ${{ env.DOCKERHUB_USERNAME != '' }}
         uses: docker/login-action@v3
+        env:
+          DOCKERHUB_USERNAME: ${{ secrets.DOCKER_USERNAME_PUBLIC_READONLY }}
         with:
           username: ${{ secrets.DOCKER_USERNAME_PUBLIC_READONLY }}
           password: ${{ secrets.DOCKER_PASSWORD_PUBLIC_READONLY }}

--- a/.github/workflows/seed.yml
+++ b/.github/workflows/seed.yml
@@ -866,8 +866,10 @@ jobs:
         uses: ./.github/actions/install
 
       - name: Log in to Docker Hub
-        if: ${{ secrets.DOCKER_USERNAME_PUBLIC_READONLY != '' }}
+        if: ${{ env.DOCKERHUB_USERNAME != '' }}
         uses: docker/login-action@v3
+        env:
+          DOCKERHUB_USERNAME: ${{ secrets.DOCKER_USERNAME_PUBLIC_READONLY }}
         with:
           username: ${{ secrets.DOCKER_USERNAME_PUBLIC_READONLY }}
           password: ${{ secrets.DOCKER_PASSWORD_PUBLIC_READONLY }}


### PR DESCRIPTION
## Description

Fixes broken CI and Seed workflows on `main` introduced by #14676. Both `ci.yml` and `seed.yml` fail at workflow validation with:

> Unrecognized named-value: 'secrets'. Located at position 1 within expression: `secrets.DOCKER_USERNAME_PUBLIC_READONLY != ''`

The `secrets` context cannot be referenced directly in step-level `if` expressions (likely due to `workflow_call` being a trigger in `seed.yml`, which changes secrets context availability, and stricter validation in `ci.yml`).

## Changes Made

- **`ci.yml`** (`test-ete` job, line 183): Changed `if: ${{ secrets.DOCKER_USERNAME_PUBLIC_READONLY != '' }}` → `if: ${{ env.DOCKERHUB_USERNAME != '' }}` with a step-level `env` mapping the secret to an env var
- **`seed.yml`** (`benchmark` job, line 869): Same fix

The `with` blocks still reference `secrets` directly for the actual login credentials, which is valid — only the `if` expression needed the workaround.

## Review Checklist

- [ ] Confirm step-level `env` is evaluated before the step's `if` condition (per [GitHub docs](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/evaluate-expressions-in-workflows-and-actions), it is)
- [ ] Verify that `secrets` in `with:` blocks still works correctly (it should — `with` inputs are evaluated in a different context than `if`)
- [ ] Note: the composite action (`cached-seed`) already avoids this issue by accepting credentials as `inputs`, not referencing `secrets` directly

## Testing

- [ ] Workflow YAML syntax is valid
- [ ] Actual validation can only be confirmed by CI running successfully after merge

Link to Devin session: https://app.devin.ai/sessions/59c37d5afae04814afa3f96c447a28ab
Requested by: @davidkonigsberg