### PR TITLE
fix(cli): detect header-parameter name collisions in validation

### DIFF
--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -1,5 +1,18 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 
+- version: 4.63.4
+  changelogEntry:
+    - summary: |
+        Add `no-conflicting-parameter-names` OSS validation rule to `fern check`.
+        Detects when header parameters and query/path parameters on the same endpoint
+        normalize to the same camelCase name, which causes broken generated SDK code
+        (Python SyntaxError from duplicate keyword arguments, TypeScript duplicate
+        interface properties). The rule reports an error at validation time so the
+        collision is caught before code generation.
+      type: fix
+  createdAt: "2026-04-08"
+  irVersion: 66
+
 - version: 4.63.3
   changelogEntry:
     - summary: |
@@ -11,7 +24,6 @@
       type: fix
   createdAt: "2026-04-08"
   irVersion: 66
-
 - version: 4.63.2
   changelogEntry:
     - summary: |
@@ -48,7 +60,6 @@
       type: fix
   createdAt: "2026-04-07"
   irVersion: 66
-
 - version: 4.62.5
   changelogEntry:
     - summary: |

--- a/packages/cli/fern-definition/validator/src/rules/no-conflicting-request-wrapper-properties/__test__/fixtures/simple/definition/camel-case-collision.yml
+++ b/packages/cli/fern-definition/validator/src/rules/no-conflicting-request-wrapper-properties/__test__/fixtures/simple/definition/camel-case-collision.yml
@@ -1,0 +1,19 @@
+service:
+  auth: true
+  base-path: /v1/plants
+  headers:
+    Organization-Id:
+      name: organizationId
+      type: string
+      docs: The organization context for the request.
+  endpoints:
+    list:
+      method: GET
+      path: ""
+      request:
+        name: ListPlantsRequest
+        query-parameters:
+          organization_id:
+            type: string
+            docs: The organization to filter plants by.
+      response: string

--- a/packages/cli/fern-definition/validator/src/rules/no-conflicting-request-wrapper-properties/__test__/no-conflicting-request-wrapper-properties.test.ts
+++ b/packages/cli/fern-definition/validator/src/rules/no-conflicting-request-wrapper-properties/__test__/no-conflicting-request-wrapper-properties.test.ts
@@ -59,6 +59,15 @@ describe("no-conflicting-request-wrapper-properties", () => {
                 relativeFilepath: RelativeFilePath.of("body-property-key.yml"),
                 name: "no-conflicting-request-wrapper-properties",
                 severity: "fatal"
+            },
+            {
+                message: `Multiple request properties resolve to the same generated name organizationId after camelCase normalization. This causes broken generated code. Use the "name" property to disambiguate.
+  - Service header "Organization-Id" (name: "organizationId")
+  - Query Parameter "organization_id" (name: "organization_id")`,
+                nodePath: ["service", "endpoints", "list"],
+                relativeFilepath: RelativeFilePath.of("camel-case-collision.yml"),
+                name: "no-conflicting-request-wrapper-properties",
+                severity: "fatal"
             }
         ]);
     });

--- a/packages/cli/fern-definition/validator/src/rules/no-conflicting-request-wrapper-properties/no-conflicting-request-wrapper-properties.ts
+++ b/packages/cli/fern-definition/validator/src/rules/no-conflicting-request-wrapper-properties/no-conflicting-request-wrapper-properties.ts
@@ -226,9 +226,7 @@ function convertRequestWrapperPropertyToString(property: RequestWrapperProperty)
  * Only reports collisions that were NOT already caught by the raw-name check above
  * (i.e., properties that have different raw names but the same camelCase name).
  */
-function getCamelCaseNormalizedCollisions(
-    nameToProperties: Record<string, RequestWrapperProperty[]>
-): RuleViolation[] {
+function getCamelCaseNormalizedCollisions(nameToProperties: Record<string, RequestWrapperProperty[]>): RuleViolation[] {
     // Build a map from camelCase-normalized name to all properties across all raw-name groups.
     const camelCaseToEntries: Record<string, { rawName: string; property: RequestWrapperProperty }[]> = {};
 

--- a/packages/cli/fern-definition/validator/src/rules/no-conflicting-request-wrapper-properties/no-conflicting-request-wrapper-properties.ts
+++ b/packages/cli/fern-definition/validator/src/rules/no-conflicting-request-wrapper-properties/no-conflicting-request-wrapper-properties.ts
@@ -14,6 +14,7 @@ import {
     TypeResolverImpl
 } from "@fern-api/ir-generator";
 import chalk from "chalk";
+import { camelCase } from "lodash-es";
 
 import { Rule, RuleViolation } from "../../Rule.js";
 import { CASINGS_GENERATOR } from "../../utils/casingsGenerator.js";
@@ -48,6 +49,13 @@ export const NoConflictingRequestWrapperPropertiesRule: Rule = {
                                     .join("\n")
                         });
                     }
+
+                    // Also check for collisions after camelCase normalization.
+                    // Different raw names (e.g. header "Organization-Id" with name: organizationId
+                    // and query param "organization_id") may normalize to the same camelCase name,
+                    // causing broken generated code (duplicate kwargs in Python, duplicate properties in TS).
+                    const camelCaseViolations = getCamelCaseNormalizedCollisions(nameToProperties);
+                    violations.push(...camelCaseViolations);
 
                     return violations;
                 }
@@ -207,4 +215,59 @@ function convertRequestWrapperPropertyToString(property: RequestWrapperProperty)
         default:
             assertNever(property);
     }
+}
+
+/**
+ * Detects collisions that only appear after camelCase normalization.
+ * For example, header "Organization-Id" (name: organizationId) and query param "organization_id"
+ * have different raw names but both normalize to "organizationId" in camelCase.
+ * This causes broken generated code (duplicate kwargs in Python, duplicate properties in TypeScript).
+ *
+ * Only reports collisions that were NOT already caught by the raw-name check above
+ * (i.e., properties that have different raw names but the same camelCase name).
+ */
+function getCamelCaseNormalizedCollisions(
+    nameToProperties: Record<string, RequestWrapperProperty[]>
+): RuleViolation[] {
+    // Build a map from camelCase-normalized name to all properties across all raw-name groups.
+    const camelCaseToEntries: Record<string, { rawName: string; property: RequestWrapperProperty }[]> = {};
+
+    for (const [rawName, properties] of Object.entries(nameToProperties)) {
+        for (const property of properties) {
+            const normalizedName = camelCase(rawName);
+            const entries = (camelCaseToEntries[normalizedName] ??= []);
+            entries.push({ rawName, property });
+        }
+    }
+
+    const violations: RuleViolation[] = [];
+    for (const [normalizedName, entries] of Object.entries(camelCaseToEntries)) {
+        if (entries.length <= 1) {
+            continue;
+        }
+
+        // Only report if there are entries from different raw-name groups.
+        // If all entries share the same raw name, the raw-name check above already caught it.
+        const distinctRawNames = new Set(entries.map((e) => e.rawName));
+        if (distinctRawNames.size <= 1) {
+            continue;
+        }
+
+        violations.push({
+            severity: "fatal",
+            message:
+                `Multiple request properties resolve to the same generated name ${chalk.bold(
+                    normalizedName
+                )} after camelCase normalization. This causes broken generated code. ` +
+                `Use the "name" property to disambiguate.\n` +
+                entries
+                    .map(
+                        (entry) =>
+                            `  - ${convertRequestWrapperPropertyToString(entry.property)} (name: "${entry.rawName}")`
+                    )
+                    .join("\n")
+        });
+    }
+
+    return violations;
 }

--- a/packages/cli/workspace/oss-validator/src/getAllRules.ts
+++ b/packages/cli/workspace/oss-validator/src/getAllRules.ts
@@ -1,5 +1,6 @@
 import { Rule } from "./Rule.js";
 import { NoComponentSchemaCollisionsRule } from "./rules/no-component-schema-collisions/index.js";
+import { NoConflictingParameterNamesRule } from "./rules/no-conflicting-parameter-names/index.js";
 import { NoDuplicateAuthHeaderParametersRule } from "./rules/no-duplicate-auth-header-parameters/index.js";
 import { NoDuplicateOverridesRule } from "./rules/no-duplicate-overrides/index.js";
 import { NoInvalidTagNamesOrFrontmatterRule } from "./rules/no-invalid-tag-names-or-frontmatter/index.js";
@@ -11,6 +12,7 @@ export function getAllRules(): Rule[] {
         NoDuplicateOverridesRule,
         NoSchemaTitleCollisionsRule,
         NoComponentSchemaCollisionsRule,
-        NoInvalidTagNamesOrFrontmatterRule
+        NoInvalidTagNamesOrFrontmatterRule,
+        NoConflictingParameterNamesRule
     ];
 }

--- a/packages/cli/workspace/oss-validator/src/rules/no-conflicting-parameter-names/__test__/fixtures/header-path-collision/generators.yml
+++ b/packages/cli/workspace/oss-validator/src/rules/no-conflicting-parameter-names/__test__/fixtures/header-path-collision/generators.yml
@@ -1,0 +1,3 @@
+api:
+  specs:
+    - openapi: ./openapi.yml

--- a/packages/cli/workspace/oss-validator/src/rules/no-conflicting-parameter-names/__test__/fixtures/header-path-collision/openapi.yml
+++ b/packages/cli/workspace/oss-validator/src/rules/no-conflicting-parameter-names/__test__/fixtures/header-path-collision/openapi.yml
@@ -1,0 +1,22 @@
+openapi: 3.0.3
+info:
+  title: Test API
+  version: 1.0.0
+paths:
+  /plants/{plant_id}:
+    get:
+      operationId: getPlant
+      parameters:
+        - name: Plant-Id
+          in: header
+          required: true
+          schema:
+            type: string
+        - name: plant_id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: OK

--- a/packages/cli/workspace/oss-validator/src/rules/no-conflicting-parameter-names/__test__/fixtures/header-query-collision/generators.yml
+++ b/packages/cli/workspace/oss-validator/src/rules/no-conflicting-parameter-names/__test__/fixtures/header-query-collision/generators.yml
@@ -1,0 +1,3 @@
+api:
+  specs:
+    - openapi: ./openapi.yml

--- a/packages/cli/workspace/oss-validator/src/rules/no-conflicting-parameter-names/__test__/fixtures/header-query-collision/openapi.yml
+++ b/packages/cli/workspace/oss-validator/src/rules/no-conflicting-parameter-names/__test__/fixtures/header-query-collision/openapi.yml
@@ -1,0 +1,28 @@
+openapi: 3.0.3
+info:
+  title: Test API
+  version: 1.0.0
+paths:
+  /plants/{plantId}:
+    parameters:
+      - name: Organization-Id
+        in: header
+        required: true
+        schema:
+          type: string
+    get:
+      operationId: getPlant
+      parameters:
+        - name: organization_id
+          in: query
+          required: true
+          schema:
+            type: string
+        - name: plantId
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: OK

--- a/packages/cli/workspace/oss-validator/src/rules/no-conflicting-parameter-names/__test__/fixtures/no-collision/generators.yml
+++ b/packages/cli/workspace/oss-validator/src/rules/no-conflicting-parameter-names/__test__/fixtures/no-collision/generators.yml
@@ -1,0 +1,3 @@
+api:
+  specs:
+    - openapi: ./openapi.yml

--- a/packages/cli/workspace/oss-validator/src/rules/no-conflicting-parameter-names/__test__/fixtures/no-collision/openapi.yml
+++ b/packages/cli/workspace/oss-validator/src/rules/no-conflicting-parameter-names/__test__/fixtures/no-collision/openapi.yml
@@ -1,0 +1,28 @@
+openapi: 3.0.3
+info:
+  title: Test API
+  version: 1.0.0
+paths:
+  /plants/{plantId}:
+    parameters:
+      - name: X-Request-Id
+        in: header
+        required: true
+        schema:
+          type: string
+    get:
+      operationId: getPlant
+      parameters:
+        - name: organization_id
+          in: query
+          required: true
+          schema:
+            type: string
+        - name: plantId
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: OK

--- a/packages/cli/workspace/oss-validator/src/rules/no-conflicting-parameter-names/__test__/no-conflicting-parameter-names.test.ts
+++ b/packages/cli/workspace/oss-validator/src/rules/no-conflicting-parameter-names/__test__/no-conflicting-parameter-names.test.ts
@@ -1,0 +1,54 @@
+import { AbsoluteFilePath, join, RelativeFilePath } from "@fern-api/fs-utils";
+import { getViolationsForRule } from "../../../testing-utils/getViolationsForRule";
+import { NoConflictingParameterNamesRule } from "../no-conflicting-parameter-names";
+
+describe("no-conflicting-parameter-names", () => {
+    it("should detect header vs query parameter name collision", async () => {
+        const violations = await getViolationsForRule({
+            rule: NoConflictingParameterNamesRule,
+            absolutePathToWorkspace: join(
+                AbsoluteFilePath.of(__dirname),
+                RelativeFilePath.of("fixtures"),
+                RelativeFilePath.of("header-query-collision")
+            )
+        });
+
+        expect(violations.length).toBe(1);
+        expect(violations[0]?.severity).toBe("error");
+        expect(violations[0]?.message).toContain("organizationId");
+        expect(violations[0]?.message).toContain("Organization-Id");
+        expect(violations[0]?.message).toContain("organization_id");
+        expect(violations[0]?.nodePath).toEqual(["paths", "/plants/{plantId}", "get"]);
+    }, 10_000);
+
+    it("should detect header vs path parameter name collision", async () => {
+        const violations = await getViolationsForRule({
+            rule: NoConflictingParameterNamesRule,
+            absolutePathToWorkspace: join(
+                AbsoluteFilePath.of(__dirname),
+                RelativeFilePath.of("fixtures"),
+                RelativeFilePath.of("header-path-collision")
+            )
+        });
+
+        expect(violations.length).toBe(1);
+        expect(violations[0]?.severity).toBe("error");
+        expect(violations[0]?.message).toContain("plantId");
+        expect(violations[0]?.message).toContain("Plant-Id");
+        expect(violations[0]?.message).toContain("plant_id");
+        expect(violations[0]?.nodePath).toEqual(["paths", "/plants/{plant_id}", "get"]);
+    }, 10_000);
+
+    it("should not report violations when parameters have different normalized names", async () => {
+        const violations = await getViolationsForRule({
+            rule: NoConflictingParameterNamesRule,
+            absolutePathToWorkspace: join(
+                AbsoluteFilePath.of(__dirname),
+                RelativeFilePath.of("fixtures"),
+                RelativeFilePath.of("no-collision")
+            )
+        });
+
+        expect(violations).toEqual([]);
+    }, 10_000);
+});

--- a/packages/cli/workspace/oss-validator/src/rules/no-conflicting-parameter-names/index.ts
+++ b/packages/cli/workspace/oss-validator/src/rules/no-conflicting-parameter-names/index.ts
@@ -1,0 +1,1 @@
+export { NoConflictingParameterNamesRule } from "./no-conflicting-parameter-names.js";

--- a/packages/cli/workspace/oss-validator/src/rules/no-conflicting-parameter-names/no-conflicting-parameter-names.ts
+++ b/packages/cli/workspace/oss-validator/src/rules/no-conflicting-parameter-names/no-conflicting-parameter-names.ts
@@ -1,0 +1,217 @@
+import { isOpenAPIV2 } from "@fern-api/api-workspace-commons";
+import { relative } from "@fern-api/fs-utils";
+import { convertOpenAPIV2ToV3 } from "@fern-api/lazy-fern-workspace";
+
+import { Rule } from "../../Rule.js";
+import { ValidationViolation } from "../../ValidationViolation.js";
+
+/**
+ * Validates that OpenAPI specs don't define header parameters whose
+ * camelCase-normalized names collide with query or path parameters on
+ * the same endpoint.
+ *
+ * When a path-level or operation-level header (e.g. `Organization-Id`)
+ * normalizes to the same camelCase name as a query or path parameter
+ * (e.g. `organization_id`), SDK generators produce broken code:
+ *   - Python: SyntaxError from duplicate keyword arguments
+ *   - TypeScript: duplicate interface property that silently shadows one value
+ */
+export const NoConflictingParameterNamesRule: Rule = {
+    name: "no-conflicting-parameter-names",
+    run: async ({ workspace, specs, loadedDocuments }) => {
+        const violations: ValidationViolation[] = [];
+
+        for (const spec of specs) {
+            if (spec.type !== "openapi") {
+                continue;
+            }
+
+            const openAPI = loadedDocuments.get(spec.absoluteFilepath);
+            if (openAPI == null) {
+                continue;
+            }
+
+            const apiToValidate = isOpenAPIV2(openAPI) ? await convertOpenAPIV2ToV3(openAPI) : openAPI;
+            const relativeFilepath = relative(workspace.absoluteFilePath, spec.source.file);
+
+            for (const [path, pathItem] of Object.entries(
+                ((apiToValidate as Record<string, unknown>).paths as Record<string, unknown>) ?? {}
+            )) {
+                if (pathItem == null || typeof pathItem !== "object") {
+                    continue;
+                }
+
+                const pathItemObj = pathItem as Record<string, unknown>;
+
+                // Collect path-level parameters
+                const pathLevelParams = resolveAllParams(pathItemObj.parameters, apiToValidate);
+
+                // Check each operation
+                for (const method of ["get", "put", "post", "delete", "options", "head", "patch", "trace"]) {
+                    const operation = pathItemObj[method] as { parameters?: unknown[] } | undefined;
+                    if (operation == null) {
+                        continue;
+                    }
+
+                    // Collect operation-level parameters
+                    const operationParams = resolveAllParams(operation.parameters, apiToValidate);
+
+                    // Merge path-level and operation-level parameters.
+                    // Operation-level params override path-level params with the same `in` + `name`.
+                    const mergedParams = mergeParameters(pathLevelParams, operationParams);
+
+                    // Group parameters by their camelCase-normalized name
+                    const nameToParams: Record<string, ResolvedParam[]> = {};
+                    for (const param of mergedParams) {
+                        const normalizedName = toCamelCase(param.name);
+                        if (normalizedName === "") {
+                            continue;
+                        }
+                        const existing = (nameToParams[normalizedName] ??= []);
+                        existing.push(param);
+                    }
+
+                    // Check for collisions between different parameter types
+                    for (const [normalizedName, params] of Object.entries(nameToParams)) {
+                        if (params.length <= 1) {
+                            continue;
+                        }
+
+                        // Only report collisions that involve at least two different `in` locations
+                        // (e.g. header + query, header + path). Same-type duplicates are a different issue.
+                        const distinctTypes = new Set(params.map((p) => p.in));
+                        if (distinctTypes.size <= 1) {
+                            continue;
+                        }
+
+                        const paramDescriptions = params.map((p) => `${p.in} parameter '${p.name}'`).join(", ");
+
+                        violations.push({
+                            name: "no-conflicting-parameter-names",
+                            severity: "error",
+                            relativeFilepath,
+                            nodePath: ["paths", path, method],
+                            message:
+                                `Parameters ${paramDescriptions} all normalize to '${normalizedName}' in generated SDKs. ` +
+                                `This causes broken code (duplicate keyword arguments in Python, duplicate properties in TypeScript). ` +
+                                `Rename one of the parameters to avoid the collision.`
+                        });
+                    }
+                }
+            }
+        }
+
+        return violations;
+    }
+};
+
+interface ResolvedParam {
+    in: string;
+    name: string;
+}
+
+/**
+ * Resolves an array of parameters (which may contain $ref objects) into
+ * a flat array of ResolvedParam objects.
+ */
+function resolveAllParams(
+    params: unknown,
+    // biome-ignore lint/suspicious/noExplicitAny: OpenAPI document type
+    api: any
+): ResolvedParam[] {
+    if (!Array.isArray(params)) {
+        return [];
+    }
+    const result: ResolvedParam[] = [];
+    for (const param of params) {
+        const resolved = resolveParam(param, api);
+        if (resolved != null) {
+            result.push(resolved);
+        }
+    }
+    return result;
+}
+
+/**
+ * Resolves a parameter, handling $ref if needed.
+ */
+function resolveParam(
+    param: unknown,
+    // biome-ignore lint/suspicious/noExplicitAny: OpenAPI document type
+    api: any,
+    visited: Set<string> = new Set()
+): ResolvedParam | undefined {
+    if (typeof param !== "object" || param == null) {
+        return undefined;
+    }
+
+    const paramObj = param as Record<string, unknown>;
+
+    // Handle $ref
+    if (typeof paramObj.$ref === "string") {
+        const refPath = paramObj.$ref;
+        if (visited.has(refPath)) {
+            return undefined;
+        }
+        if (refPath.startsWith("#/components/parameters/")) {
+            const paramName = refPath.substring("#/components/parameters/".length);
+            const components = api.components as { parameters?: Record<string, unknown> } | undefined;
+            const resolved = components?.parameters?.[paramName];
+            if (resolved != null) {
+                visited.add(refPath);
+                return resolveParam(resolved, api, visited);
+            }
+        }
+        // Try Swagger 2.0 style refs
+        if (refPath.startsWith("#/parameters/")) {
+            const paramName = refPath.substring("#/parameters/".length);
+            const parameters = api.parameters as Record<string, unknown> | undefined;
+            const resolved = parameters?.[paramName];
+            if (resolved != null) {
+                visited.add(refPath);
+                return resolveParam(resolved, api, visited);
+            }
+        }
+        return undefined;
+    }
+
+    if (typeof paramObj.in === "string" && typeof paramObj.name === "string") {
+        return { in: paramObj.in, name: paramObj.name };
+    }
+
+    return undefined;
+}
+
+/**
+ * Merges path-level and operation-level parameters following the OpenAPI spec:
+ * operation-level parameters override path-level parameters with the same
+ * `in` + `name` combination.
+ */
+function mergeParameters(pathParams: ResolvedParam[], operationParams: ResolvedParam[]): ResolvedParam[] {
+    const operationParamKeys = new Set(operationParams.map((p) => `${p.in}:${p.name}`));
+    const merged = [...operationParams];
+    for (const pathParam of pathParams) {
+        const key = `${pathParam.in}:${pathParam.name}`;
+        if (!operationParamKeys.has(key)) {
+            merged.push(pathParam);
+        }
+    }
+    return merged;
+}
+
+/**
+ * Converts a parameter name to camelCase, matching the normalization
+ * that SDK generators apply. Handles kebab-case, snake_case, and
+ * PascalCase inputs.
+ *
+ * Examples:
+ *   "Organization-Id"  → "organizationId"
+ *   "organization_id"  → "organizationId"
+ *   "Plant-Id"         → "plantId"
+ *   "plant_id"         → "plantId"
+ */
+function toCamelCase(input: string): string {
+    return input
+        .replace(/[-_]+(.)?/g, (_, char: string | undefined) => (char != null ? char.toUpperCase() : ""))
+        .replace(/^[A-Z]/, (char) => char.toLowerCase());
+}


### PR DESCRIPTION
## Description

Refs: Reported issue where a service-level header (e.g. `Organization-Id`) and an endpoint query/path parameter (e.g. `organization_id`) normalize to the same camelCase name, causing SDK generators to produce broken code — Python `SyntaxError` from duplicate keyword arguments, TypeScript duplicate interface properties.

This PR adds early detection at `fern check` time via **two** validation layers:
1. A new **OSS validation rule** for OpenAPI specs (`no-conflicting-parameter-names`)
2. An enhancement to the existing **Fern definition validator** rule (`no-conflicting-request-wrapper-properties`) to detect camelCase-normalized collisions

## Changes Made

### OSS Validator — new rule `no-conflicting-parameter-names`
- New rule in `packages/cli/workspace/oss-validator/src/rules/no-conflicting-parameter-names/`
  - Iterates all paths/operations in each OpenAPI spec
  - Merges path-level and operation-level parameters (operation overrides path per OpenAPI spec)
  - Normalizes parameter names to camelCase and flags collisions across different `in` types (header vs query, header vs path)
  - Handles `$ref` resolution for both OpenAPI 3.x and Swagger 2.0 parameter references
- Registered rule in `getAllRules.ts`

### Fern Definition Validator — enhanced `no-conflicting-request-wrapper-properties`
- Added `getCamelCaseNormalizedCollisions()` function that detects when parameters with different raw names (e.g. header `Organization-Id` with `name: organizationId` and query param `organization_id`) normalize to the same camelCase name
- Uses lodash `camelCase` (same normalization the SDK generators use via `CasingsGenerator`)
- Only reports collisions not already caught by the existing raw-name check (i.e. different raw names but same camelCase output)
- Added test fixture `camel-case-collision.yml` and updated test expectations

### Other
- Added changelog entry (v4.63.3)

## Important Review Notes

- **Custom `toCamelCase` in OSS rule vs lodash `camelCase` in Fern validator**: The OSS validator uses a hand-rolled regex implementation (lodash-es is not a dependency of oss-validator), while the Fern definition validator uses lodash `camelCase` directly. The hand-rolled version handles common patterns (`kebab-case`, `snake_case`, `PascalCase`) but may diverge from lodash on edge cases like `__foo`, `FOO_BAR`, or consecutive delimiters. See review checklist below.
- **`x-fern-parameter-name` not considered in OSS rule**: The OSS rule checks raw OpenAPI `name` values only. If a user has set `x-fern-parameter-name` to disambiguate, the rule may still flag a false positive. Worth deciding if this extension should be respected.
- **Only cross-type collisions**: Same-type duplicates (e.g. two query params with the same normalized name) are intentionally skipped — those are a separate concern.

## Testing

- [x] Unit tests added for OSS rule — 3 test cases (header-query collision, header-path collision, no-collision negative case)
- [x] Unit test added for Fern definition validator — camelCase collision case (`Organization-Id` header + `organization_id` query param)
- [x] All 26 oss-validator tests pass
- [x] All 69 fern-definition-validator tests pass (47 files)
- [x] Compilation passes
- [x] `test`, `compile`, `test-ete`, `lint`, `biome`, `depcheck`, `Validate versions.yml files` all pass
- [x] 14/16 seed-test-results checks pass; 2 failures (`go-sdk`, `java-model`) are pre-existing infrastructure issues (Go build/wire test failures, Maven Central 403 Forbidden)

### Human Review Checklist
- [ ] Verify hand-rolled `toCamelCase` regex in OSS rule produces the same results as lodash `camelCase` for realistic parameter names (especially `FOO_BAR`, `__foo`, mixed delimiters)
- [ ] Decide whether `x-fern-parameter-name` should be respected in the OSS rule to avoid false positives
- [ ] Confirm error messages are clear and actionable for API authors
- [ ] Check that the `biome-ignore lint/suspicious/noExplicitAny` usage in the OSS rule's `resolveParam` is acceptable (used for dynamic OpenAPI document traversal)

Link to Devin session: https://app.devin.ai/sessions/fdc9add787364b71aba4b59a8ad39e21
Requested by: @tstanmay13