### PR TITLE
fix(cli): add log rotation for `fern docs dev` debug logs

### DIFF
--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -1,5 +1,15 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 
+- version: 4.63.2
+  changelogEntry:
+    - summary: |
+        Add log rotation for `fern docs dev` debug logs in `~/.fern/logs/`.
+        Old log files are automatically deleted when the directory exceeds
+        100 MB, keeping the most recent logs.
+      type: fix
+  createdAt: "2026-04-08"
+  irVersion: 66
+
 - version: 4.63.1
   changelogEntry:
     - summary: |

--- a/packages/cli/docs-preview/src/DebugLogger.ts
+++ b/packages/cli/docs-preview/src/DebugLogger.ts
@@ -324,6 +324,19 @@ export class DebugLogger {
                 return;
             }
 
+            const totalSizeMB = Math.round((totalSize / 1024 / 1024) * 100) / 100;
+            await this.writeEntry({
+                timestamp: new Date().toISOString(),
+                source: getCliSource(),
+                level: "info",
+                eventType: "log_rotation",
+                data: {
+                    message: `Rotating logs: total size ${totalSizeMB} MB exceeds ${MAX_LOGS_DIR_SIZE_BYTES / 1024 / 1024} MB cap`,
+                    totalSizeMB,
+                    fileCount: fileInfos.length
+                }
+            });
+
             // Sort oldest first so we delete the oldest logs first
             fileInfos.sort((a, b) => a.mtimeMs - b.mtimeMs);
 

--- a/packages/cli/docs-preview/src/DebugLogger.ts
+++ b/packages/cli/docs-preview/src/DebugLogger.ts
@@ -162,8 +162,8 @@ export class DebugLogger {
         await writeFile(this.logFilePath, header, "utf-8");
         this.initialized = true;
 
-        // Enforce the 100 MB cap on the logs directory
-        await this.enforceLogSizeLimit(logsDir);
+        // Enforce the 100 MB cap on the logs directory (fire-and-forget)
+        void this.enforceLogSizeLimit(logsDir);
     }
 
     /**

--- a/packages/cli/docs-preview/src/DebugLogger.ts
+++ b/packages/cli/docs-preview/src/DebugLogger.ts
@@ -1,13 +1,10 @@
 import { AbsoluteFilePath, doesPathExist, join, RelativeFilePath } from "@fern-api/fs-utils";
-import { appendFile, mkdir, readdir, stat, unlink, writeFile } from "fs/promises";
+import { appendFile, mkdir, writeFile } from "fs/promises";
 import { homedir } from "os";
 import path from "path";
 
 const LOCAL_STORAGE_FOLDER = process.env.LOCAL_STORAGE_FOLDER ?? ".fern";
 const LOGS_FOLDER_NAME = "logs";
-
-// 100 MB cap for the logs directory
-const MAX_LOGS_DIR_SIZE_BYTES = 100 * 1024 * 1024;
 
 /**
  * Log level for debug messages
@@ -126,7 +123,6 @@ export class DebugLogger {
     private logFilePath: AbsoluteFilePath | null = null;
     private initialized = false;
     private sessionStartTime: number;
-    private consoleLogger: { debug: (msg: string) => void; info: (msg: string) => void } | undefined;
 
     constructor() {
         this.sessionStartTime = Date.now();
@@ -135,11 +131,10 @@ export class DebugLogger {
     /**
      * Initialize the debug logger by creating the log file
      */
-    async initialize(consoleLogger?: { debug: (msg: string) => void; info: (msg: string) => void }): Promise<void> {
+    async initialize(): Promise<void> {
         if (this.initialized) {
             return;
         }
-        this.consoleLogger = consoleLogger;
 
         const localStorageFolder = join(AbsoluteFilePath.of(homedir()), RelativeFilePath.of(LOCAL_STORAGE_FOLDER));
         const logsDir = join(localStorageFolder, RelativeFilePath.of(LOGS_FOLDER_NAME));
@@ -163,9 +158,6 @@ export class DebugLogger {
 
         await writeFile(this.logFilePath, header, "utf-8");
         this.initialized = true;
-
-        // Enforce the 100 MB cap on the logs directory (fire-and-forget)
-        void this.enforceLogSizeLimit(logsDir);
     }
 
     /**
@@ -302,57 +294,14 @@ export class DebugLogger {
     }
 
     /**
-     * Delete oldest log files until total directory size is within the cap.
+     * Get the path to the logs directory
      */
-    private async enforceLogSizeLimit(logsDir: AbsoluteFilePath): Promise<void> {
-        try {
-            const entries = await readdir(logsDir);
-            const logFiles = entries.filter((name) => name.endsWith(".log"));
-
-            // Gather size and mtime for each log file
-            const fileInfos: Array<{ name: string; fullPath: string; size: number; mtimeMs: number }> = [];
-            for (const name of logFiles) {
-                const fullPath = path.join(logsDir, name);
-                try {
-                    const stats = await stat(fullPath);
-                    fileInfos.push({ name, fullPath, size: stats.size, mtimeMs: stats.mtimeMs });
-                } catch {
-                    // File may have been removed between readdir and stat
-                }
-            }
-
-            let totalSize = fileInfos.reduce((sum, f) => sum + f.size, 0);
-            const totalSizeMB = Math.round((totalSize / 1024 / 1024) * 100) / 100;
-            const capMB = MAX_LOGS_DIR_SIZE_BYTES / 1024 / 1024;
-
-            if (totalSize <= MAX_LOGS_DIR_SIZE_BYTES) {
-                this.consoleLogger?.debug(`Log directory size ${totalSizeMB} MB does not exceed ${capMB} MB cap`);
-                return;
-            }
-
-            this.consoleLogger?.info(`Rotating logs: total size ${totalSizeMB} MB exceeds ${capMB} MB cap`);
-
-            // Sort oldest first so we delete the oldest logs first
-            fileInfos.sort((a, b) => a.mtimeMs - b.mtimeMs);
-
-            for (const file of fileInfos) {
-                if (totalSize <= MAX_LOGS_DIR_SIZE_BYTES) {
-                    break;
-                }
-                // Never delete the log file we just created in this session
-                if (this.logFilePath != null && file.fullPath === this.logFilePath) {
-                    continue;
-                }
-                try {
-                    await unlink(file.fullPath);
-                    totalSize -= file.size;
-                } catch {
-                    // Ignore errors from concurrent deletion
-                }
-            }
-        } catch {
-            // If the directory is unreadable, skip cleanup silently
-        }
+    getLogsDir(): AbsoluteFilePath {
+        return join(
+            AbsoluteFilePath.of(homedir()),
+            RelativeFilePath.of(LOCAL_STORAGE_FOLDER),
+            RelativeFilePath.of(LOGS_FOLDER_NAME)
+        );
     }
 
     private getEventType(payload: MetricEvent | MetricSummary, isAggregate: boolean): string {

--- a/packages/cli/docs-preview/src/DebugLogger.ts
+++ b/packages/cli/docs-preview/src/DebugLogger.ts
@@ -1,10 +1,13 @@
 import { AbsoluteFilePath, doesPathExist, join, RelativeFilePath } from "@fern-api/fs-utils";
-import { appendFile, mkdir, writeFile } from "fs/promises";
+import { appendFile, mkdir, readdir, stat, unlink, writeFile } from "fs/promises";
 import { homedir } from "os";
 import path from "path";
 
 const LOCAL_STORAGE_FOLDER = process.env.LOCAL_STORAGE_FOLDER ?? ".fern";
 const LOGS_FOLDER_NAME = "logs";
+
+// 100 MB cap for the logs directory
+const MAX_LOGS_DIR_SIZE_BYTES = 100 * 1024 * 1024;
 
 /**
  * Log level for debug messages
@@ -123,6 +126,7 @@ export class DebugLogger {
     private logFilePath: AbsoluteFilePath | null = null;
     private initialized = false;
     private sessionStartTime: number;
+    private consoleLogger: { debug: (msg: string) => void; info: (msg: string) => void } | undefined;
 
     constructor() {
         this.sessionStartTime = Date.now();
@@ -131,10 +135,11 @@ export class DebugLogger {
     /**
      * Initialize the debug logger by creating the log file
      */
-    async initialize(): Promise<void> {
+    async initialize(consoleLogger?: { debug: (msg: string) => void; info: (msg: string) => void }): Promise<void> {
         if (this.initialized) {
             return;
         }
+        this.consoleLogger = consoleLogger;
 
         const localStorageFolder = join(AbsoluteFilePath.of(homedir()), RelativeFilePath.of(LOCAL_STORAGE_FOLDER));
         const logsDir = join(localStorageFolder, RelativeFilePath.of(LOGS_FOLDER_NAME));
@@ -158,6 +163,9 @@ export class DebugLogger {
 
         await writeFile(this.logFilePath, header, "utf-8");
         this.initialized = true;
+
+        // Enforce the 100 MB cap on the logs directory (fire-and-forget)
+        void this.enforceLogSizeLimit(logsDir);
     }
 
     /**
@@ -294,14 +302,56 @@ export class DebugLogger {
     }
 
     /**
-     * Get the path to the logs directory
+     * Delete oldest log files until total directory size is within the cap.
      */
-    getLogsDir(): AbsoluteFilePath {
-        return join(
-            AbsoluteFilePath.of(homedir()),
-            RelativeFilePath.of(LOCAL_STORAGE_FOLDER),
-            RelativeFilePath.of(LOGS_FOLDER_NAME)
-        );
+    private async enforceLogSizeLimit(logsDir: AbsoluteFilePath): Promise<void> {
+        try {
+            const entries = await readdir(logsDir);
+            const logFiles = entries.filter((name) => name.endsWith(".log"));
+
+            const fileInfos: Array<{ name: string; fullPath: string; size: number; mtimeMs: number }> = [];
+            for (const name of logFiles) {
+                const fullPath = path.join(logsDir, name);
+                try {
+                    const stats = await stat(fullPath);
+                    fileInfos.push({ name, fullPath, size: stats.size, mtimeMs: stats.mtimeMs });
+                } catch {
+                    // File may have been removed between readdir and stat
+                }
+            }
+
+            let totalSize = fileInfos.reduce((sum, f) => sum + f.size, 0);
+            const totalSizeMB = Math.round((totalSize / 1024 / 1024) * 100) / 100;
+            const capMB = MAX_LOGS_DIR_SIZE_BYTES / 1024 / 1024;
+
+            if (totalSize <= MAX_LOGS_DIR_SIZE_BYTES) {
+                this.consoleLogger?.debug(`Log directory size ${totalSizeMB} MB does not exceed ${capMB} MB cap`);
+                return;
+            }
+
+            this.consoleLogger?.info(`Rotating logs: total size ${totalSizeMB} MB exceeds ${capMB} MB cap`);
+
+            // Sort oldest first so we delete the oldest logs first
+            fileInfos.sort((a, b) => a.mtimeMs - b.mtimeMs);
+
+            for (const file of fileInfos) {
+                if (totalSize <= MAX_LOGS_DIR_SIZE_BYTES) {
+                    break;
+                }
+                // Never delete the log file we just created in this session
+                if (this.logFilePath != null && file.fullPath === this.logFilePath) {
+                    continue;
+                }
+                try {
+                    await unlink(file.fullPath);
+                    totalSize -= file.size;
+                } catch {
+                    // Ignore errors from concurrent deletion
+                }
+            }
+        } catch {
+            // If the directory is unreadable, skip cleanup silently
+        }
     }
 
     private getEventType(payload: MetricEvent | MetricSummary, isAggregate: boolean): string {

--- a/packages/cli/docs-preview/src/DebugLogger.ts
+++ b/packages/cli/docs-preview/src/DebugLogger.ts
@@ -126,6 +126,7 @@ export class DebugLogger {
     private logFilePath: AbsoluteFilePath | null = null;
     private initialized = false;
     private sessionStartTime: number;
+    private consoleLogger: { debug: (msg: string) => void; info: (msg: string) => void } | undefined;
 
     constructor() {
         this.sessionStartTime = Date.now();
@@ -134,10 +135,11 @@ export class DebugLogger {
     /**
      * Initialize the debug logger by creating the log file
      */
-    async initialize(): Promise<void> {
+    async initialize(consoleLogger?: { debug: (msg: string) => void; info: (msg: string) => void }): Promise<void> {
         if (this.initialized) {
             return;
         }
+        this.consoleLogger = consoleLogger;
 
         const localStorageFolder = join(AbsoluteFilePath.of(homedir()), RelativeFilePath.of(LOCAL_STORAGE_FOLDER));
         const logsDir = join(localStorageFolder, RelativeFilePath.of(LOGS_FOLDER_NAME));
@@ -324,31 +326,11 @@ export class DebugLogger {
             const capMB = MAX_LOGS_DIR_SIZE_BYTES / 1024 / 1024;
 
             if (totalSize <= MAX_LOGS_DIR_SIZE_BYTES) {
-                await this.writeEntry({
-                    timestamp: new Date().toISOString(),
-                    source: getCliSource(),
-                    level: "debug",
-                    eventType: "log_rotation_check",
-                    data: {
-                        message: `Log directory size ${totalSizeMB} MB does not exceed ${capMB} MB cap`,
-                        totalSizeMB,
-                        fileCount: fileInfos.length
-                    }
-                });
+                this.consoleLogger?.debug(`Log directory size ${totalSizeMB} MB does not exceed ${capMB} MB cap`);
                 return;
             }
 
-            await this.writeEntry({
-                timestamp: new Date().toISOString(),
-                source: getCliSource(),
-                level: "info",
-                eventType: "log_rotation",
-                data: {
-                    message: `Rotating logs: total size ${totalSizeMB} MB exceeds ${capMB} MB cap`,
-                    totalSizeMB,
-                    fileCount: fileInfos.length
-                }
-            });
+            this.consoleLogger?.info(`Rotating logs: total size ${totalSizeMB} MB exceeds ${capMB} MB cap`);
 
             // Sort oldest first so we delete the oldest logs first
             fileInfos.sort((a, b) => a.mtimeMs - b.mtimeMs);

--- a/packages/cli/docs-preview/src/DebugLogger.ts
+++ b/packages/cli/docs-preview/src/DebugLogger.ts
@@ -1,10 +1,13 @@
 import { AbsoluteFilePath, doesPathExist, join, RelativeFilePath } from "@fern-api/fs-utils";
-import { appendFile, mkdir, writeFile } from "fs/promises";
+import { appendFile, mkdir, readdir, stat, unlink, writeFile } from "fs/promises";
 import { homedir } from "os";
 import path from "path";
 
 const LOCAL_STORAGE_FOLDER = process.env.LOCAL_STORAGE_FOLDER ?? ".fern";
 const LOGS_FOLDER_NAME = "logs";
+
+// 100 MB cap for the logs directory
+const MAX_LOGS_DIR_SIZE_BYTES = 100 * 1024 * 1024;
 
 /**
  * Log level for debug messages
@@ -158,6 +161,9 @@ export class DebugLogger {
 
         await writeFile(this.logFilePath, header, "utf-8");
         this.initialized = true;
+
+        // Enforce the 100 MB cap on the logs directory
+        await this.enforceLogSizeLimit(logsDir);
     }
 
     /**
@@ -291,6 +297,54 @@ export class DebugLogger {
         };
 
         await this.logCliMetric(event);
+    }
+
+    /**
+     * Delete oldest log files until total directory size is within the cap.
+     */
+    private async enforceLogSizeLimit(logsDir: AbsoluteFilePath): Promise<void> {
+        try {
+            const entries = await readdir(logsDir);
+            const logFiles = entries.filter((name) => name.endsWith(".log"));
+
+            // Gather size and mtime for each log file
+            const fileInfos: Array<{ name: string; fullPath: string; size: number; mtimeMs: number }> = [];
+            for (const name of logFiles) {
+                const fullPath = path.join(logsDir, name);
+                try {
+                    const stats = await stat(fullPath);
+                    fileInfos.push({ name, fullPath, size: stats.size, mtimeMs: stats.mtimeMs });
+                } catch {
+                    // File may have been removed between readdir and stat
+                }
+            }
+
+            let totalSize = fileInfos.reduce((sum, f) => sum + f.size, 0);
+            if (totalSize <= MAX_LOGS_DIR_SIZE_BYTES) {
+                return;
+            }
+
+            // Sort oldest first so we delete the oldest logs first
+            fileInfos.sort((a, b) => a.mtimeMs - b.mtimeMs);
+
+            for (const file of fileInfos) {
+                if (totalSize <= MAX_LOGS_DIR_SIZE_BYTES) {
+                    break;
+                }
+                // Never delete the log file we just created in this session
+                if (this.logFilePath != null && file.fullPath === this.logFilePath) {
+                    continue;
+                }
+                try {
+                    await unlink(file.fullPath);
+                    totalSize -= file.size;
+                } catch {
+                    // Ignore errors from concurrent deletion
+                }
+            }
+        } catch {
+            // If the directory is unreadable, skip cleanup silently
+        }
     }
 
     private getEventType(payload: MetricEvent | MetricSummary, isAggregate: boolean): string {

--- a/packages/cli/docs-preview/src/DebugLogger.ts
+++ b/packages/cli/docs-preview/src/DebugLogger.ts
@@ -320,18 +320,31 @@ export class DebugLogger {
             }
 
             let totalSize = fileInfos.reduce((sum, f) => sum + f.size, 0);
+            const totalSizeMB = Math.round((totalSize / 1024 / 1024) * 100) / 100;
+            const capMB = MAX_LOGS_DIR_SIZE_BYTES / 1024 / 1024;
+
             if (totalSize <= MAX_LOGS_DIR_SIZE_BYTES) {
+                await this.writeEntry({
+                    timestamp: new Date().toISOString(),
+                    source: getCliSource(),
+                    level: "debug",
+                    eventType: "log_rotation_check",
+                    data: {
+                        message: `Log directory size ${totalSizeMB} MB does not exceed ${capMB} MB cap`,
+                        totalSizeMB,
+                        fileCount: fileInfos.length
+                    }
+                });
                 return;
             }
 
-            const totalSizeMB = Math.round((totalSize / 1024 / 1024) * 100) / 100;
             await this.writeEntry({
                 timestamp: new Date().toISOString(),
                 source: getCliSource(),
                 level: "info",
                 eventType: "log_rotation",
                 data: {
-                    message: `Rotating logs: total size ${totalSizeMB} MB exceeds ${MAX_LOGS_DIR_SIZE_BYTES / 1024 / 1024} MB cap`,
+                    message: `Rotating logs: total size ${totalSizeMB} MB exceeds ${capMB} MB cap`,
                     totalSizeMB,
                     fileCount: fileInfos.length
                 }

--- a/packages/cli/docs-preview/src/runAppPreviewServer.ts
+++ b/packages/cli/docs-preview/src/runAppPreviewServer.ts
@@ -540,7 +540,10 @@ export async function runAppPreviewServer({
 
     // Initialize the debug logger for metrics collection
     const debugLogger = new DebugLogger();
-    await debugLogger.initialize();
+    await debugLogger.initialize({
+        debug: (msg) => context.logger.debug(msg),
+        info: (msg) => context.logger.info(msg)
+    });
     const debugLogPath = debugLogger.getLogFilePath();
     if (debugLogPath) {
         context.logger.info(chalk.dim(`Debug log: ${debugLogPath}`));

--- a/packages/cli/docs-preview/src/runAppPreviewServer.ts
+++ b/packages/cli/docs-preview/src/runAppPreviewServer.ts
@@ -602,8 +602,8 @@ export async function runAppPreviewServer({
         context.logger.info(chalk.dim(`Debug log: ${debugLogPath}`));
     }
 
-    // Enforce 100 MB cap on the logs directory
-    await enforceLogSizeLimit(debugLogger.getLogsDir(), debugLogPath, context);
+    // Enforce 100 MB cap on the logs directory (fire-and-forget)
+    void enforceLogSizeLimit(debugLogger.getLogsDir(), debugLogPath, context);
 
     let bunServer: BunServer | undefined;
 

--- a/packages/cli/docs-preview/src/runAppPreviewServer.ts
+++ b/packages/cli/docs-preview/src/runAppPreviewServer.ts
@@ -10,7 +10,7 @@ import { execSync } from "child_process";
 import cors from "cors";
 import express from "express";
 import fs from "fs";
-import { readFile, rm } from "fs/promises";
+import { readdir, readFile, rm, stat, unlink } from "fs/promises";
 import http, { type IncomingMessage } from "http";
 import path from "path";
 import { type Duplex } from "stream";
@@ -457,6 +457,62 @@ function killProcessesOnPort(targetPort: number, context: TaskContext): void {
     }
 }
 
+// 100 MB cap for the logs directory
+const MAX_LOGS_DIR_SIZE_BYTES = 100 * 1024 * 1024;
+
+async function enforceLogSizeLimit(
+    logsDir: string,
+    currentLogFile: string | null,
+    context: TaskContext
+): Promise<void> {
+    try {
+        const entries = await readdir(logsDir);
+        const logFiles = entries.filter((name) => name.endsWith(".log"));
+
+        const fileInfos: Array<{ fullPath: string; size: number; mtimeMs: number }> = [];
+        for (const name of logFiles) {
+            const fullPath = path.join(logsDir, name);
+            try {
+                const stats = await stat(fullPath);
+                fileInfos.push({ fullPath, size: stats.size, mtimeMs: stats.mtimeMs });
+            } catch {
+                // File may have been removed between readdir and stat
+            }
+        }
+
+        let totalSize = fileInfos.reduce((sum, f) => sum + f.size, 0);
+        const totalSizeMB = Math.round((totalSize / 1024 / 1024) * 100) / 100;
+        const capMB = MAX_LOGS_DIR_SIZE_BYTES / 1024 / 1024;
+
+        if (totalSize <= MAX_LOGS_DIR_SIZE_BYTES) {
+            context.logger.debug(`Log directory size ${totalSizeMB} MB does not exceed ${capMB} MB cap`);
+            return;
+        }
+
+        context.logger.info(`Rotating logs: total size ${totalSizeMB} MB exceeds ${capMB} MB cap`);
+
+        // Sort oldest first so we delete the oldest logs first
+        fileInfos.sort((a, b) => a.mtimeMs - b.mtimeMs);
+
+        for (const file of fileInfos) {
+            if (totalSize <= MAX_LOGS_DIR_SIZE_BYTES) {
+                break;
+            }
+            if (currentLogFile != null && file.fullPath === currentLogFile) {
+                continue;
+            }
+            try {
+                await unlink(file.fullPath);
+                totalSize -= file.size;
+            } catch {
+                // Ignore errors from concurrent deletion
+            }
+        }
+    } catch {
+        // If the directory is unreadable, skip cleanup silently
+    }
+}
+
 export async function runAppPreviewServer({
     initialProject,
     reloadProject,
@@ -540,14 +596,14 @@ export async function runAppPreviewServer({
 
     // Initialize the debug logger for metrics collection
     const debugLogger = new DebugLogger();
-    await debugLogger.initialize({
-        debug: (msg) => context.logger.debug(msg),
-        info: (msg) => context.logger.info(msg)
-    });
+    await debugLogger.initialize();
     const debugLogPath = debugLogger.getLogFilePath();
     if (debugLogPath) {
         context.logger.info(chalk.dim(`Debug log: ${debugLogPath}`));
     }
+
+    // Enforce 100 MB cap on the logs directory (fire-and-forget)
+    void enforceLogSizeLimit(debugLogger.getLogsDir(), debugLogPath, context);
 
     let bunServer: BunServer | undefined;
 

--- a/packages/cli/docs-preview/src/runAppPreviewServer.ts
+++ b/packages/cli/docs-preview/src/runAppPreviewServer.ts
@@ -602,8 +602,8 @@ export async function runAppPreviewServer({
         context.logger.info(chalk.dim(`Debug log: ${debugLogPath}`));
     }
 
-    // Enforce 100 MB cap on the logs directory (fire-and-forget)
-    void enforceLogSizeLimit(debugLogger.getLogsDir(), debugLogPath, context);
+    // Enforce 100 MB cap on the logs directory
+    await enforceLogSizeLimit(debugLogger.getLogsDir(), debugLogPath, context);
 
     let bunServer: BunServer | undefined;
 

--- a/packages/cli/docs-preview/src/runAppPreviewServer.ts
+++ b/packages/cli/docs-preview/src/runAppPreviewServer.ts
@@ -10,7 +10,7 @@ import { execSync } from "child_process";
 import cors from "cors";
 import express from "express";
 import fs from "fs";
-import { readdir, readFile, rm, stat, unlink } from "fs/promises";
+import { readFile, rm } from "fs/promises";
 import http, { type IncomingMessage } from "http";
 import path from "path";
 import { type Duplex } from "stream";
@@ -457,62 +457,6 @@ function killProcessesOnPort(targetPort: number, context: TaskContext): void {
     }
 }
 
-// 100 MB cap for the logs directory
-const MAX_LOGS_DIR_SIZE_BYTES = 100 * 1024 * 1024;
-
-async function enforceLogSizeLimit(
-    logsDir: string,
-    currentLogFile: string | null,
-    context: TaskContext
-): Promise<void> {
-    try {
-        const entries = await readdir(logsDir);
-        const logFiles = entries.filter((name) => name.endsWith(".log"));
-
-        const fileInfos: Array<{ fullPath: string; size: number; mtimeMs: number }> = [];
-        for (const name of logFiles) {
-            const fullPath = path.join(logsDir, name);
-            try {
-                const stats = await stat(fullPath);
-                fileInfos.push({ fullPath, size: stats.size, mtimeMs: stats.mtimeMs });
-            } catch {
-                // File may have been removed between readdir and stat
-            }
-        }
-
-        let totalSize = fileInfos.reduce((sum, f) => sum + f.size, 0);
-        const totalSizeMB = Math.round((totalSize / 1024 / 1024) * 100) / 100;
-        const capMB = MAX_LOGS_DIR_SIZE_BYTES / 1024 / 1024;
-
-        if (totalSize <= MAX_LOGS_DIR_SIZE_BYTES) {
-            context.logger.debug(`Log directory size ${totalSizeMB} MB does not exceed ${capMB} MB cap`);
-            return;
-        }
-
-        context.logger.info(`Rotating logs: total size ${totalSizeMB} MB exceeds ${capMB} MB cap`);
-
-        // Sort oldest first so we delete the oldest logs first
-        fileInfos.sort((a, b) => a.mtimeMs - b.mtimeMs);
-
-        for (const file of fileInfos) {
-            if (totalSize <= MAX_LOGS_DIR_SIZE_BYTES) {
-                break;
-            }
-            if (currentLogFile != null && file.fullPath === currentLogFile) {
-                continue;
-            }
-            try {
-                await unlink(file.fullPath);
-                totalSize -= file.size;
-            } catch {
-                // Ignore errors from concurrent deletion
-            }
-        }
-    } catch {
-        // If the directory is unreadable, skip cleanup silently
-    }
-}
-
 export async function runAppPreviewServer({
     initialProject,
     reloadProject,
@@ -596,14 +540,14 @@ export async function runAppPreviewServer({
 
     // Initialize the debug logger for metrics collection
     const debugLogger = new DebugLogger();
-    await debugLogger.initialize();
+    await debugLogger.initialize({
+        debug: (msg) => context.logger.debug(msg),
+        info: (msg) => context.logger.info(msg)
+    });
     const debugLogPath = debugLogger.getLogFilePath();
     if (debugLogPath) {
         context.logger.info(chalk.dim(`Debug log: ${debugLogPath}`));
     }
-
-    // Enforce 100 MB cap on the logs directory (fire-and-forget)
-    void enforceLogSizeLimit(debugLogger.getLogsDir(), debugLogPath, context);
 
     let bunServer: BunServer | undefined;
 


### PR DESCRIPTION
## Description

Closes FER-9568

`fern docs dev` writes debug logs to `~/.fern/logs/` but never cleans them up, causing unbounded disk usage over time. This adds automatic log rotation with a 100 MB directory size cap.

## Changes Made

- Added `enforceLogSizeLimit()` private method in `DebugLogger` that runs fire-and-forget at the end of `initialize()`
- Scans the logs directory, sorts files by mtime (oldest first), and deletes until total size is ≤ 100 MB
- Skips the current session's log file to avoid deleting active logs
- Added optional `consoleLogger` callback parameter to `DebugLogger.initialize()` so rotation status is logged to the console (debug when under cap, info when rotating) — wired to `context.logger` in `runAppPreviewServer.ts`
- All errors are silently caught to avoid breaking the main `fern docs dev` flow
- Added `versions.yml` entry (4.63.2, fix)

## Review Checklist

- [ ] **`file.fullPath === this.logFilePath` comparison**: `this.logFilePath` is an `AbsoluteFilePath` (branded string), while `file.fullPath` is built with `path.join()` (plain string). Works at runtime since `AbsoluteFilePath` is `string & { __AbsoluteFilePath: void }`, but verify paths are normalized consistently.
- [x] Cleanup runs fire-and-forget (`void`) — does not block startup
- [x] Cleanup only runs at startup — a single very long session could still exceed 100 MB. Acceptable tradeoff.

## Testing

- [ ] Unit tests added/updated — **not added**; cleanup logic is defensive (all errors caught) and straightforward
- [x] Lint passes (`biome check`)
- [x] Verified console output shows rotation status with `--log-level=debug`

Link to Devin session: https://app.devin.ai/sessions/0212b2e6da7543248d179fb0d4f0450a
Requested by: @thesandlord