### PR TITLE
fix(docs): remove hard restart of docs server on page changes

### DIFF
--- a/packages/cli/docs-preview/src/runAppPreviewServer.ts
+++ b/packages/cli/docs-preview/src/runAppPreviewServer.ts
@@ -681,7 +681,7 @@ export async function runAppPreviewServer({
 
     const additionalFilepaths = project.apiWorkspaces.flatMap((workspace) => workspace.getAbsoluteFilePaths());
 
-    // Create watcher but don't attach the event handler yet - we'll do that after restartNextJsServer is defined
+    // Create watcher but don't attach the event handler yet - we'll do that after the Next.js server starts
     const watcher = new Watcher([absoluteFilePathToFern, ...additionalFilepaths], {
         recursive: true,
         ignoreInitial: true,
@@ -800,46 +800,10 @@ export async function runAppPreviewServer({
         });
     };
 
-    // Function to stop the current Next.js server
-    const stopNextJsServer = (): Promise<void> => {
-        return new Promise((resolve) => {
-            if (serverProcess == null || serverProcess.killed) {
-                resolve();
-                return;
-            }
-
-            context.logger.debug(`Killing server process with PID: ${serverProcess.pid}`);
-            try {
-                serverProcess.kill();
-                // Give it a moment to clean up
-                setTimeout(() => {
-                    if (serverProcess != null && !serverProcess.killed) {
-                        context.logger.debug(`Force killing server process with PID: ${serverProcess.pid}`);
-                        try {
-                            serverProcess.kill("SIGKILL");
-                        } catch (err) {
-                            context.logger.error(`Failed to force kill server process: ${err}`);
-                        }
-                    }
-                    resolve();
-                }, 1000);
-            } catch (err) {
-                context.logger.error(`Failed to kill server process: ${err}`);
-                resolve();
-            }
-        });
-    };
-
-    // Function to restart the Next.js server
-    const restartNextJsServer = async (): Promise<void> => {
-        await stopNextJsServer();
-        await startNextJsServer();
-    };
-
     // Start the initial server
     await startNextJsServer();
 
-    // Now that restartNextJsServer is defined, attach the watcher event handler
+    // Attach the watcher event handler
     // eslint-disable-next-line @typescript-eslint/no-misused-promises
     watcher.on("all", async (event: string, targetPath: string, _targetPathNext: string) => {
         // Ignore changes to .fern/logs/ directory (contains debug logs)
@@ -882,20 +846,12 @@ export async function runAppPreviewServer({
 
                 editedAbsoluteFilepaths.length = 0;
 
-                // Restart the docs server
-                context.logger.info("Restarting docs server...");
-                await restartNextJsServer();
-
-                // Wait 1 second for the server to be ready
-                await new Promise((resolve) => setTimeout(resolve, 1000));
-
-                context.logger.info("Refreshing page. Please refresh manually if you don't see changes.");
+                isReloading = false;
 
                 sendData({
                     version: 1,
                     type: "finishReload"
                 });
-                isReloading = false;
 
                 if (reloadedDocsDefinition != null) {
                     // Detect slug changes before updating the docs definition


### PR DESCRIPTION
## Description

Removes the hard server restart from `fern docs dev` when files change. Hot reload via WebSocket (`startReload`/`finishReload` messages) handles updates now, making the full stop→start cycle unnecessary.

## Changes Made

- Removed `stopNextJsServer` and `restartNextJsServer` functions
- Removed the `await restartNextJsServer()` call and 1-second wait from the file watcher handler
- The watcher still reloads the docs definition and sends WebSocket reload events to the frontend — only the Next.js process restart is removed
- Updated stale comments referencing `restartNextJsServer`

## Human Review Checklist

- [ ] Verify that hot reload via WebSocket is sufficient — no cases where a full server restart is still needed (e.g. `docs.yml` navigation changes, new API specs)
- [ ] Note: `isReloading = false` is now set _before_ `sendData({ type: "finishReload" })` instead of after — confirm this ordering is acceptable (a new watcher event could technically start processing slightly earlier, but the debounce should prevent issues)
- [ ] `cleanup()` function directly kills `serverProcess` and does not use `stopNextJsServer`, so shutdown behavior is unaffected

## Testing

- [ ] Manual testing: run `fern docs dev`, edit a page, and confirm hot reload works without a server restart

Link to Devin session: https://app.devin.ai/sessions/0a8fa7b96c4a4c01bc06d7afcdbaf868
Requested by: @thesandlord
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/14715" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
