### PR TITLE
chore(cli): migrate @fern-api/cli to use CliError

### DIFF
--- a/packages/cli/cli/changes/unreleased/cli-error-system-migration.yml
+++ b/packages/cli/cli/changes/unreleased/cli-error-system-migration.yml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=../../../../../fern-changes-yml.schema.json
+
+- summary: |
+    Migrate CLI to a unified error system using a shared CliError class with typed error codes.
+    Error codes drive Sentry reporting eligibility; unclassified errors are temporarily suppressed
+    from Sentry until all call sites are migrated.
+  type: chore

--- a/packages/cli/cli/src/cli-context/CliContext.ts
+++ b/packages/cli/cli/src/cli-context/CliContext.ts
@@ -443,7 +443,15 @@ export class CliContext {
      * @returns Promise<string> representing the user's input
      */
     public async getInput(config: { message: string; default?: string }): Promise<string> {
-        return await input({ message: config.message, default: config.default });
+        try {
+            return await input({ message: config.message, default: config.default });
+        } catch (error) {
+            if ((error as Error)?.name === "ExitPromptError") {
+                this.logger.info("\nCancelled by user.");
+                throw new TaskAbortSignal();
+            }
+            throw error;
+        }
     }
 }
 

--- a/packages/cli/cli/src/cli-context/StdoutRedirector.ts
+++ b/packages/cli/cli/src/cli-context/StdoutRedirector.ts
@@ -1,3 +1,5 @@
+import { CliError} from "@fern-api/task-context";
+
 /**
  * Redirects process.stdout to process.stderr.
  * Can be generalized to FileDescriptorRedirector or StreamRedirector
@@ -20,7 +22,10 @@ export class StdoutRedirector {
 
     public redirect(): void {
         if (this.redirected) {
-            throw new Error("StdoutRedirector: already redirected — did you forget to restore()?");
+            throw new CliError({
+                message: "StdoutRedirector: already redirected — did you forget to restore()?",
+                code: CliError.Code.InternalError
+            });
         }
         this.originalWrite = process.stdout.write;
         process.stdout.write = process.stderr.write.bind(process.stderr) as typeof process.stdout.write;

--- a/packages/cli/cli/src/cli-context/StdoutRedirector.ts
+++ b/packages/cli/cli/src/cli-context/StdoutRedirector.ts
@@ -1,4 +1,4 @@
-import { CliError} from "@fern-api/task-context";
+import { CliError } from "@fern-api/task-context";
 
 /**
  * Redirects process.stdout to process.stderr.

--- a/packages/cli/cli/src/cli-context/upgrade-utils/getFernUpgradeMessage.ts
+++ b/packages/cli/cli/src/cli-context/upgrade-utils/getFernUpgradeMessage.ts
@@ -1,4 +1,4 @@
-import { CliError} from "@fern-api/task-context";
+import { CliError } from "@fern-api/task-context";
 import { FernRegistryClient } from "@fern-fern/generators-sdk";
 import boxen from "boxen";
 import chalk from "chalk";

--- a/packages/cli/cli/src/cli-context/upgrade-utils/getFernUpgradeMessage.ts
+++ b/packages/cli/cli/src/cli-context/upgrade-utils/getFernUpgradeMessage.ts
@@ -1,7 +1,7 @@
+import { CliError} from "@fern-api/task-context";
 import { FernRegistryClient } from "@fern-fern/generators-sdk";
 import boxen from "boxen";
 import chalk from "chalk";
-
 import { FernUpgradeInfo } from "../CliContext.js";
 import { CliEnvironment } from "../CliEnvironment.js";
 import { FernGeneratorUpgradeInfo } from "./getGeneratorVersions.js";
@@ -127,7 +127,7 @@ async function normalizeGeneratorName(generatorImage: string): Promise<string> {
     });
     const generatorResponse = await client.generators.getGeneratorByImage({ dockerImage: generatorImage });
     if (!generatorResponse.ok || generatorResponse.body == null) {
-        throw new Error(`Generator ${generatorImage} not found`);
+        throw new CliError({ message: `Generator ${generatorImage} not found`, code: CliError.Code.InternalError });
     }
     return generatorResponse.body.displayName;
 }

--- a/packages/cli/cli/src/cli-context/upgrade-utils/getLatestVersionOfCli.ts
+++ b/packages/cli/cli/src/cli-context/upgrade-utils/getLatestVersionOfCli.ts
@@ -1,3 +1,4 @@
+import { CliError } from "@fern-api/task-context";
 import latestVersion from "latest-version";
 
 import { CliEnvironment } from "../CliEnvironment.js";
@@ -14,7 +15,14 @@ export async function getLatestVersionOfCli({
     if (cliEnvironment.packageName !== "fern-api" || cliEnvironment.packageVersion === "0.0.0") {
         return cliEnvironment.packageVersion;
     }
-    return latestVersion(cliEnvironment.packageName, {
-        version: includePreReleases ? "prerelease" : "latest"
-    });
+    try {
+        return await latestVersion(cliEnvironment.packageName, {
+            version: includePreReleases ? "prerelease" : "latest"
+        });
+    } catch (error) {
+        throw new CliError({
+            message: `Failed to resolve latest CLI version: ${error instanceof Error ? error.message : String(error)}`,
+            code: CliError.Code.NetworkError
+        });
+    }
 }

--- a/packages/cli/cli/src/cli.ts
+++ b/packages/cli/cli/src/cli.ts
@@ -85,6 +85,7 @@ import { FERN_CWD_ENV_VAR } from "./cwd.js";
 import { rerunFernCliAtVersion } from "./rerunFernCliAtVersion.js";
 import { resolveGroupGithubConfig } from "./resolveGroupGithubConfig.js";
 import { RUNTIME } from "./runtime.js";
+import { CliError } from "@fern-api/task-context";
 
 void runCli();
 
@@ -177,7 +178,7 @@ async function tryRunCli(cliContext: CliContext) {
                     cliContext.logger.info(cliContext.environment.packageVersion);
                 } else {
                     cli.showHelp();
-                    cliContext.failAndThrow();
+                    cliContext.failAndThrow(undefined, undefined, { code: CliError.Code.ConfigError });
                 }
             }
         )
@@ -324,14 +325,22 @@ function addInitCommand(cli: Argv<GlobalCliOptions>, cliContext: CliContext) {
                 }
             }
             if (argv.api != null && argv.docs != null) {
-                return cliContext.failWithoutThrowing("Cannot specify both --api and --docs. Please choose one.");
+                return cliContext.failWithoutThrowing(
+                    "Cannot specify both --api and --docs. Please choose one.",
+                    undefined,
+                    { code: CliError.Code.ConfigError }
+                );
             } else if (argv.readme != null && argv.mintlify != null) {
                 return cliContext.failWithoutThrowing(
-                    "Cannot specify both --readme and --mintlify. Please choose one."
+                    "Cannot specify both --readme and --mintlify. Please choose one.",
+                    undefined,
+                    { code: CliError.Code.ConfigError }
                 );
             } else if (argv.openapi != null && argv["fern-definition"] === true) {
                 return cliContext.failWithoutThrowing(
-                    "Cannot specify both --openapi and --fern-definition. Please choose one."
+                    "Cannot specify both --openapi and --fern-definition. Please choose one.",
+                    undefined,
+                    { code: CliError.Code.ConfigError }
                 );
             } else if (argv.readme != null) {
                 await cliContext.runTask(async (context) => {
@@ -366,7 +375,7 @@ function addInitCommand(cli: Argv<GlobalCliOptions>, cliContext: CliContext) {
                         const result = await loadOpenAPIFromUrl({ url: argv.openapi, logger: cliContext.logger });
 
                         if (result.status === LoadOpenAPIStatus.Failure) {
-                            cliContext.failAndThrow(result.errorMessage);
+                            cliContext.failAndThrow(result.errorMessage, undefined, { code: CliError.Code.NetworkError });
                         }
 
                         const tmpFilepath = result.filePath;
@@ -376,7 +385,9 @@ function addInitCommand(cli: Argv<GlobalCliOptions>, cliContext: CliContext) {
                     }
                     const pathExists = await doesPathExist(absoluteOpenApiPath);
                     if (!pathExists) {
-                        cliContext.failAndThrow(`${absoluteOpenApiPath} does not exist`);
+                        cliContext.failAndThrow(`${absoluteOpenApiPath} does not exist`, undefined, {
+                            code: CliError.Code.ConfigError
+                        });
                     }
                 }
                 await cliContext.runTask(async (context) => {
@@ -429,9 +440,11 @@ function addDiffCommand(cli: Argv<GlobalCliOptions>, cliContext: CliContext) {
                 })
                 .middleware((argv) => {
                     if (!haveSameNullishness(argv.fromGeneratorVersion, argv.toGeneratorVersion)) {
-                        throw new Error(
-                            "Both --from-generator-version and --to-generator-version must be provided together, or neither should be provided"
-                        );
+                        throw new CliError({
+                            message:
+                                "Both --from-generator-version and --to-generator-version must be provided together, or neither should be provided",
+                            code: CliError.Code.ValidationError
+                        });
                     }
                 }),
         async (argv) => {
@@ -748,50 +761,84 @@ function addGenerateCommand(cli: Argv<GlobalCliOptions>, cliContext: CliContext)
                 }),
         async (argv) => {
             if (argv.api != null && argv.docs != null) {
-                return cliContext.failWithoutThrowing("Cannot specify both --api and --docs. Please choose one.");
+                return cliContext.failWithoutThrowing(
+                    "Cannot specify both --api and --docs. Please choose one.",
+                    undefined,
+                    { code: CliError.Code.ConfigError }
+                );
             }
             if (argv.id != null && !argv.preview) {
-                return cliContext.failWithoutThrowing("The --id flag can only be used with --preview.");
+                return cliContext.failWithoutThrowing("The --id flag can only be used with --preview.", undefined, {
+                    code: CliError.Code.ConfigError
+                });
             }
             if (argv.id != null && argv.docs == null) {
-                return cliContext.failWithoutThrowing("The --id flag can only be used with --docs.");
+                return cliContext.failWithoutThrowing("The --id flag can only be used with --docs.", undefined, {
+                    code: CliError.Code.ConfigError
+                });
             }
             if (argv.skipUpload && !argv.preview) {
-                return cliContext.failWithoutThrowing("The --skip-upload flag can only be used with --preview.");
+                return cliContext.failWithoutThrowing(
+                    "The --skip-upload flag can only be used with --preview.",
+                    undefined,
+                    { code: CliError.Code.ConfigError }
+                );
             }
             if (argv.skipUpload && argv.docs == null) {
-                return cliContext.failWithoutThrowing("The --skip-upload flag can only be used with --docs.");
+                return cliContext.failWithoutThrowing(
+                    "The --skip-upload flag can only be used with --docs.",
+                    undefined,
+                    { code: CliError.Code.ConfigError }
+                );
             }
             if (argv.fernignore != null && (argv.local || argv.runner != null)) {
                 return cliContext.failWithoutThrowing(
-                    "The --fernignore flag is not supported with local generation (--local or --runner). It can only be used with remote generation."
+                    "The --fernignore flag is not supported with local generation (--local or --runner). It can only be used with remote generation.",
+                    undefined,
+                    { code: CliError.Code.ConfigError }
                 );
             }
             if (argv["skip-fernignore"] && argv.fernignore != null) {
                 return cliContext.failWithoutThrowing(
-                    "The --skip-fernignore and --fernignore flags cannot be used together."
+                    "The --skip-fernignore and --fernignore flags cannot be used together.",
+                    undefined,
+                    { code: CliError.Code.ConfigError }
                 );
             }
             if (argv["dynamic-ir-only"] && (argv.local || argv.runner != null)) {
                 return cliContext.failWithoutThrowing(
-                    "The --dynamic-ir-only flag is not supported with local generation (--local or --runner). It can only be used with remote generation."
+                    "The --dynamic-ir-only flag is not supported with local generation (--local or --runner). It can only be used with remote generation.",
+                    undefined,
+                    { code: CliError.Code.ConfigError }
                 );
             }
             if (argv["dynamic-ir-only"] && argv.version == null) {
                 return cliContext.failWithoutThrowing(
-                    "The --dynamic-ir-only flag requires a version to be specified with --version."
+                    "The --dynamic-ir-only flag requires a version to be specified with --version.",
+                    undefined,
+                    { code: CliError.Code.ConfigError }
                 );
             }
             if (argv["dynamic-ir-only"] && argv.docs != null) {
                 return cliContext.failWithoutThrowing(
-                    "The --dynamic-ir-only flag can only be used for API generation, not docs generation."
+                    "The --dynamic-ir-only flag can only be used for API generation, not docs generation.",
+                    undefined,
+                    { code: CliError.Code.ConfigError }
                 );
             }
             if (argv.output != null && !argv.preview) {
-                return cliContext.failWithoutThrowing("The --output flag currently only works with --preview.");
+                return cliContext.failWithoutThrowing(
+                    "The --output flag currently only works with --preview.",
+                    undefined,
+                    { code: CliError.Code.ConfigError }
+                );
             }
             if (argv.output != null && argv.docs != null) {
-                return cliContext.failWithoutThrowing("The --output flag is not supported for docs generation.");
+                return cliContext.failWithoutThrowing(
+                    "The --output flag is not supported for docs generation.",
+                    undefined,
+                    { code: CliError.Code.ConfigError }
+                );
             }
             const correctedGeneratorFilter =
                 argv.generator != null ? warnAndCorrectIncorrectDockerOrg(argv.generator, cliContext) : undefined;
@@ -1865,18 +1912,27 @@ function addDocsDevCommand(cli: Argv<GlobalCliOptions>, cliContext: CliContext) 
             }
 
             let port: number;
-            if (argv.port != null) {
-                port = argv.port;
-            } else {
-                port = await getPort({ port: [3000, 3001, 3002, 3003, 3004, 3005, 3006, 3007, 3008, 3009, 3010] });
-            }
-
             let backendPort: number;
-            if (argv.backendPort != null) {
-                backendPort = argv.backendPort;
-            } else {
-                backendPort = await getPort({
-                    port: [3001, 3002, 3003, 3004, 3005, 3006, 3007, 3008, 3009, 3010, 3011]
+            try {
+                if (argv.port != null) {
+                    port = argv.port;
+                } else {
+                    port = await getPort({
+                        port: [3000, 3001, 3002, 3003, 3004, 3005, 3006, 3007, 3008, 3009, 3010]
+                    });
+                }
+
+                if (argv.backendPort != null) {
+                    backendPort = argv.backendPort;
+                } else {
+                    backendPort = await getPort({
+                        port: [3001, 3002, 3003, 3004, 3005, 3006, 3007, 3008, 3009, 3010, 3011]
+                    });
+                }
+            } catch (error) {
+                throw new CliError({
+                    message: `Failed to find an available port: ${error instanceof Error ? error.message : String(error)}`,
+                    code: CliError.Code.EnvironmentError
                 });
             }
             const bundlePath: string | undefined = argv.bundlePath;
@@ -1936,7 +1992,7 @@ function addDocsMdCheckCommand(cli: Argv<GlobalCliOptions>, cliContext: CliConte
             });
 
             if (project.docsWorkspaces == null) {
-                cliContext.failAndThrow("No docs workspace found");
+                cliContext.failAndThrow("No docs workspace found", undefined, { code: CliError.Code.ConfigError });
             }
 
             const docsWorkspace = project.docsWorkspaces;
@@ -1955,7 +2011,7 @@ function addDocsMdCheckCommand(cli: Argv<GlobalCliOptions>, cliContext: CliConte
             });
 
             if (hasErrors) {
-                cliContext.failWithoutThrowing();
+                cliContext.failWithoutThrowing(undefined, undefined, { code: CliError.Code.ValidationError });
             }
         }
     );
@@ -2480,7 +2536,7 @@ function addBetaCommand(cli: Argv<GlobalCliOptions>, cliContext: CliContext) {
                 await runCliV2(v2Args);
             } catch (error) {
                 cliContext.logger.error("CLI v2 failed:", String(error));
-                cliContext.failWithoutThrowing();
+                cliContext.failWithoutThrowing(undefined, error, { code: CliError.Code.InternalError });
             }
         }
     );
@@ -2625,7 +2681,11 @@ function addReplayInitCommand(cli: Argv<GlobalCliOptions>, cliContext: CliContex
 
             if (githubRepo == null) {
                 return cliContext.failAndThrow(
-                    "Missing required github config. Either use --group to read from generators.yml, or provide --github directly."
+                    "Missing required github config. Either use --group to read from generators.yml, or provide --github directly.",
+                    undefined,
+                    {
+                        code: CliError.Code.ConfigError
+                    }
                 );
             }
 
@@ -2668,7 +2728,9 @@ function addReplayInitCommand(cli: Argv<GlobalCliOptions>, cliContext: CliContex
                 }
 
                 if (result.lockfileContent == null) {
-                    return cliContext.failAndThrow("Bootstrap succeeded but lockfile content is missing.");
+                    return cliContext.failAndThrow("Bootstrap succeeded but lockfile content is missing.", undefined, {
+                        code: CliError.Code.InternalError
+                    });
                 }
 
                 // Send lockfile to Fiddle for server-side PR creation
@@ -2696,18 +2758,24 @@ function addReplayInitCommand(cli: Argv<GlobalCliOptions>, cliContext: CliContex
                     if (response.status === 404) {
                         return cliContext.failAndThrow(
                             "The Fern GitHub App is not installed on this repository. " +
-                                "Install it at https://github.com/apps/fern-api to enable server-side PR creation."
+                                "Install it at https://github.com/apps/fern-api to enable server-side PR creation.",
+                            undefined,
+                            { code: CliError.Code.ConfigError }
                         );
                     }
                     const body = await response.text();
-                    return cliContext.failAndThrow(`Failed to create PR via Fern: ${body}`);
+                    return cliContext.failAndThrow(`Failed to create PR via Fern: ${body}`, undefined, {
+                        code: CliError.Code.NetworkError
+                    });
                 }
 
                 const data = (await response.json()) as { prUrl: string };
                 cliContext.logger.info(`\nPR created: ${data.prUrl}`);
                 cliContext.logger.info("Merge the PR to enable Replay for this repository.");
             } catch (error) {
-                cliContext.failAndThrow(`Failed to initialize Replay: ${extractErrorMessage(error)}`);
+                cliContext.failAndThrow(`Failed to initialize Replay: ${extractErrorMessage(error)}`, error, {
+                    code: CliError.Code.NetworkError
+                });
             }
         }
     );
@@ -2774,12 +2842,18 @@ function addReplayResolveCommand(cli: Argv<GlobalCliOptions>, cliContext: CliCon
                                 }
                                 cliContext.logger.warn(`Resolve them first, then run \`fern replay resolve\` again.`);
                             } else {
-                                cliContext.failAndThrow(`Resolve failed: ${result.reason ?? "unknown error"}`);
+                                cliContext.failAndThrow(
+                                    `Resolve failed: ${result.reason ?? "unknown error"}`,
+                                    undefined,
+                                    { code: CliError.Code.InternalError }
+                                );
                             }
                         }
                 }
             } catch (error) {
-                cliContext.failAndThrow(`Failed to resolve: ${extractErrorMessage(error)}`);
+                cliContext.failAndThrow(`Failed to resolve: ${extractErrorMessage(error)}`, error, {
+                    code: CliError.Code.InternalError
+                });
             }
         }
     );
@@ -3039,7 +3113,7 @@ function parseOwnerRepo(githubRepo: string): { owner: string; repo: string } {
     const owner = parts[parts.length - 2];
     const repo = parts[parts.length - 1];
     if (owner == null || repo == null) {
-        throw new Error(`Could not parse owner/repo from: ${githubRepo}`);
+        throw new CliError({ message: `Could not parse owner/repo from: ${githubRepo}`, code: CliError.Code.ParseError });
     }
     return { owner, repo };
 }

--- a/packages/cli/cli/src/cli.ts
+++ b/packages/cli/cli/src/cli.ts
@@ -34,6 +34,7 @@ import {
 import { LOG_LEVELS, LogLevel } from "@fern-api/logger";
 import { askToLogin, login, logout } from "@fern-api/login";
 import { protocGenFern } from "@fern-api/protoc-gen-fern";
+import { CliError } from "@fern-api/task-context";
 import getPort from "get-port";
 import { Argv } from "yargs";
 import { hideBin } from "yargs/helpers";
@@ -85,7 +86,6 @@ import { FERN_CWD_ENV_VAR } from "./cwd.js";
 import { rerunFernCliAtVersion } from "./rerunFernCliAtVersion.js";
 import { resolveGroupGithubConfig } from "./resolveGroupGithubConfig.js";
 import { RUNTIME } from "./runtime.js";
-import { CliError } from "@fern-api/task-context";
 
 void runCli();
 
@@ -375,7 +375,9 @@ function addInitCommand(cli: Argv<GlobalCliOptions>, cliContext: CliContext) {
                         const result = await loadOpenAPIFromUrl({ url: argv.openapi, logger: cliContext.logger });
 
                         if (result.status === LoadOpenAPIStatus.Failure) {
-                            cliContext.failAndThrow(result.errorMessage, undefined, { code: CliError.Code.NetworkError });
+                            cliContext.failAndThrow(result.errorMessage, undefined, {
+                                code: CliError.Code.NetworkError
+                            });
                         }
 
                         const tmpFilepath = result.filePath;
@@ -3113,7 +3115,10 @@ function parseOwnerRepo(githubRepo: string): { owner: string; repo: string } {
     const owner = parts[parts.length - 2];
     const repo = parts[parts.length - 1];
     if (owner == null || repo == null) {
-        throw new CliError({ message: `Could not parse owner/repo from: ${githubRepo}`, code: CliError.Code.ParseError });
+        throw new CliError({
+            message: `Could not parse owner/repo from: ${githubRepo}`,
+            code: CliError.Code.ParseError
+        });
     }
     return { owner, repo };
 }

--- a/packages/cli/cli/src/cliV2.ts
+++ b/packages/cli/cli/src/cliV2.ts
@@ -15,6 +15,7 @@ import { GenerationModeFilter, getGeneratorList } from "./commands/generator-lis
 import { getGeneratorMetadata } from "./commands/generator-metadata/getGeneratorMetadata.js";
 import { getOrganization } from "./commands/organization/getOrganization.js";
 import { upgradeGenerator } from "./commands/upgrade/upgradeGenerator.js";
+import { CliError } from "@fern-api/task-context";
 
 /**
  * Corrects the incorrect "fern-api/" Docker org prefix to "fernapi/" and logs a warning.
@@ -312,7 +313,9 @@ export function addGeneratorCommands(cli: Argv<GlobalCliOptions>, cliContext: Cl
                     if (generator == null) {
                         const maybeApiFilter = argv.api ? ` for API ${argv.api}` : "";
                         cliContext.failAndThrow(
-                            `Generator ${argv.generator}, in group ${argv.group}${maybeApiFilter} was not found.`
+                            `Generator ${argv.generator}, in group ${argv.group}${maybeApiFilter} was not found.`,
+                            undefined,
+                            { code: CliError.Code.ConfigError }
                         );
                     }
 
@@ -365,7 +368,8 @@ export function addGeneratorCommands(cli: Argv<GlobalCliOptions>, cliContext: Cl
                         } catch (error) {
                             cliContext.failAndThrow(
                                 `Could not write file to the specified location: ${argv.output}`,
-                                error
+                                error,
+                                { code: CliError.Code.ConfigError }
                             );
                         }
                     }

--- a/packages/cli/cli/src/cliV2.ts
+++ b/packages/cli/cli/src/cliV2.ts
@@ -3,10 +3,10 @@ import {
     GENERATORS_CONFIGURATION_FILENAME,
     INCORRECT_DOCKER_ORG
 } from "@fern-api/configuration-loader";
+import { CliError } from "@fern-api/task-context";
 import { FernRegistry } from "@fern-fern/generators-sdk";
 import { writeFile } from "fs/promises";
 import { Argv } from "yargs";
-
 import { CliContext } from "./cli-context/CliContext.js";
 import { getGeneratorUpgradeMessage } from "./cli-context/upgrade-utils/getFernUpgradeMessage.js";
 import { getProjectGeneratorUpgrades } from "./cli-context/upgrade-utils/getGeneratorVersions.js";
@@ -15,7 +15,6 @@ import { GenerationModeFilter, getGeneratorList } from "./commands/generator-lis
 import { getGeneratorMetadata } from "./commands/generator-metadata/getGeneratorMetadata.js";
 import { getOrganization } from "./commands/organization/getOrganization.js";
 import { upgradeGenerator } from "./commands/upgrade/upgradeGenerator.js";
-import { CliError } from "@fern-api/task-context";
 
 /**
  * Corrects the incorrect "fern-api/" Docker org prefix to "fernapi/" and logs a warning.

--- a/packages/cli/cli/src/commands/diff/diff.ts
+++ b/packages/cli/cli/src/commands/diff/diff.ts
@@ -2,7 +2,7 @@ import { diffSemverOrThrow } from "@fern-api/core-utils";
 import { AbsoluteFilePath, cwd, doesPathExist, resolve, streamObjectFromFile } from "@fern-api/fs-utils";
 import { IntermediateRepresentation, serialization } from "@fern-api/ir-sdk";
 import { IntermediateRepresentationChangeDetector } from "@fern-api/ir-utils";
-import { TaskAbortSignal } from "@fern-api/task-context";
+import { CliError, TaskAbortSignal } from "@fern-api/task-context";
 import semver from "semver";
 
 import { CliContext } from "../../cli-context/CliContext.js";
@@ -56,7 +56,9 @@ export async function diff({
 
     const nextVersion = semver.inc(fromVersion, bump);
     if (!nextVersion) {
-        context.failWithoutThrowing(`Invalid current version: ${fromVersion}`, undefined, { code: CliError.Code.VersionError });
+        context.failWithoutThrowing(`Invalid current version: ${fromVersion}`, undefined, {
+            code: CliError.Code.VersionError
+        });
         throw new TaskAbortSignal();
     }
     return { bump, nextVersion, errors };
@@ -73,7 +75,9 @@ async function readIr({
 }): Promise<IntermediateRepresentation> {
     const absoluteFilepath = AbsoluteFilePath.of(resolve(cwd(), filepath));
     if (!(await doesPathExist(absoluteFilepath, "file"))) {
-        context.failWithoutThrowing(`File not found: ${absoluteFilepath}`, undefined, { code: CliError.Code.ConfigError });
+        context.failWithoutThrowing(`File not found: ${absoluteFilepath}`, undefined, {
+            code: CliError.Code.ConfigError
+        });
         throw new TaskAbortSignal();
     }
     let ir: unknown;

--- a/packages/cli/cli/src/commands/diff/diff.ts
+++ b/packages/cli/cli/src/commands/diff/diff.ts
@@ -56,7 +56,7 @@ export async function diff({
 
     const nextVersion = semver.inc(fromVersion, bump);
     if (!nextVersion) {
-        context.failWithoutThrowing(`Invalid current version: ${fromVersion}`);
+        context.failWithoutThrowing(`Invalid current version: ${fromVersion}`, undefined, { code: CliError.Code.VersionError });
         throw new TaskAbortSignal();
     }
     return { bump, nextVersion, errors };
@@ -73,13 +73,25 @@ async function readIr({
 }): Promise<IntermediateRepresentation> {
     const absoluteFilepath = AbsoluteFilePath.of(resolve(cwd(), filepath));
     if (!(await doesPathExist(absoluteFilepath, "file"))) {
-        context.failWithoutThrowing(`File not found: ${absoluteFilepath}`);
+        context.failWithoutThrowing(`File not found: ${absoluteFilepath}`, undefined, { code: CliError.Code.ConfigError });
         throw new TaskAbortSignal();
     }
-    const ir = await streamObjectFromFile(absoluteFilepath);
+    let ir: unknown;
+    try {
+        ir = await streamObjectFromFile(absoluteFilepath);
+    } catch (error) {
+        context.failWithoutThrowing(
+            `Failed to parse IR file ${absoluteFilepath}: ${error instanceof Error ? error.message : String(error)}`,
+            error,
+            { code: CliError.Code.ParseError }
+        );
+        throw new TaskAbortSignal();
+    }
     const parsed = serialization.IntermediateRepresentation.parse(ir);
     if (!parsed.ok) {
-        context.failWithoutThrowing(`Invalid --${flagName}; expected a filepath containing a valid IR`);
+        context.failWithoutThrowing(`Invalid --${flagName}; expected a filepath containing a valid IR`, undefined, {
+            code: CliError.Code.ParseError
+        });
         throw new TaskAbortSignal();
     }
     return parsed.value;
@@ -161,7 +173,9 @@ export function diffGeneratorVersions(
             errors
         };
     } catch (error) {
-        context.failWithoutThrowing(`Error diffing generator versions ${from} and ${to}: ${error}`);
+        context.failWithoutThrowing(`Error diffing generator versions ${from} and ${to}: ${error}`, undefined, {
+            code: CliError.Code.InternalError
+        });
         throw new TaskAbortSignal();
     }
 }

--- a/packages/cli/cli/src/commands/docs-diff/docsDiff.ts
+++ b/packages/cli/cli/src/commands/docs-diff/docsDiff.ts
@@ -2,10 +2,10 @@ import { FernToken } from "@fern-api/auth";
 import { AbsoluteFilePath, cwd, doesPathExist, join, RelativeFilePath } from "@fern-api/fs-utils";
 import { askToLogin } from "@fern-api/login";
 import { Project } from "@fern-api/project-loader";
+import { CliError} from "@fern-api/task-context";
 import { mkdir, readFile, writeFile } from "fs/promises";
 import { PNG } from "pngjs";
 import { Browser, launch } from "puppeteer";
-
 import { CliContext } from "../../cli-context/CliContext.js";
 
 interface FileSlugMapping {
@@ -51,7 +51,10 @@ async function getSlugForFiles({
 
     if (!response.ok) {
         const errorText = await response.text();
-        throw new Error(`Failed to get slugs for files: ${response.status} ${response.statusText} - ${errorText}`);
+        throw new CliError({
+            message: `Failed to get slugs for files: ${response.status} ${response.statusText} - ${errorText}`,
+            code: CliError.Code.InternalError
+        });
     }
 
     return (await response.json()) as GetSlugForFileResponse;
@@ -482,12 +485,12 @@ function getProductionUrlInfo(docsConfig: {
     instances: Array<{ url: string; "custom-domain"?: string }> | undefined;
 }): ProductionUrlInfo {
     if (docsConfig.instances == null || docsConfig.instances.length === 0) {
-        throw new Error("No docs instances configured in docs.yml");
+        throw new CliError({ message: "No docs instances configured in docs.yml", code: CliError.Code.InternalError });
     }
 
     const firstInstance = docsConfig.instances[0];
     if (firstInstance == null) {
-        throw new Error("No docs instances configured in docs.yml");
+        throw new CliError({ message: "No docs instances configured in docs.yml", code: CliError.Code.InternalError });
     }
 
     // Prefer custom-domain if available, otherwise use url
@@ -525,7 +528,9 @@ export async function docsDiff({
 }): Promise<DocsDiffOutput> {
     const docsWorkspace = project.docsWorkspaces;
     if (docsWorkspace == null) {
-        cliContext.failAndThrow("No docs workspace found. Make sure you have a docs.yml file.");
+        cliContext.failAndThrow("No docs workspace found. Make sure you have a docs.yml file.", undefined, {
+            code: CliError.Code.ConfigError
+        });
         return { diffs: [] };
     }
 
@@ -534,7 +539,9 @@ export async function docsDiff({
     });
 
     if (token == null) {
-        cliContext.failAndThrow("Failed to authenticate. Please run 'fern login' first.");
+        cliContext.failAndThrow("Failed to authenticate. Please run 'fern login' first.", undefined, {
+            code: CliError.Code.AuthError
+        });
         return { diffs: [] };
     }
 

--- a/packages/cli/cli/src/commands/docs-diff/docsDiff.ts
+++ b/packages/cli/cli/src/commands/docs-diff/docsDiff.ts
@@ -2,7 +2,7 @@ import { FernToken } from "@fern-api/auth";
 import { AbsoluteFilePath, cwd, doesPathExist, join, RelativeFilePath } from "@fern-api/fs-utils";
 import { askToLogin } from "@fern-api/login";
 import { Project } from "@fern-api/project-loader";
-import { CliError} from "@fern-api/task-context";
+import { CliError } from "@fern-api/task-context";
 import { mkdir, readFile, writeFile } from "fs/promises";
 import { PNG } from "pngjs";
 import { Browser, launch } from "puppeteer";

--- a/packages/cli/cli/src/commands/docs-md-generate/generateLibraryDocs.ts
+++ b/packages/cli/cli/src/commands/docs-md-generate/generateLibraryDocs.ts
@@ -7,7 +7,8 @@ import type { CppLibraryDocsIr } from "@fern-api/library-docs-generator";
 import { generate, generateCpp } from "@fern-api/library-docs-generator";
 import { askToLogin } from "@fern-api/login";
 import { Project } from "@fern-api/project-loader";
-import { InteractiveTaskContext, TaskContext } from "@fern-api/task-context";
+import { CliError, InteractiveTaskContext, TaskContext } from "@fern-api/task-context";
+
 import chalk from "chalk";
 import { readFile } from "fs/promises";
 import { CliContext } from "../../cli-context/CliContext.js";
@@ -77,7 +78,7 @@ function createLibraryDocsClient({ token }: { token: string }): LibraryDocsClien
 
         if (!response.ok) {
             const text = await response.text().catch(() => "");
-            throw new Error(`HTTP ${response.status}: ${text}`);
+            throw new CliError({ message: `HTTP ${response.status}: ${text}`, code: CliError.Code.NetworkError });
         }
 
         return (await response.json()) as T;
@@ -116,7 +117,9 @@ export async function generateLibraryDocs({ project, cliContext, library }: Gene
     const docsWorkspace = project.docsWorkspaces;
 
     if (docsWorkspace == null) {
-        cliContext.failAndThrow("No docs workspace found. Make sure you have a docs.yml file.");
+        cliContext.failAndThrow("No docs workspace found. Make sure you have a docs.yml file.", undefined, {
+            code: CliError.Code.ConfigError
+        });
         return;
     }
 
@@ -125,7 +128,9 @@ export async function generateLibraryDocs({ project, cliContext, library }: Gene
 
     if (libraries == null || Object.keys(libraries).length === 0) {
         cliContext.failAndThrow(
-            "No libraries configured in docs.yml. Add a `libraries` section to configure library documentation."
+            "No libraries configured in docs.yml. Add a `libraries` section to configure library documentation.",
+            undefined,
+            { code: CliError.Code.ConfigError }
         );
         return;
     }
@@ -134,7 +139,9 @@ export async function generateLibraryDocs({ project, cliContext, library }: Gene
 
     if (library != null && libraries[library] == null) {
         cliContext.failAndThrow(
-            `Library '${library}' not found in docs.yml. Available libraries: ${Object.keys(libraries).join(", ")}`
+            `Library '${library}' not found in docs.yml. Available libraries: ${Object.keys(libraries).join(", ")}`,
+            undefined,
+            { code: CliError.Code.ConfigError }
         );
         return;
     }
@@ -144,7 +151,9 @@ export async function generateLibraryDocs({ project, cliContext, library }: Gene
     });
 
     if (token == null) {
-        cliContext.failAndThrow("Failed to authenticate. Please run 'fern login' first.");
+        cliContext.failAndThrow("Failed to authenticate. Please run 'fern login' first.", undefined, {
+            code: CliError.Code.AuthError
+        });
         return;
     }
 
@@ -158,7 +167,9 @@ export async function generateLibraryDocs({ project, cliContext, library }: Gene
                 }
                 if (!isGitLibraryInput(config.input)) {
                     context.failAndThrow(
-                        `Library '${name}' uses 'path' input which is not yet supported. Please use 'git' input.`
+                        `Library '${name}' uses 'path' input which is not yet supported. Please use 'git' input.`,
+                        undefined,
+                        { code: CliError.Code.ConfigError }
                     );
                     return false;
                 }
@@ -204,7 +215,9 @@ async function generateSingleLibrary({
         // Validate language-specific config
         if (config.config?.doxyfile != null && config.lang !== "cpp") {
             return interactiveTaskContext.failAndThrow(
-                `Library '${name}': 'doxyfile' config is only valid for lang: cpp`
+                `Library '${name}': 'doxyfile' config is only valid for lang: cpp`,
+                undefined,
+                { code: CliError.Code.ConfigError }
             );
         }
 
@@ -216,14 +229,20 @@ async function generateSingleLibrary({
                 doxyfileContent = await readFile(doxyfilePath, "utf-8");
             } catch {
                 return interactiveTaskContext.failAndThrow(
-                    `Library '${name}': Could not read Doxyfile at '${config.config.doxyfile}' (resolved to ${doxyfilePath})`
+                    `Library '${name}': Could not read Doxyfile at '${config.config.doxyfile}' (resolved to ${doxyfilePath})`,
+                    undefined,
+                    { code: CliError.Code.ConfigError }
                 );
             }
         }
 
         const language = config.lang === "python" ? "PYTHON" : config.lang === "cpp" ? "CPP" : undefined;
         if (language == null) {
-            return interactiveTaskContext.failAndThrow(`Library '${name}': unsupported language '${config.lang}'`);
+            return interactiveTaskContext.failAndThrow(
+                `Library '${name}': unsupported language '${config.lang}'`,
+                undefined,
+                { code: CliError.Code.ConfigError }
+            );
         }
 
         const client = createLibraryDocsClient({ token: token.value });
@@ -268,7 +287,11 @@ async function generateSingleLibrary({
             });
             interactiveTaskContext.logger.debug(`Generated ${generateResult.pageCount} pages at ${resolvedOutputPath}`);
         } else {
-            return interactiveTaskContext.failAndThrow(`Library '${name}': unsupported language '${config.lang}'`);
+            return interactiveTaskContext.failAndThrow(
+                `Library '${name}': unsupported language '${config.lang}'`,
+                undefined,
+                { code: CliError.Code.ConfigError }
+            );
         }
     });
 }
@@ -302,7 +325,9 @@ async function startGeneration(
         return result.jobId;
     } catch (error) {
         return context.failAndThrow(
-            `Failed to start generation for library '${opts.name}': ${extractErrorMessage(error)}`
+            `Failed to start generation for library '${opts.name}': ${extractErrorMessage(error)}`,
+            error,
+            { code: CliError.Code.NetworkError }
         );
     }
 }
@@ -323,7 +348,9 @@ async function pollForCompletion(
             status = await client.getLibraryDocsGenerationStatus({ jobId });
         } catch (error) {
             return context.failAndThrow(
-                `Failed to check generation status for library '${libraryName}': ${extractErrorMessage(error)}`
+                `Failed to check generation status for library '${libraryName}': ${extractErrorMessage(error)}`,
+                error,
+                { code: CliError.Code.NetworkError }
             );
         }
 
@@ -339,16 +366,24 @@ async function pollForCompletion(
                 return;
             case "FAILED":
                 return context.failAndThrow(
-                    `Generation failed for library '${libraryName}': ${status.error?.message ?? "Unknown error"} (${status.error?.code ?? "UNKNOWN"})`
+                    `Generation failed for library '${libraryName}': ${status.error?.message ?? "Unknown error"} (${status.error?.code ?? "UNKNOWN"})`,
+                    undefined,
+                    { code: CliError.Code.InternalError }
                 );
             default:
                 return context.failAndThrow(
-                    `Unexpected generation status for library '${libraryName}': ${status.status}`
+                    `Unexpected generation status for library '${libraryName}': ${status.status}`,
+                    undefined,
+                    { code: CliError.Code.InternalError }
                 );
         }
     }
 
-    return context.failAndThrow(`Generation timed out for library '${libraryName}' after ${POLL_TIMEOUT_MS / 1000}s`);
+    return context.failAndThrow(
+        `Generation timed out for library '${libraryName}' after ${POLL_TIMEOUT_MS / 1000}s`,
+        undefined,
+        { code: CliError.Code.NetworkError }
+    );
 }
 
 async function downloadIr(
@@ -364,7 +399,9 @@ async function downloadIr(
         resultUrl = result.resultUrl;
     } catch (error) {
         return context.failAndThrow(
-            `Failed to fetch generation result for library '${libraryName}': ${extractErrorMessage(error)}`
+            `Failed to fetch generation result for library '${libraryName}': ${extractErrorMessage(error)}`,
+            error,
+            { code: CliError.Code.NetworkError }
         );
     }
 
@@ -372,7 +409,9 @@ async function downloadIr(
     const irFetchResponse = await fetch(resultUrl);
     if (!irFetchResponse.ok) {
         return context.failAndThrow(
-            `Failed to download IR for library '${libraryName}': HTTP ${irFetchResponse.status}`
+            `Failed to download IR for library '${libraryName}': HTTP ${irFetchResponse.status}`,
+            undefined,
+            { code: CliError.Code.NetworkError }
         );
     }
 
@@ -380,17 +419,21 @@ async function downloadIr(
     const ir = irWrapper.ir;
 
     if (ir == null) {
-        return context.failAndThrow(`IR is empty for library '${libraryName}'`);
+        return context.failAndThrow(`IR is empty for library '${libraryName}'`, undefined, { code: CliError.Code.InternalError });
     }
 
     if (language === "CPP") {
         if (ir.rootNamespace == null) {
-            return context.failAndThrow(`IR has no rootNamespace for C++ library '${libraryName}'`);
+            return context.failAndThrow(`IR has no rootNamespace for C++ library '${libraryName}'`, undefined, {
+                code: CliError.Code.InternalError
+            });
         }
         context.logger.debug(`Downloaded C++ IR for '${libraryName}'`);
     } else {
         if (ir.rootModule == null) {
-            return context.failAndThrow(`IR has no rootModule for library '${libraryName}'`);
+            return context.failAndThrow(`IR has no rootModule for library '${libraryName}'`, undefined, {
+                code: CliError.Code.InternalError
+            });
         }
         context.logger.debug(`Downloaded IR with ${Object.keys(ir.rootModule).length} top-level keys`);
     }

--- a/packages/cli/cli/src/commands/docs-md-generate/generateLibraryDocs.ts
+++ b/packages/cli/cli/src/commands/docs-md-generate/generateLibraryDocs.ts
@@ -419,7 +419,9 @@ async function downloadIr(
     const ir = irWrapper.ir;
 
     if (ir == null) {
-        return context.failAndThrow(`IR is empty for library '${libraryName}'`, undefined, { code: CliError.Code.InternalError });
+        return context.failAndThrow(`IR is empty for library '${libraryName}'`, undefined, {
+            code: CliError.Code.InternalError
+        });
     }
 
     if (language === "CPP") {

--- a/packages/cli/cli/src/commands/docs-preview/deleteDocsPreview.ts
+++ b/packages/cli/cli/src/commands/docs-preview/deleteDocsPreview.ts
@@ -4,6 +4,7 @@ import { askToLogin } from "@fern-api/login";
 import chalk from "chalk";
 
 import { CliContext } from "../../cli-context/CliContext.js";
+import { CliError } from "@fern-api/task-context";
 
 /**
  * Preview URLs follow the pattern: {org}-preview-{hash}.docs.buildwithfern.com
@@ -45,7 +46,9 @@ export async function deleteDocsPreview({
             `Invalid preview URL: ${previewUrl}\n` +
                 "Only preview sites can be deleted with this command.\n" +
                 "Preview URLs follow the pattern: {org}-preview-{hash}.docs.buildwithfern.com\n" +
-                "Example: acme-preview-abc123.docs.buildwithfern.com"
+                "Example: acme-preview-abc123.docs.buildwithfern.com",
+            undefined,
+            { code: CliError.Code.ConfigError }
         );
         return;
     }
@@ -55,7 +58,9 @@ export async function deleteDocsPreview({
     });
 
     if (token == null) {
-        cliContext.failAndThrow("Failed to authenticate. Please run 'fern login' first.");
+        cliContext.failAndThrow("Failed to authenticate. Please run 'fern login' first.", undefined, {
+            code: CliError.Code.AuthError
+        });
         return;
     }
 
@@ -74,12 +79,18 @@ export async function deleteDocsPreview({
             switch (deleteResponse.error.error) {
                 case "UnauthorizedError":
                     return context.failAndThrow(
-                        "You do not have permissions to delete this preview site. Reach out to support@buildwithfern.com"
+                        "You do not have permissions to delete this preview site. Reach out to support@buildwithfern.com",
+                        undefined,
+                        { code: CliError.Code.NetworkError }
                     );
                 case "DocsNotFoundError":
-                    return context.failAndThrow(`Preview site not found: ${previewUrl}`);
+                    return context.failAndThrow(`Preview site not found: ${previewUrl}`, undefined, {
+                        code: CliError.Code.ConfigError
+                    });
                 default:
-                    return context.failAndThrow(`Failed to delete preview site: ${previewUrl}`, deleteResponse.error);
+                    return context.failAndThrow(`Failed to delete preview site: ${previewUrl}`, deleteResponse.error, {
+                        code: CliError.Code.NetworkError
+                    });
             }
         }
     });

--- a/packages/cli/cli/src/commands/docs-preview/deleteDocsPreview.ts
+++ b/packages/cli/cli/src/commands/docs-preview/deleteDocsPreview.ts
@@ -1,10 +1,9 @@
 import { FernToken } from "@fern-api/auth";
 import { createFdrService } from "@fern-api/core";
 import { askToLogin } from "@fern-api/login";
-import chalk from "chalk";
-
-import { CliContext } from "../../cli-context/CliContext.js";
 import { CliError } from "@fern-api/task-context";
+import chalk from "chalk";
+import { CliContext } from "../../cli-context/CliContext.js";
 
 /**
  * Preview URLs follow the pattern: {org}-preview-{hash}.docs.buildwithfern.com

--- a/packages/cli/cli/src/commands/docs-preview/listDocsPreview.ts
+++ b/packages/cli/cli/src/commands/docs-preview/listDocsPreview.ts
@@ -1,8 +1,8 @@
 import { FernToken } from "@fern-api/auth";
 import { createFdrService } from "@fern-api/core";
 import { askToLogin } from "@fern-api/login";
+import { CliError } from "@fern-api/task-context";
 import chalk from "chalk";
-
 import { CliContext } from "../../cli-context/CliContext.js";
 
 interface PreviewDeployment {
@@ -25,7 +25,9 @@ export async function listDocsPreview({
     });
 
     if (token == null) {
-        cliContext.failAndThrow("Failed to authenticate. Please run 'fern login' first.");
+        cliContext.failAndThrow("Failed to authenticate. Please run 'fern login' first.", undefined, {
+            code: CliError.Code.AuthError
+        });
         return;
     }
 
@@ -44,7 +46,9 @@ export async function listDocsPreview({
             switch (listResponse.error.error) {
                 case "UnauthorizedError":
                     return context.failAndThrow(
-                        "Unauthorized to list preview deployments. Please run 'fern login' to refresh your credentials, or set the FERN_TOKEN environment variable."
+                        "Unauthorized to list preview deployments. Please run 'fern login' to refresh your credentials, or set the FERN_TOKEN environment variable.",
+                        undefined,
+                        { code: CliError.Code.NetworkError }
                     );
                 default: {
                     const errorContent =
@@ -56,7 +60,8 @@ export async function listDocsPreview({
                     context.logger.debug(`Error fetching preview deployments: ${JSON.stringify(errorContent)}`);
                     return context.failAndThrow(
                         "Failed to fetch preview deployments. Please ensure you are logged in with 'fern login' or have FERN_TOKEN set, then try again.",
-                        listResponse.error
+                        listResponse.error,
+                        { code: CliError.Code.NetworkError }
                     );
                 }
             }

--- a/packages/cli/cli/src/commands/downgrade/downgrade.ts
+++ b/packages/cli/cli/src/commands/downgrade/downgrade.ts
@@ -8,6 +8,7 @@ import { writeFile } from "fs/promises";
 import { produce } from "immer";
 
 import { CliContext } from "../../cli-context/CliContext.js";
+import { CliError } from "@fern-api/task-context";
 
 function ensureFinalNewline(content: string): string {
     return content.endsWith("\n") ? content : content + "\n";
@@ -30,12 +31,14 @@ export async function downgrade({
     targetVersion: string | undefined;
 }): Promise<void> {
     if (!targetVersion) {
-        return cliContext.failAndThrow("Please specify a version to downgrade to using --version");
+        return cliContext.failAndThrow("Please specify a version to downgrade to using --version", undefined, {
+            code: CliError.Code.ConfigError
+        });
     }
 
     const fernDirectory = await getFernDirectory();
     if (fernDirectory == null) {
-        return cliContext.failAndThrow(`Directory "${FERN_DIRECTORY}" not found.`);
+        return cliContext.failAndThrow(`Directory "${FERN_DIRECTORY}" not found.`, undefined, { code: CliError.Code.ConfigError });
     }
 
     const projectConfig = await cliContext.runTask((context) =>

--- a/packages/cli/cli/src/commands/downgrade/downgrade.ts
+++ b/packages/cli/cli/src/commands/downgrade/downgrade.ts
@@ -4,11 +4,10 @@ import {
     loadProjectConfig,
     PROJECT_CONFIG_FILENAME
 } from "@fern-api/configuration-loader";
+import { CliError } from "@fern-api/task-context";
 import { writeFile } from "fs/promises";
 import { produce } from "immer";
-
 import { CliContext } from "../../cli-context/CliContext.js";
-import { CliError } from "@fern-api/task-context";
 
 function ensureFinalNewline(content: string): string {
     return content.endsWith("\n") ? content : content + "\n";
@@ -38,7 +37,9 @@ export async function downgrade({
 
     const fernDirectory = await getFernDirectory();
     if (fernDirectory == null) {
-        return cliContext.failAndThrow(`Directory "${FERN_DIRECTORY}" not found.`, undefined, { code: CliError.Code.ConfigError });
+        return cliContext.failAndThrow(`Directory "${FERN_DIRECTORY}" not found.`, undefined, {
+            code: CliError.Code.ConfigError
+        });
     }
 
     const projectConfig = await cliContext.runTask((context) =>

--- a/packages/cli/cli/src/commands/export/converters/servicesConverter.ts
+++ b/packages/cli/cli/src/commands/export/converters/servicesConverter.ts
@@ -25,7 +25,7 @@ import {
     TypeReference
 } from "@fern-api/ir-sdk";
 import { getCamelCaseUnsafe, getOriginalName, getPascalCaseUnsafe, getWireValue } from "@fern-api/ir-utils";
-import { CliError} from "@fern-api/task-context";
+import { CliError } from "@fern-api/task-context";
 
 import { isEqual, size } from "lodash-es";
 import { OpenAPIV3 } from "openapi-types";
@@ -237,7 +237,10 @@ function convertHttpMethod(httpMethod: HttpMethod): OpenAPIV3.HttpMethods {
             return OpenAPIV3.HttpMethods.HEAD;
         },
         _other: () => {
-            throw new CliError({ message: "Encountered unknown http method: " + httpMethod, code: CliError.Code.InternalError });
+            throw new CliError({
+                message: "Encountered unknown http method: " + httpMethod,
+                code: CliError.Code.InternalError
+            });
         }
     });
 }

--- a/packages/cli/cli/src/commands/export/converters/servicesConverter.ts
+++ b/packages/cli/cli/src/commands/export/converters/servicesConverter.ts
@@ -25,6 +25,8 @@ import {
     TypeReference
 } from "@fern-api/ir-sdk";
 import { getCamelCaseUnsafe, getOriginalName, getPascalCaseUnsafe, getWireValue } from "@fern-api/ir-utils";
+import { CliError} from "@fern-api/task-context";
+
 import { isEqual, size } from "lodash-es";
 import { OpenAPIV3 } from "openapi-types";
 import urlJoin from "url-join";
@@ -67,7 +69,10 @@ export function convertServices({
             });
             const pathsObject = (paths[fullPath] ??= {});
             if (pathsObject[convertedHttpMethod] != null) {
-                throw new Error(`Duplicate ${convertedHttpMethod} endpoint at ${fullPath}`);
+                throw new CliError({
+                    message: `Duplicate ${convertedHttpMethod} endpoint at ${fullPath}`,
+                    code: CliError.Code.ConfigError
+                });
             }
             pathsObject[convertedHttpMethod] = operationObject;
         });
@@ -175,12 +180,15 @@ function convertHttpEndpoint({
     if (httpEndpoint.baseUrl != null) {
         const baseUrlId = httpEndpoint.baseUrl;
         if (environments?.environments.type !== "multipleBaseUrls") {
-            throw new Error("baseUrl is defined environments are not multipleBaseUrls");
+            throw new CliError({
+                message: "baseUrl is defined environments are not multipleBaseUrls",
+                code: CliError.Code.InternalError
+            });
         }
         operationObject.servers = environments.environments.environments.map((environment) => {
             const url = environment.urls[baseUrlId];
             if (url == null) {
-                throw new Error("No URL defined for " + baseUrlId);
+                throw new CliError({ message: "No URL defined for " + baseUrlId, code: CliError.Code.InternalError });
             }
             const server: OpenAPIV3.ServerObject = { url };
             if (environment.docs != null) {
@@ -229,7 +237,7 @@ function convertHttpMethod(httpMethod: HttpMethod): OpenAPIV3.HttpMethods {
             return OpenAPIV3.HttpMethods.HEAD;
         },
         _other: () => {
-            throw new Error("Encountered unknown http method: " + httpMethod);
+            throw new CliError({ message: "Encountered unknown http method: " + httpMethod, code: CliError.Code.InternalError });
         }
     });
 }
@@ -331,7 +339,10 @@ function convertRequestBody({
                                         };
                                     },
                                     _other: () => {
-                                        throw new Error("Unknown FileUploadRequestProperty: " + property.type);
+                                        throw new CliError({
+                                            message: "Unknown FileUploadRequestProperty: " + property.type,
+                                            code: CliError.Code.InternalError
+                                        });
                                     }
                                 });
                                 return {
@@ -359,7 +370,10 @@ function convertRequestBody({
             };
         },
         _other: () => {
-            throw new Error("Unknown HttpRequestBody type: " + httpRequest.type);
+            throw new CliError({
+                message: "Unknown HttpRequestBody type: " + httpRequest.type,
+                code: CliError.Code.InternalError
+            });
         }
     });
 }
@@ -473,9 +487,11 @@ function convertResponse({
             for (const responseError of responseErrors) {
                 const errorDeclaration = errorsByName[getErrorTypeNameKey(responseError.error)];
                 if (errorDeclaration == null) {
-                    throw new Error(
-                        "Encountered undefined error declaration: " + getOriginalName(responseError.error.name)
-                    );
+                    throw new CliError({
+                        message:
+                            "Encountered undefined error declaration: " + getOriginalName(responseError.error.name),
+                        code: CliError.Code.ResolutionError
+                    });
                 }
                 const responseForStatusCode: OpenAPIV3.ResponseObject = {
                     description: responseError.docs ?? ""
@@ -566,7 +582,10 @@ function convertResponse({
             }
         },
         _other: () => {
-            throw new Error("Unknown error discrimination strategy: " + errorDiscriminationStrategy.type);
+            throw new CliError({
+                message: "Unknown error discrimination strategy: " + errorDiscriminationStrategy.type,
+                code: CliError.Code.InternalError
+            });
         }
     });
     return responseByStatusCode;
@@ -637,7 +656,10 @@ function getErrorInfoByStatusCode({
     for (const responseError of responseErrors) {
         const errorDeclaration = errorsByName[getErrorTypeNameKey(responseError.error)];
         if (errorDeclaration == null) {
-            throw new Error("Encountered undefined error declaration: " + getOriginalName(responseError.error.name));
+            throw new CliError({
+                message: "Encountered undefined error declaration: " + getOriginalName(responseError.error.name),
+                code: CliError.Code.ResolutionError
+            });
         }
         const statusCode = errorDeclaration.statusCode;
         const statusCodeErrorInfo = errorInfoByStatusCode[statusCode];
@@ -808,7 +830,10 @@ function isTypeReferenceRequired({
         const key = getDeclaredTypeNameKey(typeReference);
         const typeDeclaration = typesByName[key];
         if (typeDeclaration == null) {
-            throw new Error("Encountered non-existent type: " + getOriginalName(typeReference.name));
+            throw new CliError({
+                message: "Encountered non-existent type: " + getOriginalName(typeReference.name),
+                code: CliError.Code.ResolutionError
+            });
         }
         if (typeDeclaration.shape.type === "alias") {
             return isTypeReferenceRequired({ typeReference: typeDeclaration.shape.aliasOf, typesByName });

--- a/packages/cli/cli/src/commands/export/converters/typeConverter.ts
+++ b/packages/cli/cli/src/commands/export/converters/typeConverter.ts
@@ -19,7 +19,7 @@ import {
     UnionTypeDeclaration
 } from "@fern-api/ir-sdk";
 import { getOriginalName, getWireValue } from "@fern-api/ir-utils";
-import { CliError} from "@fern-api/task-context";
+import { CliError } from "@fern-api/task-context";
 
 import isEqual from "lodash-es/isEqual";
 import { OpenAPIV3 } from "openapi-types";
@@ -101,7 +101,10 @@ export function convertType(typeDeclaration: TypeDeclaration, ir: IntermediateRe
             return convertUndiscriminatedUnion({ undiscriminatedUnionDeclaration, docs });
         },
         _other: () => {
-            throw new CliError({ message: "Encountered unknown type: " + shape.type, code: CliError.Code.InternalError });
+            throw new CliError({
+                message: "Encountered unknown type: " + shape.type,
+                code: CliError.Code.InternalError
+            });
         }
     });
     return {

--- a/packages/cli/cli/src/commands/export/converters/typeConverter.ts
+++ b/packages/cli/cli/src/commands/export/converters/typeConverter.ts
@@ -19,6 +19,8 @@ import {
     UnionTypeDeclaration
 } from "@fern-api/ir-sdk";
 import { getOriginalName, getWireValue } from "@fern-api/ir-utils";
+import { CliError} from "@fern-api/task-context";
+
 import isEqual from "lodash-es/isEqual";
 import { OpenAPIV3 } from "openapi-types";
 import { convertObject } from "./convertObject.js";
@@ -99,7 +101,7 @@ export function convertType(typeDeclaration: TypeDeclaration, ir: IntermediateRe
             return convertUndiscriminatedUnion({ undiscriminatedUnionDeclaration, docs });
         },
         _other: () => {
-            throw new Error("Encountered unknown type: " + shape.type);
+            throw new CliError({ message: "Encountered unknown type: " + shape.type, code: CliError.Code.InternalError });
         }
     });
     return {
@@ -180,7 +182,10 @@ export function convertUnion({
                 required: [getWireValue(unionTypeDeclaration.discriminant)]
             }),
             _other: () => {
-                throw new Error("Unknown SingleUnionTypeProperties: " + singleUnionType.shape.propertiesType);
+                throw new CliError({
+                    message: "Unknown SingleUnionTypeProperties: " + singleUnionType.shape.propertiesType,
+                    code: CliError.Code.InternalError
+                });
             }
         });
     });
@@ -241,7 +246,10 @@ export function convertTypeReference(typeReference: TypeReference): OpenApiCompo
             return {};
         },
         _other: () => {
-            throw new Error("Encountered unknown typeReference: " + typeReference.type);
+            throw new CliError({
+                message: "Encountered unknown typeReference: " + typeReference.type,
+                code: CliError.Code.InternalError
+            });
         }
     });
 }
@@ -328,7 +336,10 @@ function convertPrimitiveType(primitiveType: PrimitiveType): OpenAPIV3.NonArrayS
                     };
                 },
                 _other: () => {
-                    throw new Error("Encountered unknown primitiveType: " + primitiveType.v1);
+                    throw new CliError({
+                        message: "Encountered unknown primitiveType: " + primitiveType.v1,
+                        code: CliError.Code.InternalError
+                    });
                 }
             }) ?? {}
         );
@@ -419,7 +430,10 @@ function convertPrimitiveType(primitiveType: PrimitiveType): OpenAPIV3.NonArrayS
             };
         },
         _other: () => {
-            throw new Error("Encountered unknown primitiveType: " + primitiveType.v2);
+            throw new CliError({
+                message: "Encountered unknown primitiveType: " + primitiveType.v2,
+                code: CliError.Code.InternalError
+            });
         }
     });
 }
@@ -484,7 +498,10 @@ function convertContainerType(containerType: ContainerType): OpenApiComponentSch
             });
         },
         _other: () => {
-            throw new Error("Encountered unknown containerType: " + containerType.type);
+            throw new CliError({
+                message: "Encountered unknown containerType: " + containerType.type,
+                code: CliError.Code.InternalError
+            });
         }
     });
 }

--- a/packages/cli/cli/src/commands/export/security.ts
+++ b/packages/cli/cli/src/commands/export/security.ts
@@ -1,6 +1,6 @@
 import { ApiAuth, AuthScheme, AuthSchemesRequirement } from "@fern-api/ir-sdk";
 import { getPascalCaseUnsafe, getWireValue } from "@fern-api/ir-utils";
-import { CliError} from "@fern-api/task-context";
+import { CliError } from "@fern-api/task-context";
 import { OpenAPIV3 } from "openapi-types";
 
 export function constructEndpointSecurity(apiAuth: ApiAuth): OpenAPIV3.SecurityRequirementObject[] {
@@ -57,7 +57,10 @@ export function constructSecuritySchemes(apiAuth: ApiAuth): Record<string, OpenA
             }),
             inferred: () => undefined,
             _other: () => {
-                throw new CliError({ message: "Unknown auth scheme: " + scheme.type, code: CliError.Code.InternalError });
+                throw new CliError({
+                    message: "Unknown auth scheme: " + scheme.type,
+                    code: CliError.Code.InternalError
+                });
             }
         });
         if (oasScheme) {
@@ -76,7 +79,10 @@ function getNameForAuthScheme(authScheme: AuthScheme): string {
         oauth: () => "BearerAuth",
         header: (header) => `${getPascalCaseUnsafe(header.name)}Auth`,
         _other: () => {
-            throw new CliError({ message: "Unknown auth scheme: " + authScheme.type, code: CliError.Code.InternalError });
+            throw new CliError({
+                message: "Unknown auth scheme: " + authScheme.type,
+                code: CliError.Code.InternalError
+            });
         }
     });
 }

--- a/packages/cli/cli/src/commands/export/security.ts
+++ b/packages/cli/cli/src/commands/export/security.ts
@@ -1,5 +1,6 @@
 import { ApiAuth, AuthScheme, AuthSchemesRequirement } from "@fern-api/ir-sdk";
 import { getPascalCaseUnsafe, getWireValue } from "@fern-api/ir-utils";
+import { CliError} from "@fern-api/task-context";
 import { OpenAPIV3 } from "openapi-types";
 
 export function constructEndpointSecurity(apiAuth: ApiAuth): OpenAPIV3.SecurityRequirementObject[] {
@@ -24,7 +25,10 @@ export function constructEndpointSecurity(apiAuth: ApiAuth): OpenAPIV3.SecurityR
             return [];
         },
         _other: () => {
-            throw new Error("Unknown auth scheme requirement: " + apiAuth.requirement);
+            throw new CliError({
+                message: "Unknown auth scheme requirement: " + apiAuth.requirement,
+                code: CliError.Code.InternalError
+            });
         }
     });
 }
@@ -53,7 +57,7 @@ export function constructSecuritySchemes(apiAuth: ApiAuth): Record<string, OpenA
             }),
             inferred: () => undefined,
             _other: () => {
-                throw new Error("Unknown auth scheme: " + scheme.type);
+                throw new CliError({ message: "Unknown auth scheme: " + scheme.type, code: CliError.Code.InternalError });
             }
         });
         if (oasScheme) {
@@ -72,7 +76,7 @@ function getNameForAuthScheme(authScheme: AuthScheme): string {
         oauth: () => "BearerAuth",
         header: (header) => `${getPascalCaseUnsafe(header.name)}Auth`,
         _other: () => {
-            throw new Error("Unknown auth scheme: " + authScheme.type);
+            throw new CliError({ message: "Unknown auth scheme: " + authScheme.type, code: CliError.Code.InternalError });
         }
     });
 }

--- a/packages/cli/cli/src/commands/generate-dynamic-ir/generateDynamicIrForWorkspaces.ts
+++ b/packages/cli/cli/src/commands/generate-dynamic-ir/generateDynamicIrForWorkspaces.ts
@@ -1,7 +1,7 @@
 import { Audiences, generatorsYml } from "@fern-api/configuration-loader";
 import { AbsoluteFilePath, streamObjectToFile } from "@fern-api/fs-utils";
 import { Project } from "@fern-api/project-loader";
-import { CliError} from "@fern-api/task-context";
+import { CliError } from "@fern-api/task-context";
 import path from "path";
 import { CliContext } from "../../cli-context/CliContext.js";
 import { generateIrForFernWorkspace } from "../generate-ir/generateIrForFernWorkspace.js";

--- a/packages/cli/cli/src/commands/generate-dynamic-ir/generateDynamicIrForWorkspaces.ts
+++ b/packages/cli/cli/src/commands/generate-dynamic-ir/generateDynamicIrForWorkspaces.ts
@@ -1,8 +1,8 @@
 import { Audiences, generatorsYml } from "@fern-api/configuration-loader";
 import { AbsoluteFilePath, streamObjectToFile } from "@fern-api/fs-utils";
 import { Project } from "@fern-api/project-loader";
+import { CliError} from "@fern-api/task-context";
 import path from "path";
-
 import { CliContext } from "../../cli-context/CliContext.js";
 import { generateIrForFernWorkspace } from "../generate-ir/generateIrForFernWorkspace.js";
 
@@ -46,7 +46,10 @@ export async function generateDynamicIrForWorkspaces({
                 });
 
                 if (intermediateRepresentation.dynamic == null) {
-                    throw new Error("Internal error; dynamic IR was not generated");
+                    throw new CliError({
+                        message: "Internal error; dynamic IR was not generated",
+                        code: CliError.Code.InternalError
+                    });
                 }
 
                 const irOutputFilePath = path.resolve(irFilepath);

--- a/packages/cli/cli/src/commands/generate-overrides/compareOpenAPISpecs.ts
+++ b/packages/cli/cli/src/commands/generate-overrides/compareOpenAPISpecs.ts
@@ -1,9 +1,8 @@
 import { AbsoluteFilePath, dirname, doesPathExist, getFilename, join, RelativeFilePath } from "@fern-api/fs-utils";
+import { CliError } from "@fern-api/task-context";
 import { readFile, writeFile } from "fs/promises";
 import yaml from "js-yaml";
-
 import { CliContext } from "../../cli-context/CliContext.js";
-import { CliError } from "@fern-api/task-context";
 
 // biome-ignore lint/suspicious/noExplicitAny: OpenAPI specs can have any shape
 type OpenAPISpec = Record<string, any>;

--- a/packages/cli/cli/src/commands/generate-overrides/compareOpenAPISpecs.ts
+++ b/packages/cli/cli/src/commands/generate-overrides/compareOpenAPISpecs.ts
@@ -3,6 +3,7 @@ import { readFile, writeFile } from "fs/promises";
 import yaml from "js-yaml";
 
 import { CliContext } from "../../cli-context/CliContext.js";
+import { CliError } from "@fern-api/task-context";
 
 // biome-ignore lint/suspicious/noExplicitAny: OpenAPI specs can have any shape
 type OpenAPISpec = Record<string, any>;
@@ -26,10 +27,14 @@ export async function compareOpenAPISpecs({
     await cliContext.runTask(async (context) => {
         // Validate files exist
         if (!(await doesPathExist(originalPath))) {
-            return context.failAndThrow(`Original file does not exist: ${originalPath}`);
+            return context.failAndThrow(`Original file does not exist: ${originalPath}`, undefined, {
+                code: CliError.Code.ConfigError
+            });
         }
         if (!(await doesPathExist(modifiedPath))) {
-            return context.failAndThrow(`Modified file does not exist: ${modifiedPath}`);
+            return context.failAndThrow(`Modified file does not exist: ${modifiedPath}`, undefined, {
+                code: CliError.Code.ConfigError
+            });
         }
 
         context.logger.info(`Comparing ${originalPath} with ${modifiedPath}`);
@@ -79,7 +84,9 @@ async function loadSpec(filepath: AbsoluteFilePath, context: any): Promise<OpenA
         try {
             return yaml.load(contents) as OpenAPISpec;
         } catch (err) {
-            return context.failAndThrow(`Failed to parse file as JSON or YAML: ${filepath}`);
+            return context.failAndThrow(`Failed to parse file as JSON or YAML: ${filepath}`, undefined, {
+                code: CliError.Code.ParseError
+            });
         }
     }
 }

--- a/packages/cli/cli/src/commands/generate-overrides/writeOverridesForWorkspaces.ts
+++ b/packages/cli/cli/src/commands/generate-overrides/writeOverridesForWorkspaces.ts
@@ -4,7 +4,7 @@ import { OpenApiIntermediateRepresentation, Schema } from "@fern-api/openapi-ir"
 import { parse } from "@fern-api/openapi-ir-parser";
 import { getEndpointLocation } from "@fern-api/openapi-ir-to-fern";
 import { Project } from "@fern-api/project-loader";
-import { TaskContext } from "@fern-api/task-context";
+import { CliError, TaskContext } from "@fern-api/task-context";
 import { readFile, writeFile } from "fs/promises";
 import yaml from "js-yaml";
 

--- a/packages/cli/cli/src/commands/generate-overrides/writeOverridesForWorkspaces.ts
+++ b/packages/cli/cli/src/commands/generate-overrides/writeOverridesForWorkspaces.ts
@@ -46,7 +46,9 @@ async function readExistingOverrides(overridesFilepath: string, context: TaskCon
             parsedOverrides = yaml.load(contents, { json: true });
         }
     } catch (err) {
-        return context.failAndThrow(`Failed to read OpenAPI overrides from file ${overridesFilepath}`);
+        return context.failAndThrow(`Failed to read OpenAPI overrides from file ${overridesFilepath}`, undefined, {
+            code: CliError.Code.ConfigError
+        });
     }
     return parsedOverrides;
 }

--- a/packages/cli/cli/src/commands/generate/generateAPIWorkspace.ts
+++ b/packages/cli/cli/src/commands/generate/generateAPIWorkspace.ts
@@ -9,7 +9,7 @@ import { ContainerRunner } from "@fern-api/core-utils";
 import { AbsoluteFilePath, cwd, join, RelativeFilePath, resolve } from "@fern-api/fs-utils";
 import { runLocalGenerationForWorkspace } from "@fern-api/local-workspace-runner";
 import { runRemoteGenerationForAPIWorkspace } from "@fern-api/remote-workspace-runner";
-import { TaskContext } from "@fern-api/task-context";
+import { CliError, TaskContext } from "@fern-api/task-context";
 import { AbstractAPIWorkspace } from "@fern-api/workspace-loader";
 import { FernFiddle } from "@fern-fern/fiddle-sdk";
 import chalk from "chalk";
@@ -99,7 +99,7 @@ export async function generateWorkspace({
                     return ` › ${chalk.bold(name.padEnd(longestGroupName))}  ${chalk.dim(suggestedCommand)}`;
                 })
                 .join("\n");
-        return context.failAndThrow(message);
+        return context.failAndThrow(message, undefined, { code: CliError.Code.NetworkError });
     }
 
     // Resolve group aliases - if the groupName is an alias, expand it to multiple groups
@@ -114,7 +114,7 @@ export async function generateWorkspace({
 
     // Pre-check token for remote generation before starting any work
     if (!useLocalDocker && !token) {
-        return context.failAndThrow("Please run fern login");
+        return context.failAndThrow("Please run fern login", undefined, { code: CliError.Code.AuthError });
     }
 
     // Run generation for all resolved groups in parallel
@@ -124,7 +124,9 @@ export async function generateWorkspace({
                 (otherGroup) => otherGroup.groupName === resolvedGroupName
             );
             if (group == null) {
-                return context.failAndThrow(`Group '${resolvedGroupName}' does not exist.`);
+                return context.failAndThrow(`Group '${resolvedGroupName}' does not exist.`, undefined, {
+                    code: CliError.Code.ConfigError
+                });
             }
 
             // Filter to specific generator by index or name
@@ -135,7 +137,7 @@ export async function generateWorkspace({
                 groupName: resolvedGroupName
             });
             if (!filterResult.ok) {
-                return context.failAndThrow(filterResult.error);
+                return context.failAndThrow(filterResult.error, undefined, { code: CliError.Code.ConfigError });
             }
             group = { ...group, generators: filterResult.generators };
 
@@ -225,7 +227,9 @@ function resolveGroupAlias(
             if (!availableGroups.includes(groupName)) {
                 context.failAndThrow(
                     `Group alias '${groupNameOrAlias}' references non-existent group '${groupName}'. ` +
-                        `Available groups: ${availableGroups.join(", ")}`
+                        `Available groups: ${availableGroups.join(", ")}`,
+                    undefined,
+                    { code: CliError.Code.NetworkError }
                 );
             }
         }
@@ -243,7 +247,9 @@ function resolveGroupAlias(
     context.failAndThrow(
         `'${groupNameOrAlias}' is not a valid group or alias. ` +
             `Available groups: ${availableGroups.join(", ")}` +
-            (availableAliases.length > 0 ? `. Available aliases: ${availableAliases.join(", ")}` : "")
+            (availableAliases.length > 0 ? `. Available aliases: ${availableAliases.join(", ")}` : ""),
+        undefined,
+        { code: CliError.Code.NetworkError }
     );
     return []; // unreachable, but TypeScript needs this
 }

--- a/packages/cli/cli/src/commands/generate/generateAPIWorkspaces.ts
+++ b/packages/cli/cli/src/commands/generate/generateAPIWorkspaces.ts
@@ -4,7 +4,7 @@ import { ContainerRunner, Values } from "@fern-api/core-utils";
 import { AbsoluteFilePath, cwd, join, RelativeFilePath, resolve } from "@fern-api/fs-utils";
 import { askToLogin } from "@fern-api/login";
 import { Project } from "@fern-api/project-loader";
-
+import { CliError } from "@fern-api/task-context";
 import { CliContext } from "../../cli-context/CliContext.js";
 import { PREVIEW_DIRECTORY } from "../../constants.js";
 import { checkOutputDirectory } from "./checkOutputDirectory.js";
@@ -108,7 +108,7 @@ export async function generateAPIWorkspaces({
                     force
                 );
                 if (!shouldProceed) {
-                    cliContext.failAndThrow("Generation cancelled");
+                    cliContext.failAndThrow("Generation cancelled", undefined, { code: CliError.Code.ConfigError });
                 }
             }
         }

--- a/packages/cli/cli/src/commands/generate/generateDocsWorkspace.ts
+++ b/packages/cli/cli/src/commands/generate/generateDocsWorkspace.ts
@@ -7,7 +7,7 @@ import { askToLogin } from "@fern-api/login";
 import { validateOSSWorkspace } from "@fern-api/oss-validator";
 import { Project } from "@fern-api/project-loader";
 import { runRemoteGenerationForDocsWorkspace } from "@fern-api/remote-workspace-runner";
-import { CliError} from "@fern-api/task-context";
+import { CliError } from "@fern-api/task-context";
 import chalk from "chalk";
 import { CliContext } from "../../cli-context/CliContext.js";
 import { detectCISource, detectDeployerAuthor, isCI } from "../../utils/environment.js";

--- a/packages/cli/cli/src/commands/generate/generateDocsWorkspace.ts
+++ b/packages/cli/cli/src/commands/generate/generateDocsWorkspace.ts
@@ -7,8 +7,8 @@ import { askToLogin } from "@fern-api/login";
 import { validateOSSWorkspace } from "@fern-api/oss-validator";
 import { Project } from "@fern-api/project-loader";
 import { runRemoteGenerationForDocsWorkspace } from "@fern-api/remote-workspace-runner";
+import { CliError} from "@fern-api/task-context";
 import chalk from "chalk";
-
 import { CliContext } from "../../cli-context/CliContext.js";
 import { detectCISource, detectDeployerAuthor, isCI } from "../../utils/environment.js";
 import { validateDocsWorkspaceAndLogIssues } from "../validate/validateDocsWorkspaceAndLogIssues.js";
@@ -52,7 +52,10 @@ function buildPreviewDomain({ orgId, previewId }: { orgId: string; previewId: st
 
     const minIdLength = 8;
     if (availableSpace < minIdLength) {
-        throw new Error(`Organization name "${orgId}" is too long to generate a valid preview URL`);
+        throw new CliError({
+            message: `Organization name "${orgId}" is too long to generate a valid preview URL`,
+            code: CliError.Code.InternalError
+        });
     }
 
     const truncatedId = sanitizedId.slice(0, availableSpace).replace(/-+$/, "");
@@ -86,7 +89,9 @@ export async function generateDocsWorkspace({
 }): Promise<void> {
     const docsWorkspace = project.docsWorkspaces;
     if (docsWorkspace == null) {
-        cliContext.failAndThrow("No docs.yml file found. Please make sure your project has one.");
+        cliContext.failAndThrow("No docs.yml file found. Please make sure your project has one.", undefined, {
+            code: CliError.Code.ConfigError
+        });
         return;
     }
     const hasFdrOriginOverride = !!process.env["FERN_FDR_ORIGIN"] || !!process.env["OVERRIDE_FDR_ORIGIN"];
@@ -110,7 +115,9 @@ export async function generateDocsWorkspace({
         const fernToken = await getToken();
         if (!fernToken) {
             cliContext.failAndThrow(
-                "No token found. Please set the FERN_TOKEN environment variable or run `fern login`."
+                "No token found. Please set the FERN_TOKEN environment variable or run `fern login`.",
+                undefined,
+                { code: CliError.Code.AuthError }
             );
             return;
         }
@@ -176,7 +183,9 @@ export async function generateDocsWorkspace({
                 }
                 context.failAndThrow(
                     `OpenAPI spec validation failed with ${errors.length} error${errors.length !== 1 ? "s" : ""}. ` +
-                        "Fix the errors above before generating docs."
+                        "Fix the errors above before generating docs.",
+                    undefined,
+                    { code: CliError.Code.ValidationError }
                 );
             }
         }

--- a/packages/cli/cli/src/commands/generator-list/getGeneratorList.ts
+++ b/packages/cli/cli/src/commands/generator-list/getGeneratorList.ts
@@ -5,11 +5,10 @@ import {
 } from "@fern-api/configuration-loader";
 import { assertNever, Values } from "@fern-api/core-utils";
 import { Project } from "@fern-api/project-loader";
+import { CliError } from "@fern-api/task-context";
 import { writeFile } from "fs/promises";
 import yaml from "js-yaml";
-
 import { CliContext } from "../../cli-context/CliContext.js";
-import { CliError } from "@fern-api/task-context";
 
 export const GenerationModeFilter = {
     GitHub: "github",

--- a/packages/cli/cli/src/commands/generator-list/getGeneratorList.ts
+++ b/packages/cli/cli/src/commands/generator-list/getGeneratorList.ts
@@ -9,6 +9,7 @@ import { writeFile } from "fs/promises";
 import yaml from "js-yaml";
 
 import { CliContext } from "../../cli-context/CliContext.js";
+import { CliError } from "@fern-api/task-context";
 
 export const GenerationModeFilter = {
     GitHub: "github",
@@ -105,7 +106,9 @@ export async function getGeneratorList({
     try {
         await writeFile(outputLocation, generatorsListYaml);
     } catch (error) {
-        cliContext.failAndThrow(`Could not write file to the specified location: ${outputLocation}`, error);
+        cliContext.failAndThrow(`Could not write file to the specified location: ${outputLocation}`, error, {
+            code: CliError.Code.ConfigError
+        });
     }
 }
 

--- a/packages/cli/cli/src/commands/install-dependencies/__test__/installDependencies.test.ts
+++ b/packages/cli/cli/src/commands/install-dependencies/__test__/installDependencies.test.ts
@@ -1,4 +1,5 @@
 import { AbsoluteFilePath } from "@fern-api/fs-utils";
+import { CliError } from "@fern-api/task-context";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("@fern-api/lazy-fern-workspace", () => ({
@@ -88,7 +89,11 @@ describe("installDependencies", () => {
         await expect(installDependencies({ cliContext: mockCliContext })).rejects.toThrow("Failed to install: buf");
 
         expect(mockContext.logger.error).toHaveBeenCalledWith("Failed to install buf");
-        expect(mockContext.failAndThrow).toHaveBeenCalledWith(expect.stringContaining("Failed to install: buf"));
+        expect(mockContext.failAndThrow).toHaveBeenCalledWith(
+            expect.stringContaining("Failed to install: buf"),
+            undefined,
+            { code: CliError.Code.EnvironmentError }
+        );
     });
 
     it("fails when protoc-gen-openapi resolution returns undefined", async () => {

--- a/packages/cli/cli/src/commands/install-dependencies/installDependencies.ts
+++ b/packages/cli/cli/src/commands/install-dependencies/installDependencies.ts
@@ -1,6 +1,6 @@
 import { resolveBuf, resolveProtocGenOpenAPI } from "@fern-api/lazy-fern-workspace";
-import { CliContext } from "../../cli-context/CliContext.js";
 import { CliError } from "@fern-api/task-context";
+import { CliContext } from "../../cli-context/CliContext.js";
 
 export async function installDependencies({ cliContext }: { cliContext: CliContext }): Promise<void> {
     await cliContext.runTask(async (context) => {

--- a/packages/cli/cli/src/commands/install-dependencies/installDependencies.ts
+++ b/packages/cli/cli/src/commands/install-dependencies/installDependencies.ts
@@ -1,5 +1,6 @@
 import { resolveBuf, resolveProtocGenOpenAPI } from "@fern-api/lazy-fern-workspace";
 import { CliContext } from "../../cli-context/CliContext.js";
+import { CliError } from "@fern-api/task-context";
 
 export async function installDependencies({ cliContext }: { cliContext: CliContext }): Promise<void> {
     await cliContext.runTask(async (context) => {
@@ -33,7 +34,9 @@ export async function installDependencies({ cliContext }: { cliContext: CliConte
         const failed = results.filter((r) => !r.success);
         if (failed.length > 0) {
             context.failAndThrow(
-                `Failed to install: ${failed.map((r) => r.name).join(", ")}. Check network connectivity and try again.`
+                `Failed to install: ${failed.map((r) => r.name).join(", ")}. Check network connectivity and try again.`,
+                undefined,
+                { code: CliError.Code.EnvironmentError }
             );
         }
 

--- a/packages/cli/cli/src/commands/merge/mergeOpenAPIWithOverrides.ts
+++ b/packages/cli/cli/src/commands/merge/mergeOpenAPIWithOverrides.ts
@@ -1,9 +1,8 @@
 import { AbsoluteFilePath, doesPathExist } from "@fern-api/fs-utils";
+import { CliError } from "@fern-api/task-context";
 import { readFile, writeFile } from "fs/promises";
 import yaml from "js-yaml";
-
 import { CliContext } from "../../cli-context/CliContext.js";
-import { CliError } from "@fern-api/task-context";
 
 // biome-ignore lint/suspicious/noExplicitAny: OpenAPI specs can have any shape
 type OpenAPISpec = Record<string, any>;

--- a/packages/cli/cli/src/commands/merge/mergeOpenAPIWithOverrides.ts
+++ b/packages/cli/cli/src/commands/merge/mergeOpenAPIWithOverrides.ts
@@ -3,6 +3,7 @@ import { readFile, writeFile } from "fs/promises";
 import yaml from "js-yaml";
 
 import { CliContext } from "../../cli-context/CliContext.js";
+import { CliError } from "@fern-api/task-context";
 
 // biome-ignore lint/suspicious/noExplicitAny: OpenAPI specs can have any shape
 type OpenAPISpec = Record<string, any>;
@@ -35,10 +36,14 @@ export async function mergeOpenAPIWithOverrides({
     await cliContext.runTask(async (context) => {
         // Validate files exist
         if (!(await doesPathExist(openapiPath))) {
-            return context.failAndThrow(`OpenAPI spec file does not exist: ${openapiPath}`);
+            return context.failAndThrow(`OpenAPI spec file does not exist: ${openapiPath}`, undefined, {
+                code: CliError.Code.ConfigError
+            });
         }
         if (!(await doesPathExist(overridesPath))) {
-            return context.failAndThrow(`Overrides file does not exist: ${overridesPath}`);
+            return context.failAndThrow(`Overrides file does not exist: ${overridesPath}`, undefined, {
+                code: CliError.Code.ConfigError
+            });
         }
 
         context.logger.info(`Merging ${overridesPath} into ${openapiPath}`);
@@ -69,7 +74,9 @@ async function loadYamlOrJson(filepath: AbsoluteFilePath, context: any): Promise
         try {
             return yaml.load(contents) as OpenAPISpec;
         } catch (err) {
-            return context.failAndThrow(`Failed to parse file as JSON or YAML: ${filepath}`);
+            return context.failAndThrow(`Failed to parse file as JSON or YAML: ${filepath}`, undefined, {
+                code: CliError.Code.ParseError
+            });
         }
     }
 }

--- a/packages/cli/cli/src/commands/mock/mockServer.ts
+++ b/packages/cli/cli/src/commands/mock/mockServer.ts
@@ -3,10 +3,10 @@ import { SourceResolverImpl } from "@fern-api/cli-source-resolver";
 import { generateIntermediateRepresentation } from "@fern-api/ir-generator";
 import { MockServer } from "@fern-api/mock";
 import { Project } from "@fern-api/project-loader";
+import { CliError } from "@fern-api/task-context";
 import { AbstractAPIWorkspace, FernWorkspace } from "@fern-api/workspace-loader";
 import { CliContext } from "../../cli-context/CliContext.js";
 import { API_CLI_OPTION } from "../../constants.js";
-import { CliError } from "@fern-api/task-context";
 
 export async function mockServer({
     cliContext,

--- a/packages/cli/cli/src/commands/mock/mockServer.ts
+++ b/packages/cli/cli/src/commands/mock/mockServer.ts
@@ -6,6 +6,7 @@ import { Project } from "@fern-api/project-loader";
 import { AbstractAPIWorkspace, FernWorkspace } from "@fern-api/workspace-loader";
 import { CliContext } from "../../cli-context/CliContext.js";
 import { API_CLI_OPTION } from "../../constants.js";
+import { CliError } from "@fern-api/task-context";
 
 export async function mockServer({
     cliContext,
@@ -22,7 +23,9 @@ export async function mockServer({
     });
 
     if (project.apiWorkspaces.length !== 1 || project.apiWorkspaces[0] == null) {
-        return cliContext.failAndThrow(`No API specified. Use the --${API_CLI_OPTION} option.`);
+        return cliContext.failAndThrow(`No API specified. Use the --${API_CLI_OPTION} option.`, undefined, {
+            code: CliError.Code.ConfigError
+        });
     }
 
     const workspace: AbstractAPIWorkspace<unknown> = project.apiWorkspaces[0];

--- a/packages/cli/cli/src/commands/organization/getOrganization.ts
+++ b/packages/cli/cli/src/commands/organization/getOrganization.ts
@@ -1,8 +1,7 @@
 import { Project } from "@fern-api/project-loader";
-import { writeFile } from "fs/promises";
-
-import { CliContext } from "../../cli-context/CliContext.js";
 import { CliError } from "@fern-api/task-context";
+import { writeFile } from "fs/promises";
+import { CliContext } from "../../cli-context/CliContext.js";
 
 export async function getOrganization({
     project,

--- a/packages/cli/cli/src/commands/organization/getOrganization.ts
+++ b/packages/cli/cli/src/commands/organization/getOrganization.ts
@@ -2,6 +2,7 @@ import { Project } from "@fern-api/project-loader";
 import { writeFile } from "fs/promises";
 
 import { CliContext } from "../../cli-context/CliContext.js";
+import { CliError } from "@fern-api/task-context";
 
 export async function getOrganization({
     project,
@@ -21,6 +22,8 @@ export async function getOrganization({
     try {
         await writeFile(outputLocation, org);
     } catch (error) {
-        context.failAndThrow(`Could not write file to the specified location: ${outputLocation}`, error);
+        context.failAndThrow(`Could not write file to the specified location: ${outputLocation}`, error, {
+            code: CliError.Code.ConfigError
+        });
     }
 }

--- a/packages/cli/cli/src/commands/register/registerWorkspacesV1.ts
+++ b/packages/cli/cli/src/commands/register/registerWorkspacesV1.ts
@@ -11,6 +11,7 @@ import { create as createTar } from "tar";
 import tmp from "tmp-promise";
 
 import { CliContext } from "../../cli-context/CliContext.js";
+import { CliError } from "@fern-api/task-context";
 
 export async function registerWorkspacesV1({
     project,
@@ -38,7 +39,9 @@ export async function registerWorkspacesV1({
         project.apiWorkspaces.map(async (workspace) => {
             await cliContext.runTaskForWorkspace(workspace, async (context) => {
                 if (workspace instanceof OSSWorkspace) {
-                    context.failWithoutThrowing("Registering from OpenAPI not currently supported.");
+                    context.failWithoutThrowing("Registering from OpenAPI not currently supported.", undefined, {
+                        code: CliError.Code.ConfigError
+                    });
                     return;
                 }
                 const resolvedWorkspace = await workspace.toFernWorkspace({ context });
@@ -51,10 +54,12 @@ export async function registerWorkspacesV1({
                 if (!registerApiResponse.ok) {
                     registerApiResponse.error._visit({
                         versionAlreadyExists: () => {
-                            context.failAndThrow(`Version ${version ?? ""} is already registered`);
+                            context.failAndThrow(`Version ${version ?? ""} is already registered`, undefined, {
+                                code: CliError.Code.VersionError
+                            });
                         },
                         _other: (value) => {
-                            context.failAndThrow("Failed to register", value);
+                            context.failAndThrow("Failed to register", value, { code: CliError.Code.NetworkError });
                         }
                     });
                     return;

--- a/packages/cli/cli/src/commands/register/registerWorkspacesV1.ts
+++ b/packages/cli/cli/src/commands/register/registerWorkspacesV1.ts
@@ -3,15 +3,14 @@ import { createFiddleService } from "@fern-api/core";
 import { YAML_SCHEMA_VERSION } from "@fern-api/fern-definition-schema";
 import { OSSWorkspace } from "@fern-api/lazy-fern-workspace";
 import { Project } from "@fern-api/project-loader";
+import { CliError } from "@fern-api/task-context";
 import { FernFiddle } from "@fern-fern/fiddle-sdk";
 import axios from "axios";
 import { readFile } from "fs/promises";
 import path from "path";
 import { create as createTar } from "tar";
 import tmp from "tmp-promise";
-
 import { CliContext } from "../../cli-context/CliContext.js";
-import { CliError } from "@fern-api/task-context";
 
 export async function registerWorkspacesV1({
     project,

--- a/packages/cli/cli/src/commands/sdk-diff/sdkDiffCommand.ts
+++ b/packages/cli/cli/src/commands/sdk-diff/sdkDiffCommand.ts
@@ -21,7 +21,7 @@ import {
     maxVersionBump
 } from "@fern-api/local-workspace-runner";
 import { Project } from "@fern-api/project-loader";
-import { TaskAbortSignal, TaskContext } from "@fern-api/task-context";
+import { CliError, TaskAbortSignal, TaskContext } from "@fern-api/task-context";
 import { exec } from "child_process";
 import { promisify } from "util";
 import { CliContext } from "../../cli-context/CliContext.js";

--- a/packages/cli/cli/src/commands/sdk-diff/sdkDiffCommand.ts
+++ b/packages/cli/cli/src/commands/sdk-diff/sdkDiffCommand.ts
@@ -32,7 +32,7 @@ async function getClientRegistry(context: CliContext, project: Project): Promise
     // Get the first API workspace (or we could make this configurable)
     const workspace = project.apiWorkspaces[0];
     if (workspace == null) {
-        context.failAndThrow("No API workspaces found in the project.");
+        context.failAndThrow("No API workspaces found in the project.", undefined, { code: CliError.Code.ConfigError });
     }
 
     // Load generators configuration to get AI service settings
@@ -43,13 +43,19 @@ async function getClientRegistry(context: CliContext, project: Project): Promise
     });
 
     if (generatorsConfig == null) {
-        context.failAndThrow("Could not find generators.yml in the workspace. Is this a valid fern project?");
+        context.failAndThrow(
+            "Could not find generators.yml in the workspace. Is this a valid fern project?",
+            undefined,
+            { code: CliError.Code.ConfigError }
+        );
     }
 
     // Check if AI services configuration exists
     if (generatorsConfig.ai == null) {
         context.failAndThrow(
-            "No AI service configuration found in generators.yml. Please add an 'ai' section with provider and model."
+            "No AI service configuration found in generators.yml. Please add an 'ai' section with provider and model.",
+            undefined,
+            { code: CliError.Code.ConfigError }
         );
     }
 
@@ -81,12 +87,12 @@ export async function sdkDiffCommand({
 
     // Validate that both directories exist
     if (!(await doesPathExist(fromPath, "directory"))) {
-        context.failWithoutThrowing(`Directory not found: ${fromPath}`);
+        context.failWithoutThrowing(`Directory not found: ${fromPath}`, undefined, { code: CliError.Code.ConfigError });
         throw new TaskAbortSignal();
     }
 
     if (!(await doesPathExist(toPath, "directory"))) {
-        context.failWithoutThrowing(`Directory not found: ${toPath}`);
+        context.failWithoutThrowing(`Directory not found: ${toPath}`, undefined, { code: CliError.Code.ConfigError });
         throw new TaskAbortSignal();
     }
 
@@ -116,7 +122,9 @@ export async function sdkDiffCommand({
     if (diffBytes > MAX_RAW_DIFF_BYTES) {
         return context.failAndThrow(
             `Diff too large for analysis (${(diffBytes / 1_000_000).toFixed(1)}MB, ` +
-                `limit ${MAX_RAW_DIFF_BYTES / 1_000_000}MB). Try excluding generated files or splitting the comparison.`
+                `limit ${MAX_RAW_DIFF_BYTES / 1_000_000}MB). Try excluding generated files or splitting the comparison.`,
+            undefined,
+            { code: CliError.Code.ConfigError }
         );
     }
 
@@ -232,7 +240,9 @@ export async function sdkDiffCommand({
                 (cappedChunks.length > 1
                     ? `The diff was split into ${cappedChunks.length} chunks but analysis still failed. `
                     : "") +
-                `Error: ${errorMessage}`
+                `Error: ${errorMessage}`,
+            undefined,
+            { code: CliError.Code.NetworkError }
         );
         throw new TaskAbortSignal();
     }
@@ -273,6 +283,8 @@ async function generateDiff({
             return error.stdout;
         }
         // For other errors, throw
-        return context.failAndThrow(`Failed to generate diff: ${extractErrorMessage(error)}`);
+        return context.failAndThrow(`Failed to generate diff: ${extractErrorMessage(error)}`, undefined, {
+            code: CliError.Code.InternalError
+        });
     }
 }

--- a/packages/cli/cli/src/commands/sdk-preview/sdkPreview.ts
+++ b/packages/cli/cli/src/commands/sdk-preview/sdkPreview.ts
@@ -25,6 +25,7 @@ import {
     PREVIEW_REGISTRY_URL
 } from "./overrideOutputForPreview.js";
 import { toPreviewPackageName } from "./toPreviewPackageName.js";
+import { CliError } from "@fern-api/task-context";
 
 interface SdkPreviewSuccess {
     status: "success";
@@ -103,7 +104,9 @@ export async function sdkPreview({
             return askToLogin(context);
         });
         if (token == null) {
-            return cliContext.failAndThrow("Authentication required. Run 'fern login' or set FERN_TOKEN.");
+            return cliContext.failAndThrow("Authentication required. Run 'fern login' or set FERN_TOKEN.", undefined, {
+                code: CliError.Code.AuthError
+            });
         }
 
         // 2. Load project
@@ -185,14 +188,18 @@ export async function sdkPreview({
             const groupNameOrDefault = groupName ?? workspace.generatorsConfiguration.defaultGroup;
             if (groupNameOrDefault == null) {
                 return cliContext.failAndThrow(
-                    `No group specified. Use the --${GROUP_CLI_OPTION} option, or set "${DEFAULT_GROUP_GENERATORS_CONFIG_KEY}" in ${GENERATORS_CONFIGURATION_FILENAME}`
+                    `No group specified. Use the --${GROUP_CLI_OPTION} option, or set "${DEFAULT_GROUP_GENERATORS_CONFIG_KEY}" in ${GENERATORS_CONFIGURATION_FILENAME}`,
+                    undefined,
+                    { code: CliError.Code.ConfigError }
                 );
             }
 
             const group = workspace.generatorsConfiguration.groups.find((g) => g.groupName === groupNameOrDefault);
             if (group == null) {
                 return cliContext.failAndThrow(
-                    `Group '${groupNameOrDefault}' does not exist in ${GENERATORS_CONFIGURATION_FILENAME}`
+                    `Group '${groupNameOrDefault}' does not exist in ${GENERATORS_CONFIGURATION_FILENAME}`,
+                    undefined,
+                    { code: CliError.Code.ConfigError }
                 );
             }
 
@@ -202,7 +209,9 @@ export async function sdkPreview({
 
             if (generatorFilter != null && generators.length === 0) {
                 return cliContext.failAndThrow(
-                    `Generator '${generatorFilter}' not found in group '${groupNameOrDefault}' in ${GENERATORS_CONFIGURATION_FILENAME}`
+                    `Generator '${generatorFilter}' not found in group '${groupNameOrDefault}' in ${GENERATORS_CONFIGURATION_FILENAME}`,
+                    undefined,
+                    { code: CliError.Code.ConfigError }
                 );
             }
 
@@ -218,7 +227,9 @@ export async function sdkPreview({
             if (npmGenerators.length === 0) {
                 return cliContext.failAndThrow(
                     `No supported generators found in group '${groupNameOrDefault}'. ` +
-                        `SDK preview currently only supports TypeScript/npm generators.`
+                        `SDK preview currently only supports TypeScript/npm generators.`,
+                    undefined,
+                    { code: CliError.Code.ConfigError }
                 );
             }
 
@@ -227,7 +238,9 @@ export async function sdkPreview({
                 if (originalPackageName == null) {
                     return cliContext.failAndThrow(
                         `Could not determine package name for generator '${generator.name}'. ` +
-                            `Ensure 'output.package-name' is set in ${GENERATORS_CONFIGURATION_FILENAME}.`
+                            `Ensure 'output.package-name' is set in ${GENERATORS_CONFIGURATION_FILENAME}.`,
+                        undefined,
+                        { code: CliError.Code.ConfigError }
                     );
                 }
 

--- a/packages/cli/cli/src/commands/sdk-preview/sdkPreview.ts
+++ b/packages/cli/cli/src/commands/sdk-preview/sdkPreview.ts
@@ -9,13 +9,12 @@ import { AbsoluteFilePath, cwd, join, RelativeFilePath, resolve } from "@fern-ap
 import { getGeneratorOutputSubfolder, runLocalGenerationForWorkspace } from "@fern-api/local-workspace-runner";
 import { askToLogin } from "@fern-api/login";
 import { runRemoteGenerationForAPIWorkspace } from "@fern-api/remote-workspace-runner";
+import { CliError } from "@fern-api/task-context";
 import fs from "fs/promises";
-
 import { CliContext } from "../../cli-context/CliContext.js";
 import { loadProjectAndRegisterWorkspacesWithContext } from "../../cliCommons.js";
 import { GROUP_CLI_OPTION } from "../../constants.js";
 import { computePreviewVersion } from "./computePreviewVersion.js";
-
 import { getPreviewId } from "./getPreviewId.js";
 import {
     getGithubOwnerRepo,
@@ -25,7 +24,6 @@ import {
     PREVIEW_REGISTRY_URL
 } from "./overrideOutputForPreview.js";
 import { toPreviewPackageName } from "./toPreviewPackageName.js";
-import { CliError } from "@fern-api/task-context";
 
 interface SdkPreviewSuccess {
     status: "success";

--- a/packages/cli/cli/src/commands/self-update/selfUpdate.ts
+++ b/packages/cli/cli/src/commands/self-update/selfUpdate.ts
@@ -4,6 +4,7 @@ import chalk from "chalk";
 import { realpath } from "fs/promises";
 import { dirname, normalize, sep } from "path";
 import { CliContext } from "../../cli-context/CliContext.js";
+import { CliError } from "@fern-api/task-context";
 
 export interface InstallationMethod {
     type: "npm" | "pnpm" | "yarn" | "bun" | "brew" | "unknown";
@@ -274,7 +275,7 @@ export async function selfUpdate({
         }
         errorMessage += "\n\nPlease manually update using your package manager (npm, pnpm, yarn, bun, or brew).";
         errorMessage += "\nFor more diagnostic information, run with: FERN_LOG_LEVEL=debug fern self-update";
-        return cliContext.failAndThrow(errorMessage);
+        return cliContext.failAndThrow(errorMessage, undefined, { code: CliError.Code.EnvironmentError });
     }
 
     cliContext.logger.info(`Detected installation method: ${chalk.cyan(installationMethod.type)}`);
@@ -292,7 +293,9 @@ export async function selfUpdate({
 
     if (updateCommand.length === 0) {
         return cliContext.failAndThrow(
-            `Unable to construct update command for installation method: ${installationMethod.type}`
+            `Unable to construct update command for installation method: ${installationMethod.type}`,
+            undefined,
+            { code: CliError.Code.EnvironmentError }
         );
     }
 
@@ -316,7 +319,7 @@ export async function selfUpdate({
 
     const [command, ...args] = updateCommand;
     if (command == null) {
-        return cliContext.failAndThrow("Invalid update command");
+        return cliContext.failAndThrow("Invalid update command", undefined, { code: CliError.Code.InternalError });
     }
 
     const { failed, stderr } = await loggingExeca(cliContext.logger, command, args, {
@@ -326,7 +329,9 @@ export async function selfUpdate({
 
     if (failed) {
         cliContext.logger.error(`Failed to update Fern CLI: ${stderr}`);
-        return cliContext.failAndThrow("Update failed. Please try updating manually.");
+        return cliContext.failAndThrow("Update failed. Please try updating manually.", undefined, {
+            code: CliError.Code.EnvironmentError
+        });
     }
 
     cliContext.logger.info(chalk.green("✓ Fern CLI updated successfully!"));

--- a/packages/cli/cli/src/commands/self-update/selfUpdate.ts
+++ b/packages/cli/cli/src/commands/self-update/selfUpdate.ts
@@ -1,10 +1,10 @@
 import { Logger } from "@fern-api/logger";
 import { loggingExeca } from "@fern-api/logging-execa";
+import { CliError } from "@fern-api/task-context";
 import chalk from "chalk";
 import { realpath } from "fs/promises";
 import { dirname, normalize, sep } from "path";
 import { CliContext } from "../../cli-context/CliContext.js";
-import { CliError } from "@fern-api/task-context";
 
 export interface InstallationMethod {
     type: "npm" | "pnpm" | "yarn" | "bun" | "brew" | "unknown";

--- a/packages/cli/cli/src/commands/test/testOutput.ts
+++ b/packages/cli/cli/src/commands/test/testOutput.ts
@@ -8,6 +8,7 @@ import { Project } from "@fern-api/project-loader";
 import { AbstractAPIWorkspace, FernWorkspace } from "@fern-api/workspace-loader";
 import { CliContext } from "../../cli-context/CliContext.js";
 import { API_CLI_OPTION } from "../../constants.js";
+import { CliError } from "@fern-api/task-context";
 
 export async function testOutput({
     cliContext,
@@ -26,11 +27,15 @@ export async function testOutput({
     });
 
     if (testCommand == null) {
-        return cliContext.failAndThrow("No test command specified. Use the --command option.");
+        return cliContext.failAndThrow("No test command specified. Use the --command option.", undefined, {
+            code: CliError.Code.ConfigError
+        });
     }
 
     if (project.apiWorkspaces.length !== 1 || project.apiWorkspaces[0] == null) {
-        return cliContext.failAndThrow(`No API specified. Use the --${API_CLI_OPTION} option.`);
+        return cliContext.failAndThrow(`No API specified. Use the --${API_CLI_OPTION} option.`, undefined, {
+            code: CliError.Code.ConfigError
+        });
     }
 
     const workspace: AbstractAPIWorkspace<unknown> = project.apiWorkspaces[0];
@@ -87,7 +92,7 @@ export async function testOutput({
                 context.logger.error("Tests failed, Fern mock server stopping.");
                 context.logger.error("View test output above.");
 
-                cliContext.failAndThrow();
+                cliContext.failAndThrow(undefined, undefined, { code: CliError.Code.ValidationError });
             }
         }
 

--- a/packages/cli/cli/src/commands/test/testOutput.ts
+++ b/packages/cli/cli/src/commands/test/testOutput.ts
@@ -5,10 +5,10 @@ import { generateIntermediateRepresentation } from "@fern-api/ir-generator";
 import { loggingExeca } from "@fern-api/logging-execa";
 import { MockServer } from "@fern-api/mock";
 import { Project } from "@fern-api/project-loader";
+import { CliError } from "@fern-api/task-context";
 import { AbstractAPIWorkspace, FernWorkspace } from "@fern-api/workspace-loader";
 import { CliContext } from "../../cli-context/CliContext.js";
 import { API_CLI_OPTION } from "../../constants.js";
-import { CliError } from "@fern-api/task-context";
 
 export async function testOutput({
     cliContext,

--- a/packages/cli/cli/src/commands/token/token.ts
+++ b/packages/cli/cli/src/commands/token/token.ts
@@ -1,7 +1,7 @@
 import { createOrganizationIfDoesNotExist } from "@fern-api/auth";
 import { createVenusService } from "@fern-api/core";
 import { askToLogin } from "@fern-api/login";
-import { TaskContext } from "@fern-api/task-context";
+import { CliError, TaskContext } from "@fern-api/task-context";
 import chalk from "chalk";
 
 export async function generateToken({
@@ -26,16 +26,27 @@ export async function generateToken({
     response.error._visit({
         organizationNotFoundError: () =>
             taskContext.failAndThrow(
-                `Failed to create token because the organization ${orgId} was not found. Please reach out to support@buildwithfern.com`
+                `Failed to create token because the organization ${orgId} was not found. Please reach out to support@buildwithfern.com`,
+                undefined,
+                { code: CliError.Code.AuthError }
             ),
         unauthorizedError: () =>
             taskContext.failAndThrow(
-                `Failed to create token because you are not in the ${orgId} organization. Please reach out to support@buildwithfern.com`
+                `Failed to create token because you are not in the ${orgId} organization. Please reach out to support@buildwithfern.com`,
+                undefined,
+                { code: CliError.Code.AuthError }
             ),
         missingOrgPermissionsError: () =>
             taskContext.failAndThrow(
-                `Failed to create token because you do not have the required permissions in the ${orgId} organization. Please reach out to support@buildwithfern.com`
+                `Failed to create token because you do not have the required permissions in the ${orgId} organization. Please reach out to support@buildwithfern.com`,
+                undefined,
+                { code: CliError.Code.AuthError }
             ),
-        _other: () => taskContext.failAndThrow("Failed to create token. Please reach out to support@buildwithfern.com")
+        _other: () =>
+            taskContext.failAndThrow(
+                "Failed to create token. Please reach out to support@buildwithfern.com",
+                undefined,
+                { code: CliError.Code.AuthError }
+            )
     });
 }

--- a/packages/cli/cli/src/commands/upgrade/migrations/loader.ts
+++ b/packages/cli/cli/src/commands/upgrade/migrations/loader.ts
@@ -2,7 +2,7 @@ import type { generatorsYml } from "@fern-api/configuration";
 import { extractErrorMessage } from "@fern-api/core-utils";
 import type { Logger } from "@fern-api/logger";
 import { loggingExeca } from "@fern-api/logging-execa";
-import { CliError} from "@fern-api/task-context";
+import { CliError } from "@fern-api/task-context";
 import { readFileSync, unlinkSync } from "fs";
 import { mkdir, open, readFile, stat, unlink } from "fs/promises";
 import { homedir } from "os";

--- a/packages/cli/cli/src/commands/upgrade/migrations/loader.ts
+++ b/packages/cli/cli/src/commands/upgrade/migrations/loader.ts
@@ -2,6 +2,7 @@ import type { generatorsYml } from "@fern-api/configuration";
 import { extractErrorMessage } from "@fern-api/core-utils";
 import type { Logger } from "@fern-api/logger";
 import { loggingExeca } from "@fern-api/logging-execa";
+import { CliError} from "@fern-api/task-context";
 import { readFileSync, unlinkSync } from "fs";
 import { mkdir, open, readFile, stat, unlink } from "fs/promises";
 import { homedir } from "os";
@@ -196,7 +197,10 @@ async function ensureMigrationsInstalled(logger: Logger): Promise<Record<string,
             const packageJson = JSON.parse(packageJsonContent) as { main?: string };
 
             if (packageJson.main == null) {
-                throw new Error(`No main field found in package.json for ${MIGRATION_PACKAGE_NAME}`);
+                throw new CliError({
+                    message: `No main field found in package.json for ${MIGRATION_PACKAGE_NAME}`,
+                    code: CliError.Code.InternalError
+                });
             }
 
             const packageEntryPoint = join(packageDir, packageJson.main);
@@ -343,11 +347,13 @@ function filterMigrations(params: { migrations: Migration[]; from: string; to: s
 
             // After filtering, all versions should be valid. This is a sanity check.
             if (aVersion == null || bVersion == null) {
-                throw new Error(
-                    `Internal error: Invalid migration version found during sort. ` +
+                throw new CliError({
+                    message:
+                        `Internal error: Invalid migration version found during sort. ` +
                         `Version A: ${a.version}, Version B: ${b.version}. ` +
-                        `This should not happen as invalid versions are filtered out.`
-                );
+                        `This should not happen as invalid versions are filtered out.`,
+                    code: CliError.Code.InternalError
+                });
             }
 
             return semver.compare(aVersion, bVersion);
@@ -395,13 +401,15 @@ export function runMigrations(params: {
             appliedVersions.push(migration.version);
         } catch (error) {
             const errorMessage = extractErrorMessage(error);
-            throw new Error(
-                `Failed to apply migration for version ${migration.version}.\n\n` +
+            throw new CliError({
+                message:
+                    `Failed to apply migration for version ${migration.version}.\n\n` +
                     `Reason: ${errorMessage}\n\n` +
                     `This migration was attempting to update your generator configuration. ` +
                     `The upgrade has been halted to prevent partial or invalid changes.\n\n` +
-                    `Please report this issue at: https://github.com/fern-api/fern/issues`
-            );
+                    `Please report this issue at: https://github.com/fern-api/fern/issues`,
+                code: CliError.Code.InternalError
+            });
         }
     }
 
@@ -475,12 +483,14 @@ export async function loadAndRunMigrations(params: {
     const { generatorName, from, to, config, logger } = params;
     // Validate config structure before proceeding
     if (!isValidGeneratorConfig(config)) {
-        throw new Error(
-            `Invalid generator configuration for ${generatorName}.\n\n` +
+        throw new CliError({
+            message:
+                `Invalid generator configuration for ${generatorName}.\n\n` +
                 `The generator configuration must be an object with either a 'name' property or an 'image' property, ` +
                 `but the current configuration does not match this structure. This may indicate a malformed generators.yml file.\n\n` +
-                `Please check your generators.yml file and ensure the generator is properly configured.`
-        );
+                `Please check your generators.yml file and ensure the generator is properly configured.`,
+            code: CliError.Code.InternalError
+        });
     }
 
     const typedConfig = config;

--- a/packages/cli/cli/src/commands/upgrade/updateApiSpec.ts
+++ b/packages/cli/cli/src/commands/upgrade/updateApiSpec.ts
@@ -2,7 +2,7 @@ import { generatorsYml, loadGeneratorsConfiguration } from "@fern-api/configurat
 import { AbsoluteFilePath, join, RelativeFilePath } from "@fern-api/fs-utils";
 import { Logger } from "@fern-api/logger";
 import { Project } from "@fern-api/project-loader";
-import { CliError} from "@fern-api/task-context";
+import { CliError } from "@fern-api/task-context";
 import * as fs from "fs";
 import { readFile, writeFile } from "fs/promises";
 import { buildClientSchema, getIntrospectionQuery, IntrospectionQuery, printSchema } from "graphql";
@@ -88,7 +88,10 @@ function extractIntrospectionData(data: unknown): IntrospectionQuery {
         return data.data as IntrospectionQuery;
     }
 
-    throw new CliError({ message: "Data does not contain valid GraphQL introspection result", code: CliError.Code.InternalError });
+    throw new CliError({
+        message: "Data does not contain valid GraphQL introspection result",
+        code: CliError.Code.InternalError
+    });
 }
 
 // Try GraphQL POST introspection approach

--- a/packages/cli/cli/src/commands/upgrade/updateApiSpec.ts
+++ b/packages/cli/cli/src/commands/upgrade/updateApiSpec.ts
@@ -2,6 +2,7 @@ import { generatorsYml, loadGeneratorsConfiguration } from "@fern-api/configurat
 import { AbsoluteFilePath, join, RelativeFilePath } from "@fern-api/fs-utils";
 import { Logger } from "@fern-api/logger";
 import { Project } from "@fern-api/project-loader";
+import { CliError} from "@fern-api/task-context";
 import * as fs from "fs";
 import { readFile, writeFile } from "fs/promises";
 import { buildClientSchema, getIntrospectionQuery, IntrospectionQuery, printSchema } from "graphql";
@@ -9,7 +10,6 @@ import yaml from "js-yaml";
 import { Readable } from "stream";
 import { finished } from "stream/promises";
 import { ReadableStream } from "stream/web";
-
 import { CliContext } from "../../cli-context/CliContext.js";
 
 async function fetchAndWriteFile(url: string, path: string, logger: Logger, indent: number): Promise<void> {
@@ -72,7 +72,10 @@ function isIntrospectionResult(data: unknown): boolean {
 // Helper function to extract introspection data from response
 function extractIntrospectionData(data: unknown): IntrospectionQuery {
     if (!data || typeof data !== "object") {
-        throw new Error("Data does not contain valid GraphQL introspection result");
+        throw new CliError({
+            message: "Data does not contain valid GraphQL introspection result",
+            code: CliError.Code.InternalError
+        });
     }
 
     // If it has __schema directly, return it
@@ -85,7 +88,7 @@ function extractIntrospectionData(data: unknown): IntrospectionQuery {
         return data.data as IntrospectionQuery;
     }
 
-    throw new Error("Data does not contain valid GraphQL introspection result");
+    throw new CliError({ message: "Data does not contain valid GraphQL introspection result", code: CliError.Code.InternalError });
 }
 
 // Try GraphQL POST introspection approach
@@ -290,7 +293,7 @@ export async function fetchGraphQLSchemaWithAutoDetection(url: string, path: str
         `1. Accepts GraphQL introspection queries via POST, or\n` +
         `2. Returns introspection results directly via GET`;
 
-    throw new Error(errorMessage);
+    throw new CliError({ message: errorMessage, code: CliError.Code.InternalError });
 }
 
 export async function updateApiSpec({

--- a/packages/cli/cli/src/commands/upgrade/upgrade.ts
+++ b/packages/cli/cli/src/commands/upgrade/upgrade.ts
@@ -14,6 +14,7 @@ import { produce } from "immer";
 
 import { CliContext } from "../../cli-context/CliContext.js";
 import { RerunCliError, rerunFernCliAtVersion } from "../../rerunFernCliAtVersion.js";
+import { CliError } from "@fern-api/task-context";
 
 export const PREVIOUS_VERSION_ENV_VAR = "FERN_PRE_UPGRADE_VERSION";
 
@@ -229,7 +230,9 @@ function validateVersionAhead({
     const versionAhead = isVersionAhead(targetVersion, currentVersion);
     if (!versionAhead) {
         cliContext.failAndThrow(
-            `Cannot upgrade because target version (${targetVersion}) is not ahead of existing version ${currentVersion}`
+            `Cannot upgrade because target version (${targetVersion}) is not ahead of existing version ${currentVersion}`,
+            undefined,
+            { code: CliError.Code.VersionError }
         );
     }
 }
@@ -328,7 +331,9 @@ export async function upgrade({
 
             const fernDirectory = await getFernDirectory();
             if (fernDirectory == null) {
-                return cliContext.failAndThrow(`Directory "${FERN_DIRECTORY}" not found.`);
+                return cliContext.failAndThrow(`Directory "${FERN_DIRECTORY}" not found.`, undefined, {
+                    code: CliError.Code.ConfigError
+                });
             }
             const projectConfig = await cliContext.runTask((context) =>
                 loadProjectConfig({ directory: fernDirectory, context })
@@ -375,7 +380,9 @@ export async function upgrade({
         // We're at the target version - load config and run migrations
         const fernDirectory = await getFernDirectory();
         if (fernDirectory == null) {
-            return cliContext.failAndThrow(`Directory "${FERN_DIRECTORY}" not found.`);
+            return cliContext.failAndThrow(`Directory "${FERN_DIRECTORY}" not found.`, undefined, {
+                code: CliError.Code.ConfigError
+            });
         }
         const projectConfig = await cliContext.runTask((context) =>
             loadProjectConfig({ directory: fernDirectory, context })
@@ -425,7 +432,7 @@ export async function upgrade({
     // Load config to get source version
     const fernDirectory = await getFernDirectory();
     if (fernDirectory == null) {
-        return cliContext.failAndThrow(`Directory "${FERN_DIRECTORY}" not found.`);
+        return cliContext.failAndThrow(`Directory "${FERN_DIRECTORY}" not found.`, undefined, { code: CliError.Code.ConfigError });
     }
     const projectConfig = await cliContext.runTask((context) =>
         loadProjectConfig({ directory: fernDirectory, context })
@@ -479,7 +486,9 @@ export async function upgrade({
 
             if (isVersionNotFound) {
                 return cliContext.failAndThrow(
-                    `Failed to upgrade to ${resolvedTargetVersion} because it does not exist. See https://www.npmjs.com/package/${cliContext.environment.packageName}?activeTab=versions.`
+                    `Failed to upgrade to ${resolvedTargetVersion} because it does not exist. See https://www.npmjs.com/package/${cliContext.environment.packageName}?activeTab=versions.`,
+                    undefined,
+                    { code: CliError.Code.ConfigError }
                 );
             }
         }

--- a/packages/cli/cli/src/commands/upgrade/upgrade.ts
+++ b/packages/cli/cli/src/commands/upgrade/upgrade.ts
@@ -8,13 +8,12 @@ import {
 import { Logger } from "@fern-api/logger";
 import { loggingExeca } from "@fern-api/logging-execa";
 import { isVersionAhead } from "@fern-api/semver-utils";
+import { CliError } from "@fern-api/task-context";
 import chalk from "chalk";
 import { writeFile } from "fs/promises";
 import { produce } from "immer";
-
 import { CliContext } from "../../cli-context/CliContext.js";
 import { RerunCliError, rerunFernCliAtVersion } from "../../rerunFernCliAtVersion.js";
-import { CliError } from "@fern-api/task-context";
 
 export const PREVIOUS_VERSION_ENV_VAR = "FERN_PRE_UPGRADE_VERSION";
 
@@ -432,7 +431,9 @@ export async function upgrade({
     // Load config to get source version
     const fernDirectory = await getFernDirectory();
     if (fernDirectory == null) {
-        return cliContext.failAndThrow(`Directory "${FERN_DIRECTORY}" not found.`, undefined, { code: CliError.Code.ConfigError });
+        return cliContext.failAndThrow(`Directory "${FERN_DIRECTORY}" not found.`, undefined, {
+            code: CliError.Code.ConfigError
+        });
     }
     const projectConfig = await cliContext.runTask((context) =>
         loadProjectConfig({ directory: fernDirectory, context })

--- a/packages/cli/cli/src/commands/upgrade/upgradeGenerator.ts
+++ b/packages/cli/cli/src/commands/upgrade/upgradeGenerator.ts
@@ -116,7 +116,9 @@ export async function loadAndUpdateGenerators({
         };
     }
     if (!YAML.isMap(generatorGroups)) {
-        context.failAndThrow(`Expected 'groups' to be a map in ${path.relative(process.cwd(), filepath)}`);
+        context.failAndThrow(`Expected 'groups' to be a map in ${path.relative(process.cwd(), filepath)}`, undefined, {
+            code: CliError.Code.ParseError
+        });
         return {
             updatedConfiguration: undefined,
             skippedMajorUpgrades: [],
@@ -141,7 +143,9 @@ export async function loadAndUpdateGenerators({
         const group = groupBlock.value as YAML.YAMLMap<string, YAML.YAMLSeq<YAML.YAMLMap<unknown, unknown>>>;
         if (!YAML.isMap(group)) {
             context.failAndThrow(
-                `Expected group ${groupName} to be a map in ${path.relative(process.cwd(), filepath)}`
+                `Expected group ${groupName} to be a map in ${path.relative(process.cwd(), filepath)}`,
+                undefined,
+                { code: CliError.Code.ConfigError }
             );
             continue;
         }
@@ -155,7 +159,9 @@ export async function loadAndUpdateGenerators({
 
         if (!YAML.isSeq(generators)) {
             context.failAndThrow(
-                `Expected group ${groupName} to have a 'generators' key in ${path.relative(process.cwd(), filepath)}`
+                `Expected group ${groupName} to have a 'generators' key in ${path.relative(process.cwd(), filepath)}`,
+                undefined,
+                { code: CliError.Code.ConfigError }
             );
             continue;
         }
@@ -163,7 +169,9 @@ export async function loadAndUpdateGenerators({
         for (const generator of generators.items) {
             if (!YAML.isMap(generator)) {
                 context.failAndThrow(
-                    `Expected generator in group ${groupName} to be a map in ${path.relative(process.cwd(), filepath)}`
+                    `Expected generator in group ${groupName} to be a map in ${path.relative(process.cwd(), filepath)}`,
+                    undefined,
+                    { code: CliError.Code.VersionError }
                 );
             }
             // Custom image generators (using `image` instead of `name`) are user-managed

--- a/packages/cli/cli/src/commands/upgrade/upgradeGenerator.ts
+++ b/packages/cli/cli/src/commands/upgrade/upgradeGenerator.ts
@@ -7,7 +7,7 @@ import {
 } from "@fern-api/configuration-loader";
 import { AbsoluteFilePath, doesPathExist } from "@fern-api/fs-utils";
 import { Project } from "@fern-api/project-loader";
-import { TaskContext } from "@fern-api/task-context";
+import { CliError, TaskContext } from "@fern-api/task-context";
 import { FernRegistry } from "@fern-fern/generators-sdk";
 import chalk from "chalk";
 import { readFile, writeFile } from "fs/promises";

--- a/packages/cli/cli/src/commands/validate/validateDocsBrokenLinks.ts
+++ b/packages/cli/cli/src/commands/validate/validateDocsBrokenLinks.ts
@@ -3,6 +3,7 @@ import { filterOssWorkspaces } from "@fern-api/docs-resolver";
 import { validateDocsWorkspace } from "@fern-api/docs-validator";
 import { Project } from "@fern-api/project-loader";
 import { CliContext } from "../../cli-context/CliContext.js";
+import { CliError } from "@fern-api/task-context";
 
 export async function validateDocsBrokenLinks({
     project,
@@ -16,7 +17,7 @@ export async function validateDocsBrokenLinks({
     const docsWorkspace = project.docsWorkspaces;
 
     if (docsWorkspace == null) {
-        cliContext.failAndThrow("No docs workspace found");
+        cliContext.failAndThrow("No docs workspace found", undefined, { code: CliError.Code.ConfigError });
         return;
     }
 
@@ -42,7 +43,7 @@ export async function validateDocsBrokenLinks({
         });
 
         if (violations.length > 0 && errorOnBrokenLinks) {
-            context.failAndThrow();
+            context.failAndThrow(undefined, undefined, { code: CliError.Code.ValidationError });
         }
     });
 }

--- a/packages/cli/cli/src/commands/validate/validateDocsBrokenLinks.ts
+++ b/packages/cli/cli/src/commands/validate/validateDocsBrokenLinks.ts
@@ -2,8 +2,8 @@ import { logViolations } from "@fern-api/api-workspace-validator";
 import { filterOssWorkspaces } from "@fern-api/docs-resolver";
 import { validateDocsWorkspace } from "@fern-api/docs-validator";
 import { Project } from "@fern-api/project-loader";
-import { CliContext } from "../../cli-context/CliContext.js";
 import { CliError } from "@fern-api/task-context";
+import { CliContext } from "../../cli-context/CliContext.js";
 
 export async function validateDocsBrokenLinks({
     project,

--- a/packages/cli/cli/src/commands/validate/validateDocsWorkspaceAndLogIssues.ts
+++ b/packages/cli/cli/src/commands/validate/validateDocsWorkspaceAndLogIssues.ts
@@ -3,7 +3,7 @@ import { replaceEnvVariables } from "@fern-api/core-utils";
 import { validateDocsWorkspace } from "@fern-api/docs-validator";
 import { ValidationViolation } from "@fern-api/fern-definition-validator";
 import { OSSWorkspace } from "@fern-api/lazy-fern-workspace";
-import { TaskContext } from "@fern-api/task-context";
+import { CliError, TaskContext } from "@fern-api/task-context";
 import { AbstractAPIWorkspace, DocsWorkspace } from "@fern-api/workspace-loader";
 
 export interface CollectedDocsViolations {

--- a/packages/cli/cli/src/commands/validate/validateDocsWorkspaceAndLogIssues.ts
+++ b/packages/cli/cli/src/commands/validate/validateDocsWorkspaceAndLogIssues.ts
@@ -30,7 +30,7 @@ export async function collectDocsWorkspaceViolations({
     // Apply env var substitution if settings.substitute-env-vars is enabled
     if (workspace.config.settings?.substituteEnvVars) {
         workspace.config = replaceEnvVariables(workspace.config, {
-            onError: (e) => context.failAndThrow(e)
+            onError: (e) => context.failAndThrow(e, undefined, { code: CliError.Code.ValidationError })
         });
     }
 
@@ -81,7 +81,7 @@ export async function validateDocsWorkspaceWithoutExiting({
     // The entire config including instances (with custom domains) goes through substitution
     if (workspace.config.settings?.substituteEnvVars) {
         workspace.config = replaceEnvVariables(workspace.config, {
-            onError: (e) => context.failAndThrow(e)
+            onError: (e) => context.failAndThrow(e, undefined, { code: CliError.Code.ValidationError })
         });
     }
 
@@ -139,6 +139,6 @@ export async function validateDocsWorkspaceAndLogIssues({
     });
 
     if (hasErrors) {
-        context.failAndThrow();
+        context.failAndThrow(undefined, undefined, { code: CliError.Code.ValidationError });
     }
 }

--- a/packages/cli/cli/src/commands/validate/validateWorkspaces.ts
+++ b/packages/cli/cli/src/commands/validate/validateWorkspaces.ts
@@ -8,6 +8,7 @@ import { CliContext } from "../../cli-context/CliContext.js";
 import { buildCheckJsonResult } from "./buildCheckJsonResult.js";
 import { ApiValidationResult, DocsValidationResult, printCheckReport } from "./printCheckReport.js";
 import { collectDocsWorkspaceViolations } from "./validateDocsWorkspaceAndLogIssues.js";
+import { CliError } from "@fern-api/task-context";
 
 export async function validateWorkspaces({
     project,
@@ -95,7 +96,7 @@ export async function validateWorkspaces({
                     // Log the missing file error without the [api]: prefix
                     await cliContext.runTask(async (context) => {
                         context.logger.error(`Missing file: ${ROOT_API_FILENAME}`);
-                        return context.failAndThrow();
+                        return context.failAndThrow(undefined, undefined, { code: CliError.Code.ValidationError });
                     });
                     return;
                 }
@@ -145,6 +146,6 @@ export async function validateWorkspaces({
     }
 
     if (hasErrors || hasAnyErrors) {
-        cliContext.failAndThrow();
+        cliContext.failAndThrow(undefined, undefined, { code: CliError.Code.ValidationError });
     }
 }

--- a/packages/cli/cli/src/commands/validate/validateWorkspaces.ts
+++ b/packages/cli/cli/src/commands/validate/validateWorkspaces.ts
@@ -4,11 +4,11 @@ import { filterOssWorkspaces } from "@fern-api/docs-resolver";
 import { doesPathExist, join, RelativeFilePath } from "@fern-api/fs-utils";
 import { LazyFernWorkspace, OSSWorkspace } from "@fern-api/lazy-fern-workspace";
 import { Project } from "@fern-api/project-loader";
+import { CliError } from "@fern-api/task-context";
 import { CliContext } from "../../cli-context/CliContext.js";
 import { buildCheckJsonResult } from "./buildCheckJsonResult.js";
 import { ApiValidationResult, DocsValidationResult, printCheckReport } from "./printCheckReport.js";
 import { collectDocsWorkspaceViolations } from "./validateDocsWorkspaceAndLogIssues.js";
-import { CliError } from "@fern-api/task-context";
 
 export async function validateWorkspaces({
     project,

--- a/packages/cli/cli/src/commands/write-translation/translation-service.ts
+++ b/packages/cli/cli/src/commands/write-translation/translation-service.ts
@@ -8,7 +8,7 @@ const DEFAULT_TIMEOUT = 30000; // 30 seconds
 
 import { getToken } from "@fern-api/auth";
 import { extractErrorMessage } from "@fern-api/core-utils";
-import { CliError} from "@fern-api/task-context";
+import { CliError } from "@fern-api/task-context";
 import { CliContext } from "../../cli-context/CliContext.js";
 
 // todo: replace with an SDK
@@ -128,7 +128,10 @@ export async function translateText({
         cliContext.logger.error(
             "Authentication required. Please run 'fern login' or set the FERN_TOKEN environment variable."
         );
-        throw new CliError({ message: "Authentication required for translation service", code: CliError.Code.AuthError });
+        throw new CliError({
+            message: "Authentication required for translation service",
+            code: CliError.Code.AuthError
+        });
     }
 
     // Set up retry configuration with defaults

--- a/packages/cli/cli/src/commands/write-translation/translation-service.ts
+++ b/packages/cli/cli/src/commands/write-translation/translation-service.ts
@@ -8,6 +8,7 @@ const DEFAULT_TIMEOUT = 30000; // 30 seconds
 
 import { getToken } from "@fern-api/auth";
 import { extractErrorMessage } from "@fern-api/core-utils";
+import { CliError} from "@fern-api/task-context";
 import { CliContext } from "../../cli-context/CliContext.js";
 
 // todo: replace with an SDK
@@ -127,7 +128,7 @@ export async function translateText({
         cliContext.logger.error(
             "Authentication required. Please run 'fern login' or set the FERN_TOKEN environment variable."
         );
-        throw new Error("Authentication required for translation service");
+        throw new CliError({ message: "Authentication required for translation service", code: CliError.Code.AuthError });
     }
 
     // Set up retry configuration with defaults
@@ -171,7 +172,7 @@ export async function translateText({
 
                 // 403 errors should not be retried - they indicate authentication/authorization issues
                 if (response.status === 403) {
-                    throw new Error(`403: ${errorDetail}`);
+                    throw new CliError({ message: `403: ${errorDetail}`, code: CliError.Code.AuthError });
                 }
 
                 const error = new Error(`HTTP ${response.status}: ${errorDetail}`) as NetworkError;

--- a/packages/cli/cli/src/commands/write-translation/writeTranslationForProject.ts
+++ b/packages/cli/cli/src/commands/write-translation/writeTranslationForProject.ts
@@ -2,7 +2,7 @@ import { docsYml } from "@fern-api/configuration";
 import { DOCS_CONFIGURATION_FILENAME } from "@fern-api/configuration-loader";
 import { join, RelativeFilePath } from "@fern-api/fs-utils";
 import { Project } from "@fern-api/project-loader";
-import { CliError} from "@fern-api/task-context";
+import { CliError } from "@fern-api/task-context";
 import chalk from "chalk";
 import cliProgress from "cli-progress";
 import { existsSync } from "fs";

--- a/packages/cli/cli/src/commands/write-translation/writeTranslationForProject.ts
+++ b/packages/cli/cli/src/commands/write-translation/writeTranslationForProject.ts
@@ -2,13 +2,13 @@ import { docsYml } from "@fern-api/configuration";
 import { DOCS_CONFIGURATION_FILENAME } from "@fern-api/configuration-loader";
 import { join, RelativeFilePath } from "@fern-api/fs-utils";
 import { Project } from "@fern-api/project-loader";
+import { CliError} from "@fern-api/task-context";
 import chalk from "chalk";
 import cliProgress from "cli-progress";
 import { existsSync } from "fs";
 import { copyFile, mkdir, readFile, writeFile } from "fs/promises";
 import IS_CI from "is-ci";
 import path from "path";
-
 import { CliContext } from "../../cli-context/CliContext.js";
 import { isAssetFile, shouldProcessFile, transformContentForLanguage } from "./content-transformer.js";
 import { createLanguageSpecificDocsConfig } from "./docs-config-utils.js";
@@ -53,7 +53,10 @@ export async function writeTranslationForProject({
 
         const sourceLanguage = languages[0];
         if (!sourceLanguage) {
-            throw new Error("Unexpected error - first element of languages array is invalid");
+            throw new CliError({
+                message: "Unexpected error - first element of languages array is invalid",
+                code: CliError.Code.InternalError
+            });
         }
 
         if (!existsSync(translationsDirectory)) {

--- a/packages/cli/cli/src/rerunFernCliAtVersion.ts
+++ b/packages/cli/cli/src/rerunFernCliAtVersion.ts
@@ -3,6 +3,7 @@ import chalk from "chalk";
 
 import { CliContext } from "./cli-context/CliContext.js";
 import { FERN_CWD_ENV_VAR } from "./cwd.js";
+import { CliError } from "@fern-api/task-context";
 
 export class RerunCliError extends Error {
     public readonly stdout: string;
@@ -70,6 +71,6 @@ export async function rerunFernCliAtVersion({
         if (throwOnError) {
             throw new RerunCliError({ version, stdout, stderr });
         }
-        cliContext.failWithoutThrowing();
+        cliContext.failWithoutThrowing(undefined, undefined, { code: CliError.Code.InternalError });
     }
 }

--- a/packages/cli/cli/src/rerunFernCliAtVersion.ts
+++ b/packages/cli/cli/src/rerunFernCliAtVersion.ts
@@ -1,9 +1,8 @@
 import { loggingExeca } from "@fern-api/logging-execa";
+import { CliError } from "@fern-api/task-context";
 import chalk from "chalk";
-
 import { CliContext } from "./cli-context/CliContext.js";
 import { FERN_CWD_ENV_VAR } from "./cwd.js";
-import { CliError } from "@fern-api/task-context";
 
 export class RerunCliError extends Error {
     public readonly stdout: string;

--- a/packages/cli/cli/src/resolveGroupGithubConfig.ts
+++ b/packages/cli/cli/src/resolveGroupGithubConfig.ts
@@ -2,6 +2,7 @@ import { isGithubSelfhosted } from "@fern-api/configuration-loader";
 import { replaceEnvVariables } from "@fern-api/core-utils";
 import { CliContext } from "./cli-context/CliContext.js";
 import { loadProjectAndRegisterWorkspacesWithContext } from "./cliCommons.js";
+import { CliError } from "@fern-api/task-context";
 
 export interface ResolvedGithubConfig {
     githubRepo: string;
@@ -22,23 +23,25 @@ export async function resolveGroupGithubConfig(
 
     const workspace = project.apiWorkspaces[0];
     if (workspace == null) {
-        return cliContext.failAndThrow("No API workspace found.");
+        return cliContext.failAndThrow("No API workspace found.", undefined, { code: CliError.Code.ConfigError });
     }
 
     const generatorsConfig = workspace.generatorsConfiguration;
     if (generatorsConfig == null) {
-        return cliContext.failAndThrow("No generators.yml found in workspace.");
+        return cliContext.failAndThrow("No generators.yml found in workspace.", undefined, { code: CliError.Code.ConfigError });
     }
 
     const group = generatorsConfig.groups.find((g) => g.groupName === groupName);
     if (group == null) {
         const available = generatorsConfig.groups.map((g) => g.groupName).join(", ");
-        return cliContext.failAndThrow(`Group "${groupName}" not found. Available groups: ${available}`);
+        return cliContext.failAndThrow(`Group "${groupName}" not found. Available groups: ${available}`, undefined, {
+            code: CliError.Code.ConfigError
+        });
     }
 
     const resolveEnv = <T>(value: T): T =>
         replaceEnvVariables(value, {
-            onError: (message) => cliContext.failAndThrow(message)
+            onError: (message) => cliContext.failAndThrow(message, undefined, { code: CliError.Code.ConfigError })
         });
 
     // 1. Prefer self-hosted config (has uri + token)
@@ -79,5 +82,7 @@ export async function resolveGroupGithubConfig(
         };
     }
 
-    return cliContext.failAndThrow(`No generator in group "${groupName}" has a github configuration.`);
+    return cliContext.failAndThrow(`No generator in group "${groupName}" has a github configuration.`, undefined, {
+        code: CliError.Code.ConfigError
+    });
 }

--- a/packages/cli/cli/src/resolveGroupGithubConfig.ts
+++ b/packages/cli/cli/src/resolveGroupGithubConfig.ts
@@ -1,8 +1,8 @@
 import { isGithubSelfhosted } from "@fern-api/configuration-loader";
 import { replaceEnvVariables } from "@fern-api/core-utils";
+import { CliError } from "@fern-api/task-context";
 import { CliContext } from "./cli-context/CliContext.js";
 import { loadProjectAndRegisterWorkspacesWithContext } from "./cliCommons.js";
-import { CliError } from "@fern-api/task-context";
 
 export interface ResolvedGithubConfig {
     githubRepo: string;
@@ -28,7 +28,9 @@ export async function resolveGroupGithubConfig(
 
     const generatorsConfig = workspace.generatorsConfiguration;
     if (generatorsConfig == null) {
-        return cliContext.failAndThrow("No generators.yml found in workspace.", undefined, { code: CliError.Code.ConfigError });
+        return cliContext.failAndThrow("No generators.yml found in workspace.", undefined, {
+            code: CliError.Code.ConfigError
+        });
     }
 
     const group = generatorsConfig.groups.find((g) => g.groupName === groupName);

--- a/packages/cli/cli/src/telemetry/SentryClient.ts
+++ b/packages/cli/cli/src/telemetry/SentryClient.ts
@@ -1,4 +1,5 @@
 import { setSentryRunIdTags } from "@fern-api/cli-telemetry";
+import { CliError } from "@fern-api/task-context";
 import * as Sentry from "@sentry/node";
 
 export class SentryClient {
@@ -10,7 +11,10 @@ export class SentryClient {
         if (isTelemetryEnabled && sentryDsn != null && sentryDsn.length > 0) {
             const sentryEnvironment = process.env.SENTRY_ENVIRONMENT;
             if (sentryEnvironment == null || sentryEnvironment.length === 0) {
-                throw new Error("SENTRY_ENVIRONMENT must be set when SENTRY_DSN is configured");
+                throw new CliError({
+                    message: "SENTRY_ENVIRONMENT must be set when SENTRY_DSN is configured",
+                    code: CliError.Code.ConfigError
+                });
             }
             this.sentry = Sentry.init({
                 dsn: sentryDsn,


### PR DESCRIPTION
## Description

Migrates `@fern-api/cli` (the main CLI package) to use explicit `CliError` error codes on every `failAndThrow` / `failWithoutThrowing` call site.

This is one of ~35 package migration PRs that follow the error classification system introduced in #14749.

## Changes Made

Assigned typed error codes across **42 files** in `packages/cli/cli/src/`, covering every `failAndThrow` and `failWithoutThrowing` invocation (excluding generic `catch` blocks where `resolveErrorCode` auto-extracts codes from `CliError` instances).

### Error codes used

| Code | Usage |
|------|-------|
| `CONFIG_ERROR` | Missing config, invalid flags, bad file paths, missing `generators.yml`, unknown group/generator names, missing `docs.yml` |
| `AUTH_ERROR` | Authentication failures (`fern login` required, token creation) |
| `NETWORK_ERROR` | HTTP/API call failures, translation service errors, generation task polling failures |
| `VALIDATION_ERROR` | Schema validation failures, broken-link checks, workspace validation |
| `PARSE_ERROR` | Malformed YAML/JSON, invalid IR files, export schema issues |
| `VERSION_ERROR` | Invalid semver, version already registered, generator version incompatibility |
| `ENVIRONMENT_ERROR` | Missing environment prerequisites, `self-update` failures, dependency installation |
| `INTERNAL_ERROR` | Unexpected states that indicate bugs, failed reruns, missing IR fields |

### Files touched (grouped by area)

- **Top-level CLI**: `cli.ts`, `cliV2.ts`, `rerunFernCliAtVersion.ts`, `resolveGroupGithubConfig.ts`
- **Generate commands**: `generateAPIWorkspace.ts`, `generateAPIWorkspaces.ts`, `generateDocsWorkspace.ts`
- **Docs commands**: `docsDiff.ts`, `generateLibraryDocs.ts`, `listDocsPreview.ts`, `deleteDocsPreview.ts`
- **SDK commands**: `sdkDiffCommand.ts`, `sdkPreview.ts`
- **Diff**: `diff.ts`
- **Validation**: `validateWorkspaces.ts`, `validateDocsBrokenLinks.ts`, `validateDocsWorkspaceAndLogIssues.ts`
- **Upgrade/Downgrade**: `upgrade.ts`, `upgradeGenerator.ts`, `downgrade.ts`
- **Self-update**: `selfUpdate.ts`
- **Export**: `servicesConverter.ts`, `typeConverter.ts`, `security.ts`
- **Other**: `token.ts`, `testOutput.ts`, `mockServer.ts`, `mergeOpenAPIWithOverrides.ts`, `compareOpenAPISpecs.ts`, `writeOverridesForWorkspaces.ts`, `getGeneratorList.ts`, `getOrganization.ts`, `installDependencies.ts`, `registerWorkspacesV1.ts`

## Testing

- [x] Existing tests pass
