### PR TITLE
chore(cli): make instrumentPostHogEvent synchronous

### DIFF
--- a/packages/cli/cli-v2/src/context/adapter/TaskContextAdapter.ts
+++ b/packages/cli/cli-v2/src/context/adapter/TaskContextAdapter.ts
@@ -115,8 +115,8 @@ export class TaskContextAdapter implements TaskContext {
         }
     }
 
-    public async instrumentPostHogEvent(_event: PosthogEvent): Promise<void> {
-        // no-op for now
+    public instrumentPostHogEvent(_event: PosthogEvent): void {
+        // no-op — v2 uses TelemetryClient.sendEvent directly
     }
 
     private formatError(error: unknown): string | undefined {

--- a/packages/cli/cli/src/__test__/mockCliContext.ts
+++ b/packages/cli/cli/src/__test__/mockCliContext.ts
@@ -8,7 +8,14 @@ export class MockCliContext extends CliContext {
         process.env.CLI_VERSION = "0.0.0";
         process.env.CLI_NAME = "test-cli";
 
-        super(process.stdout, process.stderr, { isLocal: true });
+        super(process.stdout, process.stderr, {
+            isLocal: true,
+            posthogManager: {
+                sendEvent: () => undefined,
+                identify: () => undefined,
+                flush: async () => undefined
+            }
+        });
     }
 
     // Override exit to prevent process.exit in tests

--- a/packages/cli/cli/src/cli-context/CliContext.ts
+++ b/packages/cli/cli/src/cli-context/CliContext.ts
@@ -1,6 +1,6 @@
 import { Log, logErrorMessage, TtyAwareLogger } from "@fern-api/cli-logger";
 import { createLogger, LOG_LEVELS, LogLevel } from "@fern-api/logger";
-import { getPosthogManager } from "@fern-api/posthog-manager";
+import { getPosthogManager, PosthogManager } from "@fern-api/posthog-manager";
 import { Project } from "@fern-api/project-loader";
 import { isVersionAhead } from "@fern-api/semver-utils";
 import { Finishable, PosthogEvent, Startable, TaskAbortSignal, TaskContext, TaskResult } from "@fern-api/task-context";
@@ -31,6 +31,7 @@ export interface FernUpgradeInfo {
 export class CliContext {
     public readonly environment: CliEnvironment;
     private readonly sentryClient: SentryClient;
+    private readonly posthogManager: PosthogManager;
 
     private didSucceed = true;
 
@@ -42,9 +43,23 @@ export class CliContext {
     private readonly stdoutRedirector = new StdoutRedirector();
     private jsonMode = false;
 
-    constructor(stdout: NodeJS.WriteStream, stderr: NodeJS.WriteStream, { isLocal }: { isLocal?: boolean }) {
+    public static async create(
+        stdout: NodeJS.WriteStream,
+        stderr: NodeJS.WriteStream,
+        { isLocal }: { isLocal?: boolean }
+    ): Promise<CliContext> {
+        const posthogManager = await getPosthogManager();
+        return new CliContext(stdout, stderr, { isLocal, posthogManager });
+    }
+
+    protected constructor(
+        stdout: NodeJS.WriteStream,
+        stderr: NodeJS.WriteStream,
+        { isLocal, posthogManager }: { isLocal?: boolean; posthogManager: PosthogManager }
+    ) {
         this.ttyAwareLogger = new TtyAwareLogger(stdout, stderr);
         this.isLocal = isLocal ?? false;
+        this.posthogManager = posthogManager;
 
         const packageName = this.getPackageName();
         const packageVersion = this.getPackageVersion();
@@ -138,8 +153,7 @@ export class CliContext {
             await this.nudgeUpgradeIfAvailable();
         }
         this.ttyAwareLogger.finish();
-        const posthogManager = await getPosthogManager();
-        await posthogManager.flush();
+        await this.posthogManager.flush();
         await this.sentryClient.flush();
         this.exitProgram({ code });
     }
@@ -240,9 +254,9 @@ export class CliContext {
         return result;
     }
 
-    public async instrumentPostHogEvent(event: PosthogEvent): Promise<void> {
+    public instrumentPostHogEvent(event: PosthogEvent): void {
         if (!this.isLocal) {
-            (await getPosthogManager()).sendEvent(event);
+            this.posthogManager.sendEvent(event);
         }
     }
 
@@ -287,8 +301,8 @@ export class CliContext {
                     this.didSucceed = false;
                 }
             },
-            instrumentPostHogEvent: async (event) => {
-                await this.instrumentPostHogEvent(event);
+            instrumentPostHogEvent: (event) => {
+                this.instrumentPostHogEvent(event);
             },
             shouldBufferLogs: false
         };

--- a/packages/cli/cli/src/cli-context/TaskContextImpl.ts
+++ b/packages/cli/cli/src/cli-context/TaskContextImpl.ts
@@ -23,7 +23,7 @@ export declare namespace TaskContextImpl {
          */
         onResult?: (result: TaskResult) => void;
         shouldBufferLogs: boolean;
-        instrumentPostHogEvent: (event: PosthogEvent) => Promise<void>;
+        instrumentPostHogEvent: (event: PosthogEvent) => void;
     }
 }
 
@@ -36,7 +36,7 @@ export class TaskContextImpl implements Startable<TaskContext>, Finishable, Task
     private bufferedLogs: Log[] = [];
     protected status: "notStarted" | "running" | "finished" = "notStarted";
     private onResult: ((result: TaskResult) => void) | undefined;
-    private instrumentPostHogEventImpl: (event: PosthogEvent) => Promise<void>;
+    private instrumentPostHogEventImpl: (event: PosthogEvent) => void;
     public constructor({
         logImmediately,
         logPrefix,
@@ -89,8 +89,8 @@ export class TaskContextImpl implements Startable<TaskContext>, Finishable, Task
         return this.result;
     }
 
-    public async instrumentPostHogEvent(event: PosthogEvent): Promise<void> {
-        await this.instrumentPostHogEventImpl(event);
+    public instrumentPostHogEvent(event: PosthogEvent): void {
+        this.instrumentPostHogEventImpl(event);
     }
 
     protected logAtLevel(level: LogLevel, ...parts: string[]): void {
@@ -132,7 +132,7 @@ export class TaskContextImpl implements Startable<TaskContext>, Finishable, Task
             takeOverTerminal: this.takeOverTerminal,
             onResult: this.onResult,
             shouldBufferLogs: this.shouldBufferLogs,
-            instrumentPostHogEvent: async (event) => await this.instrumentPostHogEventImpl(event)
+            instrumentPostHogEvent: (event) => this.instrumentPostHogEventImpl(event)
         });
         this.subtasks.push(subtask);
         return subtask;

--- a/packages/cli/cli/src/cli.ts
+++ b/packages/cli/cli/src/cli.ts
@@ -95,7 +95,7 @@ async function runCli() {
     getOrCreateFernRunId();
 
     const isLocal = process.argv.includes("--local");
-    const cliContext = new CliContext(process.stdout, process.stderr, { isLocal });
+    const cliContext = await CliContext.create(process.stdout, process.stderr, { isLocal });
 
     const exit = async () => {
         await cliContext.exit();
@@ -135,7 +135,7 @@ async function runCli() {
             });
         }
     } catch (error) {
-        await cliContext.instrumentPostHogEvent({
+        cliContext.instrumentPostHogEvent({
             command: process.argv.join(" "),
             properties: {
                 failed: true,
@@ -537,7 +537,7 @@ function addSdkDiffCommand(cli: Argv<GlobalCliOptions>, cliContext: CliContext) 
                     description: "Output result as JSON"
                 }),
         async (argv) => {
-            await cliContext.instrumentPostHogEvent({
+            cliContext.instrumentPostHogEvent({
                 command: "fern sdk-diff"
             });
 
@@ -1355,7 +1355,7 @@ function addUpdateApiSpecCommand(cli: Argv<GlobalCliOptions>, cliContext: CliCon
                     default: 2
                 }),
         async (argv) => {
-            await cliContext.instrumentPostHogEvent({
+            cliContext.instrumentPostHogEvent({
                 command: "fern api update"
             });
             await updateApiSpec({
@@ -1386,7 +1386,7 @@ function addSelfUpdateCommand(cli: Argv<GlobalCliOptions>, cliContext: CliContex
                     default: false
                 }),
         async (argv) => {
-            await cliContext.instrumentPostHogEvent({
+            cliContext.instrumentPostHogEvent({
                 command: "fern self-update"
             });
             await selfUpdate({
@@ -1415,7 +1415,7 @@ function addLoginCommand(cli: Argv<GlobalCliOptions>, cliContext: CliContext) {
                 }),
         async (argv) => {
             await cliContext.runTask(async (context) => {
-                await cliContext.instrumentPostHogEvent({
+                cliContext.instrumentPostHogEvent({
                     command: "fern login"
                 });
                 await login(context, { useDeviceCodeFlow: argv.deviceCode, email: argv.email });
@@ -1431,7 +1431,7 @@ function addLogoutCommand(cli: Argv<GlobalCliOptions>, cliContext: CliContext) {
         (yargs) => yargs,
         async () => {
             await cliContext.runTask(async (context) => {
-                await cliContext.instrumentPostHogEvent({
+                cliContext.instrumentPostHogEvent({
                     command: "fern logout"
                 });
                 await logout(context);
@@ -1456,7 +1456,7 @@ function addFormatCommand(cli: Argv<GlobalCliOptions>, cliContext: CliContext) {
                     description: "Only run the command on the provided API"
                 }),
         async (argv) => {
-            await cliContext.instrumentPostHogEvent({
+            cliContext.instrumentPostHogEvent({
                 command: "fern format"
             });
             await formatWorkspaces({
@@ -1490,7 +1490,7 @@ function addTestCommand(cli: Argv<GlobalCliOptions>, cliContext: CliContext) {
                     description: "Run the tests configured to a specific language"
                 }),
         async (argv) => {
-            await cliContext.instrumentPostHogEvent({
+            cliContext.instrumentPostHogEvent({
                 command: "fern test"
             });
             await testOutput({
@@ -1523,7 +1523,7 @@ function addMockCommand(cli: Argv<GlobalCliOptions>, cliContext: CliContext) {
                     description: "The API to mock."
                 }),
         async (argv) => {
-            await cliContext.instrumentPostHogEvent({
+            cliContext.instrumentPostHogEvent({
                 command: "fern mock"
             });
             await mockServer({
@@ -1568,7 +1568,7 @@ function addOverridesCompareCommand(cli: Argv<GlobalCliOptions>, cliContext: Cli
                     description: "Path to write the overrides file (defaults to <original>-overrides.yml)"
                 }),
         async (argv) => {
-            await cliContext.instrumentPostHogEvent({
+            cliContext.instrumentPostHogEvent({
                 command: "fern overrides compare"
             });
             const originalPath = resolve(cwd(), argv.original as string);
@@ -1601,7 +1601,7 @@ function addOverridesWriteCommand(cli: Argv<GlobalCliOptions>, cliContext: CliCo
             })
         ],
         async (argv) => {
-            await cliContext.instrumentPostHogEvent({
+            cliContext.instrumentPostHogEvent({
                 command: "fern overrides write"
             });
             await writeOverridesForWorkspaces({
@@ -1637,7 +1637,7 @@ function addWriteOverridesCommand(cli: Argv<GlobalCliOptions>, cliContext: CliCo
         ],
         async (argv) => {
             cliContext.logger.warn("The 'write-overrides' command is deprecated. Use 'fern overrides write' instead.");
-            await cliContext.instrumentPostHogEvent({
+            cliContext.instrumentPostHogEvent({
                 command: "fern write-overrides"
             });
             await writeOverridesForWorkspaces({
@@ -1672,7 +1672,7 @@ function addWriteDefinitionCommand(cli: Argv<GlobalCliOptions>, cliContext: CliC
                 }),
         async (argv) => {
             const preserveSchemaIds = argv.preserveSchemas != null;
-            await cliContext.instrumentPostHogEvent({
+            cliContext.instrumentPostHogEvent({
                 command: "fern write-definition"
             });
             await writeDefinitionForWorkspaces({
@@ -1721,7 +1721,7 @@ function addDocsMdGenerateCommand(cli: Argv<GlobalCliOptions>, cliContext: CliCo
                 description: "Name of a specific library defined in docs.yml to generate docs for"
             }),
         async (argv) => {
-            await cliContext.instrumentPostHogEvent({
+            cliContext.instrumentPostHogEvent({
                 command: "fern docs md generate"
             });
 
@@ -1762,7 +1762,7 @@ function addDocsDiffCommand(cli: Argv<GlobalCliOptions>, cliContext: CliContext)
                     description: "Output directory for diff images"
                 }),
         async (argv) => {
-            await cliContext.instrumentPostHogEvent({
+            cliContext.instrumentPostHogEvent({
                 command: "fern docs diff"
             });
 
@@ -1807,7 +1807,7 @@ function addDocsPreviewListCommand(cli: Argv<GlobalCliOptions>, cliContext: CliC
                     description: "Page number for pagination (starts at 1)"
                 }),
         async (argv) => {
-            await cliContext.instrumentPostHogEvent({
+            cliContext.instrumentPostHogEvent({
                 command: "fern docs preview list"
             });
             await listDocsPreview({
@@ -1831,7 +1831,7 @@ function addDocsPreviewDeleteCommand(cli: Argv<GlobalCliOptions>, cliContext: Cl
                 demandOption: true
             }),
         async (argv) => {
-            await cliContext.instrumentPostHogEvent({
+            cliContext.instrumentPostHogEvent({
                 command: "fern docs preview delete"
             });
             await deleteDocsPreview({
@@ -1950,7 +1950,7 @@ function addDocsMdCheckCommand(cli: Argv<GlobalCliOptions>, cliContext: CliConte
             // No additional options for this command
         },
         async () => {
-            await cliContext.instrumentPostHogEvent({
+            cliContext.instrumentPostHogEvent({
                 command: "fern docs md check"
             });
 
@@ -2006,7 +2006,7 @@ function addGenerateJsonschemaCommand(cli: Argv<GlobalCliOptions>, cliContext: C
                     description: "The type to generate JSON Schema for (e.g. 'MySchema' or 'mypackage.MySchema')"
                 }),
         async (argv) => {
-            await cliContext.instrumentPostHogEvent({
+            cliContext.instrumentPostHogEvent({
                 command: "fern jsonschema",
                 properties: {
                     output: argv.output
@@ -2036,7 +2036,7 @@ function addWriteDocsDefinitionCommand(cli: Argv<GlobalCliOptions>, cliContext: 
                 demandOption: true
             }),
         async (argv) => {
-            await cliContext.instrumentPostHogEvent({
+            cliContext.instrumentPostHogEvent({
                 command: "fern write-docs-definition",
                 properties: {
                     outputPath: argv.outputPath
@@ -2067,7 +2067,7 @@ function addWriteTranslationCommand(cli: Argv<GlobalCliOptions>, cliContext: Cli
                 description: "Return content as-is without calling the translation service"
             }),
         async (argv) => {
-            await cliContext.instrumentPostHogEvent({
+            cliContext.instrumentPostHogEvent({
                 command: "fern write-translation"
             });
 
@@ -2104,7 +2104,7 @@ function addExportCommand(cli: Argv<GlobalCliOptions>, cliContext: CliContext) {
                     default: 2
                 }),
         async (argv) => {
-            await cliContext.instrumentPostHogEvent({
+            cliContext.instrumentPostHogEvent({
                 command: "fern export",
                 properties: {
                     outputPath: argv.outputPath
@@ -2148,7 +2148,7 @@ function addEnrichCommand(cli: Argv<GlobalCliOptions>, cliContext: CliContext) {
                     demandOption: true
                 }),
         async (argv) => {
-            await cliContext.instrumentPostHogEvent({
+            cliContext.instrumentPostHogEvent({
                 command: "fern api enrich"
             });
             const openapiPath = resolve(cwd(), argv.openapi as string);
@@ -2470,7 +2470,7 @@ function addSdkPreviewCommand(cli: Argv<GlobalCliOptions>, cliContext: CliContex
                         "Cannot be combined with --local."
                 }),
         async (argv) => {
-            await cliContext.instrumentPostHogEvent({
+            cliContext.instrumentPostHogEvent({
                 command: "fern sdk preview"
             });
             const generatorFilter =
@@ -2632,7 +2632,7 @@ function addReplayInitCommand(cli: Argv<GlobalCliOptions>, cliContext: CliContex
                     description: "Overwrite existing lockfile if Replay is already initialized"
                 }),
         async (argv) => {
-            await cliContext.instrumentPostHogEvent({
+            cliContext.instrumentPostHogEvent({
                 command: "fern replay init"
             });
 
@@ -2754,7 +2754,7 @@ function addReplayResolveCommand(cli: Argv<GlobalCliOptions>, cliContext: CliCon
                     description: "Skip checking for remaining conflict markers before committing"
                 }),
         async (argv) => {
-            await cliContext.instrumentPostHogEvent({
+            cliContext.instrumentPostHogEvent({
                 command: "fern replay resolve"
             });
 

--- a/packages/cli/cli/src/cliV2.ts
+++ b/packages/cli/cli/src/cliV2.ts
@@ -42,7 +42,7 @@ export function addGetOrganizationCommand(cli: Argv<GlobalCliOptions>, cliContex
                 description: "The location to output the organization name as a text file, defaults to standard out."
             }),
         async (argv) => {
-            await cliContext.instrumentPostHogEvent({
+            cliContext.instrumentPostHogEvent({
                 command: "fern organization",
                 properties: {
                     outputLocation: argv.output
@@ -110,7 +110,7 @@ export function addGeneratorCommands(cli: Argv<GlobalCliOptions>, cliContext: Cl
                             description: "The generator output modes to exclude within the outputted list."
                         }),
                 async (argv) => {
-                    await cliContext.instrumentPostHogEvent({
+                    cliContext.instrumentPostHogEvent({
                         command: "fern generator list",
                         properties: {
                             outputLocation: argv.output
@@ -183,7 +183,7 @@ export function addGeneratorCommands(cli: Argv<GlobalCliOptions>, cliContext: Cl
                                 "Skip upgrading generators that have autorelease: false set in their configuration."
                         }),
                 async (argv) => {
-                    await cliContext.instrumentPostHogEvent({
+                    cliContext.instrumentPostHogEvent({
                         command: "fern generator upgrade",
                         properties: {
                             generator: argv.generator,
@@ -282,7 +282,7 @@ export function addGeneratorCommands(cli: Argv<GlobalCliOptions>, cliContext: Cl
                         }),
                 async (argv) => {
                     const correctedGetGenerator = warnAndCorrectIncorrectDockerOrgV2(argv.generator, cliContext);
-                    await cliContext.instrumentPostHogEvent({
+                    cliContext.instrumentPostHogEvent({
                         command: "fern generator get",
                         properties: {
                             generator: correctedGetGenerator,

--- a/packages/cli/cli/src/commands/docs-dev/devDocsWorkspace.ts
+++ b/packages/cli/cli/src/commands/docs-dev/devDocsWorkspace.ts
@@ -31,7 +31,7 @@ export async function previewDocsWorkspace({
     }
 
     if (legacyPreview) {
-        await cliContext.instrumentPostHogEvent({
+        cliContext.instrumentPostHogEvent({
             orgId: project.config.organization,
             command: "fern docs dev --legacy"
         });
@@ -79,7 +79,7 @@ export async function previewDocsWorkspace({
         });
     }
 
-    await cliContext.instrumentPostHogEvent({
+    cliContext.instrumentPostHogEvent({
         orgId: project.config.organization,
         command: "fern docs dev --beta"
     });

--- a/packages/cli/cli/src/commands/generate-overrides/__test__/writeOverridesForWorkspaces.test.ts
+++ b/packages/cli/cli/src/commands/generate-overrides/__test__/writeOverridesForWorkspaces.test.ts
@@ -29,7 +29,7 @@ function createMockContext(): TaskContext {
             throw new Error("Not implemented in mock");
         },
         runInteractiveTask: async () => false,
-        instrumentPostHogEvent: async () => {
+        instrumentPostHogEvent: () => {
             return;
         }
     };

--- a/packages/cli/cli/src/commands/generate/generateAPIWorkspaces.ts
+++ b/packages/cli/cli/src/commands/generate/generateAPIWorkspaces.ts
@@ -114,7 +114,7 @@ export async function generateAPIWorkspaces({
         }
     }
 
-    await cliContext.instrumentPostHogEvent({
+    cliContext.instrumentPostHogEvent({
         orgId: project.config.organization,
         command: "fern generate",
         properties: {

--- a/packages/cli/cli/src/commands/generate/generateDocsWorkspace.ts
+++ b/packages/cli/cli/src/commands/generate/generateDocsWorkspace.ts
@@ -149,7 +149,7 @@ export async function generateDocsWorkspace({
         }
     }
 
-    await cliContext.instrumentPostHogEvent({
+    cliContext.instrumentPostHogEvent({
         orgId: project.config.organization,
         command: "fern generate --docs"
     });

--- a/packages/cli/cli/src/commands/mock/mockServer.ts
+++ b/packages/cli/cli/src/commands/mock/mockServer.ts
@@ -16,7 +16,7 @@ export async function mockServer({
     project: Project;
     port: number | undefined;
 }): Promise<void> {
-    await cliContext.instrumentPostHogEvent({
+    cliContext.instrumentPostHogEvent({
         orgId: project.config.organization,
         command: "fern mock"
     });

--- a/packages/cli/cli/src/commands/test/testOutput.ts
+++ b/packages/cli/cli/src/commands/test/testOutput.ts
@@ -20,7 +20,7 @@ export async function testOutput({
     testCommand: string | undefined;
     generationLanguage: generatorsYml.GenerationLanguage | undefined;
 }): Promise<void> {
-    await cliContext.instrumentPostHogEvent({
+    cliContext.instrumentPostHogEvent({
         orgId: project.config.organization,
         command: "fern test"
     });

--- a/packages/cli/cli/src/commands/write-translation/__test__/writeTranslationIntegration.test.ts
+++ b/packages/cli/cli/src/commands/write-translation/__test__/writeTranslationIntegration.test.ts
@@ -70,7 +70,7 @@ describe("writeTranslationForProject - Integration Tests", () => {
 
         return {
             logger,
-            instrumentPostHogEvent: async () => {
+            instrumentPostHogEvent: () => {
                 // empty block
             },
             runTaskForWorkspace: async (workspace: unknown, fn: (context: unknown) => Promise<void>) => {

--- a/packages/cli/generation/remote-generation/remote-workspace-runner/src/publishDocs.ts
+++ b/packages/cli/generation/remote-generation/remote-workspace-runner/src/publishDocs.ts
@@ -721,7 +721,7 @@ async function startDocsRegisterFailed(
     organization: string,
     domain: string
 ): Promise<never> {
-    await context.instrumentPostHogEvent({
+    context.instrumentPostHogEvent({
         command: "docs-generation",
         properties: {
             error: JSON.stringify(error)

--- a/packages/cli/login/src/login.ts
+++ b/packages/cli/login/src/login.ts
@@ -14,7 +14,7 @@ export async function login(
     context: TaskContext,
     { useDeviceCodeFlow = false, email }: { useDeviceCodeFlow?: boolean; email?: string } = {}
 ): Promise<FernUserToken> {
-    await context.instrumentPostHogEvent({
+    context.instrumentPostHogEvent({
         command: "Login initiated"
     });
 

--- a/packages/cli/login/src/logout.ts
+++ b/packages/cli/login/src/logout.ts
@@ -5,7 +5,7 @@ import open from "open";
 import { AUTH0_CLIENT_ID, AUTH0_DOMAIN } from "./constants.js";
 
 export async function logout(context: TaskContext): Promise<void> {
-    await context.instrumentPostHogEvent({
+    context.instrumentPostHogEvent({
         command: "Logout initiated"
     });
 
@@ -35,7 +35,7 @@ export async function logout(context: TaskContext): Promise<void> {
         );
     }
 
-    await context.instrumentPostHogEvent({
+    context.instrumentPostHogEvent({
         command: "Logout successful"
     });
 }

--- a/packages/cli/task-context/src/TaskContext.ts
+++ b/packages/cli/task-context/src/TaskContext.ts
@@ -11,7 +11,7 @@ export interface TaskContext {
         params: CreateInteractiveTaskParams,
         run: (context: InteractiveTaskContext) => void | Promise<void>
     ) => Promise<boolean>;
-    instrumentPostHogEvent: (event: PosthogEvent) => Promise<void>;
+    instrumentPostHogEvent: (event: PosthogEvent) => void;
 }
 
 export interface InteractiveTaskContext extends TaskContext {

--- a/packages/cli/workspace/lazy-fern-workspace/src/__test__/helpers/createMockTaskContext.ts
+++ b/packages/cli/workspace/lazy-fern-workspace/src/__test__/helpers/createMockTaskContext.ts
@@ -25,8 +25,6 @@ export function createMockTaskContext(): TaskContext {
             throw new Error("Not implemented in mock");
         },
         runInteractiveTask: async () => false,
-        instrumentPostHogEvent: async () => {
-            return;
-        }
+        instrumentPostHogEvent: noop
     };
 }

--- a/packages/cli/workspace/lazy-fern-workspace/src/protobuf/__test__/ProtobufOpenAPIGeneratorResolution.test.ts
+++ b/packages/cli/workspace/lazy-fern-workspace/src/protobuf/__test__/ProtobufOpenAPIGeneratorResolution.test.ts
@@ -66,7 +66,7 @@ function createMockTaskContext(): TaskContext {
             throw new Error("Not implemented in mock");
         },
         runInteractiveTask: async () => false,
-        instrumentPostHogEvent: async () => {
+        instrumentPostHogEvent: () => {
             return;
         }
     };

--- a/packages/seed/src/TaskContextImpl.ts
+++ b/packages/seed/src/TaskContextImpl.ts
@@ -27,7 +27,7 @@ export declare namespace TaskContextImpl {
          */
         onResult?: (result: TaskResult) => void;
         shouldBufferLogs: boolean;
-        instrumentPostHogEvent: (event: PosthogEvent) => Promise<void>;
+        instrumentPostHogEvent: (event: PosthogEvent) => void;
     }
 }
 
@@ -40,7 +40,7 @@ export class TaskContextImpl implements Startable<TaskContext>, Finishable, Task
     private bufferedLogs: Log[] = [];
     protected status: "notStarted" | "running" | "finished" = "notStarted";
     private onResult: ((result: TaskResult) => void) | undefined;
-    private instrumentPostHogEventImpl: (event: PosthogEvent) => Promise<void>;
+    private instrumentPostHogEventImpl: (event: PosthogEvent) => void;
     public constructor({
         logImmediately,
         logPrefix,
@@ -101,7 +101,7 @@ export class TaskContextImpl implements Startable<TaskContext>, Finishable, Task
         return TaskResult.Success;
     }
 
-    public async instrumentPostHogEvent(event: PosthogEvent): Promise<void> {
+    public instrumentPostHogEvent(event: PosthogEvent): void {
         this.instrumentPostHogEventImpl(event);
     }
 
@@ -144,7 +144,7 @@ export class TaskContextImpl implements Startable<TaskContext>, Finishable, Task
             takeOverTerminal: this.takeOverTerminal,
             onResult: this.onResult,
             shouldBufferLogs: this.shouldBufferLogs,
-            instrumentPostHogEvent: async (event) => await this.instrumentPostHogEventImpl(event)
+            instrumentPostHogEvent: (event) => this.instrumentPostHogEventImpl(event)
         });
         this.subtasks.push(subtask);
         return subtask;

--- a/packages/seed/src/commands/test/TaskContextFactory.ts
+++ b/packages/seed/src/commands/test/TaskContextFactory.ts
@@ -50,8 +50,8 @@ export class TaskContextFactory {
                 return;
             },
             shouldBufferLogs: false,
-            instrumentPostHogEvent: async () => {
-                return;
+            instrumentPostHogEvent: () => {
+                // no-op in seed
             },
             logPrefix: prefixWithColor
         });

--- a/packages/snippets/core/src/utils/createTaskContext.ts
+++ b/packages/snippets/core/src/utils/createTaskContext.ts
@@ -27,7 +27,7 @@ export function createTaskContext(): TaskContext {
             // no-op
             return false;
         },
-        instrumentPostHogEvent: async (_event: PosthogEvent) => {
+        instrumentPostHogEvent: (_event: PosthogEvent) => {
             // no-op
         }
     };


### PR DESCRIPTION
## Description

Part of the CLI error classification effort — see #14749 for full context.

Makes `instrumentPostHogEvent` synchronous in **CLI v1** by removing its `async` qualifier and dropping unnecessary `await` calls at all call sites. This is the CLI v1 counterpart to #14748 (CLI v2).

## Why

The new error system (#14749) needs to call telemetry from `failWithoutThrowing` — a synchronous method on the `TaskContext` interface. If `instrumentPostHogEvent` remains async, every `failWithoutThrowing` call site would need to become async too, rippling changes through the entire `TaskContext` interface. Making telemetry synchronous avoids that: PostHog's `capture()` is fire-and-forget anyway (it buffers locally and flushes in the background), so the `async` was always unnecessary.

## Changes Made

- Changed `instrumentPostHogEvent` from `async` to synchronous in `TaskContext` interface, `CliContext`, `TaskContextImpl`, `TaskContextAdapter`, and test helpers
- Removed `await` from all call sites (21 files)

## Testing

- [x] Existing tests pass (behavioral no-op)
