### PR TITLE
fix(python): deduplicate union base properties and fix exported client mypy overload error

### DIFF
--- a/generators/python/src/fern_python/generators/pydantic_model/type_declaration_handler/discriminated_union/discriminated_union_with_utils_generator.py
+++ b/generators/python/src/fern_python/generators/pydantic_model/type_declaration_handler/discriminated_union/discriminated_union_with_utils_generator.py
@@ -204,7 +204,19 @@ class DiscriminatedUnionWithUtilsGenerator(AbstractTypeGenerator):
                         single_union_type=single_union_type
                     )
 
-                    internal_pydantic_model_for_single_union_type.add_field(discriminant_field)
+                    # For samePropertiesAsObject variants, skip adding the discriminant field
+                    # if it already exists in the referenced type's property chain
+                    shape = single_union_type.shape.get_as_union()
+                    should_add_discriminant = True
+                    if shape.properties_type == "samePropertiesAsObject":
+                        all_props = self._context.get_all_properties_including_extensions(shape.type_id)
+                        for prop in all_props:
+                            if prop.name.wire_value == self._union.discriminant.wire_value:
+                                should_add_discriminant = False
+                                break
+
+                    if should_add_discriminant:
+                        internal_pydantic_model_for_single_union_type.add_field(discriminant_field)
 
                     shape = single_union_type.shape.get_as_union()
                     if shape.properties_type == "singleProperty":

--- a/generators/python/src/fern_python/generators/pydantic_model/type_declaration_handler/discriminated_union/simple_discriminated_union_generator.py
+++ b/generators/python/src/fern_python/generators/pydantic_model/type_declaration_handler/discriminated_union/simple_discriminated_union_generator.py
@@ -138,10 +138,13 @@ class AbstractSimpleDiscriminatedUnionGenerator(AbstractTypeGenerator, ABC):
                     )
                 ]
                 discriminant_wire_value = self._union.discriminant.wire_value
+                base_property_wire_values = {bp.name.wire_value for bp in self._union.base_properties}
                 object_properties = self._context.get_all_properties_including_extensions(shape.type_id)
                 for object_property in object_properties:
-                    # Skip properties that match the discriminant field to avoid duplicate fields
+                    # Skip properties that match the discriminant field or union base properties to avoid duplicate fields
                     if object_property.name.wire_value == discriminant_wire_value:
+                        continue
+                    if object_property.name.wire_value in base_property_wire_values:
                         continue
                     self._all_referenced_types.append(object_property.value_type)
                     same_properties_as_object_property_fields.append(

--- a/generators/python/src/fern_python/generators/sdk/client_generator/generated_root_client.py
+++ b/generators/python/src/fern_python/generators/sdk/client_generator/generated_root_client.py
@@ -12,6 +12,7 @@ class RootClient:
     class_reference: AST.ClassReference
     parameters: List[ConstructorParameter]
     init_parameters: Optional[List[ConstructorParameter]] = field(default=None)
+    has_overloaded_init: bool = field(default=False)
 
 
 @dataclass

--- a/generators/python/src/fern_python/generators/sdk/client_generator/root_client_generator.py
+++ b/generators/python/src/fern_python/generators/sdk/client_generator/root_client_generator.py
@@ -1831,11 +1831,13 @@ class RootClientGenerator(BaseWrappedClientGenerator[RootClientConstructorParame
                     class_reference=async_class_reference,
                     parameters=self._constructor_parameters,
                     init_parameters=self._async_init_parameters,
+                    has_overloaded_init=self._oauth_token_override,
                 ),
                 sync_instantiations=sync_instantiations,
                 sync_client=RootClient(
                     class_reference=sync_class_reference,
                     parameters=self._constructor_parameters,
                     init_parameters=self._sync_init_parameters,
+                    has_overloaded_init=self._oauth_token_override,
                 ),
             )

--- a/generators/python/src/fern_python/generators/sdk/sdk_generator.py
+++ b/generators/python/src/fern_python/generators/sdk/sdk_generator.py
@@ -616,7 +616,10 @@ class SdkGenerator(AbstractGenerator):
         ]
 
         def write_super_init(writer: AST.NodeWriter) -> None:
-            writer.write_line("super().__init__(")
+            if root_client.has_overloaded_init:
+                writer.write_line("super().__init__(  # type: ignore[call-overload, misc]")
+            else:
+                writer.write_line("super().__init__(")
             with writer.indent():
                 for param in params:
                     writer.write_line(f"{param.constructor_parameter_name}={param.constructor_parameter_name},")

--- a/seed/python-sdk/unions/union-utils/src/seed/types/types/union_with_duplicative_discriminants.py
+++ b/seed/python-sdk/unions/union-utils/src/seed/types/types/union_with_duplicative_discriminants.py
@@ -107,8 +107,6 @@ class UnionWithDuplicativeDiscriminants(UniversalRootModel):
 
 class _UnionWithDuplicativeDiscriminants:
     class FirstItemType(types_types_first_item_type_FirstItemType):
-        type: typing.Literal["firstItemType"] = "firstItemType"
-
         if IS_PYDANTIC_V2:
             model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(frozen=True)  # type: ignore # Pydantic v2
         else:
@@ -118,8 +116,6 @@ class _UnionWithDuplicativeDiscriminants:
                 smart_union = True
 
     class SecondItemType(types_types_second_item_type_SecondItemType):
-        type: typing.Literal["secondItemType"] = "secondItemType"
-
         if IS_PYDANTIC_V2:
             model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(frozen=True)  # type: ignore # Pydantic v2
         else:


### PR DESCRIPTION
## Description

Two related Python generator fixes:

1. **Duplicate field declarations in discriminated union variants** — When using `x-fern-streaming` with a `stream-condition` property, the stream condition field (e.g., `stream_response`) could appear twice in generated Pydantic models: once as a literal discriminant pin and again inherited from the base schema via `allOf`.

2. **mypy `call-overload` error in exported client wrappers** — When using `exported_class_name` with OAuth client credentials, the generated subclass (e.g., `Vectara(BaseVectara)`) forwards all parameters to `super().__init__()`, but the parent has overloaded `__init__` signatures (OAuth vs token). mypy cannot match the forwarded call against either overload.

## Changes Made

### Discriminated union deduplication (Pydantic models)

- **`simple_discriminated_union_generator.py`** — When building fields for `samePropertiesAsObject` variants, properties whose wire value matches a union-level `baseProperty` are now skipped (extending the existing discriminant-wire-value skip pattern).
- **`discriminated_union_with_utils_generator.py`** — Before adding the discriminant field to a `samePropertiesAsObject` variant's Pydantic model, the generator now checks whether the discriminant already exists in the referenced type's full property chain (via `get_all_properties_including_extensions`). If it does, the explicit `add_field` is skipped.

No changes needed in `pydantic_model_simple_discriminated_union_generator.py` or `typeddict_simple_discriminated_union_generator.py` — they receive the already-deduplicated field list from the base class.

### Exported client wrapper mypy fix (SDK client)

- **`generated_root_client.py`** — Added `has_overloaded_init` field to `RootClient` dataclass.
- **`root_client_generator.py`** — Sets `has_overloaded_init=True` when OAuth token override is enabled (i.e., when the parent class has overloaded `__init__` signatures).
- **`sdk_generator.py`** — When generating the exported wrapper's `super().__init__()` call, conditionally emits `# type: ignore[call-overload, misc]` only when the parent has overloaded init. This suppresses both the overload mismatch and the "too many unions" mypy errors.

## Testing

- [x] Pre-commit hooks pass (`ruff`, `ruff-format`, etc.)
- [x] Verified fix against customer fixture — `seed run` passes build (mypy) and tests
- [ ] Unit tests added/updated
- [ ] Seed test fixture for streaming + `stream-condition` discriminated unions

## Reviewer Checklist

- In `discriminated_union_with_utils_generator.py`, `shape` is assigned twice in the `generate()` loop (line 209 new, line 221 existing) — harmless reassignment of the same value, but could be consolidated
- The `# type: ignore[call-overload, misc]` suppresses two error codes; `misc` covers mypy's "not all union combinations were tried" which fires when there are many `Optional` params. Verify this is acceptable vs. narrowing the call
- `has_overloaded_init` is tied to `_oauth_token_override` — if other overload patterns are added to `_get_constructor_overloads` in the future, this flag would need updating

Link to Devin session: https://app.devin.ai/sessions/bfc42ca24d4f42ff9e75514b5d4658bc
Requested by: @jsklan
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/14738" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
