### PR TITLE
chore(cli): eagerly resolve TelemetryClient distinctId via async factory

### DIFF
--- a/packages/cli/cli-v2/src/__test__/ApiChecker.test.ts
+++ b/packages/cli/cli-v2/src/__test__/ApiChecker.test.ts
@@ -26,7 +26,7 @@ describe("ApiChecker", () => {
             }
 
             const checker = new ApiChecker({
-                context: createTestContext({ cwd }),
+                context: await createTestContext({ cwd }),
                 cliVersion: "0.0.0"
             });
 
@@ -53,7 +53,7 @@ describe("ApiChecker", () => {
             }
 
             const checker = new ApiChecker({
-                context: createTestContext({ cwd }),
+                context: await createTestContext({ cwd }),
                 cliVersion: "0.0.0"
             });
 
@@ -71,7 +71,7 @@ describe("ApiChecker", () => {
             const workspace = await loadWorkspace("simple-api");
 
             const checker = new ApiChecker({
-                context: createTestContext({ cwd }),
+                context: await createTestContext({ cwd }),
                 cliVersion: "0.0.0"
             });
 
@@ -89,7 +89,7 @@ describe("ApiChecker", () => {
             const workspace = await loadWorkspace("simple-api");
 
             const checker = new ApiChecker({
-                context: createTestContext({ cwd }),
+                context: await createTestContext({ cwd }),
                 cliVersion: "0.0.0"
             });
 
@@ -110,7 +110,7 @@ describe("ApiChecker", () => {
             const workspace = await loadWorkspace("simple-api");
 
             const checker = new ApiChecker({
-                context: createTestContext({ cwd }),
+                context: await createTestContext({ cwd }),
                 cliVersion: "0.0.0"
             });
 
@@ -128,7 +128,7 @@ describe("ApiChecker", () => {
             const workspace = await loadWorkspace("simple-api");
 
             const checker = new ApiChecker({
-                context: createTestContext({ cwd }),
+                context: await createTestContext({ cwd }),
                 cliVersion: "0.0.0"
             });
 
@@ -146,7 +146,7 @@ describe("ApiChecker", () => {
             const workspace = await loadWorkspace("simple-api");
 
             const checker = new ApiChecker({
-                context: createTestContext({ cwd }),
+                context: await createTestContext({ cwd }),
                 cliVersion: "0.0.0"
             });
 

--- a/packages/cli/cli-v2/src/__test__/DocsChecker.test.ts
+++ b/packages/cli/cli-v2/src/__test__/DocsChecker.test.ts
@@ -29,7 +29,7 @@ describe("DocsChecker", () => {
             const cwd = AbsoluteFilePath.of(join(__dirname, "fixtures/simple-api"));
 
             const checker = new DocsChecker({
-                context: createTestContext({ cwd })
+                context: await createTestContext({ cwd })
             });
 
             const result = await checker.check({ workspace });
@@ -49,7 +49,7 @@ describe("DocsChecker", () => {
 
             const workspace = await loadTempWorkspace(testDir);
             const checker = new DocsChecker({
-                context: createTestContext({ cwd: testDir })
+                context: await createTestContext({ cwd: testDir })
             });
 
             const result = await checker.check({ workspace });
@@ -69,7 +69,7 @@ describe("DocsChecker", () => {
 
             const workspace = await loadTempWorkspace(testDir);
             const checker = new DocsChecker({
-                context: createTestContext({ cwd: testDir })
+                context: await createTestContext({ cwd: testDir })
             });
 
             const result = await checker.check({ workspace });
@@ -84,7 +84,7 @@ describe("DocsChecker", () => {
 
             const workspace = await loadTempWorkspace(testDir);
             const checker = new DocsChecker({
-                context: createTestContext({ cwd: testDir })
+                context: await createTestContext({ cwd: testDir })
             });
 
             const resultStrict = await checker.check({ workspace, strict: true });
@@ -133,7 +133,7 @@ docs:
 
             const workspace = await loadTempWorkspace(testDir);
             const checker = new DocsChecker({
-                context: createTestContext({ cwd: testDir })
+                context: await createTestContext({ cwd: testDir })
             });
 
             const result = await checker.check({ workspace, strict: true });

--- a/packages/cli/cli-v2/src/__test__/GeneratorPipeline.test.ts
+++ b/packages/cli/cli-v2/src/__test__/GeneratorPipeline.test.ts
@@ -32,7 +32,7 @@ function makeTarget(overrides: Partial<Target>): Target {
 describe("GeneratorPipeline", () => {
     describe("custom registry constraint", () => {
         it("rejects custom registry with remote generation", async () => {
-            const context = createTestContext({ cwd: AbsoluteFilePath.of("/tmp") });
+            const context = await createTestContext({ cwd: AbsoluteFilePath.of("/tmp") });
             const pipeline = new GeneratorPipeline({ context, cliVersion: "0.0.0" });
             const task = createMockTask();
 
@@ -50,7 +50,7 @@ describe("GeneratorPipeline", () => {
         });
 
         it("allows undefined registry with remote generation", async () => {
-            const context = createTestContext({ cwd: AbsoluteFilePath.of("/tmp") });
+            const context = await createTestContext({ cwd: AbsoluteFilePath.of("/tmp") });
             const pipeline = new GeneratorPipeline({ context, cliVersion: "0.0.0" });
             const task = createMockTask();
 

--- a/packages/cli/cli-v2/src/__test__/LegacyApiSpecAdapter.test.ts
+++ b/packages/cli/cli-v2/src/__test__/LegacyApiSpecAdapter.test.ts
@@ -1,17 +1,23 @@
 import type { OpenAPISpec, OpenRPCSpec } from "@fern-api/api-workspace-commons";
 import { generatorsYml } from "@fern-api/configuration";
 import { AbsoluteFilePath } from "@fern-api/fs-utils";
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it } from "vitest";
 import { LegacyApiSpecAdapter } from "../api/adapter/LegacyApiSpecAdapter.js";
 import type { AsyncApiSpec } from "../api/config/AsyncApiSpec.js";
 import type { OpenApiSpec } from "../api/config/OpenApiSpec.js";
 import type { OpenRpcSpec } from "../api/config/OpenRpcSpec.js";
+import type { Context } from "../context/Context.js";
 import { createTestContext } from "./utils/createTestContext.js";
 
 describe("LegacyApiSpecAdapter", () => {
     const cwd = AbsoluteFilePath.of("/test/path");
-    const context = createTestContext({ cwd });
-    const adapter = new LegacyApiSpecAdapter({ context });
+    let context: Context;
+    let adapter: LegacyApiSpecAdapter;
+
+    beforeEach(async () => {
+        context = await createTestContext({ cwd });
+        adapter = new LegacyApiSpecAdapter({ context });
+    });
 
     describe("convertOpenApiSettings", () => {
         it("returns undefined when settings are not provided", () => {

--- a/packages/cli/cli-v2/src/__test__/LegacyFernWorkspaceAdapter.test.ts
+++ b/packages/cli/cli-v2/src/__test__/LegacyFernWorkspaceAdapter.test.ts
@@ -27,7 +27,7 @@ describe("LegacyFernWorkspaceAdapter", () => {
 
         it("adapts Fern spec to FernWorkspace using LazyFernWorkspace", async () => {
             const { cwd, apiDefinition } = await loadApiDefinition("fern-definition");
-            const adapter = createAdapter(cwd);
+            const adapter = await createAdapter(cwd);
 
             const fernWorkspace = await adapter.adapt(apiDefinition);
             expect(fernWorkspace).toBeDefined();
@@ -44,7 +44,7 @@ describe("LegacyFernWorkspaceAdapter", () => {
 
         it("loads types and services from Fern definition files", async () => {
             const { cwd, apiDefinition } = await loadApiDefinition("fern-definition");
-            const adapter = createAdapter(cwd);
+            const adapter = await createAdapter(cwd);
 
             const fernWorkspace = await adapter.adapt(apiDefinition);
             const definitionFiles = fernWorkspace.definition.namedDefinitionFiles;
@@ -82,7 +82,7 @@ describe("LegacyFernWorkspaceAdapter", () => {
                 expect(isOpenApiSpec(firstSpec)).toBe(true);
             }
 
-            const adapter = createAdapter(cwd);
+            const adapter = await createAdapter(cwd);
             const fernWorkspace = await adapter.adapt(apiDefinition);
             expect(fernWorkspace).toBeDefined();
             expect(fernWorkspace.definition).toBeDefined();
@@ -103,7 +103,7 @@ describe("LegacyFernWorkspaceAdapter", () => {
 
         it("adapts Conjure spec to FernWorkspace using ConjureWorkspace", async () => {
             const { cwd, apiDefinition } = await loadApiDefinition("conjure-definition");
-            const adapter = createAdapter(cwd);
+            const adapter = await createAdapter(cwd);
 
             const fernWorkspace = await adapter.adapt(apiDefinition);
             expect(fernWorkspace).toBeDefined();
@@ -120,7 +120,7 @@ describe("LegacyFernWorkspaceAdapter", () => {
                 expect(spec.conjure.toString()).toContain("conjure-definition/conjure");
             }
 
-            const adapter = createAdapter(cwd);
+            const adapter = await createAdapter(cwd);
             const fernWorkspace = await adapter.adapt(apiDefinition);
             expect(fernWorkspace).toBeDefined();
             expect(fernWorkspace.absoluteFilePath.toString()).toBe(cwd.toString());
@@ -130,7 +130,7 @@ describe("LegacyFernWorkspaceAdapter", () => {
     describe("Multiple OpenAPI Specs", () => {
         it("allows multiple OpenAPI specs to be mixed together", async () => {
             const cwd = AbsoluteFilePath.of(join(FIXTURES_DIR, "simple-api"));
-            const adapter = createAdapter(cwd);
+            const adapter = await createAdapter(cwd);
 
             const openApiSpec1: OpenApiSpec = {
                 openapi: AbsoluteFilePath.of(join(FIXTURES_DIR, "simple-api", "openapi.yml"))
@@ -173,7 +173,7 @@ describe("LegacyFernWorkspaceAdapter", () => {
 
         it("override auth scheme", async () => {
             const { cwd, apiDefinition } = await loadApiDefinition("api-config-override");
-            const adapter = createAdapter(cwd);
+            const adapter = await createAdapter(cwd);
 
             const fernWorkspace = await adapter.adapt(apiDefinition);
             expect(fernWorkspace).toBeDefined();
@@ -186,7 +186,7 @@ describe("LegacyFernWorkspaceAdapter", () => {
 
         it("override environments", async () => {
             const { cwd, apiDefinition } = await loadApiDefinition("api-config-override");
-            const adapter = createAdapter(cwd);
+            const adapter = await createAdapter(cwd);
 
             const fernWorkspace = await adapter.adapt(apiDefinition);
             expect(fernWorkspace).toBeDefined();
@@ -207,8 +207,8 @@ describe("LegacyFernWorkspaceAdapter", () => {
 /**
  * Creates an adapter for testing with the given cwd.
  */
-function createAdapter(cwd: AbsoluteFilePath): LegacyFernWorkspaceAdapter {
-    const context = createTestContext({ cwd });
+async function createAdapter(cwd: AbsoluteFilePath): Promise<LegacyFernWorkspaceAdapter> {
+    const context = await createTestContext({ cwd });
     const task = createMockTask();
     return new LegacyFernWorkspaceAdapter({
         context,

--- a/packages/cli/cli-v2/src/__test__/SdkChecker.test.ts
+++ b/packages/cli/cli-v2/src/__test__/SdkChecker.test.ts
@@ -34,7 +34,7 @@ describe("SdkChecker", () => {
             const workspace = await loadWorkspace("simple-api");
 
             const checker = new SdkChecker({
-                context: createTestContext({ cwd }),
+                context: await createTestContext({ cwd }),
                 versionChecker: NOOP_VERSION_CHECKER
             });
 
@@ -61,7 +61,7 @@ api:
             const workspace = await loadTempWorkspace(testDir);
 
             const checker = new SdkChecker({
-                context: createTestContext({ cwd: testDir }),
+                context: await createTestContext({ cwd: testDir }),
                 versionChecker: NOOP_VERSION_CHECKER
             });
 
@@ -98,7 +98,7 @@ sdks:
 
             const workspace = await loadTempWorkspace(testDir);
             const checker = new SdkChecker({
-                context: createTestContext({ cwd: testDir }),
+                context: await createTestContext({ cwd: testDir }),
                 versionChecker: NOOP_VERSION_CHECKER
             });
 
@@ -113,7 +113,7 @@ sdks:
             const workspace = await loadWorkspace("simple-api");
 
             const checker = new SdkChecker({
-                context: createTestContext({ cwd }),
+                context: await createTestContext({ cwd }),
                 versionChecker: NOOP_VERSION_CHECKER
             });
 
@@ -146,7 +146,7 @@ sdks:
 
             const workspace = await loadTempWorkspace(testDir);
             const checker = new SdkChecker({
-                context: createTestContext({ cwd: testDir }),
+                context: await createTestContext({ cwd: testDir }),
                 versionChecker: NOOP_VERSION_CHECKER
             });
 
@@ -163,7 +163,7 @@ sdks:
             const workspace = await loadWorkspace("simple-api");
 
             const checker = new SdkChecker({
-                context: createTestContext({ cwd }),
+                context: await createTestContext({ cwd }),
                 versionChecker: NOOP_VERSION_CHECKER
             });
 
@@ -198,7 +198,7 @@ sdks:
 
             const workspace = await loadTempWorkspace(testDir);
             const checker = new SdkChecker({
-                context: createTestContext({ cwd: testDir }),
+                context: await createTestContext({ cwd: testDir }),
                 versionChecker: NOOP_VERSION_CHECKER
             });
 
@@ -213,7 +213,7 @@ sdks:
             const workspace = await loadWorkspace("simple-api");
 
             const checker = new SdkChecker({
-                context: createTestContext({ cwd }),
+                context: await createTestContext({ cwd }),
                 versionChecker: NOOP_VERSION_CHECKER
             });
 
@@ -229,7 +229,7 @@ sdks:
             const workspace = await loadWorkspace("simple-api");
 
             const checker = new SdkChecker({
-                context: createTestContext({ cwd }),
+                context: await createTestContext({ cwd }),
                 versionChecker: async ({ target }) => ({
                     violation: {
                         severity: "warning",

--- a/packages/cli/cli-v2/src/__test__/check.test.ts
+++ b/packages/cli/cli-v2/src/__test__/check.test.ts
@@ -51,7 +51,7 @@ paths: {}
 `
         );
 
-        const { context, getStdout, getStderr } = createTestContextWithCapture({ cwd: testDir });
+        const { context, getStdout, getStderr } = await createTestContextWithCapture({ cwd: testDir });
         const cmd = new CheckCommand();
 
         // The sdk checker will find the defaultGroup violation, which causes an error exit.
@@ -129,7 +129,7 @@ paths: {}
 `
         );
 
-        const { context, getStdout, getStderr } = createTestContextWithCapture({ cwd: testDir });
+        const { context, getStdout, getStderr } = await createTestContextWithCapture({ cwd: testDir });
         const cmd = new SdkCheckCommand();
 
         try {

--- a/packages/cli/cli-v2/src/__test__/compile.test.ts
+++ b/packages/cli/cli-v2/src/__test__/compile.test.ts
@@ -39,7 +39,7 @@ describe("fern api compile", () => {
         });
 
         it("writes valid IR JSON to the specified file", async () => {
-            const { context } = createTestContextWithCapture({ cwd: SIMPLE_API_DIR });
+            const { context } = await createTestContextWithCapture({ cwd: SIMPLE_API_DIR });
             await cmd.handle(context, baseArgs({ output: outputPath }));
 
             expect(await doesPathExist(AbsoluteFilePath.of(outputPath))).toBe(true);
@@ -50,7 +50,7 @@ describe("fern api compile", () => {
         });
 
         it("writes no human-readable output to stderr at default log level", async () => {
-            const { context, getStderr } = createTestContextWithCapture({ cwd: SIMPLE_API_DIR });
+            const { context, getStderr } = await createTestContextWithCapture({ cwd: SIMPLE_API_DIR });
             await cmd.handle(context, baseArgs({ output: outputPath }));
 
             expect(getStderr()).toBe("");
@@ -59,14 +59,14 @@ describe("fern api compile", () => {
 
     describe("no --output (validate only)", () => {
         it("produces no stdout output", async () => {
-            const { context, getStdout } = createTestContextWithCapture({ cwd: SIMPLE_API_DIR });
+            const { context, getStdout } = await createTestContextWithCapture({ cwd: SIMPLE_API_DIR });
             await cmd.handle(context, baseArgs());
 
             expect(getStdout()).toBe("");
         });
 
         it("produces no stderr output at default log level", async () => {
-            const { context, getStderr } = createTestContextWithCapture({ cwd: SIMPLE_API_DIR });
+            const { context, getStderr } = await createTestContextWithCapture({ cwd: SIMPLE_API_DIR });
             await cmd.handle(context, baseArgs());
 
             expect(getStderr()).toBe("");
@@ -89,7 +89,7 @@ describe("fern api compile", () => {
         });
 
         it("compiles a specific API by name", async () => {
-            const { context } = createTestContextWithCapture({ cwd: SIMPLE_API_DIR });
+            const { context } = await createTestContextWithCapture({ cwd: SIMPLE_API_DIR });
             await cmd.handle(context, baseArgs({ api: "api", output: outputPath }));
 
             const content = await readFile(outputPath, "utf-8");
@@ -98,7 +98,7 @@ describe("fern api compile", () => {
         });
 
         it("throws CliError for a non-existent API name", async () => {
-            const { context } = createTestContextWithCapture({ cwd: SIMPLE_API_DIR });
+            const { context } = await createTestContextWithCapture({ cwd: SIMPLE_API_DIR });
             await expect(cmd.handle(context, baseArgs({ api: "nonexistent" }))).rejects.toThrow(
                 "API 'nonexistent' not found"
             );
@@ -107,7 +107,7 @@ describe("fern api compile", () => {
 
     describe("validation errors", () => {
         it("throws CliError with error details for an invalid API", async () => {
-            const { context, getStderr } = createTestContextWithCapture({ cwd: INVALID_API_DIR });
+            const { context, getStderr } = await createTestContextWithCapture({ cwd: INVALID_API_DIR });
             await expect(cmd.handle(context, baseArgs())).rejects.toThrow(CliError);
 
             const stderr = getStderr();

--- a/packages/cli/cli-v2/src/__test__/integration.test.ts
+++ b/packages/cli/cli-v2/src/__test__/integration.test.ts
@@ -80,7 +80,7 @@ describe("SDK Generate Integration", () => {
             const apiDefinition = workspace.apis["api"];
             expect(apiDefinition).toBeDefined();
 
-            const adapter = new LegacyApiSpecAdapter({ context: createTestContext({ cwd }) });
+            const adapter = new LegacyApiSpecAdapter({ context: await createTestContext({ cwd }) });
 
             const v1Specs = adapter.convertAll(apiDefinition?.specs ?? []);
             expect(v1Specs).toHaveLength(1);
@@ -135,7 +135,7 @@ describe("SDK Generate Integration", () => {
             const apiDefinition = workspace.apis["api"];
             expect(apiDefinition).toBeDefined();
 
-            const adapter = new LegacyApiSpecAdapter({ context: createTestContext({ cwd }) });
+            const adapter = new LegacyApiSpecAdapter({ context: await createTestContext({ cwd }) });
 
             const v1Specs = adapter.convertAll(apiDefinition?.specs ?? []);
             const filteredSpecs = v1Specs.filter((spec): spec is OpenAPISpec | ProtobufSpec => {
@@ -184,7 +184,7 @@ describe("SDK Generate Integration", () => {
             const { workspace } = result;
             expect(workspace.apis["api"]).toBeDefined();
 
-            const adapter = new LegacyApiSpecAdapter({ context: createTestContext({ cwd }) });
+            const adapter = new LegacyApiSpecAdapter({ context: await createTestContext({ cwd }) });
 
             const v1Specs = adapter.convertAll(workspace.apis["api"]?.specs ?? []);
             expect(v1Specs).toHaveLength(1);

--- a/packages/cli/cli-v2/src/__test__/utils/createTestContext.ts
+++ b/packages/cli/cli-v2/src/__test__/utils/createTestContext.ts
@@ -8,8 +8,8 @@ import { Context } from "../../context/Context.js";
  * This creates a Context instance with streams that discard output,
  * suitable for unit tests where console output is not needed.
  */
-export function createTestContext({ cwd }: { cwd: AbsoluteFilePath }): Context {
-    return new Context({
+export async function createTestContext({ cwd }: { cwd: AbsoluteFilePath }): Promise<Context> {
+    return Context.create({
         stdout: createNullStream(),
         stderr: createNullStream(),
         cwd
@@ -19,15 +19,16 @@ export function createTestContext({ cwd }: { cwd: AbsoluteFilePath }): Context {
 /**
  * Create a Context whose stdout/stderr are captured for assertion.
  */
-export function createTestContextWithCapture({ cwd }: { cwd: AbsoluteFilePath }): {
+export async function createTestContextWithCapture({ cwd }: { cwd: AbsoluteFilePath }): Promise<{
     context: Context;
     getStdout: () => string;
     getStderr: () => string;
-} {
+}> {
     const stdout = createCapturingStream();
     const stderr = createCapturingStream();
+    const context = await Context.create({ stdout: stdout.stream, stderr: stderr.stream, cwd });
     return {
-        context: new Context({ stdout: stdout.stream, stderr: stderr.stream, cwd }),
+        context,
         getStdout: stdout.getOutput,
         getStderr: stderr.getOutput
     };

--- a/packages/cli/cli-v2/src/context/Context.ts
+++ b/packages/cli/cli-v2/src/context/Context.ts
@@ -41,7 +41,7 @@ export class Context {
     public readonly tokenService: TokenService;
     public readonly ttyAwareLogger: TtyAwareLogger;
 
-    constructor({
+    public static async create({
         stdout,
         stderr,
         cwd,
@@ -51,6 +51,24 @@ export class Context {
         stderr: NodeJS.WriteStream;
         cwd?: AbsoluteFilePath;
         logLevel?: LogLevel;
+    }): Promise<Context> {
+        const ttyAwareLogger = new TtyAwareLogger(stdout, stderr);
+        const telemetry = await TelemetryClient.create({ isTTY: ttyAwareLogger.isTTY });
+        return new Context({ stdout, stderr, cwd, logLevel, ttyAwareLogger, telemetry });
+    }
+
+    private constructor({
+        cwd,
+        logLevel,
+        ttyAwareLogger,
+        telemetry
+    }: {
+        stdout: NodeJS.WriteStream;
+        stderr: NodeJS.WriteStream;
+        cwd?: AbsoluteFilePath;
+        logLevel?: LogLevel;
+        ttyAwareLogger: TtyAwareLogger;
+        telemetry: TelemetryClient;
     }) {
         this.cwd = cwd ?? AbsoluteFilePath.of(process.cwd());
         this.logLevel = logLevel ?? LogLevel.Info;
@@ -59,8 +77,8 @@ export class Context {
         this.stderr = createLogger((level: LogLevel, ...args: string[]) => this.logStderr(level, ...args));
         this.cache = new Cache({ logger: this.stderr });
         this.logs = new LogFileWriter(this.cache.logs.absoluteFilePath);
-        this.ttyAwareLogger = new TtyAwareLogger(stdout, stderr);
-        this.telemetry = new TelemetryClient({ isTTY: this.isTTY });
+        this.ttyAwareLogger = ttyAwareLogger;
+        this.telemetry = telemetry;
         this.tokenService = new TokenService({ credential: new CredentialStore() });
     }
 

--- a/packages/cli/cli-v2/src/context/withContext.ts
+++ b/packages/cli/cli-v2/src/context/withContext.ts
@@ -25,13 +25,13 @@ export function withContext<T extends GlobalArgs>(
     handler: (context: Context, args: T) => Promise<void>
 ): (args: T) => Promise<void> {
     return async (args: T) => {
-        const context = createContext(args);
+        const context = await createContext(args);
         const startTime = Date.now();
         setupSignalHandler(context);
 
         try {
             await handler(context, args);
-            await context.telemetry.sendLifecycleEvent({
+            context.telemetry.sendLifecycleEvent({
                 command: context.info.command,
                 status: "success",
                 durationMs: Date.now() - startTime
@@ -41,9 +41,9 @@ export function withContext<T extends GlobalArgs>(
             await exitGracefully(0);
         } catch (error) {
             if (shouldReportToSentry(error)) {
-                await context.telemetry.captureException(error);
+                context.telemetry.captureException(error);
             }
-            await context.telemetry.sendLifecycleEvent({
+            context.telemetry.sendLifecycleEvent({
                 command: context.info.command,
                 status: "error",
                 durationMs: Date.now() - startTime,
@@ -57,9 +57,9 @@ export function withContext<T extends GlobalArgs>(
     };
 }
 
-function createContext(options: GlobalArgs): Context {
+async function createContext(options: GlobalArgs): Promise<Context> {
     const logLevel = parseLogLevel(options["log-level"] ?? "info");
-    return new Context({
+    return Context.create({
         stdout: process.stdout,
         stderr: process.stderr,
         logLevel

--- a/packages/cli/cli-v2/src/telemetry/TelemetryClient.ts
+++ b/packages/cli/cli-v2/src/telemetry/TelemetryClient.ts
@@ -18,9 +18,15 @@ export class TelemetryClient {
     private readonly sentry: Sentry.NodeClient | undefined;
     private readonly baseTags: Tags;
     private readonly accumulatedTags: Tags = {};
-    private cachedDistinctId: string | undefined;
+    private readonly distinctId: string;
 
-    constructor({ isTTY }: { isTTY: boolean }) {
+    public static async create({ isTTY }: { isTTY: boolean }): Promise<TelemetryClient> {
+        const distinctId = await TelemetryClient.getDistinctId();
+        return new TelemetryClient({ isTTY, distinctId });
+    }
+
+    private constructor({ isTTY, distinctId }: { isTTY: boolean; distinctId: string }) {
+        this.distinctId = distinctId;
         const isTelemetryEnabled = this.isTelemetryEnabled();
         const apiKey = process.env.POSTHOG_API_KEY;
         this.baseTags = {
@@ -52,13 +58,13 @@ export class TelemetryClient {
     }
 
     /** Send a named event that inherits base + accumulated properties. */
-    public async sendEvent(event: string, tags?: Tags): Promise<void> {
+    public sendEvent(event: string, tags?: Tags): void {
         if (this.posthog == null) {
             return;
         }
         try {
             this.posthog.capture({
-                distinctId: await this.getDistinctId(),
+                distinctId: this.distinctId,
                 event,
                 properties: { ...this.baseTags, ...this.accumulatedTags, ...tags }
             });
@@ -71,13 +77,13 @@ export class TelemetryClient {
      *
      * This is not meant to be called directly by command handlers.
      */
-    public async sendLifecycleEvent(event: LifecycleEvent): Promise<void> {
+    public sendLifecycleEvent(event: LifecycleEvent): void {
         if (this.posthog == null) {
             return;
         }
         try {
             this.posthog.capture({
-                distinctId: await this.getDistinctId(),
+                distinctId: this.distinctId,
                 event: "cli",
                 properties: {
                     ...this.baseTags,
@@ -101,14 +107,14 @@ export class TelemetryClient {
      * The caller is responsible for deciding which errors are worth reporting
      * (see `shouldReportToSentry` in withContext.ts).
      */
-    public async captureException(error: unknown): Promise<void> {
+    public captureException(error: unknown): void {
         if (this.sentry === undefined) {
             return;
         }
         try {
             this.sentry.captureException(error, {
                 captureContext: {
-                    user: { id: await this.getDistinctId() },
+                    user: { id: this.distinctId },
                     tags: { ...this.baseTags, ...this.accumulatedTags }
                 }
             });
@@ -128,12 +134,9 @@ export class TelemetryClient {
         await Promise.all(promises);
     }
 
-    private async getDistinctId(): Promise<string> {
-        if (this.cachedDistinctId != null) {
-            return this.cachedDistinctId;
-        }
-
-        const distinctIdFilepath = this.getDistinctIdFilepath();
+    private static async getDistinctId(): Promise<string> {
+        const distinctIdFilepath = TelemetryClient.getDistinctIdFilepath();
+        let distinctId: string | null = null;
 
         try {
             if (!(await doesPathExist(distinctIdFilepath))) {
@@ -142,23 +145,22 @@ export class TelemetryClient {
             }
 
             const content = (await readFile(distinctIdFilepath)).toString().trim();
-            this.cachedDistinctId = content;
-
+            distinctId = content;
             if (!isValidUUID(content)) {
                 // Update the cached ID if it was corrupted.
                 const newId = uuidv4();
                 await writeFile(distinctIdFilepath, newId);
-                this.cachedDistinctId = newId;
+                distinctId = newId;
             }
         } catch {
-            this.cachedDistinctId = uuidv4(); // Fallback to a new ID.
+            distinctId = uuidv4(); // Fallback to a new ID.
         }
 
-        if (this.cachedDistinctId == null || this.cachedDistinctId.length === 0) {
-            this.cachedDistinctId = uuidv4();
+        if (distinctId == null || distinctId.length === 0) {
+            distinctId = uuidv4();
         }
 
-        return this.cachedDistinctId;
+        return distinctId;
     }
 
     /**
@@ -167,7 +169,7 @@ export class TelemetryClient {
      * Note that all telemetry is anonymous, but we still use a shared distinct ID
      * to correlate metrics from the same user/machine across multiple CLI invocations.
      */
-    private getDistinctIdFilepath(): AbsoluteFilePath {
+    private static getDistinctIdFilepath(): AbsoluteFilePath {
         return join(AbsoluteFilePath.of(homedir()), RelativeFilePath.of(".fern"), RelativeFilePath.of("id"));
     }
 

--- a/packages/cli/cli-v2/src/telemetry/__test__/TelemetryClient.test.ts
+++ b/packages/cli/cli-v2/src/telemetry/__test__/TelemetryClient.test.ts
@@ -44,9 +44,9 @@ afterEach(async () => {
 describe("TelemetryClient", () => {
     describe("sendLifecycleEvent", () => {
         it("captures a cli event with the expected shape", async () => {
-            const client = new TelemetryClient({ isTTY: true });
+            const client = await TelemetryClient.create({ isTTY: true });
 
-            await client.sendLifecycleEvent({
+            client.sendLifecycleEvent({
                 command: "sdk generate",
                 status: "success",
                 durationMs: 1234
@@ -70,10 +70,10 @@ describe("TelemetryClient", () => {
         });
 
         it("merges tag() into the event", async () => {
-            const client = new TelemetryClient({ isTTY: false });
+            const client = await TelemetryClient.create({ isTTY: false });
             client.tag({ generator: "typescript" });
 
-            await client.sendLifecycleEvent({
+            client.sendLifecycleEvent({
                 command: "sdk generate",
                 status: "success",
                 durationMs: 100
@@ -91,10 +91,10 @@ describe("TelemetryClient", () => {
 
     describe("sendEvent", () => {
         it("captures a named event inheriting base and accumulated properties", async () => {
-            const client = new TelemetryClient({ isTTY: false });
+            const client = await TelemetryClient.create({ isTTY: false });
             client.tag({ org: "acme" });
 
-            await client.sendEvent("generator:run", { language: "typescript" });
+            client.sendEvent("generator:run", { language: "typescript" });
 
             expect(mockCapture).toHaveBeenCalledOnce();
             expect(mockCapture).toHaveBeenCalledWith(
@@ -112,14 +112,14 @@ describe("TelemetryClient", () => {
 
     describe("flush", () => {
         it("delegates to the posthog client", async () => {
-            const client = new TelemetryClient({ isTTY: false });
+            const client = await TelemetryClient.create({ isTTY: false });
             await client.flush();
             expect(mockShutdown).toHaveBeenCalledOnce();
         });
 
         it("is a no-op when disabled", async () => {
             delete process.env["POSTHOG_API_KEY"];
-            const client = new TelemetryClient({ isTTY: false });
+            const client = await TelemetryClient.create({ isTTY: false });
             await client.flush();
             expect(mockShutdown).not.toHaveBeenCalled();
         });
@@ -128,37 +128,37 @@ describe("TelemetryClient", () => {
     describe("disabled", () => {
         it("is a no-op when POSTHOG_API_KEY is not set", async () => {
             delete process.env["POSTHOG_API_KEY"];
-            const client = new TelemetryClient({ isTTY: false });
-            await client.sendLifecycleEvent({ command: "check", status: "success", durationMs: 0 });
+            const client = await TelemetryClient.create({ isTTY: false });
+            client.sendLifecycleEvent({ command: "check", status: "success", durationMs: 0 });
             expect(mockCapture).not.toHaveBeenCalled();
         });
 
         it("is a no-op when FERN_TELEMETRY_DISABLED=1", async () => {
             process.env["FERN_TELEMETRY_DISABLED"] = "1";
-            const client = new TelemetryClient({ isTTY: false });
-            await client.sendLifecycleEvent({ command: "check", status: "success", durationMs: 0 });
+            const client = await TelemetryClient.create({ isTTY: false });
+            client.sendLifecycleEvent({ command: "check", status: "success", durationMs: 0 });
             expect(mockCapture).not.toHaveBeenCalled();
         });
 
         it("is a no-op when FERN_TELEMETRY_DISABLED=true", async () => {
             process.env["FERN_TELEMETRY_DISABLED"] = "true";
-            const client = new TelemetryClient({ isTTY: false });
-            await client.sendLifecycleEvent({ command: "check", status: "success", durationMs: 0 });
+            const client = await TelemetryClient.create({ isTTY: false });
+            client.sendLifecycleEvent({ command: "check", status: "success", durationMs: 0 });
             expect(mockCapture).not.toHaveBeenCalled();
         });
 
         it("is a no-op when fernrc has telemetry.enabled: false", async () => {
             await writeFile(join(tempHome, ".fernrc"), "version: v1\ntelemetry:\n  enabled: false\n", "utf-8");
-            const client = new TelemetryClient({ isTTY: false });
-            await client.sendLifecycleEvent({ command: "check", status: "success", durationMs: 0 });
+            const client = await TelemetryClient.create({ isTTY: false });
+            client.sendLifecycleEvent({ command: "check", status: "success", durationMs: 0 });
             expect(mockCapture).not.toHaveBeenCalled();
         });
 
         it("FERN_TELEMETRY_DISABLED takes precedence over fernrc enabled: true", async () => {
             process.env["FERN_TELEMETRY_DISABLED"] = "1";
             await writeFile(join(tempHome, ".fernrc"), "version: v1\ntelemetry:\n  enabled: true\n", "utf-8");
-            const client = new TelemetryClient({ isTTY: false });
-            await client.sendLifecycleEvent({ command: "check", status: "success", durationMs: 0 });
+            const client = await TelemetryClient.create({ isTTY: false });
+            client.sendLifecycleEvent({ command: "check", status: "success", durationMs: 0 });
             expect(mockCapture).not.toHaveBeenCalled();
         });
     });

--- a/packages/cli/cli/src/__test__/diff.test.ts
+++ b/packages/cli/cli/src/__test__/diff.test.ts
@@ -1,12 +1,13 @@
 import { beforeAll, describe, expect, it } from "vitest";
+import { CliContext } from "../cli-context/CliContext.js";
 import { type Bump, diffGeneratorVersions, mergeDiffResults } from "../commands/diff/diff.js";
-import { MockCliContext } from "./mockCliContext.js";
+import { createMockCliContext } from "./mockCliContext.js";
 
 describe("mergeDiffResults tests", () => {
-    let context: MockCliContext;
+    let context: CliContext;
 
-    beforeAll(() => {
-        context = new MockCliContext();
+    beforeAll(async () => {
+        context = await createMockCliContext();
     });
 
     it.each([

--- a/packages/cli/cli/src/__test__/mockCliContext.ts
+++ b/packages/cli/cli/src/__test__/mockCliContext.ts
@@ -1,25 +1,9 @@
 import { CliContext } from "../cli-context/CliContext.js";
 
-// Create a test-specific context that doesn't exit
-export class MockCliContext extends CliContext {
-    constructor() {
-        // Set required environment variables to prevent constructor from calling exitProgram
-        process.env.CLI_PACKAGE_NAME = "test-package";
-        process.env.CLI_VERSION = "0.0.0";
-        process.env.CLI_NAME = "test-cli";
+export async function createMockCliContext(): Promise<CliContext> {
+    process.env.CLI_PACKAGE_NAME = "test-package";
+    process.env.CLI_VERSION = "0.0.0";
+    process.env.CLI_NAME = "test-cli";
 
-        super(process.stdout, process.stderr, {
-            isLocal: true,
-            posthogManager: {
-                sendEvent: () => undefined,
-                identify: () => undefined,
-                flush: async () => undefined
-            }
-        });
-    }
-
-    // Override exit to prevent process.exit in tests
-    async exit({ code }: { code?: number } = {}): Promise<never> {
-        throw new Error(`CliContext.exit called with code: ${code}`);
-    }
+    return CliContext.create(process.stdout, process.stderr, { isLocal: true });
 }


### PR DESCRIPTION
## Description

Part of the CLI error classification effort — see #14749 for full context.

Makes telemetry synchronous in **CLI v2** by eagerly resolving the PostHog `distinctId` at startup via an async factory, so that `Context.telemetry` becomes a synchronous `TelemetryClient`. This is the CLI v2 counterpart to #14747 (CLI v1).

## Why

Same motivation as #14747: the new error system (#14749) introduces a `reportError` function called from `failWithoutThrowing` and top-level catch blocks. This function needs synchronous access to telemetry to capture Sentry exceptions with PostHog correlation. Previously `Context.telemetry` was a `Promise<TelemetryClient>`, which forced all error handlers to be async. Moving the async resolution to startup keeps the hot path simple and avoids changing the `TaskContext` interface.

## Changes Made

- Added `TelemetryClient.create()` async factory that resolves `distinctId` eagerly
- `Context.telemetry` is now a synchronous `TelemetryClient` (no more `Promise<TelemetryClient>`)
- Updated all test helpers to use the new factory (`TelemetryClient.create()` or direct construction)
- Adjusted CLI v2 `withContext` to `await` telemetry creation at startup

## Testing

- [x] Updated TelemetryClient tests for new factory pattern
- [x] Updated test context helpers
