### PR TITLE
fix(cli): resolve absolute links within version/product context in broken-link checker

### DIFF
--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -5,8 +5,7 @@
   changelogEntry:
     - summary: |
         Fix broken-link checker incorrectly flagging absolute links in versioned
-        docs pages as broken. Absolute links like `/about` in versioned pages now
-        correctly resolve within the version context.
+        docs pages as broken.
       type: fix
   createdAt: "2026-04-10"
 

--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -1,5 +1,15 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 
+- version: 4.65.3
+  changelogEntry:
+    - summary: |
+        Fix broken-link checker incorrectly flagging absolute links in versioned
+        docs pages as broken. Absolute links like `/about` in versioned pages now
+        correctly resolve within the version context.
+      type: fix
+  createdAt: "2026-04-09"
+  irVersion: 66
+
 - version: 4.65.2
   changelogEntry:
     - summary: |
@@ -9,7 +19,6 @@
       type: fix
   createdAt: "2026-04-10"
   irVersion: 66
-
 - version: 4.65.1
   changelogEntry:
     - summary: |
@@ -19,7 +28,6 @@
       type: fix
   createdAt: "2026-04-09"
   irVersion: 66
-
 - version: 4.65.0
   changelogEntry:
     - summary: |
@@ -30,7 +38,6 @@
       type: feat
   createdAt: "2026-04-08"
   irVersion: 66
-
 - version: 4.64.1
   changelogEntry:
     - summary: |
@@ -42,7 +49,6 @@
       type: chore
   createdAt: "2026-04-09"
   irVersion: 66
-
 - version: 4.64.0
   changelogEntry:
     - summary: |
@@ -53,7 +59,6 @@
       type: feat
   createdAt: "2026-04-08"
   irVersion: 66
-
 - version: 4.63.5
   changelogEntry:
     - summary: |
@@ -62,7 +67,6 @@
       type: fix
   createdAt: "2026-04-08"
   irVersion: 66
-
 - version: 4.63.4
   changelogEntry:
     - summary: |
@@ -75,7 +79,6 @@
       type: fix
   createdAt: "2026-04-08"
   irVersion: 66
-
 - version: 4.63.3
   changelogEntry:
     - summary: |

--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -1,5 +1,6 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 
+
 - version: 4.65.3
   changelogEntry:
     - summary: |
@@ -7,7 +8,8 @@
         docs pages as broken. Absolute links like `/about` in versioned pages now
         correctly resolve within the version context.
       type: fix
-  createdAt: "2026-04-09"
+  createdAt: "2026-04-10"
+
   irVersion: 66
 
 - version: 4.65.2

--- a/packages/cli/ete-tests/src/tests/broken-links/broken-links.test.ts
+++ b/packages/cli/ete-tests/src/tests/broken-links/broken-links.test.ts
@@ -64,6 +64,17 @@ describe("fern docs broken-links", () => {
         expect(stripAnsi(stdout)).toContain("All checks passed");
     }, 20_000);
 
+    it("absolute links in product-based docs should resolve within product context", async ({ signal }) => {
+        const { stdout } = await runFernCli(["docs", "broken-links"], {
+            cwd: join(fixturesDir, RelativeFilePath.of("product-docs")),
+            reject: false,
+            signal
+        });
+        // Absolute links like /guides/getting-started in product pages should resolve
+        // within the product context (e.g., product-sdks/guides/getting-started) and not be flagged as broken
+        expect(stripAnsi(stdout)).toContain("All checks passed");
+    }, 20_000);
+
     it("broken links in sections with path property should be detected", async ({ signal }) => {
         const { stdout } = await runFernCli(["docs", "broken-links"], {
             cwd: join(fixturesDir, RelativeFilePath.of("section-with-path")),

--- a/packages/cli/ete-tests/src/tests/broken-links/broken-links.test.ts
+++ b/packages/cli/ete-tests/src/tests/broken-links/broken-links.test.ts
@@ -53,6 +53,17 @@ describe("fern docs broken-links", () => {
         expect(stripAnsi(stdout)).toContain("All checks passed");
     }, 20_000);
 
+    it("absolute links in versioned docs should resolve within version context", async ({ signal }) => {
+        const { stdout } = await runFernCli(["docs", "broken-links"], {
+            cwd: join(fixturesDir, RelativeFilePath.of("versioned-docs")),
+            reject: false,
+            signal
+        });
+        // Absolute links like /plants/aesthetic in versioned pages should resolve
+        // within the version context (e.g., v2/plants/aesthetic) and not be flagged as broken
+        expect(stripAnsi(stdout)).toContain("All checks passed");
+    }, 20_000);
+
     it("broken links in sections with path property should be detected", async ({ signal }) => {
         const { stdout } = await runFernCli(["docs", "broken-links"], {
             cwd: join(fixturesDir, RelativeFilePath.of("section-with-path")),

--- a/packages/cli/ete-tests/src/tests/broken-links/fixtures/product-docs/fern/docs.yml
+++ b/packages/cli/ete-tests/src/tests/broken-links/fixtures/product-docs/fern/docs.yml
@@ -1,0 +1,10 @@
+instances:
+  - url: product-test.docs.dev.buildwithfern.com
+
+products:
+  - display-name: Docs
+    path: ./products/product-a/docs.yml
+    slug: product-docs
+  - display-name: SDKs
+    path: ./products/product-b/sdks.yml
+    slug: product-sdks

--- a/packages/cli/ete-tests/src/tests/broken-links/fixtures/product-docs/fern/fern.config.json
+++ b/packages/cli/ete-tests/src/tests/broken-links/fixtures/product-docs/fern/fern.config.json
@@ -1,0 +1,4 @@
+{
+  "organization": "test-org",
+  "version": "*"
+}

--- a/packages/cli/ete-tests/src/tests/broken-links/fixtures/product-docs/fern/pages/guides/advanced.mdx
+++ b/packages/cli/ete-tests/src/tests/broken-links/fixtures/product-docs/fern/pages/guides/advanced.mdx
@@ -1,0 +1,5 @@
+# Advanced
+
+Advanced configuration options.
+
+See the [overview](/overview) for an introduction.

--- a/packages/cli/ete-tests/src/tests/broken-links/fixtures/product-docs/fern/pages/guides/getting-started.mdx
+++ b/packages/cli/ete-tests/src/tests/broken-links/fixtures/product-docs/fern/pages/guides/getting-started.mdx
@@ -1,0 +1,5 @@
+# Getting Started
+
+Follow this guide to get up and running.
+
+See the [advanced guide](/guides/advanced) for more details.

--- a/packages/cli/ete-tests/src/tests/broken-links/fixtures/product-docs/fern/pages/overview.mdx
+++ b/packages/cli/ete-tests/src/tests/broken-links/fixtures/product-docs/fern/pages/overview.mdx
@@ -1,0 +1,5 @@
+# Overview
+
+Welcome to the documentation.
+
+Check out our [getting started guide](/guides/getting-started) to begin.

--- a/packages/cli/ete-tests/src/tests/broken-links/fixtures/product-docs/fern/products/product-a/docs.yml
+++ b/packages/cli/ete-tests/src/tests/broken-links/fixtures/product-docs/fern/products/product-a/docs.yml
@@ -1,0 +1,9 @@
+navigation:
+  - page: Overview
+    path: ../../pages/overview.mdx
+  - section: Guides
+    contents:
+      - page: Getting Started
+        path: ../../pages/guides/getting-started.mdx
+      - page: Advanced
+        path: ../../pages/guides/advanced.mdx

--- a/packages/cli/ete-tests/src/tests/broken-links/fixtures/product-docs/fern/products/product-b/sdks.yml
+++ b/packages/cli/ete-tests/src/tests/broken-links/fixtures/product-docs/fern/products/product-b/sdks.yml
@@ -1,0 +1,9 @@
+navigation:
+  - page: Overview
+    path: ../../pages/overview.mdx
+  - section: Guides
+    contents:
+      - page: Getting Started
+        path: ../../pages/guides/getting-started.mdx
+      - page: Advanced
+        path: ../../pages/guides/advanced.mdx

--- a/packages/cli/ete-tests/src/tests/broken-links/fixtures/versioned-docs/fern/docs.yml
+++ b/packages/cli/ete-tests/src/tests/broken-links/fixtures/versioned-docs/fern/docs.yml
@@ -1,0 +1,8 @@
+instances:
+  - url: versioned-test.docs.dev.buildwithfern.com
+
+versions:
+  - display-name: v2
+    path: ./versions/v2.yml
+  - display-name: v1
+    path: ./versions/v1.yml

--- a/packages/cli/ete-tests/src/tests/broken-links/fixtures/versioned-docs/fern/fern.config.json
+++ b/packages/cli/ete-tests/src/tests/broken-links/fixtures/versioned-docs/fern/fern.config.json
@@ -1,0 +1,4 @@
+{
+  "organization": "test-org",
+  "version": "*"
+}

--- a/packages/cli/ete-tests/src/tests/broken-links/fixtures/versioned-docs/fern/pages/overview.mdx
+++ b/packages/cli/ete-tests/src/tests/broken-links/fixtures/versioned-docs/fern/pages/overview.mdx
@@ -1,0 +1,5 @@
+# Overview
+
+Welcome to the plant documentation.
+
+Check out our [filters](/plants/filters) for processing plant data.

--- a/packages/cli/ete-tests/src/tests/broken-links/fixtures/versioned-docs/fern/pages/plants/aesthetic.mdx
+++ b/packages/cli/ete-tests/src/tests/broken-links/fixtures/versioned-docs/fern/pages/plants/aesthetic.mdx
@@ -1,0 +1,5 @@
+# Aesthetic filter
+
+The aesthetic filter evaluates plant images for visual quality.
+
+See the [overview](/overview) for more details.

--- a/packages/cli/ete-tests/src/tests/broken-links/fixtures/versioned-docs/fern/pages/plants/embeddings.mdx
+++ b/packages/cli/ete-tests/src/tests/broken-links/fixtures/versioned-docs/fern/pages/plants/embeddings.mdx
@@ -1,0 +1,5 @@
+# Embeddings
+
+Generate vector embeddings from plant data.
+
+See the [filters](/plants/filters) page for related processing steps.

--- a/packages/cli/ete-tests/src/tests/broken-links/fixtures/versioned-docs/fern/pages/plants/filters.mdx
+++ b/packages/cli/ete-tests/src/tests/broken-links/fixtures/versioned-docs/fern/pages/plants/filters.mdx
@@ -1,0 +1,7 @@
+# Filters
+
+Learn about filtering plant data.
+
+See the [aesthetic filter](/plants/aesthetic) for visual quality filtering.
+
+See the [embeddings](/plants/embeddings) for vector representations.

--- a/packages/cli/ete-tests/src/tests/broken-links/fixtures/versioned-docs/fern/versions/v1.yml
+++ b/packages/cli/ete-tests/src/tests/broken-links/fixtures/versioned-docs/fern/versions/v1.yml
@@ -1,0 +1,9 @@
+navigation:
+  - page: Overview
+    path: ../pages/overview.mdx
+  - section: Plants
+    contents:
+      - page: Filters
+        path: ../pages/plants/filters.mdx
+      - page: Aesthetic
+        path: ../pages/plants/aesthetic.mdx

--- a/packages/cli/ete-tests/src/tests/broken-links/fixtures/versioned-docs/fern/versions/v2.yml
+++ b/packages/cli/ete-tests/src/tests/broken-links/fixtures/versioned-docs/fern/versions/v2.yml
@@ -1,0 +1,11 @@
+navigation:
+  - page: Overview
+    path: ../pages/overview.mdx
+  - section: Plants
+    contents:
+      - page: Filters
+        path: ../pages/plants/filters.mdx
+      - page: Aesthetic
+        path: ../pages/plants/aesthetic.mdx
+      - page: Embeddings
+        path: ../pages/plants/embeddings.mdx

--- a/packages/cli/yaml/docs-validator/src/rules/valid-markdown-link/check-if-pathname-exists.ts
+++ b/packages/cli/yaml/docs-validator/src/rules/valid-markdown-link/check-if-pathname-exists.ts
@@ -22,7 +22,8 @@ export async function checkIfPathnameExists({
     pageSlugs,
     absoluteFilePathsToSlugs,
     redirects = [],
-    baseUrl
+    baseUrl,
+    versionSlugs = []
 }: {
     pathname: string;
     markdown: boolean;
@@ -39,6 +40,7 @@ export async function checkIfPathnameExists({
         domain: string;
         basePath?: string;
     };
+    versionSlugs?: string[];
 }): Promise<true | string[]> {
     pathname = removeTrailingSlash(pathname);
     const slugs = absoluteFilepath != null ? (absoluteFilePathsToSlugs.get(absoluteFilepath) ?? []) : [];
@@ -71,6 +73,24 @@ export async function checkIfPathnameExists({
 
         if (markdown && pageSlugs.has(removeLeadingSlash(redirectedPath))) {
             return true;
+        }
+
+        // For versioned pages, absolute links like `/about` resolve within the current version context.
+        // Check if the pathname exists under any version prefix that the current file belongs to.
+        if (markdown && versionSlugs.length > 0) {
+            const currentFileSlugs =
+                absoluteFilepath != null ? (absoluteFilePathsToSlugs.get(absoluteFilepath) ?? []) : [];
+            for (const slug of currentFileSlugs) {
+                for (const versionSlug of versionSlugs) {
+                    if (slug.startsWith(versionSlug + "/") || slug === versionSlug) {
+                        const versionedPath = `${versionSlug}/${removeLeadingSlash(redirectedPath)}`;
+                        if (pageSlugs.has(versionedPath)) {
+                            return true;
+                        }
+                        break;
+                    }
+                }
+            }
         }
 
         const absolutePath = join(workspaceAbsoluteFilePath, RelativeFilePath.of(removeLeadingSlash(pathname)));

--- a/packages/cli/yaml/docs-validator/src/rules/valid-markdown-link/check-if-pathname-exists.ts
+++ b/packages/cli/yaml/docs-validator/src/rules/valid-markdown-link/check-if-pathname-exists.ts
@@ -78,9 +78,7 @@ export async function checkIfPathnameExists({
         // For versioned pages, absolute links like `/about` resolve within the current version context.
         // Check if the pathname exists under any version prefix that the current file belongs to.
         if (markdown && versionSlugs.length > 0) {
-            const currentFileSlugs =
-                absoluteFilepath != null ? (absoluteFilePathsToSlugs.get(absoluteFilepath) ?? []) : [];
-            for (const slug of currentFileSlugs) {
+            for (const slug of slugs) {
                 for (const versionSlug of versionSlugs) {
                     if (slug.startsWith(versionSlug + "/") || slug === versionSlug) {
                         const versionedPath = `${versionSlug}/${removeLeadingSlash(redirectedPath)}`;

--- a/packages/cli/yaml/docs-validator/src/rules/valid-markdown-link/check-if-pathname-exists.ts
+++ b/packages/cli/yaml/docs-validator/src/rules/valid-markdown-link/check-if-pathname-exists.ts
@@ -23,7 +23,8 @@ export async function checkIfPathnameExists({
     absoluteFilePathsToSlugs,
     redirects = [],
     baseUrl,
-    versionSlugs = []
+    versionSlugs = [],
+    productSlugs = []
 }: {
     pathname: string;
     markdown: boolean;
@@ -41,6 +42,7 @@ export async function checkIfPathnameExists({
         basePath?: string;
     };
     versionSlugs?: string[];
+    productSlugs?: string[];
 }): Promise<true | string[]> {
     pathname = removeTrailingSlash(pathname);
     const slugs = absoluteFilepath != null ? (absoluteFilePathsToSlugs.get(absoluteFilepath) ?? []) : [];
@@ -75,14 +77,15 @@ export async function checkIfPathnameExists({
             return true;
         }
 
-        // For versioned pages, absolute links like `/about` resolve within the current version context.
-        // Check if the pathname exists under any version prefix that the current file belongs to.
-        if (markdown && versionSlugs.length > 0) {
+        // For versioned/product pages, absolute links like `/about` resolve within the current context.
+        // Check if the pathname exists under any version or product prefix that the current file belongs to.
+        const contextSlugs = [...versionSlugs, ...productSlugs];
+        if (markdown && contextSlugs.length > 0) {
             for (const slug of slugs) {
-                for (const versionSlug of versionSlugs) {
-                    if (slug.startsWith(versionSlug + "/") || slug === versionSlug) {
-                        const versionedPath = `${versionSlug}/${removeLeadingSlash(redirectedPath)}`;
-                        if (pageSlugs.has(versionedPath)) {
+                for (const contextSlug of contextSlugs) {
+                    if (slug.startsWith(contextSlug + "/") || slug === contextSlug) {
+                        const prefixedPath = `${contextSlug}/${removeLeadingSlash(redirectedPath)}`;
+                        if (pageSlugs.has(prefixedPath)) {
                             return true;
                         }
                         break;

--- a/packages/cli/yaml/docs-validator/src/rules/valid-markdown-link/valid-markdown-link.ts
+++ b/packages/cli/yaml/docs-validator/src/rules/valid-markdown-link/valid-markdown-link.ts
@@ -76,6 +76,9 @@ export const ValidMarkdownLinks: Rule = {
             absoluteFilePathsToSlugs.set(absoluteFilePath, slugs);
         });
 
+        // Collect version slugs for version-aware absolute link resolution
+        const versionSlugs = collector.getVersionNodes().map((v) => v.slug);
+
         const specialDocPages = ["/llms-full.txt", "/llms.txt"];
 
         for (const specialPage of specialDocPages) {
@@ -118,7 +121,8 @@ export const ValidMarkdownLinks: Rule = {
                             pageSlugs: visitableSlugs,
                             absoluteFilePathsToSlugs,
                             redirects: workspace.config.redirects,
-                            baseUrl
+                            baseUrl,
+                            versionSlugs
                         });
 
                         if (exists === true) {
@@ -198,7 +202,8 @@ export const ValidMarkdownLinks: Rule = {
                             pageSlugs: visitableSlugs,
                             absoluteFilePathsToSlugs,
                             redirects: workspace.config.redirects,
-                            baseUrl
+                            baseUrl,
+                            versionSlugs
                         });
 
                         if (exists === true) {

--- a/packages/cli/yaml/docs-validator/src/rules/valid-markdown-link/valid-markdown-link.ts
+++ b/packages/cli/yaml/docs-validator/src/rules/valid-markdown-link/valid-markdown-link.ts
@@ -76,8 +76,9 @@ export const ValidMarkdownLinks: Rule = {
             absoluteFilePathsToSlugs.set(absoluteFilePath, slugs);
         });
 
-        // Collect version slugs for version-aware absolute link resolution
+        // Collect version and product slugs for context-aware absolute link resolution
         const versionSlugs = collector.getVersionNodes().map((v) => v.slug);
+        const productSlugs = collector.getProductNodes().filter(FernNavigation.isInternalProductNode).map((p) => p.slug);
 
         const specialDocPages = ["/llms-full.txt", "/llms.txt"];
 
@@ -122,7 +123,8 @@ export const ValidMarkdownLinks: Rule = {
                             absoluteFilePathsToSlugs,
                             redirects: workspace.config.redirects,
                             baseUrl,
-                            versionSlugs
+                            versionSlugs,
+                            productSlugs
                         });
 
                         if (exists === true) {
@@ -203,7 +205,8 @@ export const ValidMarkdownLinks: Rule = {
                             absoluteFilePathsToSlugs,
                             redirects: workspace.config.redirects,
                             baseUrl,
-                            versionSlugs
+                            versionSlugs,
+                            productSlugs
                         });
 
                         if (exists === true) {

--- a/packages/cli/yaml/docs-validator/src/rules/valid-markdown-link/valid-markdown-link.ts
+++ b/packages/cli/yaml/docs-validator/src/rules/valid-markdown-link/valid-markdown-link.ts
@@ -78,7 +78,10 @@ export const ValidMarkdownLinks: Rule = {
 
         // Collect version and product slugs for context-aware absolute link resolution
         const versionSlugs = collector.getVersionNodes().map((v) => v.slug);
-        const productSlugs = collector.getProductNodes().filter(FernNavigation.isInternalProductNode).map((p) => p.slug);
+        const productSlugs = collector
+            .getProductNodes()
+            .filter(FernNavigation.isInternalProductNode)
+            .map((p) => p.slug);
 
         const specialDocPages = ["/llms-full.txt", "/llms.txt"];
 


### PR DESCRIPTION
## Description
Linear ticket: Closes FER-9584

Fixes broken-link checker incorrectly flagging absolute links in versioned and product-based docs as broken.

## Problem

When you have versioned (or product-based) docs and write an absolute link like `/about` in a page, the Fern docs runtime automatically prefixes it with the current version/product slug (e.g., `/v1/about`). The link checker didn't know about this behavior, so it only checked if the unprefixed `/about` existed, which failed for non-default versions/products.

## Changes Made

- **`check-if-pathname-exists.ts`**: Added `versionSlugs` and `productSlugs` parameters. For absolute links, checks if `<contextSlug>/<pathname>` exists in the slug set, where context slugs include both version and product prefixes.
- **`valid-markdown-link.ts`**: Collects version slugs via `collector.getVersionNodes()` and product slugs via `collector.getProductNodes()` (filtered to internal products only), then passes both to `checkIfPathnameExists`.
- **`versions.yml`**: Added changelog entry for v4.65.3.
- Added ETE test fixtures for both versioned docs and product-based docs, with corresponding test cases.

## Testing

- [x] ETE test added for versioned docs (absolute links resolving within version context)
- [x] ETE test added for product-based docs (absolute links resolving within product context — two products: default "Docs" and non-default "SDKs" with shared pages containing absolute links)
- [x] Manual testing on [ryanstep-config test repo](https://github.com/fern-api/ryanstep-config/pull/39) — false positives gone, true broken links still detected

<img width="3000" height="2112" alt="CleanShot 2026-04-09 at 20 55 34@2x" src="https://github.com/user-attachments/assets/49954494-3997-48e9-babb-29020511f7c3" />
(error on the right terminal is intended, the 6 duplicate errors are not intended due to the version prefixing)

## ⚠️ Human Review Checklist

- [ ] Consider whether nested product+version scenarios (`<productSlug>/<versionSlug>/<page>`) need additional handling — currently version and product slugs are checked independently, not as combined prefixes
- [ ] Confirm `isInternalProductNode` filter correctly excludes external product nodes (`productLink` type) that lack a `slug` property
- [ ] The context slug matching logic iterates all context slugs for each file slug — verify this doesn't produce false negatives for files that belong to multiple contexts

Link to Devin session: https://app.devin.ai/sessions/19e0cecae19c4e41a500df39d9f158ac
Requested by: @Ryan-Amirthan