### PR TITLE
feat(cli): speed up docs bundle refresh with async old bundle removal

### DIFF
--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -1,5 +1,14 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 
+- version: 4.63.0
+  changelogEntry:
+    - summary: |
+        Show a progress bar for the "Removing old docs bundle" step during
+        `fern docs dev`, filling the gap between the download and unzip bars.
+      type: feat
+  createdAt: "2026-04-07"
+  irVersion: 66
+
 - version: 4.62.6
   changelogEntry:
     - summary: |

--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -3,8 +3,8 @@
 - version: 4.63.0
   changelogEntry:
     - summary: |
-        Show a progress bar for the "Removing old docs bundle" step during
-        `fern docs dev`, filling the gap between the download and unzip bars.
+        Speed up `fern docs dev` bundle refresh by renaming the old bundle
+        and deleting it asynchronously instead of blocking on removal.
       type: feat
   createdAt: "2026-04-07"
   irVersion: 66

--- a/packages/cli/docs-preview/src/downloadLocalDocsBundle.ts
+++ b/packages/cli/docs-preview/src/downloadLocalDocsBundle.ts
@@ -14,7 +14,7 @@ const DOCS_PREFIX = chalk.cyan("[docs]:");
 const ETAG_FILENAME = "etag";
 
 // Progress bar label alignment - pad labels to the longest one for consistent bar positioning
-const PROGRESS_LABEL_WIDTH = "Downloading docs bundle".length;
+const PROGRESS_LABEL_WIDTH = "Removing old docs bundle".length;
 const formatProgressLabel = (label: string): string => label.padEnd(PROGRESS_LABEL_WIDTH, " ");
 const PREVIEW_FOLDER_NAME = "preview";
 const APP_PREVIEW_FOLDER_NAME = "app-preview";
@@ -226,7 +226,41 @@ export async function downloadBundle({
         const absolutePathToPreviewFolder = getPathToPreviewFolder({ app });
         if (await doesPathExist(absolutePathToPreviewFolder)) {
             logger.debug(`Removing previously cached bundle at: ${absolutePathToPreviewFolder}`);
-            await rm(absolutePathToPreviewFolder, { recursive: true });
+
+            let removeProgressBar: cliProgress.SingleBar | undefined;
+            let removeInterval: NodeJS.Timeout | undefined;
+
+            if (app) {
+                removeProgressBar = new cliProgress.SingleBar({
+                    format: `${DOCS_PREFIX} ${formatProgressLabel("Removing old docs bundle")} [{bar}] {percentage}%`,
+                    barCompleteChar: "\u2588",
+                    barIncompleteChar: "\u2591",
+                    hideCursor: true
+                });
+                removeProgressBar.start(100, 0);
+
+                const REMOVE_DURATION_MS = 10000;
+                const startTime = Date.now();
+                removeInterval = setInterval(() => {
+                    const elapsed = Date.now() - startTime;
+                    const t = Math.min(elapsed / REMOVE_DURATION_MS, 1);
+                    const p = 1 - Math.pow(1 - t, 3);
+                    const percentage = Math.min(99, Math.floor(p * 100));
+                    removeProgressBar?.update(percentage);
+                }, 50);
+            }
+
+            try {
+                await rm(absolutePathToPreviewFolder, { recursive: true });
+            } finally {
+                if (removeInterval) {
+                    clearInterval(removeInterval);
+                }
+                if (removeProgressBar) {
+                    removeProgressBar.update(100);
+                    removeProgressBar.stop();
+                }
+            }
         }
         await mkdir(absolutePathToPreviewFolder, { recursive: true });
 

--- a/packages/cli/docs-preview/src/downloadLocalDocsBundle.ts
+++ b/packages/cli/docs-preview/src/downloadLocalDocsBundle.ts
@@ -4,7 +4,7 @@ import { loggingExeca } from "@fern-api/logging-execa";
 import chalk from "chalk";
 import cliProgress from "cli-progress";
 import decompress from "decompress";
-import { mkdir, readFile, rm, writeFile } from "fs/promises";
+import { mkdir, readFile, rename, rm, writeFile } from "fs/promises";
 import { homedir } from "os";
 import tmp from "tmp-promise";
 import xml2js from "xml2js";
@@ -14,7 +14,7 @@ const DOCS_PREFIX = chalk.cyan("[docs]:");
 const ETAG_FILENAME = "etag";
 
 // Progress bar label alignment - pad labels to the longest one for consistent bar positioning
-const PROGRESS_LABEL_WIDTH = "Removing old docs bundle".length;
+const PROGRESS_LABEL_WIDTH = "Downloading docs bundle".length;
 const formatProgressLabel = (label: string): string => label.padEnd(PROGRESS_LABEL_WIDTH, " ");
 const PREVIEW_FOLDER_NAME = "preview";
 const APP_PREVIEW_FOLDER_NAME = "app-preview";
@@ -225,42 +225,14 @@ export async function downloadBundle({
 
         const absolutePathToPreviewFolder = getPathToPreviewFolder({ app });
         if (await doesPathExist(absolutePathToPreviewFolder)) {
-            logger.debug(`Removing previously cached bundle at: ${absolutePathToPreviewFolder}`);
+            const oldBundlePath = AbsoluteFilePath.of(`${absolutePathToPreviewFolder}-old-${Date.now()}`);
+            logger.debug(`Moving previously cached bundle to: ${oldBundlePath}`);
+            await rename(absolutePathToPreviewFolder, oldBundlePath);
 
-            let removeProgressBar: cliProgress.SingleBar | undefined;
-            let removeInterval: NodeJS.Timeout | undefined;
-
-            if (app) {
-                removeProgressBar = new cliProgress.SingleBar({
-                    format: `${DOCS_PREFIX} ${formatProgressLabel("Removing old docs bundle")} [{bar}] {percentage}%`,
-                    barCompleteChar: "\u2588",
-                    barIncompleteChar: "\u2591",
-                    hideCursor: true
-                });
-                removeProgressBar.start(100, 0);
-
-                const REMOVE_DURATION_MS = 10000;
-                const startTime = Date.now();
-                removeInterval = setInterval(() => {
-                    const elapsed = Date.now() - startTime;
-                    const t = Math.min(elapsed / REMOVE_DURATION_MS, 1);
-                    const p = 1 - Math.pow(1 - t, 3);
-                    const percentage = Math.min(99, Math.floor(p * 100));
-                    removeProgressBar?.update(percentage);
-                }, 50);
-            }
-
-            try {
-                await rm(absolutePathToPreviewFolder, { recursive: true });
-            } finally {
-                if (removeInterval) {
-                    clearInterval(removeInterval);
-                }
-                if (removeProgressBar) {
-                    removeProgressBar.update(100);
-                    removeProgressBar.stop();
-                }
-            }
+            // Delete the old bundle asynchronously so it doesn't block the rest of the setup
+            rm(oldBundlePath, { recursive: true }).catch((error) => {
+                logger.debug(`Failed to remove old bundle at ${oldBundlePath}: ${error}`);
+            });
         }
         await mkdir(absolutePathToPreviewFolder, { recursive: true });
 


### PR DESCRIPTION
## Description

Speeds up `fern docs dev` bundle refresh by replacing the synchronous `rm -rf` of the old docs bundle with an instant `rename` followed by an asynchronous delete. Previously, the removal step blocked the entire setup pipeline and only logged at `debug` level, leaving a silent gap between the download and unzip steps.

## Changes Made

- Replace synchronous `rm(absolutePathToPreviewFolder)` with `rename` to `{path}-old-{timestamp}`, then fire-and-forget `rm` of the renamed directory
- Deletion errors are caught and logged at `debug` level so they don't crash the setup
- Added `versions.yml` entry for CLI v4.63.0

## Testing

- No unit tests added — this is a small behavioral change to an existing I/O path
- [ ] Manual testing completed

## Human Review Checklist

- [ ] Verify that stale `-old-*` directories don't accumulate over time (e.g., if the async `rm` consistently fails or the process exits before it completes). Consider whether a startup cleanup sweep is needed.
- [ ] Confirm `rename` works correctly across filesystems — `rename` may fail if the source and destination are on different mount points (unlikely for paths under `~/.fern/`, but worth verifying)

Link to Devin session: https://app.devin.ai/sessions/5f928682f769497fa4e387662901b1d4
Requested by: @thesandlord