### PR TITLE
fix(ci): use env var for secrets check in seed.yml workflow_call

### DIFF
--- a/.github/workflows/seed.yml
+++ b/.github/workflows/seed.yml
@@ -866,11 +866,13 @@ jobs:
         uses: ./.github/actions/install
 
       - name: Log in to Docker Hub
-        if: ${{ secrets.DOCKER_USERNAME_PUBLIC_READONLY != '' }}
+        if: ${{ env.DOCKER_USERNAME != '' }}
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_USERNAME_PUBLIC_READONLY }}
           password: ${{ secrets.DOCKER_PASSWORD_PUBLIC_READONLY }}
+        env:
+          DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME_PUBLIC_READONLY }}
 
       - name: Clear stale Docker image cache
         run: rm -rf /tmp/docker-cache


### PR DESCRIPTION
## Description

Fixes the workflow validation error: `Unrecognized named-value: 'secrets'. Located at position 1 within expression: secrets.DOCKER_USERNAME_PUBLIC_READONLY != ''`

Ref: https://github.com/fern-api/fern/actions/runs/24091543554/workflow

## Changes Made

- Replaced `secrets.DOCKER_USERNAME_PUBLIC_READONLY` with `env.DOCKER_USERNAME` in the step's `if` condition for the benchmark job's Docker Hub login step
- Added an `env` block to pass the secret into an environment variable for the conditional check

### Why

`seed.yml` declares `workflow_call` as a trigger (line 14), making it a reusable workflow. GitHub Actions does not allow the `secrets` context in `if` expressions for reusable workflows. The `env` context is allowed, so we pass the secret through an env var as a proxy for the check.

Note: `secrets` references in `with:` (username/password) are unaffected — the restriction is specific to `if` expressions.

## Review Checklist

- [ ] Verify `env` on a step is evaluated before the step's `if` condition (this is the [documented GitHub Actions workaround](https://docs.github.com/en/actions/security-for-github-actions/security-guides/using-secrets-in-github-actions#using-secrets-in-a-workflow))
- [ ] Confirm no other `secrets` usage in `if` conditions in this file

## Testing

- [ ] CI workflow file validation should pass (was previously failing)

Link to Devin session: https://app.devin.ai/sessions/0157d3dfd9254a91b9c1a31520025b61
Requested by: @Swimburger
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/14713" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
