### PR TITLE
chore(ci): add hourly docs dev stability test

### DIFF
--- a/.github/workflows/docs-dev-stability.yml
+++ b/.github/workflows/docs-dev-stability.yml
@@ -56,7 +56,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: docs-dev-server-log
-          path: /tmp/*/server.log
+          path: /tmp/docs-dev-server-log/server.log
           retention-days: 7
           if-no-files-found: ignore
 

--- a/.github/workflows/docs-dev-stability.yml
+++ b/.github/workflows/docs-dev-stability.yml
@@ -59,3 +59,15 @@ jobs:
           path: /tmp/*/server.log
           retention-days: 7
           if-no-files-found: ignore
+
+      - name: Notify #docs-notifs on failure
+        if: failure()
+        uses: slackapi/slack-github-action@v3
+        with:
+          method: chat.postMessage
+          token: ${{ secrets.FERNIE_SLACK_APP_TOKEN }}
+          payload: |
+            {
+              "channel": "#docs-notifs",
+              "text": "*Docs Dev Stability Test failed* :warning:\n\nThe hourly `fern docs dev` stability test detected an issue (process leak, disk growth, or server crash).\n\n<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View workflow run>"
+            }

--- a/.github/workflows/docs-dev-stability.yml
+++ b/.github/workflows/docs-dev-stability.yml
@@ -1,0 +1,61 @@
+name: Docs Dev Stability Test
+
+on:
+  schedule:
+    # Run every hour
+    - cron: "0 * * * *"
+  workflow_dispatch:
+    inputs:
+      cycles:
+        description: "Number of edit/check cycles to run"
+        required: false
+        default: "10"
+        type: string
+      cycle_delay:
+        description: "Seconds to wait between mutations"
+        required: false
+        default: "5"
+        type: string
+
+concurrency:
+  group: docs-dev-stability
+  cancel-in-progress: true
+
+env:
+  DO_NOT_TRACK: "1"
+  TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+  TURBO_TEAM: "buildwithfern"
+  TURBO_NO_UPDATE_NOTIFIER: "1"
+  TURBO_DAEMON: "false"
+
+jobs:
+  stability-test:
+    if: github.repository == 'fern-api/fern'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v6
+
+      - name: Install
+        uses: ./.github/actions/install
+
+      - name: Build CLI
+        run: pnpm turbo run dist:cli:dev --filter=@fern-api/cli
+
+      - name: Run docs dev stability test
+        env:
+          FERN_TOKEN: ${{ secrets.FERN_ORG_TOKEN_DEV }}
+        run: |
+          CYCLES="${{ github.event.inputs.cycles || '10' }}"
+          CYCLE_DELAY="${{ github.event.inputs.cycle_delay || '5' }}"
+          bash scripts/docs-dev-stability-test.sh --cycles "$CYCLES" --cycle-delay "$CYCLE_DELAY"
+
+      - name: Upload server log on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: docs-dev-server-log
+          path: /tmp/*/server.log
+          retention-days: 7
+          if-no-files-found: ignore

--- a/scripts/docs-dev-stability-test.sh
+++ b/scripts/docs-dev-stability-test.sh
@@ -1,0 +1,292 @@
+#!/usr/bin/env bash
+#
+# docs-dev-stability-test.sh
+#
+# Long-running stability test for `fern docs dev`.
+# Starts the dev server, then simulates repeated doc changes (add/modify/delete)
+# while checking that:
+#   1. No duplicate server processes are spawned
+#   2. Disk usage does not grow unboundedly
+#   3. The server remains responsive
+#
+# Usage: ./scripts/docs-dev-stability-test.sh [--cycles N] [--cycle-delay SECONDS]
+#
+# Environment:
+#   CLI_PATH  - path to the built Fern CLI (default: packages/cli/cli/dist/dev/cli.cjs)
+#   FERN_TOKEN - auth token (optional, for authenticated fixtures)
+
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+CYCLES=10
+CYCLE_DELAY=5
+BACKEND_PORT=48200
+SERVER_STARTUP_TIMEOUT=120
+DISK_GROWTH_THRESHOLD_KB=102400  # 100 MB
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --cycles) CYCLES="$2"; shift 2 ;;
+        --cycle-delay) CYCLE_DELAY="$2"; shift 2 ;;
+        *) echo "Unknown option: $1"; exit 1 ;;
+    esac
+done
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+CLI_PATH="${CLI_PATH:-$REPO_ROOT/packages/cli/cli/dist/dev/cli.cjs}"
+FIXTURE_SRC="$REPO_ROOT/packages/cli/ete-tests/src/tests/docs-dev/fixtures/simple/fern"
+
+# Create an isolated working directory so we don't pollute the repo
+WORK_DIR="$(mktemp -d)"
+FERN_DIR="$WORK_DIR/fern"
+trap 'cleanup' EXIT
+
+SERVER_PID=""
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+cleanup() {
+    echo ""
+    echo "=== Cleaning up ==="
+    if [[ -n "$SERVER_PID" ]] && kill -0 "$SERVER_PID" 2>/dev/null; then
+        kill "$SERVER_PID" 2>/dev/null || true
+        # Give it a moment, then force kill
+        sleep 2
+        kill -9 "$SERVER_PID" 2>/dev/null || true
+    fi
+    rm -rf "$WORK_DIR"
+    echo "Cleanup complete."
+}
+
+fail() {
+    echo "FAIL: $1" >&2
+    exit 1
+}
+
+pass() {
+    echo "PASS: $1"
+}
+
+# Wait for the backend to respond to the load-with-url endpoint
+wait_for_server() {
+    local url="http://localhost:${BACKEND_PORT}/v2/registry/docs/load-with-url"
+    local elapsed=0
+    echo "Waiting for server to start on port $BACKEND_PORT (timeout: ${SERVER_STARTUP_TIMEOUT}s)..."
+    while [[ $elapsed -lt $SERVER_STARTUP_TIMEOUT ]]; do
+        if curl -sf -X POST "$url" -o /dev/null 2>/dev/null; then
+            echo "Server is ready after ${elapsed}s."
+            return 0
+        fi
+        sleep 2
+        elapsed=$((elapsed + 2))
+    done
+    fail "Server did not start within ${SERVER_STARTUP_TIMEOUT}s"
+}
+
+# Check the server still responds with a valid JSON body
+check_server_health() {
+    local url="http://localhost:${BACKEND_PORT}/v2/registry/docs/load-with-url"
+    local response
+    response=$(curl -sf -X POST "$url" 2>/dev/null) || fail "Server health check failed - no response"
+
+    # Verify it's valid JSON with expected keys
+    echo "$response" | node -e "
+        const data = JSON.parse(require('fs').readFileSync('/dev/stdin', 'utf8'));
+        const keys = Object.keys(data).sort();
+        const expected = ['baseUrl', 'definition', 'lightModeEnabled', 'orgId'];
+        if (JSON.stringify(keys) !== JSON.stringify(expected)) {
+            console.error('Unexpected response keys:', keys);
+            process.exit(1);
+        }
+    " || fail "Server returned invalid response"
+}
+
+# Count how many node processes are running the CLI server
+count_server_processes() {
+    # Count node processes whose command line contains our CLI path and "docs dev"
+    local count
+    count=$(ps aux | grep -E "node.*cli\.cjs.*docs" | grep -v grep | wc -l)
+    echo "$count"
+}
+
+# Get disk usage of the working directory in KB
+get_disk_usage_kb() {
+    du -sk "$WORK_DIR" 2>/dev/null | awk '{print $1}'
+}
+
+# ---------------------------------------------------------------------------
+# Setup
+# ---------------------------------------------------------------------------
+
+echo "=== Docs Dev Stability Test ==="
+echo "Cycles:        $CYCLES"
+echo "Cycle delay:   ${CYCLE_DELAY}s"
+echo "Backend port:  $BACKEND_PORT"
+echo "CLI path:      $CLI_PATH"
+echo "Work dir:      $WORK_DIR"
+echo ""
+
+# Verify CLI exists
+if [[ ! -f "$CLI_PATH" ]]; then
+    fail "CLI not found at $CLI_PATH. Build it first with: pnpm turbo run dist:cli:dev --filter=@fern-api/cli"
+fi
+
+# Copy fixture to working directory
+echo "Copying fixture to $WORK_DIR ..."
+cp -r "$FIXTURE_SRC" "$FERN_DIR"
+
+# Record baseline disk usage
+BASELINE_DISK_KB=$(get_disk_usage_kb)
+echo "Baseline disk usage: ${BASELINE_DISK_KB} KB"
+
+# ---------------------------------------------------------------------------
+# Start the server
+# ---------------------------------------------------------------------------
+
+echo ""
+echo "=== Starting fern docs dev ==="
+cd "$WORK_DIR"
+
+FERN_NO_VERSION_REDIRECTION=true node --enable-source-maps "$CLI_PATH" \
+    docs dev --backend-port "$BACKEND_PORT" \
+    > "$WORK_DIR/server.log" 2>&1 &
+SERVER_PID=$!
+
+echo "Server started with PID $SERVER_PID"
+
+# Wait for server to be ready
+wait_for_server
+
+# Initial health check
+check_server_health
+pass "Initial server health check"
+
+# Record process count after startup
+INITIAL_PROCESS_COUNT=$(count_server_processes)
+echo "Initial server process count: $INITIAL_PROCESS_COUNT"
+
+# ---------------------------------------------------------------------------
+# Run stability cycles
+# ---------------------------------------------------------------------------
+
+echo ""
+echo "=== Running $CYCLES stability cycles ==="
+
+for ((i = 1; i <= CYCLES; i++)); do
+    echo ""
+    echo "--- Cycle $i/$CYCLES ---"
+
+    # Verify server process is still alive
+    if ! kill -0 "$SERVER_PID" 2>/dev/null; then
+        fail "Server process (PID $SERVER_PID) died before cycle $i"
+    fi
+
+    # --- Mutation 1: Modify an existing file ---
+    echo "  [modify] Updating foo.md ..."
+    cat > "$FERN_DIR/foo.md" <<EOF
+# Hello from cycle $i
+
+This content was updated during stability test cycle $i.
+
+Some additional content to make the file a bit larger.
+EOF
+
+    sleep "$CYCLE_DELAY"
+
+    # --- Mutation 2: Add a new page ---
+    echo "  [add] Creating new-page-$i.md ..."
+    cat > "$FERN_DIR/new-page-$i.md" <<EOF
+# New Page $i
+
+This page was added during stability test cycle $i.
+EOF
+
+    sleep "$CYCLE_DELAY"
+
+    # --- Mutation 3: Delete the page we just added (after cycle 1) ---
+    if [[ $i -gt 1 ]]; then
+        local_prev=$((i - 1))
+        if [[ -f "$FERN_DIR/new-page-$local_prev.md" ]]; then
+            echo "  [delete] Removing new-page-$local_prev.md ..."
+            rm -f "$FERN_DIR/new-page-$local_prev.md"
+            sleep "$CYCLE_DELAY"
+        fi
+    fi
+
+    # --- Check 1: Server still alive ---
+    if ! kill -0 "$SERVER_PID" 2>/dev/null; then
+        echo ""
+        echo "=== Server log tail ==="
+        tail -50 "$WORK_DIR/server.log" || true
+        fail "Server process died during cycle $i"
+    fi
+    pass "Cycle $i: Server process alive"
+
+    # --- Check 2: Server still responds correctly ---
+    check_server_health
+    pass "Cycle $i: Server health check"
+
+    # --- Check 3: No duplicate processes ---
+    CURRENT_PROCESS_COUNT=$(count_server_processes)
+    echo "  Process count: $CURRENT_PROCESS_COUNT (initial: $INITIAL_PROCESS_COUNT)"
+    if [[ "$CURRENT_PROCESS_COUNT" -gt $((INITIAL_PROCESS_COUNT + 2)) ]]; then
+        echo ""
+        echo "=== Process list ==="
+        ps aux | grep -E "node.*cli\.cjs" | grep -v grep || true
+        fail "Cycle $i: Process count grew from $INITIAL_PROCESS_COUNT to $CURRENT_PROCESS_COUNT (possible process leak)"
+    fi
+    pass "Cycle $i: No duplicate processes"
+
+    # --- Check 4: Disk usage not growing unboundedly ---
+    CURRENT_DISK_KB=$(get_disk_usage_kb)
+    DISK_GROWTH_KB=$((CURRENT_DISK_KB - BASELINE_DISK_KB))
+    echo "  Disk usage: ${CURRENT_DISK_KB} KB (growth: ${DISK_GROWTH_KB} KB, threshold: ${DISK_GROWTH_THRESHOLD_KB} KB)"
+    if [[ "$DISK_GROWTH_KB" -gt "$DISK_GROWTH_THRESHOLD_KB" ]]; then
+        echo ""
+        echo "=== Disk usage breakdown ==="
+        du -sh "$WORK_DIR"/* 2>/dev/null || true
+        fail "Cycle $i: Disk usage grew by ${DISK_GROWTH_KB} KB (exceeds threshold of ${DISK_GROWTH_THRESHOLD_KB} KB)"
+    fi
+    pass "Cycle $i: Disk usage within bounds"
+done
+
+# ---------------------------------------------------------------------------
+# Final checks
+# ---------------------------------------------------------------------------
+
+echo ""
+echo "=== Final checks ==="
+
+# Clean up the last added page
+if [[ -f "$FERN_DIR/new-page-$CYCLES.md" ]]; then
+    rm -f "$FERN_DIR/new-page-$CYCLES.md"
+fi
+
+# Restore foo.md
+cat > "$FERN_DIR/foo.md" <<EOF
+# hi
+EOF
+
+sleep "$CYCLE_DELAY"
+
+# Final health check
+check_server_health
+pass "Final server health check"
+
+# Final process count
+FINAL_PROCESS_COUNT=$(count_server_processes)
+echo "Final process count: $FINAL_PROCESS_COUNT (initial: $INITIAL_PROCESS_COUNT)"
+
+# Final disk usage
+FINAL_DISK_KB=$(get_disk_usage_kb)
+FINAL_GROWTH_KB=$((FINAL_DISK_KB - BASELINE_DISK_KB))
+echo "Final disk usage: ${FINAL_DISK_KB} KB (total growth: ${FINAL_GROWTH_KB} KB)"
+
+echo ""
+echo "=== All $CYCLES stability cycles passed ==="
+echo "Server remained stable through $CYCLES cycles of doc modifications."
+exit 0

--- a/scripts/docs-dev-stability-test.sh
+++ b/scripts/docs-dev-stability-test.sh
@@ -44,6 +44,7 @@ FERN_DIR="$WORK_DIR/fern"
 trap 'cleanup' EXIT
 
 SERVER_PID=""
+EXIT_CODE=0
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -58,12 +59,20 @@ cleanup() {
         sleep 2
         kill -9 "$SERVER_PID" 2>/dev/null || true
     fi
+    # On failure, preserve server.log so the CI workflow can upload it as an artifact
+    if [[ "$EXIT_CODE" -ne 0 ]] && [[ -f "$WORK_DIR/server.log" ]]; then
+        local log_dest="/tmp/docs-dev-server-log"
+        mkdir -p "$log_dest"
+        cp "$WORK_DIR/server.log" "$log_dest/server.log"
+        echo "Server log preserved at $log_dest/server.log"
+    fi
     rm -rf "$WORK_DIR"
     echo "Cleanup complete."
 }
 
 fail() {
     echo "FAIL: $1" >&2
+    EXIT_CODE=1
     exit 1
 }
 


### PR DESCRIPTION
## Description

Adds an automated, long-running stability test for `fern docs dev` that runs on an hourly cron. This addresses concerns about potential regressions where the dev server could leak processes, accumulate disk usage, or crash during repeated doc editing sessions.

On failure, the workflow posts an alert to `#docs-notifs` via Slack.

## Changes Made

- **New workflow** (`.github/workflows/docs-dev-stability.yml`): Hourly cron job (also manually dispatchable with configurable cycle count/delay) that builds the dev CLI and runs the stability script. On failure, uploads server logs as an artifact and sends a Slack alert to `#docs-notifs` using the same `slackapi/slack-github-action@v3` + `FERNIE_SLACK_APP_TOKEN` pattern used in fern-platform.
- **New script** (`scripts/docs-dev-stability-test.sh`): Bash script that:
  1. Copies the existing `simple` docs-dev fixture to a temp directory
  2. Starts `fern docs dev` in the background
  3. Runs N cycles (default 10) of file mutations (modify, add, delete `.md` files)
  4. After each cycle, asserts: server process alive, health endpoint returns valid JSON, no process count leak (tolerance: +2), disk growth under 100 MB threshold
  5. On failure, preserves `server.log` to a stable path (`/tmp/docs-dev-server-log/`) before cleaning up the temp dir, so the workflow can upload it as an artifact
  6. Cleans up server process and temp dir on exit

## Things for reviewers to check

- **`FERNIE_SLACK_APP_TOKEN` secret**: This secret is used in `fern-platform` workflows. Verify it is also available in the `fern` repo, or the Slack notification step will silently fail.
- **`APP_DOCS_TAR_PREVIEW_BUCKET` / `APP_DOCS_PREVIEW_BUCKET` env vars**: The `runAppPreviewServer` code requires these to download the docs bundle. They are **not set** in the workflow — the server will likely fail to start without them. We may need to add these as secrets or use `--legacy` mode which uses `DOCS_PREVIEW_BUCKET` instead.
- **Process counting heuristic**: Uses `ps aux | grep -E "node.*cli\.cjs.*docs"` — may be fragile in CI depending on the actual process tree. Worth verifying after first run.
- **File mutations are content-only**: The test modifies/adds/deletes `.md` files but does not touch `docs.yml` navigation config. This tests the file watcher reload path but not config-change scenarios.

## Testing

- [x] Lint and format checks pass (`pnpm format:check`, `pnpm check:biome`)
- [x] Script tested locally (3 cycles) — all assertions passed, process count stable at 1, disk growth 4 KB
- [ ] Not yet run end-to-end in CI — first hourly run will be the real validation (or trigger manually via `workflow_dispatch`)

Link to Devin session: https://app.devin.ai/sessions/107f7921f3894cf6abb9381c1dc847be
Requested by: @thesandlord
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/14716" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
