### PR TITLE
feat(swift): generate Version.swift with sdkVersion constant

### DIFF
--- a/generators/swift/sdk/src/SdkGeneratorCli.ts
+++ b/generators/swift/sdk/src/SdkGeneratorCli.ts
@@ -172,6 +172,7 @@ export class SdkGeneratorCLI extends AbstractSwiftGeneratorCli<SdkCustomConfigSc
         this.generateSourceSchemaFiles(context);
         this.generateSourceRootClientFile(context);
         this.generateSourceEnvironmentFile(context);
+        this.generateVersionFile(context);
     }
 
     private async generateSourceAsIsFiles(context: SdkGeneratorContext): Promise<void> {
@@ -574,6 +575,18 @@ export class SdkGeneratorCLI extends AbstractSwiftGeneratorCli<SdkCustomConfigSc
             directory: RelativeFilePath.of(""),
             contents: [rootClientClass]
         });
+    }
+
+    private generateVersionFile(context: SdkGeneratorContext): void {
+        const spmDetails = context.getSPMDetails();
+        const version = spmDetails.minVersion;
+        if (version != null) {
+            context.project.addSourceAsIsFile({
+                nameCandidateWithoutExtension: "Version",
+                directory: RelativeFilePath.of(""),
+                contents: `let sdkVersion = "${version}"\n`
+            });
+        }
     }
 
     private generateSourceEnvironmentFile(context: SdkGeneratorContext): void {

--- a/generators/swift/sdk/src/SdkGeneratorCli.ts
+++ b/generators/swift/sdk/src/SdkGeneratorCli.ts
@@ -584,7 +584,7 @@ export class SdkGeneratorCLI extends AbstractSwiftGeneratorCli<SdkCustomConfigSc
             context.project.addSourceAsIsFile({
                 nameCandidateWithoutExtension: "Version",
                 directory: RelativeFilePath.of(""),
-                contents: `let sdkVersion = "${version}"\n`
+                contents: `public let sdkVersion = "${version}"\n`
             });
         }
     }

--- a/generators/swift/sdk/versions.yml
+++ b/generators/swift/sdk/versions.yml
@@ -1,5 +1,16 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 
+- version: 0.30.1
+  changelogEntry:
+    - summary: |
+        Generate a `Version.swift` source file containing the SDK version
+        string. This embeds the version in the generated source code for
+        consistency with other generators and fixes auto-versioning for
+        Swift SDKs.
+      type: feat
+  createdAt: "2026-04-07"
+  irVersion: 61
+
 - version: 0.30.0
   changelogEntry:
     - summary: |

--- a/generators/swift/sdk/versions.yml
+++ b/generators/swift/sdk/versions.yml
@@ -1,6 +1,6 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 
-- version: 0.30.1
+- version: 0.31.0
   changelogEntry:
     - summary: |
         Generate a `Version.swift` source file containing the SDK version

--- a/seed/swift-sdk/accept-header/Sources/Version.swift
+++ b/seed/swift-sdk/accept-header/Sources/Version.swift
@@ -1,0 +1,1 @@
+public let sdkVersion = "0.0.1"

--- a/seed/swift-sdk/alias-extends/Sources/Version.swift
+++ b/seed/swift-sdk/alias-extends/Sources/Version.swift
@@ -1,0 +1,1 @@
+public let sdkVersion = "0.0.1"

--- a/seed/swift-sdk/alias/Sources/Version.swift
+++ b/seed/swift-sdk/alias/Sources/Version.swift
@@ -1,0 +1,1 @@
+public let sdkVersion = "0.0.1"

--- a/seed/swift-sdk/any-auth/Sources/Version.swift
+++ b/seed/swift-sdk/any-auth/Sources/Version.swift
@@ -1,0 +1,1 @@
+public let sdkVersion = "0.0.1"

--- a/seed/swift-sdk/api-wide-base-path/Sources/Version.swift
+++ b/seed/swift-sdk/api-wide-base-path/Sources/Version.swift
@@ -1,0 +1,1 @@
+public let sdkVersion = "0.0.1"

--- a/seed/swift-sdk/audiences/Sources/Version.swift
+++ b/seed/swift-sdk/audiences/Sources/Version.swift
@@ -1,0 +1,1 @@
+public let sdkVersion = "0.0.1"

--- a/seed/swift-sdk/basic-auth-environment-variables/Sources/Version.swift
+++ b/seed/swift-sdk/basic-auth-environment-variables/Sources/Version.swift
@@ -1,0 +1,1 @@
+public let sdkVersion = "0.0.1"

--- a/seed/swift-sdk/basic-auth-pw-omitted/Sources/Version.swift
+++ b/seed/swift-sdk/basic-auth-pw-omitted/Sources/Version.swift
@@ -1,0 +1,1 @@
+public let sdkVersion = "0.0.1"

--- a/seed/swift-sdk/basic-auth/Sources/Version.swift
+++ b/seed/swift-sdk/basic-auth/Sources/Version.swift
@@ -1,0 +1,1 @@
+public let sdkVersion = "0.0.1"

--- a/seed/swift-sdk/bearer-token-environment-variable/Sources/Version.swift
+++ b/seed/swift-sdk/bearer-token-environment-variable/Sources/Version.swift
@@ -1,0 +1,1 @@
+public let sdkVersion = "0.0.1"

--- a/seed/swift-sdk/bytes-download/Sources/Version.swift
+++ b/seed/swift-sdk/bytes-download/Sources/Version.swift
@@ -1,0 +1,1 @@
+public let sdkVersion = "0.0.1"

--- a/seed/swift-sdk/bytes-upload/Sources/Version.swift
+++ b/seed/swift-sdk/bytes-upload/Sources/Version.swift
@@ -1,0 +1,1 @@
+public let sdkVersion = "0.0.1"

--- a/seed/swift-sdk/circular-references-advanced/Sources/Version.swift
+++ b/seed/swift-sdk/circular-references-advanced/Sources/Version.swift
@@ -1,0 +1,1 @@
+public let sdkVersion = "0.0.1"

--- a/seed/swift-sdk/circular-references/Sources/Version.swift
+++ b/seed/swift-sdk/circular-references/Sources/Version.swift
@@ -1,0 +1,1 @@
+public let sdkVersion = "0.0.1"

--- a/seed/swift-sdk/client-side-params/no-custom-config/Sources/Version.swift
+++ b/seed/swift-sdk/client-side-params/no-custom-config/Sources/Version.swift
@@ -1,0 +1,1 @@
+public let sdkVersion = "0.0.1"

--- a/seed/swift-sdk/client-side-params/with-custom-config/Sources/Version.swift
+++ b/seed/swift-sdk/client-side-params/with-custom-config/Sources/Version.swift
@@ -1,0 +1,1 @@
+public let sdkVersion = "0.0.1"

--- a/seed/swift-sdk/content-type/Sources/Version.swift
+++ b/seed/swift-sdk/content-type/Sources/Version.swift
@@ -1,0 +1,1 @@
+public let sdkVersion = "0.0.1"

--- a/seed/swift-sdk/cross-package-type-names/Sources/Version.swift
+++ b/seed/swift-sdk/cross-package-type-names/Sources/Version.swift
@@ -1,0 +1,1 @@
+public let sdkVersion = "0.0.1"

--- a/seed/swift-sdk/dollar-string-examples/Sources/Version.swift
+++ b/seed/swift-sdk/dollar-string-examples/Sources/Version.swift
@@ -1,0 +1,1 @@
+public let sdkVersion = "0.0.1"

--- a/seed/swift-sdk/empty-clients/Sources/Version.swift
+++ b/seed/swift-sdk/empty-clients/Sources/Version.swift
@@ -1,0 +1,1 @@
+public let sdkVersion = "0.0.1"

--- a/seed/swift-sdk/endpoint-security-auth/Sources/Version.swift
+++ b/seed/swift-sdk/endpoint-security-auth/Sources/Version.swift
@@ -1,0 +1,1 @@
+public let sdkVersion = "0.0.1"

--- a/seed/swift-sdk/enum/Sources/Version.swift
+++ b/seed/swift-sdk/enum/Sources/Version.swift
@@ -1,0 +1,1 @@
+public let sdkVersion = "0.0.1"

--- a/seed/swift-sdk/error-property/Sources/Version.swift
+++ b/seed/swift-sdk/error-property/Sources/Version.swift
@@ -1,0 +1,1 @@
+public let sdkVersion = "0.0.1"

--- a/seed/swift-sdk/errors/Sources/Version.swift
+++ b/seed/swift-sdk/errors/Sources/Version.swift
@@ -1,0 +1,1 @@
+public let sdkVersion = "0.0.1"

--- a/seed/swift-sdk/examples/no-custom-config/Sources/Version.swift
+++ b/seed/swift-sdk/examples/no-custom-config/Sources/Version.swift
@@ -1,0 +1,1 @@
+public let sdkVersion = "0.0.1"

--- a/seed/swift-sdk/examples/readme-config/Sources/Version.swift
+++ b/seed/swift-sdk/examples/readme-config/Sources/Version.swift
@@ -1,0 +1,1 @@
+public let sdkVersion = "0.0.1"

--- a/seed/swift-sdk/exhaustive/Sources/Version.swift
+++ b/seed/swift-sdk/exhaustive/Sources/Version.swift
@@ -1,0 +1,1 @@
+public let sdkVersion = "0.0.1"

--- a/seed/swift-sdk/extends/Sources/Version.swift
+++ b/seed/swift-sdk/extends/Sources/Version.swift
@@ -1,0 +1,1 @@
+public let sdkVersion = "0.0.1"

--- a/seed/swift-sdk/extra-properties/Sources/Version.swift
+++ b/seed/swift-sdk/extra-properties/Sources/Version.swift
@@ -1,0 +1,1 @@
+public let sdkVersion = "0.0.1"

--- a/seed/swift-sdk/file-download/Sources/Version.swift
+++ b/seed/swift-sdk/file-download/Sources/Version.swift
@@ -1,0 +1,1 @@
+public let sdkVersion = "0.0.1"

--- a/seed/swift-sdk/file-upload-openapi/Sources/Version.swift
+++ b/seed/swift-sdk/file-upload-openapi/Sources/Version.swift
@@ -1,0 +1,1 @@
+public let sdkVersion = "0.0.1"

--- a/seed/swift-sdk/file-upload/Sources/Version.swift
+++ b/seed/swift-sdk/file-upload/Sources/Version.swift
@@ -1,0 +1,1 @@
+public let sdkVersion = "0.0.1"

--- a/seed/swift-sdk/folders/Sources/Version.swift
+++ b/seed/swift-sdk/folders/Sources/Version.swift
@@ -1,0 +1,1 @@
+public let sdkVersion = "0.0.1"

--- a/seed/swift-sdk/header-auth-environment-variable/Sources/Version.swift
+++ b/seed/swift-sdk/header-auth-environment-variable/Sources/Version.swift
@@ -1,0 +1,1 @@
+public let sdkVersion = "0.0.1"

--- a/seed/swift-sdk/header-auth/Sources/Version.swift
+++ b/seed/swift-sdk/header-auth/Sources/Version.swift
@@ -1,0 +1,1 @@
+public let sdkVersion = "0.0.1"

--- a/seed/swift-sdk/http-head/Sources/Version.swift
+++ b/seed/swift-sdk/http-head/Sources/Version.swift
@@ -1,0 +1,1 @@
+public let sdkVersion = "0.0.1"

--- a/seed/swift-sdk/idempotency-headers/Sources/Version.swift
+++ b/seed/swift-sdk/idempotency-headers/Sources/Version.swift
@@ -1,0 +1,1 @@
+public let sdkVersion = "0.0.1"

--- a/seed/swift-sdk/imdb/Sources/Version.swift
+++ b/seed/swift-sdk/imdb/Sources/Version.swift
@@ -1,0 +1,1 @@
+public let sdkVersion = "0.0.1"

--- a/seed/swift-sdk/inferred-auth-explicit/Sources/Version.swift
+++ b/seed/swift-sdk/inferred-auth-explicit/Sources/Version.swift
@@ -1,0 +1,1 @@
+public let sdkVersion = "0.0.1"

--- a/seed/swift-sdk/inferred-auth-implicit-api-key/Sources/Version.swift
+++ b/seed/swift-sdk/inferred-auth-implicit-api-key/Sources/Version.swift
@@ -1,0 +1,1 @@
+public let sdkVersion = "0.0.1"

--- a/seed/swift-sdk/inferred-auth-implicit-no-expiry/Sources/Version.swift
+++ b/seed/swift-sdk/inferred-auth-implicit-no-expiry/Sources/Version.swift
@@ -1,0 +1,1 @@
+public let sdkVersion = "0.0.1"

--- a/seed/swift-sdk/inferred-auth-implicit-reference/Sources/Version.swift
+++ b/seed/swift-sdk/inferred-auth-implicit-reference/Sources/Version.swift
@@ -1,0 +1,1 @@
+public let sdkVersion = "0.0.1"

--- a/seed/swift-sdk/inferred-auth-implicit/Sources/Version.swift
+++ b/seed/swift-sdk/inferred-auth-implicit/Sources/Version.swift
@@ -1,0 +1,1 @@
+public let sdkVersion = "0.0.1"

--- a/seed/swift-sdk/license/Sources/Version.swift
+++ b/seed/swift-sdk/license/Sources/Version.swift
@@ -1,0 +1,1 @@
+public let sdkVersion = "0.0.1"

--- a/seed/swift-sdk/literals-unions/Sources/Version.swift
+++ b/seed/swift-sdk/literals-unions/Sources/Version.swift
@@ -1,0 +1,1 @@
+public let sdkVersion = "0.0.1"

--- a/seed/swift-sdk/mixed-case/Sources/Version.swift
+++ b/seed/swift-sdk/mixed-case/Sources/Version.swift
@@ -1,0 +1,1 @@
+public let sdkVersion = "0.0.1"

--- a/seed/swift-sdk/mixed-file-directory/Sources/Version.swift
+++ b/seed/swift-sdk/mixed-file-directory/Sources/Version.swift
@@ -1,0 +1,1 @@
+public let sdkVersion = "0.0.1"

--- a/seed/swift-sdk/multi-line-docs/Sources/Version.swift
+++ b/seed/swift-sdk/multi-line-docs/Sources/Version.swift
@@ -1,0 +1,1 @@
+public let sdkVersion = "0.0.1"

--- a/seed/swift-sdk/multi-url-environment-no-default/Sources/Version.swift
+++ b/seed/swift-sdk/multi-url-environment-no-default/Sources/Version.swift
@@ -1,0 +1,1 @@
+public let sdkVersion = "0.0.1"

--- a/seed/swift-sdk/multi-url-environment/Sources/Version.swift
+++ b/seed/swift-sdk/multi-url-environment/Sources/Version.swift
@@ -1,0 +1,1 @@
+public let sdkVersion = "0.0.1"

--- a/seed/swift-sdk/multiple-request-bodies/Sources/Version.swift
+++ b/seed/swift-sdk/multiple-request-bodies/Sources/Version.swift
@@ -1,0 +1,1 @@
+public let sdkVersion = "0.0.1"

--- a/seed/swift-sdk/no-content-response/Sources/Version.swift
+++ b/seed/swift-sdk/no-content-response/Sources/Version.swift
@@ -1,0 +1,1 @@
+public let sdkVersion = "0.0.1"

--- a/seed/swift-sdk/no-environment/Sources/Version.swift
+++ b/seed/swift-sdk/no-environment/Sources/Version.swift
@@ -1,0 +1,1 @@
+public let sdkVersion = "0.0.1"

--- a/seed/swift-sdk/no-retries/Sources/Version.swift
+++ b/seed/swift-sdk/no-retries/Sources/Version.swift
@@ -1,0 +1,1 @@
+public let sdkVersion = "0.0.1"

--- a/seed/swift-sdk/null-type/Sources/Version.swift
+++ b/seed/swift-sdk/null-type/Sources/Version.swift
@@ -1,0 +1,1 @@
+public let sdkVersion = "0.0.1"

--- a/seed/swift-sdk/nullable-allof-extends/Sources/Version.swift
+++ b/seed/swift-sdk/nullable-allof-extends/Sources/Version.swift
@@ -1,0 +1,1 @@
+public let sdkVersion = "0.0.1"

--- a/seed/swift-sdk/nullable-optional/no-custom-config/Sources/Version.swift
+++ b/seed/swift-sdk/nullable-optional/no-custom-config/Sources/Version.swift
@@ -1,0 +1,1 @@
+public let sdkVersion = "0.0.1"

--- a/seed/swift-sdk/nullable-optional/nullable-as-optional/Sources/Version.swift
+++ b/seed/swift-sdk/nullable-optional/nullable-as-optional/Sources/Version.swift
@@ -1,0 +1,1 @@
+public let sdkVersion = "0.0.1"

--- a/seed/swift-sdk/nullable-request-body/Sources/Version.swift
+++ b/seed/swift-sdk/nullable-request-body/Sources/Version.swift
@@ -1,0 +1,1 @@
+public let sdkVersion = "0.0.1"

--- a/seed/swift-sdk/nullable/no-custom-config/Sources/Version.swift
+++ b/seed/swift-sdk/nullable/no-custom-config/Sources/Version.swift
@@ -1,0 +1,1 @@
+public let sdkVersion = "0.0.1"

--- a/seed/swift-sdk/nullable/nullable-as-optional/Sources/Version.swift
+++ b/seed/swift-sdk/nullable/nullable-as-optional/Sources/Version.swift
@@ -1,0 +1,1 @@
+public let sdkVersion = "0.0.1"

--- a/seed/swift-sdk/oauth-client-credentials-custom/Sources/Version.swift
+++ b/seed/swift-sdk/oauth-client-credentials-custom/Sources/Version.swift
@@ -1,0 +1,1 @@
+public let sdkVersion = "0.0.1"

--- a/seed/swift-sdk/oauth-client-credentials-default/Sources/Version.swift
+++ b/seed/swift-sdk/oauth-client-credentials-default/Sources/Version.swift
@@ -1,0 +1,1 @@
+public let sdkVersion = "0.0.1"

--- a/seed/swift-sdk/oauth-client-credentials-environment-variables/Sources/Version.swift
+++ b/seed/swift-sdk/oauth-client-credentials-environment-variables/Sources/Version.swift
@@ -1,0 +1,1 @@
+public let sdkVersion = "0.0.1"

--- a/seed/swift-sdk/oauth-client-credentials-mandatory-auth/Sources/Version.swift
+++ b/seed/swift-sdk/oauth-client-credentials-mandatory-auth/Sources/Version.swift
@@ -1,0 +1,1 @@
+public let sdkVersion = "0.0.1"

--- a/seed/swift-sdk/oauth-client-credentials-nested-root/Sources/Version.swift
+++ b/seed/swift-sdk/oauth-client-credentials-nested-root/Sources/Version.swift
@@ -1,0 +1,1 @@
+public let sdkVersion = "0.0.1"

--- a/seed/swift-sdk/oauth-client-credentials-openapi/Sources/Version.swift
+++ b/seed/swift-sdk/oauth-client-credentials-openapi/Sources/Version.swift
@@ -1,0 +1,1 @@
+public let sdkVersion = "0.0.1"

--- a/seed/swift-sdk/oauth-client-credentials-reference/Sources/Version.swift
+++ b/seed/swift-sdk/oauth-client-credentials-reference/Sources/Version.swift
@@ -1,0 +1,1 @@
+public let sdkVersion = "0.0.1"

--- a/seed/swift-sdk/oauth-client-credentials-with-variables/Sources/Version.swift
+++ b/seed/swift-sdk/oauth-client-credentials-with-variables/Sources/Version.swift
@@ -1,0 +1,1 @@
+public let sdkVersion = "0.0.1"

--- a/seed/swift-sdk/oauth-client-credentials/Sources/Version.swift
+++ b/seed/swift-sdk/oauth-client-credentials/Sources/Version.swift
@@ -1,0 +1,1 @@
+public let sdkVersion = "0.0.1"

--- a/seed/swift-sdk/object/Sources/Version.swift
+++ b/seed/swift-sdk/object/Sources/Version.swift
@@ -1,0 +1,1 @@
+public let sdkVersion = "0.0.1"

--- a/seed/swift-sdk/objects-with-imports/Sources/Version.swift
+++ b/seed/swift-sdk/objects-with-imports/Sources/Version.swift
@@ -1,0 +1,1 @@
+public let sdkVersion = "0.0.1"

--- a/seed/swift-sdk/optional/Sources/Version.swift
+++ b/seed/swift-sdk/optional/Sources/Version.swift
@@ -1,0 +1,1 @@
+public let sdkVersion = "0.0.1"

--- a/seed/swift-sdk/package-yml/Sources/Version.swift
+++ b/seed/swift-sdk/package-yml/Sources/Version.swift
@@ -1,0 +1,1 @@
+public let sdkVersion = "0.0.1"

--- a/seed/swift-sdk/pagination-custom/Sources/Version.swift
+++ b/seed/swift-sdk/pagination-custom/Sources/Version.swift
@@ -1,0 +1,1 @@
+public let sdkVersion = "0.0.1"

--- a/seed/swift-sdk/pagination-uri-path/Sources/Version.swift
+++ b/seed/swift-sdk/pagination-uri-path/Sources/Version.swift
@@ -1,0 +1,1 @@
+public let sdkVersion = "0.0.1"

--- a/seed/swift-sdk/pagination/custom-pager-with-exception-handler/Sources/Version.swift
+++ b/seed/swift-sdk/pagination/custom-pager-with-exception-handler/Sources/Version.swift
@@ -1,0 +1,1 @@
+public let sdkVersion = "0.0.1"

--- a/seed/swift-sdk/pagination/custom-pager/Sources/Version.swift
+++ b/seed/swift-sdk/pagination/custom-pager/Sources/Version.swift
@@ -1,0 +1,1 @@
+public let sdkVersion = "0.0.1"

--- a/seed/swift-sdk/pagination/no-custom-config/Sources/Version.swift
+++ b/seed/swift-sdk/pagination/no-custom-config/Sources/Version.swift
@@ -1,0 +1,1 @@
+public let sdkVersion = "0.0.1"

--- a/seed/swift-sdk/path-parameters/Sources/Version.swift
+++ b/seed/swift-sdk/path-parameters/Sources/Version.swift
@@ -1,0 +1,1 @@
+public let sdkVersion = "0.0.1"

--- a/seed/swift-sdk/plain-text/Sources/Version.swift
+++ b/seed/swift-sdk/plain-text/Sources/Version.swift
@@ -1,0 +1,1 @@
+public let sdkVersion = "0.0.1"

--- a/seed/swift-sdk/property-access/Sources/Version.swift
+++ b/seed/swift-sdk/property-access/Sources/Version.swift
@@ -1,0 +1,1 @@
+public let sdkVersion = "0.0.1"

--- a/seed/swift-sdk/public-object/Sources/Version.swift
+++ b/seed/swift-sdk/public-object/Sources/Version.swift
@@ -1,0 +1,1 @@
+public let sdkVersion = "0.0.1"

--- a/seed/swift-sdk/query-param-name-conflict/Sources/Version.swift
+++ b/seed/swift-sdk/query-param-name-conflict/Sources/Version.swift
@@ -1,0 +1,1 @@
+public let sdkVersion = "0.0.1"

--- a/seed/swift-sdk/query-parameters-openapi-as-objects/Sources/Version.swift
+++ b/seed/swift-sdk/query-parameters-openapi-as-objects/Sources/Version.swift
@@ -1,0 +1,1 @@
+public let sdkVersion = "0.0.1"

--- a/seed/swift-sdk/query-parameters-openapi/Sources/Version.swift
+++ b/seed/swift-sdk/query-parameters-openapi/Sources/Version.swift
@@ -1,0 +1,1 @@
+public let sdkVersion = "0.0.1"

--- a/seed/swift-sdk/query-parameters/Sources/Version.swift
+++ b/seed/swift-sdk/query-parameters/Sources/Version.swift
@@ -1,0 +1,1 @@
+public let sdkVersion = "0.0.1"

--- a/seed/swift-sdk/request-parameters/Sources/Version.swift
+++ b/seed/swift-sdk/request-parameters/Sources/Version.swift
@@ -1,0 +1,1 @@
+public let sdkVersion = "0.0.1"

--- a/seed/swift-sdk/required-nullable/no-custom-config/Sources/Version.swift
+++ b/seed/swift-sdk/required-nullable/no-custom-config/Sources/Version.swift
@@ -1,0 +1,1 @@
+public let sdkVersion = "0.0.1"

--- a/seed/swift-sdk/required-nullable/nullable-as-optional/Sources/Version.swift
+++ b/seed/swift-sdk/required-nullable/nullable-as-optional/Sources/Version.swift
@@ -1,0 +1,1 @@
+public let sdkVersion = "0.0.1"

--- a/seed/swift-sdk/reserved-keywords/Sources/Version.swift
+++ b/seed/swift-sdk/reserved-keywords/Sources/Version.swift
@@ -1,0 +1,1 @@
+public let sdkVersion = "0.0.1"

--- a/seed/swift-sdk/response-property/Sources/Version.swift
+++ b/seed/swift-sdk/response-property/Sources/Version.swift
@@ -1,0 +1,1 @@
+public let sdkVersion = "0.0.1"

--- a/seed/swift-sdk/schemaless-request-body-examples/Sources/Version.swift
+++ b/seed/swift-sdk/schemaless-request-body-examples/Sources/Version.swift
@@ -1,0 +1,1 @@
+public let sdkVersion = "0.0.1"

--- a/seed/swift-sdk/server-sent-event-examples/Sources/Version.swift
+++ b/seed/swift-sdk/server-sent-event-examples/Sources/Version.swift
@@ -1,0 +1,1 @@
+public let sdkVersion = "0.0.1"

--- a/seed/swift-sdk/server-sent-events-openapi/Sources/Version.swift
+++ b/seed/swift-sdk/server-sent-events-openapi/Sources/Version.swift
@@ -1,0 +1,1 @@
+public let sdkVersion = "0.0.1"

--- a/seed/swift-sdk/server-sent-events/Sources/Version.swift
+++ b/seed/swift-sdk/server-sent-events/Sources/Version.swift
@@ -1,0 +1,1 @@
+public let sdkVersion = "0.0.1"

--- a/seed/swift-sdk/server-url-templating/Sources/Version.swift
+++ b/seed/swift-sdk/server-url-templating/Sources/Version.swift
@@ -1,0 +1,1 @@
+public let sdkVersion = "0.0.1"

--- a/seed/swift-sdk/simple-api/Sources/Version.swift
+++ b/seed/swift-sdk/simple-api/Sources/Version.swift
@@ -1,0 +1,1 @@
+public let sdkVersion = "0.0.1"

--- a/seed/swift-sdk/simple-fhir/Sources/Version.swift
+++ b/seed/swift-sdk/simple-fhir/Sources/Version.swift
@@ -1,0 +1,1 @@
+public let sdkVersion = "0.0.1"

--- a/seed/swift-sdk/single-url-environment-default/no-custom-config/Sources/Version.swift
+++ b/seed/swift-sdk/single-url-environment-default/no-custom-config/Sources/Version.swift
@@ -1,0 +1,1 @@
+public let sdkVersion = "0.0.1"

--- a/seed/swift-sdk/single-url-environment-default/with-custom-config/Sources/Version.swift
+++ b/seed/swift-sdk/single-url-environment-default/with-custom-config/Sources/Version.swift
@@ -1,0 +1,1 @@
+public let sdkVersion = "0.0.1"

--- a/seed/swift-sdk/single-url-environment-no-default/Sources/Version.swift
+++ b/seed/swift-sdk/single-url-environment-no-default/Sources/Version.swift
@@ -1,0 +1,1 @@
+public let sdkVersion = "0.0.1"

--- a/seed/swift-sdk/streaming-parameter/Sources/Version.swift
+++ b/seed/swift-sdk/streaming-parameter/Sources/Version.swift
@@ -1,0 +1,1 @@
+public let sdkVersion = "0.0.1"

--- a/seed/swift-sdk/streaming/Sources/Version.swift
+++ b/seed/swift-sdk/streaming/Sources/Version.swift
@@ -1,0 +1,1 @@
+public let sdkVersion = "0.0.1"

--- a/seed/swift-sdk/trace/Sources/Version.swift
+++ b/seed/swift-sdk/trace/Sources/Version.swift
@@ -1,0 +1,1 @@
+public let sdkVersion = "0.0.1"

--- a/seed/swift-sdk/undiscriminated-union-with-response-property/Sources/Version.swift
+++ b/seed/swift-sdk/undiscriminated-union-with-response-property/Sources/Version.swift
@@ -1,0 +1,1 @@
+public let sdkVersion = "0.0.1"

--- a/seed/swift-sdk/undiscriminated-unions/Sources/Version.swift
+++ b/seed/swift-sdk/undiscriminated-unions/Sources/Version.swift
@@ -1,0 +1,1 @@
+public let sdkVersion = "0.0.1"

--- a/seed/swift-sdk/unions-with-local-date/Sources/Version.swift
+++ b/seed/swift-sdk/unions-with-local-date/Sources/Version.swift
@@ -1,0 +1,1 @@
+public let sdkVersion = "0.0.1"

--- a/seed/swift-sdk/unions/Sources/Version.swift
+++ b/seed/swift-sdk/unions/Sources/Version.swift
@@ -1,0 +1,1 @@
+public let sdkVersion = "0.0.1"

--- a/seed/swift-sdk/unknown/Sources/Version.swift
+++ b/seed/swift-sdk/unknown/Sources/Version.swift
@@ -1,0 +1,1 @@
+public let sdkVersion = "0.0.1"

--- a/seed/swift-sdk/url-form-encoded/Sources/Version.swift
+++ b/seed/swift-sdk/url-form-encoded/Sources/Version.swift
@@ -1,0 +1,1 @@
+public let sdkVersion = "0.0.1"

--- a/seed/swift-sdk/validation/Sources/Version.swift
+++ b/seed/swift-sdk/validation/Sources/Version.swift
@@ -1,0 +1,1 @@
+public let sdkVersion = "0.0.1"

--- a/seed/swift-sdk/variables/Sources/Version.swift
+++ b/seed/swift-sdk/variables/Sources/Version.swift
@@ -1,0 +1,1 @@
+public let sdkVersion = "0.0.1"

--- a/seed/swift-sdk/version-no-default/Sources/Version.swift
+++ b/seed/swift-sdk/version-no-default/Sources/Version.swift
@@ -1,0 +1,1 @@
+public let sdkVersion = "0.0.1"

--- a/seed/swift-sdk/version/Sources/Version.swift
+++ b/seed/swift-sdk/version/Sources/Version.swift
@@ -1,0 +1,1 @@
+public let sdkVersion = "0.0.1"

--- a/seed/swift-sdk/webhook-audience/Sources/Version.swift
+++ b/seed/swift-sdk/webhook-audience/Sources/Version.swift
@@ -1,0 +1,1 @@
+public let sdkVersion = "0.0.1"

--- a/seed/swift-sdk/webhooks/Sources/Version.swift
+++ b/seed/swift-sdk/webhooks/Sources/Version.swift
@@ -1,0 +1,1 @@
+public let sdkVersion = "0.0.1"

--- a/seed/swift-sdk/websocket-bearer-auth/Sources/Version.swift
+++ b/seed/swift-sdk/websocket-bearer-auth/Sources/Version.swift
@@ -1,0 +1,1 @@
+public let sdkVersion = "0.0.1"

--- a/seed/swift-sdk/websocket-inferred-auth/Sources/Version.swift
+++ b/seed/swift-sdk/websocket-inferred-auth/Sources/Version.swift
@@ -1,0 +1,1 @@
+public let sdkVersion = "0.0.1"

--- a/seed/swift-sdk/websocket-multi-url/Sources/Version.swift
+++ b/seed/swift-sdk/websocket-multi-url/Sources/Version.swift
@@ -1,0 +1,1 @@
+public let sdkVersion = "0.0.1"

--- a/seed/swift-sdk/websocket/Sources/Version.swift
+++ b/seed/swift-sdk/websocket/Sources/Version.swift
@@ -1,0 +1,1 @@
+public let sdkVersion = "0.0.1"

--- a/seed/swift-sdk/x-fern-default/Sources/Version.swift
+++ b/seed/swift-sdk/x-fern-default/Sources/Version.swift
@@ -1,0 +1,1 @@
+public let sdkVersion = "0.0.1"


### PR DESCRIPTION
## Description

Adds `Version.swift` generation to the Swift SDK generator, embedding the SDK version as a `public` source-level constant. This brings the Swift generator in line with other SDK generators and fixes auto-versioning for Swift SDKs (the magic placeholder version will now appear in git diffs, allowing the auto-versioning system to detect and bump versions).

Split from #14719 (git tag fallback for auto-versioning) so each concern can be reviewed independently.

## Changes Made

- Added `generateVersionFile()` method to `SdkGeneratorCli.ts` that emits `Version.swift` with a top-level `public let sdkVersion` constant
- The file is only generated when `minVersion` is available (i.e., GitHub output mode with a version configured — not for local/download modes)
- Added `versions.yml` entry for Swift SDK generator `0.31.0`

## Updates since last revision

- Made `sdkVersion` constant `public` so SDK consumers can access it (Swift defaults to `internal` access)
- Ran seed tests (`swift-sdk`): 122/123 passed (1 expected failure in `literal`)
- Committed seed test snapshot updates — all fixtures now include `Version.swift` with `public let sdkVersion = "0.0.1"` (the seed default version)

## Testing

- [x] Seed tests run and passing (122/123, 1 expected failure)
- [x] Seed snapshots committed (122 `Version.swift` files added across all swift-sdk fixtures)
- [ ] Manual testing not performed locally

## Review Checklist

- [x] Verify that `addSourceAsIsFile` with name `"Version"` won't collide with any IR-generated type names
- [x] Confirm top-level `public let sdkVersion = "..."` is acceptable Swift style (vs. namespacing inside a `struct` or `enum`)
- [x] Confirm the generated constant is intentionally not yet wired into User-Agent or other headers (this PR is purely for consistency and auto-versioning support)

Link to Devin session: https://app.devin.ai/sessions/eeaa831f68d14737a731b1c8cb4968b4
Requested by: @Swimburger
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/14724" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
