### PR TITLE
chore(cli): rename FernCliError to TaskAbortSignal

### DIFF
--- a/packages/cli/cli-logger/src/logErrorMessage.ts
+++ b/packages/cli/cli-logger/src/logErrorMessage.ts
@@ -1,5 +1,5 @@
 import { Logger, LogLevel } from "@fern-api/logger";
-import { FernCliError } from "@fern-api/task-context";
+import { TaskAbortSignal } from "@fern-api/task-context";
 import chalk from "chalk";
 
 export function logErrorMessage({
@@ -20,7 +20,7 @@ export function logErrorMessage({
     }
 
     // thrower is responsible for logging, so we don't need to log the error's message too
-    if (error instanceof FernCliError) {
+    if (error instanceof TaskAbortSignal) {
         return;
     }
 

--- a/packages/cli/cli-v2/src/context/adapter/TaskContextAdapter.ts
+++ b/packages/cli/cli-v2/src/context/adapter/TaskContextAdapter.ts
@@ -7,7 +7,7 @@ import type {
     Startable,
     TaskContext
 } from "@fern-api/task-context";
-import { FernCliError, TaskResult } from "@fern-api/task-context";
+import { TaskAbortSignal, TaskResult } from "@fern-api/task-context";
 import type { Task } from "../../ui/Task.js";
 import type { Context } from "../Context.js";
 import { TaskContextLogger } from "./TaskContextLogger.js";
@@ -50,7 +50,7 @@ export class TaskContextAdapter implements TaskContext {
 
     public failAndThrow(message?: string, error?: unknown): never {
         this.failWithoutThrowing(message, error);
-        throw new FernCliError();
+        throw new TaskAbortSignal();
     }
 
     public failWithoutThrowing(message?: string, error?: unknown): void {

--- a/packages/cli/cli-v2/src/context/withContext.ts
+++ b/packages/cli/cli-v2/src/context/withContext.ts
@@ -1,5 +1,5 @@
 import { LogLevel } from "@fern-api/logger";
-import { FernCliError } from "@fern-api/task-context";
+import { TaskAbortSignal } from "@fern-api/task-context";
 import chalk from "chalk";
 import { KeyringUnavailableError } from "../auth/errors/KeyringUnavailableError.js";
 import { CliError } from "../errors/CliError.js";
@@ -90,9 +90,7 @@ function handleError(context: Context, error: unknown): void {
         return;
     }
 
-    if (error instanceof FernCliError) {
-        // FernCliError is thrown by failAndThrow() after logging the error
-        // message via the TaskContext logger. No additional output needed.
+    if (error instanceof TaskAbortSignal) {
         return;
     }
 
@@ -119,24 +117,18 @@ function handleError(context: Context, error: unknown): void {
  *
  * Only unexpected/internal errors are reported. User-facing errors
  * (validation, auth, CLI usage) are not bugs and should not be tracked.
- *
- * TODO: FernCliError is currently excluded because it loses context --
- * it's a blank marker error thrown by failAndThrow() after logging.
- * Many FernCliError instances originate from shared packages and represent
- * server-side failures (e.g. API registration, protobuf upload) that
- * *should* be reported. A refactoring is needed to make FernCliError
- * carry its original cause/code so we can distinguish reportable
- * server failures from user config errors.
  */
 function shouldReportToSentry(error: unknown): boolean {
+    if (error instanceof TaskAbortSignal) {
+        return false;
+    }
     if (error instanceof CliError) {
         return error.code === "INTERNAL_ERROR";
     }
     if (
         error instanceof ValidationError ||
         error instanceof SourcedValidationError ||
-        error instanceof KeyringUnavailableError ||
-        error instanceof FernCliError
+        error instanceof KeyringUnavailableError
     ) {
         return false;
     }

--- a/packages/cli/cli/src/cli-context/CliContext.ts
+++ b/packages/cli/cli/src/cli-context/CliContext.ts
@@ -3,7 +3,7 @@ import { createLogger, LOG_LEVELS, LogLevel } from "@fern-api/logger";
 import { getPosthogManager } from "@fern-api/posthog-manager";
 import { Project } from "@fern-api/project-loader";
 import { isVersionAhead } from "@fern-api/semver-utils";
-import { FernCliError, Finishable, PosthogEvent, Startable, TaskContext, TaskResult } from "@fern-api/task-context";
+import { Finishable, PosthogEvent, Startable, TaskAbortSignal, TaskContext, TaskResult } from "@fern-api/task-context";
 import { Workspace } from "@fern-api/workspace-loader";
 import { input, select } from "@inquirer/prompts";
 import chalk from "chalk";
@@ -95,7 +95,7 @@ export class CliContext {
 
     public failAndThrow(message?: string, error?: unknown): never {
         this.failWithoutThrowing(message, error);
-        throw new FernCliError();
+        throw new TaskAbortSignal();
     }
 
     public failWithoutThrowing(message?: string, error?: unknown): void {
@@ -223,13 +223,17 @@ export class CliContext {
         try {
             result = await run(context);
         } catch (error) {
+            if (error instanceof TaskAbortSignal) {
+                // thrower is responsible for logging, so we generally don't need to log here.
+                throw error;
+            }
             if ((error as Error).message.includes("globalThis")) {
                 context.logger.error(this.USE_NODE_18_OR_ABOVE_MESSAGE);
                 context.failWithoutThrowing();
             } else {
                 context.failWithoutThrowing(undefined, error);
             }
-            throw new FernCliError();
+            throw new TaskAbortSignal();
         } finally {
             context.finish();
         }
@@ -398,7 +402,7 @@ export class CliContext {
             // User pressed Ctrl+C
             if ((error as Error)?.name === "ExitPromptError") {
                 this.logger.info("\nCancelled by user.");
-                throw new FernCliError();
+                throw new TaskAbortSignal();
             }
             throw error;
         }

--- a/packages/cli/cli/src/cli-context/TaskContextImpl.ts
+++ b/packages/cli/cli/src/cli-context/TaskContextImpl.ts
@@ -3,11 +3,11 @@ import { addPrefixToString } from "@fern-api/core-utils";
 import { createLogger, LogLevel } from "@fern-api/logger";
 import {
     CreateInteractiveTaskParams,
-    FernCliError,
     Finishable,
     InteractiveTaskContext,
     PosthogEvent,
     Startable,
+    TaskAbortSignal,
     TaskContext,
     TaskResult
 } from "@fern-api/task-context";
@@ -77,7 +77,7 @@ export class TaskContextImpl implements Startable<TaskContext>, Finishable, Task
     public failAndThrow(message?: string, error?: unknown): never {
         this.failWithoutThrowing(message, error);
         this.finish();
-        throw new FernCliError();
+        throw new TaskAbortSignal();
     }
 
     public failWithoutThrowing(message?: string, error?: unknown): void {

--- a/packages/cli/cli/src/cli.ts
+++ b/packages/cli/cli/src/cli.ts
@@ -34,7 +34,7 @@ import {
 import { LOG_LEVELS, LogLevel } from "@fern-api/logger";
 import { askToLogin, login, logout } from "@fern-api/login";
 import { protocGenFern } from "@fern-api/protoc-gen-fern";
-import { FernCliError, LoggableFernCliError } from "@fern-api/task-context";
+import { LoggableFernCliError, TaskAbortSignal } from "@fern-api/task-context";
 import getPort from "get-port";
 import { Argv } from "yargs";
 import { hideBin } from "yargs/helpers";
@@ -142,11 +142,11 @@ async function runCli() {
                 error
             }
         });
-        if ((error as Error)?.message.includes("globalThis")) {
-            cliContext.logger.error(USE_NODE_18_OR_ABOVE_MESSAGE);
-            cliContext.failWithoutThrowing();
-        } else if (error instanceof FernCliError) {
+        if (error instanceof TaskAbortSignal) {
             // thrower is responsible for logging, so we generally don't need to log here.
+            cliContext.failWithoutThrowing();
+        } else if ((error as Error)?.message.includes("globalThis")) {
+            cliContext.logger.error(USE_NODE_18_OR_ABOVE_MESSAGE);
             cliContext.failWithoutThrowing();
         } else if (error instanceof LoggableFernCliError) {
             cliContext.logger.error(`Failed. ${error.log}`);

--- a/packages/cli/cli/src/commands/diff/diff.ts
+++ b/packages/cli/cli/src/commands/diff/diff.ts
@@ -2,7 +2,7 @@ import { diffSemverOrThrow } from "@fern-api/core-utils";
 import { AbsoluteFilePath, cwd, doesPathExist, resolve, streamObjectFromFile } from "@fern-api/fs-utils";
 import { IntermediateRepresentation, serialization } from "@fern-api/ir-sdk";
 import { IntermediateRepresentationChangeDetector } from "@fern-api/ir-utils";
-import { FernCliError } from "@fern-api/task-context";
+import { TaskAbortSignal } from "@fern-api/task-context";
 import semver from "semver";
 
 import { CliContext } from "../../cli-context/CliContext.js";
@@ -57,7 +57,7 @@ export async function diff({
     const nextVersion = semver.inc(fromVersion, bump);
     if (!nextVersion) {
         context.failWithoutThrowing(`Invalid current version: ${fromVersion}`);
-        throw new FernCliError();
+        throw new TaskAbortSignal();
     }
     return { bump, nextVersion, errors };
 }
@@ -74,13 +74,13 @@ async function readIr({
     const absoluteFilepath = AbsoluteFilePath.of(resolve(cwd(), filepath));
     if (!(await doesPathExist(absoluteFilepath, "file"))) {
         context.failWithoutThrowing(`File not found: ${absoluteFilepath}`);
-        throw new FernCliError();
+        throw new TaskAbortSignal();
     }
     const ir = await streamObjectFromFile(absoluteFilepath);
     const parsed = serialization.IntermediateRepresentation.parse(ir);
     if (!parsed.ok) {
         context.failWithoutThrowing(`Invalid --${flagName}; expected a filepath containing a valid IR`);
-        throw new FernCliError();
+        throw new TaskAbortSignal();
     }
     return parsed.value;
 }
@@ -162,7 +162,7 @@ export function diffGeneratorVersions(
         };
     } catch (error) {
         context.failWithoutThrowing(`Error diffing generator versions ${from} and ${to}: ${error}`);
-        throw new FernCliError();
+        throw new TaskAbortSignal();
     }
 }
 

--- a/packages/cli/cli/src/commands/sdk-diff/sdkDiffCommand.ts
+++ b/packages/cli/cli/src/commands/sdk-diff/sdkDiffCommand.ts
@@ -21,7 +21,7 @@ import {
     maxVersionBump
 } from "@fern-api/local-workspace-runner";
 import { Project } from "@fern-api/project-loader";
-import { FernCliError, TaskContext } from "@fern-api/task-context";
+import { TaskAbortSignal, TaskContext } from "@fern-api/task-context";
 import { exec } from "child_process";
 import { promisify } from "util";
 import { CliContext } from "../../cli-context/CliContext.js";
@@ -82,12 +82,12 @@ export async function sdkDiffCommand({
     // Validate that both directories exist
     if (!(await doesPathExist(fromPath, "directory"))) {
         context.failWithoutThrowing(`Directory not found: ${fromPath}`);
-        throw new FernCliError();
+        throw new TaskAbortSignal();
     }
 
     if (!(await doesPathExist(toPath, "directory"))) {
         context.failWithoutThrowing(`Directory not found: ${toPath}`);
-        throw new FernCliError();
+        throw new TaskAbortSignal();
     }
 
     const clientRegistry = await getClientRegistry(context, project);
@@ -234,7 +234,7 @@ export async function sdkDiffCommand({
                     : "") +
                 `Error: ${errorMessage}`
         );
-        throw new FernCliError();
+        throw new TaskAbortSignal();
     }
 }
 

--- a/packages/cli/configuration-loader/src/docs-yml/__test__/collapsibleNavigationConfig.test.ts
+++ b/packages/cli/configuration-loader/src/docs-yml/__test__/collapsibleNavigationConfig.test.ts
@@ -1,7 +1,7 @@
 import { docsYml } from "@fern-api/configuration";
 import { validateAgainstJsonSchema } from "@fern-api/core-utils";
 import { AbsoluteFilePath } from "@fern-api/fs-utils";
-import { createMockTaskContext, FernCliError } from "@fern-api/task-context";
+import { createMockTaskContext, TaskAbortSignal } from "@fern-api/task-context";
 import fs from "fs";
 import os from "os";
 import path from "path";
@@ -38,7 +38,7 @@ describe("docs.yml navigation collapsible config", () => {
                 absoluteFilepathToDocsConfig: AbsoluteFilePath.of("/tmp/docs.yml"),
                 context
             })
-        ).rejects.toBeInstanceOf(FernCliError);
+        ).rejects.toBeInstanceOf(TaskAbortSignal);
     });
 
     it("should throw if collapsible is used alongside deprecated collapsed", async () => {
@@ -64,7 +64,7 @@ describe("docs.yml navigation collapsible config", () => {
                 absoluteFilepathToDocsConfig: AbsoluteFilePath.of("/tmp/docs.yml"),
                 context
             })
-        ).rejects.toBeInstanceOf(FernCliError);
+        ).rejects.toBeInstanceOf(TaskAbortSignal);
     });
 
     it("should throw if collapsible is used alongside deprecated collapsed: open-by-default", async () => {
@@ -90,7 +90,7 @@ describe("docs.yml navigation collapsible config", () => {
                 absoluteFilepathToDocsConfig: AbsoluteFilePath.of("/tmp/docs.yml"),
                 context
             })
-        ).rejects.toBeInstanceOf(FernCliError);
+        ).rejects.toBeInstanceOf(TaskAbortSignal);
     });
 
     it("should accept open-by-default as a collapsed value on sections", async () => {
@@ -246,7 +246,7 @@ describe("docs.yml navigation collapsible config", () => {
                 absoluteFilepathToDocsConfig: AbsoluteFilePath.of(docsConfigPath),
                 context
             })
-        ).rejects.toBeInstanceOf(FernCliError);
+        ).rejects.toBeInstanceOf(TaskAbortSignal);
     });
 });
 

--- a/packages/cli/generation/local-generation/local-workspace-runner/src/GenerationRunner.ts
+++ b/packages/cli/generation/local-generation/local-workspace-runner/src/GenerationRunner.ts
@@ -4,7 +4,7 @@ import { generatorsYml, SNIPPET_JSON_FILENAME } from "@fern-api/configuration";
 import { AbsoluteFilePath, join, RelativeFilePath } from "@fern-api/fs-utils";
 import { generateIntermediateRepresentation } from "@fern-api/ir-generator";
 import { IntermediateRepresentation } from "@fern-api/ir-sdk";
-import { FernCliError, LoggableFernCliError, TaskContext } from "@fern-api/task-context";
+import { LoggableFernCliError, TaskAbortSignal, TaskContext } from "@fern-api/task-context";
 import { FernGeneratorExec } from "@fern-fern/generator-exec-sdk";
 import chalk from "chalk";
 import { generateDynamicSnippetTests } from "./dynamic-snippets/generateDynamicSnippetTests.js";
@@ -99,7 +99,7 @@ export class GenerationRunner {
                                 );
                             }
                         } catch (error) {
-                            if (error instanceof FernCliError) {
+                            if (error instanceof TaskAbortSignal) {
                                 // already logged by failAndThrow, nothing to do
                             } else if (error instanceof LoggableFernCliError) {
                                 interactiveTaskContext.failWithoutThrowing(`Generation failed: ${error.log}`, error);

--- a/packages/cli/generation/remote-generation/remote-workspace-runner/src/__test__/substituteEnvVariables.test.ts
+++ b/packages/cli/generation/remote-generation/remote-workspace-runner/src/__test__/substituteEnvVariables.test.ts
@@ -1,6 +1,6 @@
 import { replaceEnvVariables } from "@fern-api/core-utils";
 import { NOOP_LOGGER } from "@fern-api/logger";
-import { createMockTaskContext, FernCliError } from "@fern-api/task-context";
+import { createMockTaskContext, TaskAbortSignal } from "@fern-api/task-context";
 
 describe("substituteEnvVariables", () => {
     it("basic", () => {
@@ -34,7 +34,9 @@ describe("substituteEnvVariables", () => {
             plugh: "${FOO_VAR}"
         };
         const context = createMockTaskContext({ logger: NOOP_LOGGER });
-        expect(() => replaceEnvVariables(content, { onError: (e) => context.failAndThrow(e) })).toThrow(FernCliError);
+        expect(() => replaceEnvVariables(content, { onError: (e) => context.failAndThrow(e) })).toThrow(
+            TaskAbortSignal
+        );
     });
 
     it("substitutes as empty in preview mode when substituteEnvVars is false", () => {

--- a/packages/cli/task-context/src/FernCliError.ts
+++ b/packages/cli/task-context/src/FernCliError.ts
@@ -1,6 +1,0 @@
-export class FernCliError extends Error {
-    constructor() {
-        super();
-        Object.setPrototypeOf(this, FernCliError.prototype);
-    }
-}

--- a/packages/cli/task-context/src/MockTaskContext.ts
+++ b/packages/cli/task-context/src/MockTaskContext.ts
@@ -1,6 +1,6 @@
 import { CONSOLE_LOGGER, Logger } from "@fern-api/logger";
 
-import { FernCliError } from "./FernCliError.js";
+import { TaskAbortSignal } from "./TaskAbortSignal.js";
 import { TaskContext, TaskResult } from "./TaskContext.js";
 
 export function createMockTaskContext({ logger = CONSOLE_LOGGER }: { logger?: Logger } = {}): TaskContext {
@@ -20,7 +20,7 @@ export function createMockTaskContext({ logger = CONSOLE_LOGGER }: { logger?: Lo
             if (parts.length > 0) {
                 context.logger.error(...parts);
             }
-            throw new FernCliError();
+            throw new TaskAbortSignal();
         },
         failWithoutThrowing: (message?: string, error?: unknown) => {
             // in mock contexts, any failures should throw

--- a/packages/cli/task-context/src/TaskAbortSignal.ts
+++ b/packages/cli/task-context/src/TaskAbortSignal.ts
@@ -1,0 +1,10 @@
+/**
+ * Thrown by `failAndThrow` to unwind the call stack after an error has
+ * already been logged and (if applicable) reported to Sentry.
+ *
+ * This is NOT a real error — it carries no message, code, or stack trace.
+ * Catch sites should silently swallow it or re-throw without logging.
+ */
+export class TaskAbortSignal {
+    readonly __brand = "TaskAbortSignal" as const;
+}

--- a/packages/cli/task-context/src/index.ts
+++ b/packages/cli/task-context/src/index.ts
@@ -1,6 +1,6 @@
-export { FernCliError } from "./FernCliError.js";
 export { LoggableFernCliError } from "./LoggableFernCliError.js";
 export { createMockTaskContext } from "./MockTaskContext.js";
+export { TaskAbortSignal } from "./TaskAbortSignal.js";
 export {
     type CreateInteractiveTaskParams,
     type Finishable,

--- a/packages/seed/src/TaskContextImpl.ts
+++ b/packages/seed/src/TaskContextImpl.ts
@@ -4,11 +4,11 @@ import { addPrefixToString } from "@fern-api/core-utils";
 import { createLogger, LogLevel } from "@fern-api/logger";
 import {
     CreateInteractiveTaskParams,
-    FernCliError,
     Finishable,
     InteractiveTaskContext,
     PosthogEvent,
     Startable,
+    TaskAbortSignal,
     TaskContext,
     TaskResult
 } from "@fern-api/task-context";
@@ -81,7 +81,7 @@ export class TaskContextImpl implements Startable<TaskContext>, Finishable, Task
     public failAndThrow(message?: string, error?: unknown): never {
         this.failWithoutThrowing(message, error);
         this.finish();
-        throw new FernCliError();
+        throw new TaskAbortSignal();
     }
 
     public failWithoutThrowing(message?: string, error?: unknown): void {

--- a/packages/seed/src/logErrorMessage.ts
+++ b/packages/seed/src/logErrorMessage.ts
@@ -1,7 +1,7 @@
 // HACKHACK: copied from cli folder
 
 import { Logger, LogLevel } from "@fern-api/logger";
-import { FernCliError } from "@fern-api/task-context";
+import { TaskAbortSignal } from "@fern-api/task-context";
 import chalk from "chalk";
 
 export function logErrorMessage({
@@ -22,7 +22,7 @@ export function logErrorMessage({
     }
 
     // thrower is responsible for logging, so we don't need to log the error's message too
-    if (error instanceof FernCliError) {
+    if (error instanceof TaskAbortSignal) {
         return;
     }
 


### PR DESCRIPTION
## Description

Part of the CLI error classification effort — see #14749 for full context.

Renames `FernCliError` to `TaskAbortSignal` to better reflect its purpose: it is a control-flow signal used to abort a task after an error has already been logged, not an error class itself. This clears the naming space for the `CliError` class introduced in #14749.

## Changes Made

- Renamed `FernCliError` class to `TaskAbortSignal` across all usages
- Deleted `packages/cli/task-context/src/FernCliError.ts`, created `packages/cli/task-context/src/TaskAbortSignal.ts`
- Updated all `import { FernCliError }` → `import { TaskAbortSignal }` and `instanceof FernCliError` → `instanceof TaskAbortSignal` across CLI v1, CLI v2, seed, and test helpers

## Context

The old `FernCliError` was thrown by `failAndThrow()` purely as a sentinel to unwind the call stack — it carried no error metadata. Renaming it to `TaskAbortSignal` makes this intent explicit and avoids confusion with the new `CliError` class that carries typed error codes for Sentry routing.

## Testing

- [x] Existing tests pass (rename is mechanical)
