### PR TITLE
fix(go): normalize Go package name for dynamic snippet IR generation

### DIFF
--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -1,5 +1,17 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 
+- version: 4.63.1
+  changelogEntry:
+    - summary: |
+        Fix Go dynamic snippets not being generated during docs publish.
+        The Go package name comparison between snippet configuration and
+        generator output was failing due to an `https://` prefix mismatch,
+        causing docs to fall back to raw `net/http` code instead of
+        SDK-idiomatic snippets.
+      type: fix
+  createdAt: "2026-04-08"
+  irVersion: 66
+
 - version: 4.63.0
   changelogEntry:
     - summary: |

--- a/packages/cli/generation/remote-generation/remote-workspace-runner/src/publishDocs.ts
+++ b/packages/cli/generation/remote-generation/remote-workspace-runner/src/publishDocs.ts
@@ -1216,6 +1216,12 @@ async function generateLanguageSpecificDynamicIRs({
                     packageName = (generatorInvocation.config as { packageName?: string }).packageName ?? "";
                 }
 
+                // Normalize Go package names to strip https:// prefix,
+                // matching how snippetConfiguration values are normalized
+                if (generatorInvocation.language === "go" && packageName) {
+                    packageName = normalizeGoPackageForLookup(packageName);
+                }
+
                 if (!generatorInvocation.language) {
                     continue;
                 }


### PR DESCRIPTION
## Description

Fixes Go dynamic snippets not being generated during `fern docs publish`, causing docs sites to fall back to raw `net/http` HTTP snippets instead of SDK-idiomatic Go code.

## Root Cause

In `generateLanguageSpecificDynamicIRs`, the snippet configuration's Go package name is normalized via `normalizeGoPackageForLookup()` (stripping the `https://` prefix), but the `packageName` extracted from the generator's output config (`repoUrl`) retains the `https://` prefix. The strict equality check (`===`) always fails for Go, so the dynamic IR is never generated and never uploaded to FDR.

- `snippetConfiguration.go` → `github.com/owner/repo` (normalized)
- `packageName` (from generator config) → `https://github.com/owner/repo` (not normalized)

## Changes Made

- Normalize the Go `packageName` with `normalizeGoPackageForLookup()` before the comparison, matching how `snippetConfiguration.go` is already normalized
- Added changelog entry (v4.63.1)

## Testing

- [ ] Unit tests added/updated — no new tests; this is a runtime code path during docs publish that requires FDR integration
- [x] Lint passes (`pnpm run check`)

## Review Checklist

- [ ] Verify the root cause by tracing both sides of the comparison at line ~1234 of `publishDocs.ts`
- [ ] **Check whether Swift has the same bug** — `snippetConfiguration.swift` comes from `snippetsConfig.swiftSdk?.package` (not normalized), while Swift's `packageName` also comes from `repoUrl` (with `https://`). If `swiftSdk.package` can be a GitHub URL, Swift would have the same mismatch.

Link to Devin session: https://app.devin.ai/sessions/97992dbbc8c7438bbdf2c381765313d1
Requested by: @iamnamananand996