### PR TITLE
feat(cli): add FERN_RESOLVE_VERSION env var for version redirection

### DIFF
--- a/packages/cli/cli/src/__test__/getIntendedVersionOfCli.test.ts
+++ b/packages/cli/cli/src/__test__/getIntendedVersionOfCli.test.ts
@@ -19,8 +19,11 @@ vi.mock("../cli-context/upgrade-utils/getLatestVersionOfCli.js", () => ({
 
 const CURRENT_VERSION = "0.40.0";
 
+const mockInfo = vi.fn();
+
 const mockCliContext = {
     environment: { packageVersion: CURRENT_VERSION },
+    logger: { info: mockInfo },
     runTask: (fn: (context: unknown) => Promise<unknown>) => mockRunTask(fn)
 };
 
@@ -35,6 +38,7 @@ beforeEach(() => {
     mockGetFernDirectory.mockResolvedValue(undefined);
     mockGetLatestVersionOfCli.mockResolvedValue("0.99.0");
     mockLoadProjectConfig.mockResolvedValue({ version: "0.50.0" });
+    mockInfo.mockClear();
 });
 
 afterEach(() => {
@@ -90,6 +94,12 @@ describe("FERN_RESOLVE_VERSION", () => {
         process.env.FERN_RESOLVE_VERSION = "";
         mockGetFernDirectory.mockResolvedValue("/workspace/fern");
         expect(await getIntended()).toBe("0.50.0");
+    });
+
+    it("passes npm tags through as-is", async () => {
+        process.env.FERN_RESOLVE_VERSION = "beta";
+        expect(await getIntended()).toBe("beta");
+        expect(mockGetFernDirectory).not.toHaveBeenCalled();
     });
 });
 

--- a/packages/cli/cli/src/__test__/getIntendedVersionOfCli.test.ts
+++ b/packages/cli/cli/src/__test__/getIntendedVersionOfCli.test.ts
@@ -1,0 +1,146 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockGetLatestVersionOfCli, mockGetFernDirectory, mockLoadProjectConfig, mockRunTask } = vi.hoisted(() => {
+    const mockGetLatestVersionOfCli = vi.fn().mockResolvedValue("0.99.0");
+    const mockGetFernDirectory = vi.fn().mockResolvedValue(undefined);
+    const mockLoadProjectConfig = vi.fn().mockResolvedValue({ version: "0.50.0" });
+    const mockRunTask = vi.fn(async (fn: (context: unknown) => Promise<unknown>) => fn({}));
+    return { mockGetLatestVersionOfCli, mockGetFernDirectory, mockLoadProjectConfig, mockRunTask };
+});
+
+vi.mock("@fern-api/configuration-loader", () => ({
+    getFernDirectory: () => mockGetFernDirectory(),
+    loadProjectConfig: (...args: unknown[]) => mockLoadProjectConfig(...args)
+}));
+
+vi.mock("../cli-context/upgrade-utils/getLatestVersionOfCli.js", () => ({
+    getLatestVersionOfCli: (...args: unknown[]) => mockGetLatestVersionOfCli(...args)
+}));
+
+const CURRENT_VERSION = "0.40.0";
+
+const mockCliContext = {
+    environment: { packageVersion: CURRENT_VERSION },
+    runTask: (fn: (context: unknown) => Promise<unknown>) => mockRunTask(fn)
+};
+
+async function getIntended(): Promise<string> {
+    const { getIntendedVersionOfCli } = await import("../getIntendedVersionOfCli.js");
+    return getIntendedVersionOfCli(mockCliContext as never);
+}
+
+beforeEach(() => {
+    delete process.env.FERN_NO_VERSION_REDIRECTION;
+    delete process.env.FERN_RESOLVE_VERSION;
+    mockGetFernDirectory.mockResolvedValue(undefined);
+    mockGetLatestVersionOfCli.mockResolvedValue("0.99.0");
+    mockLoadProjectConfig.mockResolvedValue({ version: "0.50.0" });
+});
+
+afterEach(() => {
+    vi.clearAllMocks();
+});
+
+describe("FERN_NO_VERSION_REDIRECTION", () => {
+    it("returns current binary version when set to 'true'", async () => {
+        process.env.FERN_NO_VERSION_REDIRECTION = "true";
+        expect(await getIntended()).toBe(CURRENT_VERSION);
+        expect(mockGetLatestVersionOfCli).not.toHaveBeenCalled();
+        expect(mockGetFernDirectory).not.toHaveBeenCalled();
+    });
+
+    it("does not short-circuit when set to other values", async () => {
+        process.env.FERN_NO_VERSION_REDIRECTION = "false";
+        expect(await getIntended()).toBe("0.99.0"); // falls through to latest
+    });
+});
+
+describe("FERN_RESOLVE_VERSION", () => {
+    it("returns current binary version for 'inherit'", async () => {
+        process.env.FERN_RESOLVE_VERSION = "inherit";
+        expect(await getIntended()).toBe(CURRENT_VERSION);
+        expect(mockGetLatestVersionOfCli).not.toHaveBeenCalled();
+    });
+
+    it("resolves to latest for 'latest'", async () => {
+        process.env.FERN_RESOLVE_VERSION = "latest";
+        expect(await getIntended()).toBe("0.99.0");
+        expect(mockGetLatestVersionOfCli).toHaveBeenCalledOnce();
+    });
+
+    it("returns the specific version as-is", async () => {
+        process.env.FERN_RESOLVE_VERSION = "0.15.0";
+        expect(await getIntended()).toBe("0.15.0");
+        expect(mockGetLatestVersionOfCli).not.toHaveBeenCalled();
+        expect(mockGetFernDirectory).not.toHaveBeenCalled();
+    });
+
+    it("falls through to fern.config.json for 'auto'", async () => {
+        process.env.FERN_RESOLVE_VERSION = "auto";
+        mockGetFernDirectory.mockResolvedValue("/workspace/fern");
+        expect(await getIntended()).toBe("0.50.0");
+    });
+
+    it("falls through to fern.config.json when not set", async () => {
+        mockGetFernDirectory.mockResolvedValue("/workspace/fern");
+        expect(await getIntended()).toBe("0.50.0");
+    });
+
+    it("falls through to fern.config.json for empty string", async () => {
+        process.env.FERN_RESOLVE_VERSION = "";
+        mockGetFernDirectory.mockResolvedValue("/workspace/fern");
+        expect(await getIntended()).toBe("0.50.0");
+    });
+});
+
+describe("fern.config.json resolution", () => {
+    it("returns latest when no fern directory exists", async () => {
+        mockGetFernDirectory.mockResolvedValue(undefined);
+        expect(await getIntended()).toBe("0.99.0");
+        expect(mockGetLatestVersionOfCli).toHaveBeenCalledOnce();
+    });
+
+    it("returns current binary version for '*'", async () => {
+        mockGetFernDirectory.mockResolvedValue("/workspace/fern");
+        mockLoadProjectConfig.mockResolvedValue({ version: "*" });
+        expect(await getIntended()).toBe(CURRENT_VERSION);
+        expect(mockGetLatestVersionOfCli).not.toHaveBeenCalled();
+    });
+
+    it("resolves to latest for 'latest' in config", async () => {
+        mockGetFernDirectory.mockResolvedValue("/workspace/fern");
+        mockLoadProjectConfig.mockResolvedValue({ version: "latest" });
+        expect(await getIntended()).toBe("0.99.0");
+        expect(mockGetLatestVersionOfCli).toHaveBeenCalledOnce();
+    });
+
+    it("returns pinned version from config", async () => {
+        mockGetFernDirectory.mockResolvedValue("/workspace/fern");
+        mockLoadProjectConfig.mockResolvedValue({ version: "0.50.0" });
+        expect(await getIntended()).toBe("0.50.0");
+        expect(mockGetLatestVersionOfCli).not.toHaveBeenCalled();
+    });
+});
+
+describe("precedence", () => {
+    it("FERN_NO_VERSION_REDIRECTION takes priority over FERN_RESOLVE_VERSION", async () => {
+        process.env.FERN_NO_VERSION_REDIRECTION = "true";
+        process.env.FERN_RESOLVE_VERSION = "0.15.0";
+        expect(await getIntended()).toBe(CURRENT_VERSION);
+    });
+
+    it("FERN_RESOLVE_VERSION takes priority over fern.config.json", async () => {
+        process.env.FERN_RESOLVE_VERSION = "0.15.0";
+        mockGetFernDirectory.mockResolvedValue("/workspace/fern");
+        mockLoadProjectConfig.mockResolvedValue({ version: "0.50.0" });
+        expect(await getIntended()).toBe("0.15.0");
+        expect(mockGetFernDirectory).not.toHaveBeenCalled();
+    });
+
+    it("fern.config.json takes priority over latest fallback", async () => {
+        mockGetFernDirectory.mockResolvedValue("/workspace/fern");
+        mockLoadProjectConfig.mockResolvedValue({ version: "0.50.0" });
+        expect(await getIntended()).toBe("0.50.0");
+        expect(mockGetLatestVersionOfCli).not.toHaveBeenCalled();
+    });
+});

--- a/packages/cli/cli/src/cli.ts
+++ b/packages/cli/cli/src/cli.ts
@@ -81,6 +81,7 @@ import { writeDefinitionForWorkspaces } from "./commands/write-definition/writeD
 import { writeDocsDefinitionForProject } from "./commands/write-docs-definition/writeDocsDefinitionForProject.js";
 import { writeTranslationForProject } from "./commands/write-translation/writeTranslationForProject.js";
 import { FERN_CWD_ENV_VAR } from "./cwd.js";
+import { getIntendedVersionOfCli } from "./getIntendedVersionOfCli.js";
 import { rerunFernCliAtVersion } from "./rerunFernCliAtVersion.js";
 import { resolveGroupGithubConfig } from "./resolveGroupGithubConfig.js";
 import { RUNTIME } from "./runtime.js";
@@ -265,26 +266,6 @@ async function tryRunCli(cliContext: CliContext) {
     });
 
     await cli.parse();
-}
-
-async function getIntendedVersionOfCli(cliContext: CliContext): Promise<string> {
-    if (process.env.FERN_NO_VERSION_REDIRECTION === "true") {
-        return cliContext.environment.packageVersion;
-    }
-    const fernDirectory = await getFernDirectory();
-    if (fernDirectory != null) {
-        const projectConfig = await cliContext.runTask((context) =>
-            loadProjectConfig({ directory: fernDirectory, context })
-        );
-        if (projectConfig.version === "*") {
-            return cliContext.environment.packageVersion;
-        }
-        if (projectConfig.version === "latest") {
-            return getLatestVersionOfCli({ cliEnvironment: cliContext.environment });
-        }
-        return projectConfig.version;
-    }
-    return getLatestVersionOfCli({ cliEnvironment: cliContext.environment });
 }
 
 async function getOrganization(cliContext: CliContext): Promise<string | undefined> {

--- a/packages/cli/cli/src/cli.ts
+++ b/packages/cli/cli/src/cli.ts
@@ -126,10 +126,33 @@ async function runCli() {
         if (cliContext.environment.packageVersion === versionOfCliToRun) {
             await tryRunCli(cliContext);
         } else {
-            await rerunFernCliAtVersion({
-                version: versionOfCliToRun,
-                cliContext
-            });
+            try {
+                await rerunFernCliAtVersion({
+                    version: versionOfCliToRun,
+                    cliContext,
+                    throwOnError: true
+                });
+            } catch (error) {
+                if (process.env.FERN_RESOLVE_VERSION && process.env.FERN_RESOLVE_VERSION !== "auto") {
+                    cliContext.logger.warn(
+                        `Failed to resolve FERN_RESOLVE_VERSION='${process.env.FERN_RESOLVE_VERSION}'. Falling back to default version resolution.`
+                    );
+                    const originalValue = process.env.FERN_RESOLVE_VERSION;
+                    delete process.env.FERN_RESOLVE_VERSION;
+                    const fallbackVersion = await getIntendedVersionOfCli(cliContext);
+                    process.env.FERN_RESOLVE_VERSION = originalValue;
+                    if (cliContext.environment.packageVersion === fallbackVersion) {
+                        await tryRunCli(cliContext);
+                    } else {
+                        await rerunFernCliAtVersion({
+                            version: fallbackVersion,
+                            cliContext
+                        });
+                    }
+                } else {
+                    throw error;
+                }
+            }
         }
     } catch (error) {
         await cliContext.instrumentPostHogEvent({

--- a/packages/cli/cli/src/getIntendedVersionOfCli.ts
+++ b/packages/cli/cli/src/getIntendedVersionOfCli.ts
@@ -14,6 +14,7 @@ export async function getIntendedVersionOfCli(cliContext: CliContext): Promise<s
         if (resolveVersion === "latest") {
             return getLatestVersionOfCli({ cliEnvironment: cliContext.environment });
         }
+        cliContext.logger.info(`Resolving Fern CLI to version '${resolveVersion}' via FERN_RESOLVE_VERSION.`);
         return resolveVersion;
     }
     const fernDirectory = await getFernDirectory();

--- a/packages/cli/cli/src/getIntendedVersionOfCli.ts
+++ b/packages/cli/cli/src/getIntendedVersionOfCli.ts
@@ -1,0 +1,33 @@
+import { getFernDirectory, loadProjectConfig } from "@fern-api/configuration-loader";
+import { CliContext } from "./cli-context/CliContext.js";
+import { getLatestVersionOfCli } from "./cli-context/upgrade-utils/getLatestVersionOfCli.js";
+
+export async function getIntendedVersionOfCli(cliContext: CliContext): Promise<string> {
+    if (process.env.FERN_NO_VERSION_REDIRECTION === "true") {
+        return cliContext.environment.packageVersion;
+    }
+    if (process.env.FERN_RESOLVE_VERSION && process.env.FERN_RESOLVE_VERSION !== "auto") {
+        const resolveVersion = process.env.FERN_RESOLVE_VERSION;
+        if (resolveVersion === "inherit") {
+            return cliContext.environment.packageVersion;
+        }
+        if (resolveVersion === "latest") {
+            return getLatestVersionOfCli({ cliEnvironment: cliContext.environment });
+        }
+        return resolveVersion;
+    }
+    const fernDirectory = await getFernDirectory();
+    if (fernDirectory != null) {
+        const projectConfig = await cliContext.runTask((context) =>
+            loadProjectConfig({ directory: fernDirectory, context })
+        );
+        if (projectConfig.version === "*") {
+            return cliContext.environment.packageVersion;
+        }
+        if (projectConfig.version === "latest") {
+            return getLatestVersionOfCli({ cliEnvironment: cliContext.environment });
+        }
+        return projectConfig.version;
+    }
+    return getLatestVersionOfCli({ cliEnvironment: cliContext.environment });
+}

--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -4,7 +4,9 @@
   changelogEntry:
     - summary: |
         Add FERN_RESOLVE_VERSION env var to control CLI version redirection.
-        Supports 'auto', 'latest', 'inherit', or a specific version string.
+        Supports 'auto', 'latest', 'inherit', a specific version, or any npm
+        tag (e.g. 'beta'). Gracefully falls back to default resolution if
+        the requested version cannot be resolved.
       type: chore
   createdAt: "2026-04-08"
   irVersion: 66

--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -1,5 +1,14 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 
+- version: 4.63.1
+  changelogEntry:
+    - summary: |
+        Add FERN_RESOLVE_VERSION env var to control CLI version redirection.
+        Supports 'auto', 'latest', 'inherit', or a specific version string.
+      type: chore
+  createdAt: "2026-04-08"
+  irVersion: 66
+
 - version: 4.63.0
   changelogEntry:
     - summary: |


### PR DESCRIPTION
## Summary
- Adds FERN_RESOLVE_VERSION env var to control CLI version redirection
- Supported values: auto (respect fern.config.json, the default), latest, inherit (use current binary), or a specific version (e.g. 0.15.0)
- Extracts getIntendedVersionOfCli into its own file for testability

## Motivation
GitHub Actions that call the Fern CLI need a way to control which version is used without modifying fern.config.json. FERN_RESOLVE_VERSION lets each action step declare its intent:
- auto: respect the repo's fern.config.json (default for generate/verify/upgrade actions)
- latest: always use the newest release (default for sync-specs/pull-spec actions)
- inherit: use whatever CLI binary is already installed, skip redirection
- 0.15.0: pin to a specific version

## Precedence
1. FERN_NO_VERSION_REDIRECTION=true -> use current binary (unchanged)
2. FERN_RESOLVE_VERSION -> resolve as described above
3. fern.config.json version field
4. Latest from npm

## Test plan
- 15 unit tests covering all values and the full precedence chain
- Empty string falls through to fern.config.json (not treated as a version)
- Full test suite passes (386 tests)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/14759" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
