### PR TITLE
fix(python): undisciminated union variant matching in wire tests

### DIFF
--- a/generators/python-v2/dynamic-snippets/src/context/DynamicTypeLiteralMapper.ts
+++ b/generators/python-v2/dynamic-snippets/src/context/DynamicTypeLiteralMapper.ts
@@ -483,7 +483,7 @@ export class DynamicTypeLiteralMapper {
             const errorsBefore = this.context.errors.size();
             try {
                 const instantiation = this.convert({ typeReference, value });
-                if (python.TypeInstantiation.isNop(instantiation)) {
+                if (python.TypeInstantiation.isNop(instantiation) || this.context.errors.size() > errorsBefore) {
                     this.context.errors.truncate(errorsBefore);
                     continue;
                 }

--- a/generators/python/sdk/versions.yml
+++ b/generators/python/sdk/versions.yml
@@ -1,5 +1,15 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 # For unreleased changes, use unreleased.yml
+- version: 5.3.3
+  changelogEntry:
+    - summary: |
+        Fix wire test generation for undiscriminated unions where a non-first variant is used.
+        Previously, enum mismatches in nested objects were not detected during union matching,
+        causing empty values (e.g. `strategy=,`) in generated code.
+      type: fix
+  createdAt: "2026-04-08"
+  irVersion: 65
+
 - version: 5.3.2
   changelogEntry:
     - summary: |
@@ -15,11 +25,6 @@
         Fix objects and discriminated unions in reference.md and README snippets being
         rendered as dict literals instead of Pydantic model constructors. For example,
         `order_type=OrderType_Market()` instead of `order_type={"type": "MARKET"}`.
-      type: fix
-    - summary: |
-        Fix wire test generation for undiscriminated unions where a non-first variant is used.
-        Previously, enum mismatches in nested objects were not detected during union matching,
-        causing empty values (e.g. `strategy=,`) in generated code.
       type: fix
   createdAt: "2026-04-06"
   irVersion: 65

--- a/generators/python/sdk/versions.yml
+++ b/generators/python/sdk/versions.yml
@@ -16,6 +16,11 @@
         rendered as dict literals instead of Pydantic model constructors. For example,
         `order_type=OrderType_Market()` instead of `order_type={"type": "MARKET"}`.
       type: fix
+    - summary: |
+        Fix wire test generation for undiscriminated unions where a non-first variant is used.
+        Previously, enum mismatches in nested objects were not detected during union matching,
+        causing empty values (e.g. `strategy=,`) in generated code.
+      type: fix
   createdAt: "2026-04-06"
   irVersion: 65
 


### PR DESCRIPTION
## Description
Linear ticket: Closes FER-9562 
In `DynamicTypeLiteralMapper.ts`, `findMatchingUndiscriminatedUnionType` iterates union variants and tries to convert the example value against each one; it just checks `isNop()` to see if it should skip a variant, but that doesn't hit variants that were errors wrapped in a non-nop class instantiation. Now it also checks if the number of `errors` have increased.

## Changes Made
One-liner to `DynamicTypeLiteralMapper.ts` in `python-v2`.

## Testing
Fixes a specific problem in Auth0's MyOrg API.
- [X] Unit tests added/updated
- [X] Manual testing completed
