### PR TITLE
fix(cli): use copyFile+unlink instead of rename for Windows EPERM compatibility

### DIFF
--- a/packages/cli/workspace/lazy-fern-workspace/src/protobuf/ProtobufOpenAPIGenerator.ts
+++ b/packages/cli/workspace/lazy-fern-workspace/src/protobuf/ProtobufOpenAPIGenerator.ts
@@ -1,7 +1,7 @@
 import { AbsoluteFilePath, join, RelativeFilePath, relative } from "@fern-api/fs-utils";
 import { createLoggingExecutable } from "@fern-api/logging-execa";
 import { TaskContext } from "@fern-api/task-context";
-import { access, cp, readFile, rename, unlink, writeFile } from "fs/promises";
+import { access, copyFile, cp, readFile, unlink, writeFile } from "fs/promises";
 import path from "path";
 import tmp from "tmp-promise";
 import { resolveProtocGenOpenAPI } from "./ProtocGenOpenAPIDownloader.js";
@@ -168,10 +168,13 @@ export class ProtobufOpenAPIGenerator {
             this.context.failAndThrow(bufGenerateResult.stderr);
         }
 
-        // Move output to a unique temp file so the next call doesn't overwrite it
+        // Move output to a unique temp file so the next call doesn't overwrite it.
+        // Use copyFile + unlink instead of rename because rename fails with EPERM
+        // on Windows when the target file already exists (tmp.file creates it).
         const outputPath = join(preparedDir.cwd, RelativeFilePath.of(PROTOBUF_GENERATOR_OUTPUT_FILEPATH));
         const uniqueOutput = AbsoluteFilePath.of((await tmp.file({ postfix: ".yaml" })).path);
-        await rename(outputPath, uniqueOutput);
+        await copyFile(outputPath, uniqueOutput);
+        await unlink(outputPath);
 
         return { absoluteFilepath: uniqueOutput };
     }


### PR DESCRIPTION
## Description

Refs: fern-api/fern-platform#9546

Fixes `EPERM: operation not permitted` error when running `fern docs dev` on Windows with protobuf/gRPC API specs.

## Changes Made

- Replaced `fs.rename` with `fs.copyFile` + `fs.unlink` in `ProtobufOpenAPIGenerator.generateFromPrepared()` to avoid a Windows-specific failure

### Root Cause

`tmp.file({ postfix: ".yaml" })` creates an empty file at the destination path. On POSIX, `fs.rename` atomically replaces existing files. On Windows, `fs.rename` fails with `EPERM` when the target already exists. This caused `fern docs dev` to fail reading the docs configuration on Windows, rendering a blank page with all routes returning 500.

## Human Review Checklist

- [ ] `copyFile` overwrites existing files by default in Node.js — confirm this matches the intended behavior (it does)
- [ ] The loss of atomicity (`rename` → `copyFile` + `unlink`) is acceptable for temp build artifacts
- [ ] Check if other `rename` calls in the codebase have the same Windows issue (the `doGenerateLocal` path at line 314 returns the output path directly without renaming, so it's fine)

## Testing

- [ ] Unit tests added/updated — no new tests; this is a platform-specific I/O fix verified via the fern-platform Windows smoke test CI
- [x] Verified the fix addresses the exact error seen in [fern-platform#9546](https://github.com/fern-api/fern-platform/pull/9546) CI logs: `EPERM: operation not permitted, rename '...\output\openapi.yaml' -> '...'`

Link to Devin session: https://app.devin.ai/sessions/762b6ec9085f4ec0849edcca9e133472
Requested by: @thesandlord