### PR TITLE
fix(cli): polyfill Node.js built-ins for browser-compatible workspace bundle

### DIFF
--- a/packages/cli/workspace/browser-compatible-fern-workspace/build.mjs
+++ b/packages/cli/workspace/browser-compatible-fern-workspace/build.mjs
@@ -1,5 +1,6 @@
 import { readFile, rm, writeFile } from "fs/promises";
 import path from "path";
+import { polyfillNode } from "esbuild-plugin-polyfill-node";
 import tsup from "tsup";
 import { fileURLToPath } from "url";
 import packageJson from "./package.json" with { type: "json" };
@@ -31,7 +32,7 @@ async function main() {
 
     // Bundle all workspace:* deps (internal to fern monorepo) into the output.
     // Keep npm-published deps external so consumers manage them via package.json.
-    const externalDeps = ["@fern-api/fdr-sdk", "@open-rpc/meta-schema", "openapi-types"];
+    const externalDeps = ["@open-rpc/meta-schema", "openapi-types"];
 
     await tsup.build({
         entry: ["src/index.ts"],
@@ -44,11 +45,24 @@ async function main() {
         clean: true,
         // Bundle everything except external deps
         noExternal: [/.*/],
-        external: externalDeps
+        external: externalDeps,
+        esbuildPlugins: [
+            // Polyfill Node.js built-ins (util, path, assert) so transitive deps
+            // like object-inspect (qs → side-channel → object-inspect) don't break
+            // in Turbopack/browser environments with `require('util')`.
+            // Disable fs/crypto polyfills so workspace deps that use them keep
+            // the native Node.js externals intact.
+            polyfillNode({
+                globals: false,
+                polyfills: {
+                    fs: false,
+                    crypto: false
+                }
+            })
+        ]
     });
 
     const version = process.argv[2] || process.env.PACKAGE_VERSION || "0.0.1";
-    const fdrSdkVersion = await resolveCatalogVersion("@fern-api/fdr-sdk");
     const openRpcMetaSchemaVersion = await resolveCatalogVersion("@open-rpc/meta-schema");
 
     await writeFile(
@@ -72,17 +86,8 @@ async function main() {
                 types: "dist/index.d.ts",
                 files: ["**"],
                 dependencies: {
-                    "@fern-api/fdr-sdk": fdrSdkVersion,
                     "@open-rpc/meta-schema": openRpcMetaSchemaVersion,
                     "openapi-types": packageJson.dependencies["openapi-types"]
-                },
-                peerDependencies: {
-                    "@fern-api/fdr-sdk": ">=0.100.0"
-                },
-                peerDependenciesMeta: {
-                    "@fern-api/fdr-sdk": {
-                        optional: true
-                    }
                 },
                 license: "MIT"
             },

--- a/packages/cli/workspace/browser-compatible-fern-workspace/build.mjs
+++ b/packages/cli/workspace/browser-compatible-fern-workspace/build.mjs
@@ -1,6 +1,6 @@
+import { polyfillNode } from "esbuild-plugin-polyfill-node";
 import { readFile, rm, writeFile } from "fs/promises";
 import path from "path";
-import { polyfillNode } from "esbuild-plugin-polyfill-node";
 import tsup from "tsup";
 import { fileURLToPath } from "url";
 import packageJson from "./package.json" with { type: "json" };

--- a/packages/cli/workspace/browser-compatible-fern-workspace/package.json
+++ b/packages/cli/workspace/browser-compatible-fern-workspace/package.json
@@ -54,6 +54,7 @@
     "@fern-api/configs": "workspace:*",
     "@types/node": "catalog:",
     "esbuild": "catalog:",
+    "esbuild-plugin-polyfill-node": "catalog:",
     "tsup": "catalog:",
     "typescript": "catalog:",
     "vitest": "catalog:"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6903,6 +6903,9 @@ importers:
       esbuild:
         specifier: 'catalog:'
         version: 0.27.7
+      esbuild-plugin-polyfill-node:
+        specifier: 'catalog:'
+        version: 0.3.0(esbuild@0.27.7)
       tsup:
         specifier: 'catalog:'
         version: 8.5.1(jiti@2.6.1)(postcss@8.5.8)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)


### PR DESCRIPTION
## Summary
  - Adds `esbuild-plugin-polyfill-node` to polyfill Node.js built-ins (`util`, `path`, `assert`) so transitive deps like `object-inspect` (via `qs →
  side-channel → object-inspect`) don't break in Turbopack/browser environments that can't resolve `require('util')`
  - Bundles `@fern-api/fdr-sdk` into the output instead of keeping it external, removing it from the published package's `dependencies` and `peerDependencies`
  - Disables `fs` and `crypto` polyfills to preserve native Node.js externals for workspace deps that use them
  
  FER-9557

  ## Test plan
  - [ ] Verify the browser-compatible bundle builds successfully (`pnpm turbo run compile --filter browser-compatible-fern-workspace`)
  - [ ] Confirm the bundle works in a Turbopack/browser environment without `require('util')` errors
  - [ ] Verify `@fern-api/fdr-sdk` is fully inlined and no longer listed as a dependency in the published `package.json`