### PR TITLE
chore(ci): add retry logic for Docker Hub login in seed CI

### DIFF
--- a/.github/actions/cached-seed/action.yaml
+++ b/.github/actions/cached-seed/action.yaml
@@ -42,6 +42,8 @@ runs:
         DOCKERHUB_USERNAME: ${{ inputs.dockerhub-username }}
         DOCKERHUB_TOKEN: ${{ inputs.dockerhub-token }}
       run: |
+        # Ensure the token is masked in logs even if it wasn't registered as a secret
+        echo "::add-mask::$DOCKERHUB_TOKEN"
         for attempt in 1 2 3; do
           if echo "$DOCKERHUB_TOKEN" | docker login --username "$DOCKERHUB_USERNAME" --password-stdin docker.io 2>&1; then
             echo "Docker Hub login succeeded (attempt $attempt)"

--- a/.github/actions/cached-seed/action.yaml
+++ b/.github/actions/cached-seed/action.yaml
@@ -35,27 +35,35 @@ runs:
     - name: Install
       uses: ./.github/actions/install
 
-    - name: Log in to Docker Hub (with retry)
+    - name: Log in to Docker Hub
+      id: docker-login
+      if: ${{ inputs.dockerhub-username != '' }}
+      uses: docker/login-action@v3
+      continue-on-error: true
+      with:
+        username: ${{ inputs.dockerhub-username }}
+        password: ${{ inputs.dockerhub-token }}
+
+    - name: Retry Docker Hub login
+      id: docker-login-retry
+      if: ${{ inputs.dockerhub-username != '' && steps.docker-login.outcome == 'failure' }}
+      uses: docker/login-action@v3
+      continue-on-error: true
+      with:
+        username: ${{ inputs.dockerhub-username }}
+        password: ${{ inputs.dockerhub-token }}
+
+    - name: Docker Hub login status
       if: ${{ inputs.dockerhub-username != '' }}
       shell: bash
-      env:
-        DOCKERHUB_USERNAME: ${{ inputs.dockerhub-username }}
-        DOCKERHUB_TOKEN: ${{ inputs.dockerhub-token }}
       run: |
-        # Ensure the token is masked in logs even if it wasn't registered as a secret
-        echo "::add-mask::$DOCKERHUB_TOKEN"
-        for attempt in 1 2 3; do
-          if echo "$DOCKERHUB_TOKEN" | docker login --username "$DOCKERHUB_USERNAME" --password-stdin docker.io 2>&1; then
-            echo "Docker Hub login succeeded (attempt $attempt)"
-            break
-          fi
-          if [ "$attempt" -eq 3 ]; then
-            echo "Docker Hub login failed after 3 attempts"
-            exit 1
-          fi
-          echo "Docker Hub login failed (attempt $attempt/3), retrying in 15s..."
-          sleep 15
-        done
+        if [[ "${{ steps.docker-login.outcome }}" == "success" ]]; then
+          echo "Docker Hub login succeeded on first attempt"
+        elif [[ "${{ steps.docker-login-retry.outcome }}" == "success" ]]; then
+          echo "Docker Hub login succeeded on retry"
+        else
+          echo "::warning::Docker Hub login failed after 2 attempts — continuing without authentication (may hit rate limits)"
+        fi
 
     - name: Clear stale Docker image cache
       shell: bash

--- a/.github/actions/cached-seed/action.yaml
+++ b/.github/actions/cached-seed/action.yaml
@@ -35,12 +35,25 @@ runs:
     - name: Install
       uses: ./.github/actions/install
 
-    - name: Log in to Docker Hub
+    - name: Log in to Docker Hub (with retry)
       if: ${{ inputs.dockerhub-username != '' }}
-      uses: docker/login-action@v3
-      with:
-        username: ${{ inputs.dockerhub-username }}
-        password: ${{ inputs.dockerhub-token }}
+      shell: bash
+      env:
+        DOCKERHUB_USERNAME: ${{ inputs.dockerhub-username }}
+        DOCKERHUB_TOKEN: ${{ inputs.dockerhub-token }}
+      run: |
+        for attempt in 1 2 3; do
+          if echo "$DOCKERHUB_TOKEN" | docker login --username "$DOCKERHUB_USERNAME" --password-stdin docker.io 2>&1; then
+            echo "Docker Hub login succeeded (attempt $attempt)"
+            break
+          fi
+          if [ "$attempt" -eq 3 ]; then
+            echo "Docker Hub login failed after 3 attempts"
+            exit 1
+          fi
+          echo "Docker Hub login failed (attempt $attempt/3), retrying in 15s..."
+          sleep 15
+        done
 
     - name: Clear stale Docker image cache
       shell: bash


### PR DESCRIPTION
## Description

Adds retry logic to the Docker Hub login step in the `cached-seed` composite action to handle transient Docker Hub failures (timeouts, 502 Bad Gateway) that have been causing seed CI jobs to fail.

Docker Hub login is used to avoid rate limits on image pulls — it is not critical for seed tests to succeed. If login fails after 2 attempts, the job continues unauthenticated.

## Changes Made

- Added `continue-on-error: true` to the existing `docker/login-action@v3` step
- Added a second `docker/login-action@v3` retry step that runs only if the first attempt fails (also `continue-on-error: true`)
- Added a status step that logs whether login succeeded on first attempt, retry, or failed entirely (emits a `::warning::` in the failure case)
- Login failure is **non-fatal** — the job continues without Docker Hub authentication, which may result in rate-limited pulls

## Testing

- [ ] CI infrastructure change — can only be validated by the next seed CI run that encounters a transient Docker Hub issue
- [ ] Verified the diff uses only `docker/login-action@v3` (no shell-based credential handling)

## Human Review Checklist

- [ ] Confirm `steps.docker-login.outcome` resolves correctly within composite action steps (should work per [GitHub docs](https://docs.github.com/en/actions/sharing-automations/creating-actions/creating-a-composite-action))
- [ ] Verify the `::warning::` annotation is visible enough in CI summaries to help debug unexpected rate-limit issues downstream

Link to Devin session: https://app.devin.ai/sessions/84226268f67e4344b5eb2474787df2ef
Requested by: @Swimburger
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/14756" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
