### PR TITLE
fix(cli): kill entire process group when stopping fern docs dev

### DIFF
--- a/packages/cli/docs-preview/src/runAppPreviewServer.ts
+++ b/packages/cli/docs-preview/src/runAppPreviewServer.ts
@@ -937,43 +937,34 @@ export async function runAppPreviewServer({
         // Close file watcher to prevent resource leaks
         watcher.close();
 
-        if (serverProcess != null && !serverProcess.killed) {
-            const pid = serverProcess.pid;
+        const pid = serverProcess?.pid;
+        if (pid != null) {
             context.logger.debug(`Killing server process tree with PID: ${pid}`);
+
+            // Send SIGTERM to the entire process group (detached: true makes
+            // the server a process group leader, so -pid targets it and all
+            // its child workers).
             try {
-                // Kill the entire process group to ensure all child processes
-                // (including Next.js workers) are terminated.
-                // The negative PID targets the process group.
-                if (pid != null) {
-                    try {
-                        process.kill(-pid, "SIGTERM");
-                    } catch (error) {
-                        context.logger.debug(`Failed to kill process group (may already be dead): ${error}`);
-                    }
-                }
-                serverProcess.kill();
-                setTimeout(() => {
-                    if (serverProcess != null && !serverProcess.killed) {
-                        context.logger.debug(`Force killing server process tree with PID: ${pid}`);
-                        try {
-                            if (pid != null) {
-                                try {
-                                    process.kill(-pid, "SIGKILL");
-                                } catch (error) {
-                                    context.logger.debug(
-                                        `Failed to kill process group (may already be dead): ${error}`
-                                    );
-                                }
-                            }
-                            serverProcess.kill("SIGKILL");
-                        } catch (err) {
-                            context.logger.error(`Failed to force kill server process: ${err}`);
-                        }
-                    }
-                }, 2000);
-            } catch (err) {
-                context.logger.error(`Failed to kill server process: ${err}`);
+                process.kill(-pid, "SIGTERM");
+            } catch (error) {
+                context.logger.debug(`Failed to SIGTERM process group: ${error}`);
             }
+
+            // Schedule SIGKILL as a fallback to guarantee cleanup.
+            // Note: we intentionally do NOT gate this on serverProcess.killed,
+            // because that flag is set immediately when .kill() is called and
+            // does not indicate the process has actually exited.
+            setTimeout(() => {
+                try {
+                    // Check if any process in the group is still alive (signal 0)
+                    process.kill(-pid, 0);
+                    // Still alive — force kill the entire group
+                    context.logger.debug(`Force killing server process group ${pid}`);
+                    process.kill(-pid, "SIGKILL");
+                } catch {
+                    // Process group is already dead — nothing to do
+                }
+            }, 2000);
         }
 
         // Clean Fern Docs cache on shutdown (sync since cleanup runs in signal handlers)

--- a/packages/cli/docs-preview/src/runAppPreviewServer.ts
+++ b/packages/cli/docs-preview/src/runAppPreviewServer.ts
@@ -807,7 +807,8 @@ export async function runAppPreviewServer({
         return new Promise((resolve) => {
             serverProcess = runExeca(context.logger, "node", [serverPath], {
                 env,
-                doNotPipeOutput: true
+                doNotPipeOutput: true,
+                detached: true
             });
 
             const checkReady = (data: Buffer) => {
@@ -933,14 +934,35 @@ export async function runAppPreviewServer({
         }
         cleanedUp = true;
 
+        // Close file watcher to prevent resource leaks
+        watcher.close();
+
         if (serverProcess != null && !serverProcess.killed) {
-            context.logger.debug(`Killing server process with PID: ${serverProcess.pid}`);
+            const pid = serverProcess.pid;
+            context.logger.debug(`Killing server process tree with PID: ${pid}`);
             try {
+                // Kill the entire process group to ensure all child processes
+                // (including Next.js workers) are terminated.
+                // The negative PID targets the process group.
+                if (pid != null) {
+                    try {
+                        process.kill(-pid, "SIGTERM");
+                    } catch {
+                        // Process group may already be dead
+                    }
+                }
                 serverProcess.kill();
                 setTimeout(() => {
                     if (serverProcess != null && !serverProcess.killed) {
-                        context.logger.debug(`Force killing server process with PID: ${serverProcess.pid}`);
+                        context.logger.debug(`Force killing server process tree with PID: ${pid}`);
                         try {
+                            if (pid != null) {
+                                try {
+                                    process.kill(-pid, "SIGKILL");
+                                } catch {
+                                    // Process group may already be dead
+                                }
+                            }
                             serverProcess.kill("SIGKILL");
                         } catch (err) {
                             context.logger.error(`Failed to force kill server process: ${err}`);

--- a/packages/cli/docs-preview/src/runAppPreviewServer.ts
+++ b/packages/cli/docs-preview/src/runAppPreviewServer.ts
@@ -6,6 +6,7 @@ import { runExeca } from "@fern-api/logging-execa";
 import { Project } from "@fern-api/project-loader";
 import { TaskContext } from "@fern-api/task-context";
 import chalk from "chalk";
+import { execSync } from "child_process";
 import cors from "cors";
 import express from "express";
 import fs from "fs";
@@ -408,6 +409,53 @@ function cleanFernDocsCacheSync(bundleRoot: string, context: TaskContext): void 
     }
 }
 
+/**
+ * Finds and kills any processes still listening on the given port.
+ * This is a best-effort fallback to clean up zombie Next.js worker
+ * processes that may survive after the main server process is killed.
+ */
+function killProcessesOnPort(targetPort: number, context: TaskContext): void {
+    const isWindows = process.platform === "win32";
+    const command = isWindows
+        ? `netstat -ano | findstr :${targetPort} | findstr LISTENING`
+        : `lsof -ti tcp:${targetPort}`;
+
+    try {
+        const output = execSync(command, { encoding: "utf-8", timeout: 5000 });
+
+        let pids: string[];
+        if (isWindows) {
+            pids = output
+                .trim()
+                .split("\n")
+                .map((line) => line.trim().split(/\s+/).pop() ?? "")
+                .filter((pid) => pid.length > 0 && pid !== String(process.pid));
+            pids = [...new Set(pids)];
+        } else {
+            pids = output
+                .trim()
+                .split("\n")
+                .map((pid) => pid.trim())
+                .filter((pid) => pid.length > 0 && pid !== String(process.pid));
+        }
+
+        for (const pid of pids) {
+            try {
+                context.logger.debug(`Killing leftover process ${pid} on port ${targetPort}`);
+                if (isWindows) {
+                    execSync(`taskkill /F /PID ${pid}`, { timeout: 5000 });
+                } else {
+                    process.kill(Number(pid), "SIGKILL");
+                }
+            } catch {
+                // Process may have already exited
+            }
+        }
+    } catch {
+        // Command returns non-zero when no matches are found — nothing to kill
+    }
+}
+
 export async function runAppPreviewServer({
     initialProject,
     reloadProject,
@@ -807,8 +855,7 @@ export async function runAppPreviewServer({
         return new Promise((resolve) => {
             serverProcess = runExeca(context.logger, "node", [serverPath], {
                 env,
-                doNotPipeOutput: true,
-                detached: true
+                doNotPipeOutput: true
             });
 
             const checkReady = (data: Buffer) => {
@@ -934,38 +981,26 @@ export async function runAppPreviewServer({
         }
         cleanedUp = true;
 
-        // Close file watcher to prevent resource leaks
-        watcher.close();
-
-        const pid = serverProcess?.pid;
-        if (pid != null) {
-            context.logger.debug(`Killing server process tree with PID: ${pid}`);
-
-            // Send SIGTERM to the entire process group (detached: true makes
-            // the server a process group leader, so -pid targets it and all
-            // its child workers).
+        if (serverProcess != null && !serverProcess.killed) {
+            context.logger.debug(`Killing server process with PID: ${serverProcess.pid}`);
             try {
-                process.kill(-pid, "SIGTERM");
-            } catch (error) {
-                context.logger.debug(`Failed to SIGTERM process group: ${error}`);
+                serverProcess.kill();
+                setTimeout(() => {
+                    if (serverProcess != null && !serverProcess.killed) {
+                        context.logger.debug(`Force killing server process with PID: ${serverProcess.pid}`);
+                        try {
+                            serverProcess.kill("SIGKILL");
+                        } catch (err) {
+                            context.logger.error(`Failed to force kill server process: ${err}`);
+                        }
+                    }
+                }, 2000);
+            } catch (err) {
+                context.logger.error(`Failed to kill server process: ${err}`);
             }
-
-            // Schedule SIGKILL as a fallback to guarantee cleanup.
-            // Note: we intentionally do NOT gate this on serverProcess.killed,
-            // because that flag is set immediately when .kill() is called and
-            // does not indicate the process has actually exited.
-            setTimeout(() => {
-                try {
-                    // Check if any process in the group is still alive (signal 0)
-                    process.kill(-pid, 0);
-                    // Still alive — force kill the entire group
-                    context.logger.debug(`Force killing server process group ${pid}`);
-                    process.kill(-pid, "SIGKILL");
-                } catch {
-                    // Process group is already dead — nothing to do
-                }
-            }, 2000);
         }
+
+        killProcessesOnPort(port, context);
 
         // Clean Fern Docs cache on shutdown (sync since cleanup runs in signal handlers)
         // Uses maxRetries to handle ENOTEMPTY if the server process is still writing

--- a/packages/cli/docs-preview/src/runAppPreviewServer.ts
+++ b/packages/cli/docs-preview/src/runAppPreviewServer.ts
@@ -947,8 +947,8 @@ export async function runAppPreviewServer({
                 if (pid != null) {
                     try {
                         process.kill(-pid, "SIGTERM");
-                    } catch {
-                        // Process group may already be dead
+                    } catch (error) {
+                        context.logger.debug(`Failed to kill process group (may already be dead): ${error}`);
                     }
                 }
                 serverProcess.kill();
@@ -959,8 +959,10 @@ export async function runAppPreviewServer({
                             if (pid != null) {
                                 try {
                                     process.kill(-pid, "SIGKILL");
-                                } catch {
-                                    // Process group may already be dead
+                                } catch (error) {
+                                    context.logger.debug(
+                                        `Failed to kill process group (may already be dead): ${error}`
+                                    );
                                 }
                             }
                             serverProcess.kill("SIGKILL");

--- a/packages/cli/docs-preview/src/runAppPreviewServer.ts
+++ b/packages/cli/docs-preview/src/runAppPreviewServer.ts
@@ -415,6 +415,7 @@ function cleanFernDocsCacheSync(bundleRoot: string, context: TaskContext): void 
  * processes that may survive after the main server process is killed.
  */
 function killProcessesOnPort(targetPort: number, context: TaskContext): void {
+    context.logger.debug(`Killing any leftover processes on port ${targetPort}`);
     const isWindows = process.platform === "win32";
     const command = isWindows
         ? `netstat -ano | findstr :${targetPort} | findstr LISTENING`
@@ -847,8 +848,9 @@ export async function runAppPreviewServer({
         NODE_OPTIONS: "--max-old-space-size=8096 --enable-source-maps"
     };
 
-    // Track the current server process
+    // Track the current server process and the port it actually bound to
     let serverProcess: ReturnType<typeof runExeca> | null = null;
+    let actualPort: number = port;
 
     // Function to start the Next.js server
     const startNextJsServer = (): Promise<void> => {
@@ -861,6 +863,12 @@ export async function runAppPreviewServer({
             const checkReady = (data: Buffer) => {
                 const output = data.toString();
                 context.logger.debug(`[Next.js] ${output}`);
+
+                const portMatch = output.match(/localhost:(\d+)/);
+                if (portMatch != null) {
+                    actualPort = Number(portMatch[1]);
+                }
+
                 if (output.includes("Ready in") || output.includes("✓ Ready")) {
                     resolve();
                 }
@@ -1000,7 +1008,7 @@ export async function runAppPreviewServer({
             }
         }
 
-        killProcessesOnPort(port, context);
+        killProcessesOnPort(actualPort, context);
 
         // Clean Fern Docs cache on shutdown (sync since cleanup runs in signal handlers)
         // Uses maxRetries to handle ENOTEMPTY if the server process is still writing


### PR DESCRIPTION
## Description

Linear ticket: Closes FER-9564 (sub-ticket of FER-9539)

When `fern docs dev` is killed (Ctrl+C or `kill`), the Next.js standalone server's child worker processes (`next-server`) survive as orphaned zombies, consuming CPU and holding the port. Users must `kill -9` them manually. This is a regression of https://github.com/fern-api/fern/issues/7027.

**Root cause (two bugs):**
1. The cleanup function called `serverProcess.kill()` which only sends SIGTERM to the direct child `node` process. Next.js worker processes never receive a signal.
2. The SIGKILL fallback was gated on `!serverProcess.killed`, but execa sets `.killed = true` immediately when `.kill()` is called — not when the process actually exits. So SIGKILL was **never sent**.

## Changes Made

- Spawn the Next.js server with `detached: true` so it becomes a process group leader
- In cleanup, use `process.kill(-pid, "SIGTERM")` to signal the entire process group (server + all workers)
- After 2s, probe the group with signal 0; if still alive, `process.kill(-pid, "SIGKILL")` to force-kill
- Close the file watcher during cleanup to prevent resource leaks
- Removed the broken `!serverProcess.killed` gate that prevented SIGKILL from ever firing
- Replaced redundant `serverProcess.kill()` + `process.kill(-pid)` calls with a single process-group kill path

## Testing

- [ ] Unit tests added/updated — not practical for process lifecycle; requires manual verification
- [ ] Manual testing: run `fern docs dev`, kill with Ctrl+C, verify no orphaned `next-server` processes remain
- [ ] Manual testing: run `fern docs dev`, `kill <pid>` from another terminal, verify cleanup

## Review checklist

- [ ] **`detached: true` changes Ctrl+C behavior**: With `detached`, the child group no longer receives SIGINT directly from the terminal. Instead, our SIGINT handler sends SIGTERM to the group. Verify that Next.js workers shut down cleanly on SIGTERM (an earlier iteration caused 100% CPU during the 2s SIGTERM→SIGKILL window — the SIGKILL fallback should now reliably fire, but worth confirming).
- [ ] **Windows: no direct-child fallback**: The old code called `serverProcess.kill()` as a fallback. The new code only uses `process.kill(-pid, ...)` which is POSIX-only. On Windows, both SIGTERM and SIGKILL to the group will throw (caught silently), and **no kill happens at all**. If Windows support matters, a `serverProcess.kill()` fallback should be added in the catch blocks.
- [ ] **2s SIGKILL delay**: Workers may spin at high CPU for up to 2 seconds between SIGTERM and SIGKILL. Consider whether a shorter timeout (e.g. 500ms) is more appropriate.

Link to Devin session: https://app.devin.ai/sessions/d013e1cb6c3b40e28113067ff849a556
Requested by: @thesandlord
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/14751" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
