### PR TITLE
fix(cli): add .gitattributes creation and sync .fernignore entries with fern-replay

### DIFF
--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -1,5 +1,13 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 
+- version: 4.62.5
+  changelogEntry:
+    - summary: |
+        Fix replay init to create .gitattributes with linguist-generated markers and sync .fernignore entries with fern-replay.
+      type: fix
+  createdAt: "2026-04-07"
+  irVersion: 66
+
 - version: 4.62.4
   changelogEntry:
     - summary: |

--- a/packages/generator-cli/src/__test__/replay-pure.test.ts
+++ b/packages/generator-cli/src/__test__/replay-pure.test.ts
@@ -396,7 +396,9 @@ describe("parseCommitMessageForPR", () => {
 describe("fernignore", () => {
     it("REPLAY_FERNIGNORE_ENTRIES contains expected values", () => {
         expect(REPLAY_FERNIGNORE_ENTRIES).toContain(".fern/replay.lock");
-        expect(REPLAY_FERNIGNORE_ENTRIES.length).toBeGreaterThanOrEqual(1);
+        expect(REPLAY_FERNIGNORE_ENTRIES).toContain(".fern/replay.yml");
+        expect(REPLAY_FERNIGNORE_ENTRIES).toContain(".gitattributes");
+        expect(REPLAY_FERNIGNORE_ENTRIES.length).toBeGreaterThanOrEqual(3);
     });
 
     it("creates .fernignore with entries when no file exists, returns true", async () => {

--- a/packages/generator-cli/src/replay/fernignore.ts
+++ b/packages/generator-cli/src/replay/fernignore.ts
@@ -2,7 +2,9 @@ import { existsSync, readFileSync, writeFileSync } from "fs";
 import { readFile, writeFile } from "fs/promises";
 import { join } from "path";
 
-export const REPLAY_FERNIGNORE_ENTRIES = [".fern/replay.lock"];
+export const REPLAY_FERNIGNORE_ENTRIES = [".fern/replay.lock", ".fern/replay.yml", ".gitattributes"];
+
+const GITATTRIBUTES_ENTRIES = [".fern/replay.lock linguist-generated=true"];
 
 export async function ensureReplayFernignoreEntries(outputDir: string): Promise<boolean> {
     const fernignorePath = join(outputDir, ".fernignore");
@@ -22,6 +24,22 @@ export async function ensureReplayFernignoreEntries(outputDir: string): Promise<
     return false;
 }
 
+export async function ensureGitattributesEntries(outputDir: string): Promise<void> {
+    const gitattributesPath = join(outputDir, ".gitattributes");
+    let content = "";
+    try {
+        content = await readFile(gitattributesPath, "utf-8");
+    } catch {
+        // .gitattributes doesn't exist yet
+    }
+    const lines = content.split("\n");
+    const toAdd = GITATTRIBUTES_ENTRIES.filter((entry) => !lines.some((line) => line.trim() === entry));
+    if (toAdd.length > 0) {
+        const suffix = content.length > 0 && !content.endsWith("\n") ? "\n" : "";
+        await writeFile(gitattributesPath, content + suffix + toAdd.join("\n") + "\n", "utf-8");
+    }
+}
+
 export function ensureReplayFernignoreEntriesSync(outputDir: string): void {
     const fernignorePath = join(outputDir, ".fernignore");
     let content = "";
@@ -33,5 +51,19 @@ export function ensureReplayFernignoreEntriesSync(outputDir: string): void {
     if (toAdd.length > 0) {
         const suffix = content.length > 0 && !content.endsWith("\n") ? "\n" : "";
         writeFileSync(fernignorePath, content + suffix + toAdd.join("\n") + "\n", "utf-8");
+    }
+}
+
+export function ensureGitattributesEntriesSync(outputDir: string): void {
+    const gitattributesPath = join(outputDir, ".gitattributes");
+    let content = "";
+    if (existsSync(gitattributesPath)) {
+        content = readFileSync(gitattributesPath, "utf-8");
+    }
+    const lines = content.split("\n");
+    const toAdd = GITATTRIBUTES_ENTRIES.filter((entry) => !lines.some((line) => line.trim() === entry));
+    if (toAdd.length > 0) {
+        const suffix = content.length > 0 && !content.endsWith("\n") ? "\n" : "";
+        writeFileSync(gitattributesPath, content + suffix + toAdd.join("\n") + "\n", "utf-8");
     }
 }

--- a/packages/generator-cli/src/replay/replay-init.ts
+++ b/packages/generator-cli/src/replay/replay-init.ts
@@ -3,7 +3,11 @@ import { type BootstrapResult, bootstrap } from "@fern-api/replay";
 import { existsSync, readFileSync } from "fs";
 import { join } from "path";
 import tmp from "tmp-promise";
-import { ensureGitattributesEntriesSync, ensureReplayFernignoreEntriesSync, REPLAY_FERNIGNORE_ENTRIES } from "./fernignore";
+import {
+    ensureGitattributesEntriesSync,
+    ensureReplayFernignoreEntriesSync,
+    REPLAY_FERNIGNORE_ENTRIES
+} from "./fernignore";
 
 export interface ReplayInitParams {
     /** GitHub repo URI (e.g., "fern-demo/fern-replay-testbed-java-sdk") */

--- a/packages/generator-cli/src/replay/replay-init.ts
+++ b/packages/generator-cli/src/replay/replay-init.ts
@@ -3,7 +3,7 @@ import { type BootstrapResult, bootstrap } from "@fern-api/replay";
 import { existsSync, readFileSync } from "fs";
 import { join } from "path";
 import tmp from "tmp-promise";
-import { ensureReplayFernignoreEntriesSync, REPLAY_FERNIGNORE_ENTRIES } from "./fernignore";
+import { ensureGitattributesEntriesSync, ensureReplayFernignoreEntriesSync, REPLAY_FERNIGNORE_ENTRIES } from "./fernignore";
 
 export interface ReplayInitParams {
     /** GitHub repo URI (e.g., "fern-demo/fern-replay-testbed-java-sdk") */
@@ -74,8 +74,9 @@ export async function replayInit(params: ReplayInitParams): Promise<ReplayInitRe
         return { bootstrap: bootstrapResult, fernignoreEntries: [] };
     }
 
-    // 3. Ensure .fernignore has replay entries
+    // 3. Ensure .fernignore has replay entries and .gitattributes marks lockfile as generated
     ensureReplayFernignoreEntriesSync(repoPath);
+    ensureGitattributesEntriesSync(repoPath);
 
     // 4. Read lockfile content from disk
     const lockfilePath = join(repoPath, ".fern", "replay.lock");

--- a/packages/generator-cli/src/replay/replay-run.ts
+++ b/packages/generator-cli/src/replay/replay-run.ts
@@ -3,7 +3,7 @@ import { execFileSync } from "child_process";
 import { existsSync } from "fs";
 import { join } from "path";
 import type { PipelineLogger } from "../pipeline/PipelineLogger";
-import { ensureReplayFernignoreEntries } from "./fernignore";
+import { ensureGitattributesEntries, ensureReplayFernignoreEntries } from "./fernignore";
 
 export interface ReplayRunParams {
     outputDir: string;
@@ -157,6 +157,7 @@ export async function replayRun(params: ReplayRunParams): Promise<ReplayRunResul
     }
 
     const fernignoreUpdated = await ensureReplayFernignoreEntries(outputDir);
+    await ensureGitattributesEntries(outputDir);
 
     return {
         report,

--- a/packages/generator-cli/versions.yml
+++ b/packages/generator-cli/versions.yml
@@ -1,6 +1,13 @@
 # yaml-language-server: $schema=../../versions-yml.schema.json
 - changelogEntry:
     - summary: |
+        Add .gitattributes with linguist-generated markers for replay lockfile. Sync .fernignore entries with fern-replay to include .fern/replay.yml and .gitattributes.
+      type: fix
+  createdAt: "2026-04-07"
+  version: 0.9.3
+
+- changelogEntry:
+    - summary: |
         Re-publish to include Go SDK after upgrading fern-go-sdk from 0.22.0 to 1.33.2.
       type: chore
   createdAt: "2026-04-07"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -37,8 +37,8 @@ catalogs:
       specifier: 0.0.6-2ee1b7e28
       version: 0.0.6-2ee1b7e28
     '@fern-api/generator-cli':
-      specifier: 0.9.1
-      version: 0.9.1
+      specifier: 0.9.2
+      version: 0.9.2
     '@fern-api/venus-api-sdk':
       specifier: 0.17.3-3-gf696595
       version: 0.17.3-3-gf696595
@@ -657,7 +657,7 @@ importers:
         version: link:packages/configs
       '@fern-api/generator-cli':
         specifier: 'catalog:'
-        version: 0.9.1
+        version: 0.9.2
       '@rolldown/binding-darwin-arm64':
         specifier: 'catalog:'
         version: 1.0.0-rc.5
@@ -723,7 +723,7 @@ importers:
         version: link:../../packages/commons/fs-utils
       '@fern-api/generator-cli':
         specifier: 'catalog:'
-        version: 0.9.1
+        version: 0.9.2
       '@fern-api/ir-sdk':
         specifier: workspace:*
         version: link:../../packages/ir-sdk
@@ -2451,7 +2451,7 @@ importers:
         version: link:../../../packages/commons/fs-utils
       '@fern-api/generator-cli':
         specifier: 'catalog:'
-        version: 0.9.1
+        version: 0.9.2
       '@fern-api/logger':
         specifier: workspace:*
         version: link:../../../packages/cli/logger
@@ -9353,8 +9353,8 @@ packages:
   '@fern-api/fdr-sdk@0.145.12-b50d999d1':
     resolution: {integrity: sha512-qTHoosyHoHFqXM/ZcHjdiAw5tByBo1mxcfMLkId9qZ4LRSw/hJmybQEa00k7dstirNnG5DvBta6Kwq74F8NfjQ==}
 
-  '@fern-api/generator-cli@0.9.1':
-    resolution: {integrity: sha512-FT/xhmlUt1BK/Jg/bUtYnvJiigLNZzb5j/Or07byAGDewKJNRaVetMPUT07zTIKgncqaORkYrHAP2JzddzA8Vw==}
+  '@fern-api/generator-cli@0.9.2':
+    resolution: {integrity: sha512-RnXUAs1Y/NjALKbiAtiVvXr0V5kAmHnOJ2PmiPUgfpTWUivId9eevqpX79f2mZXAwntVMioAEd52X1JL0mxsZQ==}
     hasBin: true
 
   '@fern-api/logger@0.4.24-rc1':
@@ -16285,7 +16285,7 @@ snapshots:
       - encoding
       - typescript
 
-  '@fern-api/generator-cli@0.9.1':
+  '@fern-api/generator-cli@0.9.2':
     dependencies:
       '@fern-api/replay': 0.9.1
       '@octokit/rest': 22.0.1

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -61,7 +61,7 @@ catalog:
   "@fern-api/docs-parsers": 0.0.65
   "@fern-api/fai-sdk": 0.0.6-2ee1b7e28
   "@fern-api/fdr-sdk": 1.1.13-c1ad12a2b8
-  "@fern-api/generator-cli": 0.9.3
+  "@fern-api/generator-cli": 0.9.2
   "@fern-api/ui-core-utils": 0.129.4-b6c699ad2
   "@fern-api/venus-api-sdk": 0.17.3-3-gf696595
   "@fern-fern/docs-config": 0.0.80

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -61,7 +61,7 @@ catalog:
   "@fern-api/docs-parsers": 0.0.65
   "@fern-api/fai-sdk": 0.0.6-2ee1b7e28
   "@fern-api/fdr-sdk": 1.1.13-c1ad12a2b8
-  "@fern-api/generator-cli": 0.9.1
+  "@fern-api/generator-cli": 0.9.3
   "@fern-api/ui-core-utils": 0.129.4-b6c699ad2
   "@fern-api/venus-api-sdk": 0.17.3-3-gf696595
   "@fern-fern/docs-config": 0.0.80


### PR DESCRIPTION
## Summary
- Sync `REPLAY_FERNIGNORE_ENTRIES` in generator-cli with fern-replay to include `.fern/replay.yml` and `.gitattributes`
- Add `.gitattributes` creation with `linguist-generated=true` markers for `.fern/replay.lock` in both `replay-init` and `replay-run` paths
- Bump generator-cli to `0.9.3`, CLI to `4.62.5`

## Context
generator-cli's fernignore entries were out of sync with fern-replay — only `[".fern/replay.lock"]` vs the full `[".fern/replay.lock", ".fern/replay.yml", ".gitattributes"]`. This caused `fern replay init` PRs (e.g. https://github.com/Frameio/python-sdk/pull/6) to miss `.gitattributes` (linguist-generated markers) and `.fern/replay.yml` protection.

## Test plan
- [x] `pnpm turbo run compile --filter @fern-api/generator-cli` passes
- [x] `pnpm turbo run test --filter @fern-api/generator-cli` — 145 tests pass
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)