### PR TITLE
fix(go): auth in wire tests, seed test failures on main

### DIFF
--- a/generators/go-v2/sdk/src/wire-tests/WireTestGenerator.ts
+++ b/generators/go-v2/sdk/src/wire-tests/WireTestGenerator.ts
@@ -611,26 +611,74 @@ export class WireTestGenerator {
         endpoint: FernIr.HttpEndpoint;
         snippet: string;
     }): go.CodeBlock {
-        // Generate the client constructor directly with WireMockBaseURL instead of parsing from snippet
-        // The snippet uses the original constructor args (e.g., WithToken), but we need WithBaseURL
+        // Generate the client constructor with WireMockBaseURL and auth options matching the WireMock matchers.
         return go.codeblock((writer) => {
             writer.write("client := ");
+            const arguments_: go.AstNode[] = [
+                go.invokeFunc({
+                    func: go.typeReference({
+                        name: "WithBaseURL",
+                        importPath: this.context.getOptionImportPath()
+                    }),
+                    arguments_: [go.codeblock("WireMockBaseURL")],
+                    multiline: false
+                })
+            ];
+            // Add auth options when the endpoint requires authentication, so that the
+            // request matches the WireMock stub's header matchers.
+            if (endpoint.auth) {
+                for (const scheme of this.context.ir.auth.schemes) {
+                    switch (scheme.type) {
+                        case "bearer":
+                            arguments_.push(
+                                go.invokeFunc({
+                                    func: go.typeReference({
+                                        name: "WithToken",
+                                        importPath: this.context.getOptionImportPath()
+                                    }),
+                                    arguments_: [go.codeblock('"test-token"')],
+                                    multiline: false
+                                })
+                            );
+                            break;
+                        case "basic":
+                            arguments_.push(
+                                go.invokeFunc({
+                                    func: go.typeReference({
+                                        name: "WithBasicAuth",
+                                        importPath: this.context.getOptionImportPath()
+                                    }),
+                                    arguments_: [go.codeblock('"test-username"'), go.codeblock('"test-password"')],
+                                    multiline: false
+                                })
+                            );
+                            break;
+                        case "header": {
+                            const fieldName = scheme.name?.name?.pascalCase?.unsafeName;
+                            if (fieldName) {
+                                arguments_.push(
+                                    go.invokeFunc({
+                                        func: go.typeReference({
+                                            name: `With${fieldName}`,
+                                            importPath: this.context.getOptionImportPath()
+                                        }),
+                                        arguments_: [go.codeblock('"test-value"')],
+                                        multiline: false
+                                    })
+                                );
+                            }
+                            break;
+                        }
+                    }
+                }
+            }
             writer.writeNode(
                 go.invokeFunc({
                     func: go.typeReference({
                         name: this.context.getClientConstructorName(),
                         importPath: this.context.getRootClientImportPath()
                     }),
-                    arguments_: [
-                        go.invokeFunc({
-                            func: go.typeReference({
-                                name: "WithBaseURL",
-                                importPath: this.context.getOptionImportPath()
-                            }),
-                            arguments_: [go.codeblock("WireMockBaseURL")],
-                            multiline: false
-                        })
-                    ],
+                    arguments_,
                     multiline: true
                 })
             );

--- a/generators/go/sdk/versions.yml
+++ b/generators/go/sdk/versions.yml
@@ -1,4 +1,14 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 1.33.4
+  changelogEntry:
+    - summary: |
+        Fix wire test client construction to include auth options (e.g.
+        WithToken) when the endpoint requires authentication, so that
+        requests match WireMock stub header matchers.
+      type: fix
+  createdAt: "2026-04-08"
+  irVersion: 61
+
 - version: 1.33.3
   changelogEntry:
     - summary: |

--- a/seed/go-sdk/exhaustive/omit-empty-request-wrappers/core/request_option.go
+++ b/seed/go-sdk/exhaustive/omit-empty-request-wrappers/core/request_option.go
@@ -17,14 +17,15 @@ type RequestOption interface {
 // This type is primarily used by the generated code and is not meant
 // to be used directly; use the option package instead.
 type RequestOptions struct {
-	BaseURL         string
-	HTTPClient      HTTPClient
-	HTTPHeader      http.Header
-	BodyProperties  map[string]interface{}
-	QueryParameters url.Values
-	MaxAttempts     uint
-	MaxBufSize      int
-	Token           string
+	BaseURL              string
+	HTTPClient           HTTPClient
+	HTTPHeader           http.Header
+	BodyProperties       map[string]interface{}
+	QueryParameters      url.Values
+	MaxAttempts          uint
+	MaxBufSize           int
+	MaxReconnectAttempts *int
+	Token                string
 }
 
 // NewRequestOptions returns a new *RequestOptions value.
@@ -123,6 +124,15 @@ type MaxBufSizeOption struct {
 
 func (m *MaxBufSizeOption) applyRequestOptions(opts *RequestOptions) {
 	opts.MaxBufSize = m.MaxBufSize
+}
+
+// MaxReconnectAttemptsOption implements the RequestOption interface.
+type MaxReconnectAttemptsOption struct {
+	MaxReconnectAttempts *int
+}
+
+func (m *MaxReconnectAttemptsOption) applyRequestOptions(opts *RequestOptions) {
+	opts.MaxReconnectAttempts = m.MaxReconnectAttempts
 }
 
 // TokenOption implements the RequestOption interface.

--- a/seed/go-sdk/exhaustive/omit-empty-request-wrappers/option/request_option.go
+++ b/seed/go-sdk/exhaustive/omit-empty-request-wrappers/option/request_option.go
@@ -72,6 +72,14 @@ func WithMaxStreamBufSize(size int) *core.MaxBufSizeOption {
 	}
 }
 
+// WithMaxReconnectAttempts configures the maximum number of reconnection
+// attempts for SSE streams. Default is 10. Set to 0 to disable auto-reconnection.
+func WithMaxReconnectAttempts(attempts int) *core.MaxReconnectAttemptsOption {
+	return &core.MaxReconnectAttemptsOption{
+		MaxReconnectAttempts: &attempts,
+	}
+}
+
 // WithToken sets the 'Authorization: Bearer <token>' request header.
 func WithToken(token string) *core.TokenOption {
 	return &core.TokenOption{

--- a/seed/go-sdk/exhaustive/omit-empty-request-wrappers/wiremock/wiremock-mappings.json
+++ b/seed/go-sdk/exhaustive/omit-empty-request-wrappers/wiremock/wiremock-mappings.json
@@ -5,12 +5,7 @@
       "name": "getAndReturnListOfPrimitives - default",
       "request": {
         "urlPathTemplate": "/container/list-of-primitives",
-        "method": "POST",
-        "headers": {
-          "Authorization": {
-            "matches": "Bearer .+"
-          }
-        }
+        "method": "POST"
       },
       "response": {
         "status": 200,
@@ -36,12 +31,7 @@
       "name": "getAndReturnListOfObjects - default",
       "request": {
         "urlPathTemplate": "/container/list-of-objects",
-        "method": "POST",
-        "headers": {
-          "Authorization": {
-            "matches": "Bearer .+"
-          }
-        }
+        "method": "POST"
       },
       "response": {
         "status": 200,
@@ -67,12 +57,7 @@
       "name": "getAndReturnSetOfPrimitives - default",
       "request": {
         "urlPathTemplate": "/container/set-of-primitives",
-        "method": "POST",
-        "headers": {
-          "Authorization": {
-            "matches": "Bearer .+"
-          }
-        }
+        "method": "POST"
       },
       "response": {
         "status": 200,
@@ -98,12 +83,7 @@
       "name": "getAndReturnSetOfObjects - default",
       "request": {
         "urlPathTemplate": "/container/set-of-objects",
-        "method": "POST",
-        "headers": {
-          "Authorization": {
-            "matches": "Bearer .+"
-          }
-        }
+        "method": "POST"
       },
       "response": {
         "status": 200,
@@ -129,12 +109,7 @@
       "name": "getAndReturnMapPrimToPrim - default",
       "request": {
         "urlPathTemplate": "/container/map-prim-to-prim",
-        "method": "POST",
-        "headers": {
-          "Authorization": {
-            "matches": "Bearer .+"
-          }
-        }
+        "method": "POST"
       },
       "response": {
         "status": 200,
@@ -160,12 +135,7 @@
       "name": "getAndReturnMapOfPrimToObject - default",
       "request": {
         "urlPathTemplate": "/container/map-prim-to-object",
-        "method": "POST",
-        "headers": {
-          "Authorization": {
-            "matches": "Bearer .+"
-          }
-        }
+        "method": "POST"
       },
       "response": {
         "status": 200,
@@ -191,12 +161,7 @@
       "name": "getAndReturnMapOfPrimToUndiscriminatedUnion - default",
       "request": {
         "urlPathTemplate": "/container/map-prim-to-union",
-        "method": "POST",
-        "headers": {
-          "Authorization": {
-            "matches": "Bearer .+"
-          }
-        }
+        "method": "POST"
       },
       "response": {
         "status": 200,
@@ -222,12 +187,7 @@
       "name": "getAndReturnOptional - default",
       "request": {
         "urlPathTemplate": "/container/opt-objects",
-        "method": "POST",
-        "headers": {
-          "Authorization": {
-            "matches": "Bearer .+"
-          }
-        }
+        "method": "POST"
       },
       "response": {
         "status": 200,
@@ -253,12 +213,7 @@
       "name": "postJsonPatchContentType - default",
       "request": {
         "urlPathTemplate": "/foo/bar",
-        "method": "POST",
-        "headers": {
-          "Authorization": {
-            "matches": "Bearer .+"
-          }
-        }
+        "method": "POST"
       },
       "response": {
         "status": 200,
@@ -284,12 +239,7 @@
       "name": "postJsonPatchContentWithCharsetType - default",
       "request": {
         "urlPathTemplate": "/foo/baz",
-        "method": "POST",
-        "headers": {
-          "Authorization": {
-            "matches": "Bearer .+"
-          }
-        }
+        "method": "POST"
       },
       "response": {
         "status": 200,
@@ -315,12 +265,7 @@
       "name": "getAndReturnEnum - default",
       "request": {
         "urlPathTemplate": "/enum",
-        "method": "POST",
-        "headers": {
-          "Authorization": {
-            "matches": "Bearer .+"
-          }
-        }
+        "method": "POST"
       },
       "response": {
         "status": 200,
@@ -347,11 +292,6 @@
       "request": {
         "urlPathTemplate": "/http-methods/{id}",
         "method": "GET",
-        "headers": {
-          "Authorization": {
-            "matches": "Bearer .+"
-          }
-        },
         "pathParameters": {
           "id": {
             "equalTo": "id"
@@ -382,12 +322,7 @@
       "name": "testPost - default",
       "request": {
         "urlPathTemplate": "/http-methods",
-        "method": "POST",
-        "headers": {
-          "Authorization": {
-            "matches": "Bearer .+"
-          }
-        }
+        "method": "POST"
       },
       "response": {
         "status": 200,
@@ -414,11 +349,6 @@
       "request": {
         "urlPathTemplate": "/http-methods/{id}",
         "method": "PUT",
-        "headers": {
-          "Authorization": {
-            "matches": "Bearer .+"
-          }
-        },
         "pathParameters": {
           "id": {
             "equalTo": "id"
@@ -450,11 +380,6 @@
       "request": {
         "urlPathTemplate": "/http-methods/{id}",
         "method": "PATCH",
-        "headers": {
-          "Authorization": {
-            "matches": "Bearer .+"
-          }
-        },
         "pathParameters": {
           "id": {
             "equalTo": "id"
@@ -486,11 +411,6 @@
       "request": {
         "urlPathTemplate": "/http-methods/{id}",
         "method": "DELETE",
-        "headers": {
-          "Authorization": {
-            "matches": "Bearer .+"
-          }
-        },
         "pathParameters": {
           "id": {
             "equalTo": "id"
@@ -521,12 +441,7 @@
       "name": "getAndReturnWithOptionalField - default",
       "request": {
         "urlPathTemplate": "/object/get-and-return-with-optional-field",
-        "method": "POST",
-        "headers": {
-          "Authorization": {
-            "matches": "Bearer .+"
-          }
-        }
+        "method": "POST"
       },
       "response": {
         "status": 200,
@@ -552,12 +467,7 @@
       "name": "getAndReturnWithRequiredField - default",
       "request": {
         "urlPathTemplate": "/object/get-and-return-with-required-field",
-        "method": "POST",
-        "headers": {
-          "Authorization": {
-            "matches": "Bearer .+"
-          }
-        }
+        "method": "POST"
       },
       "response": {
         "status": 200,
@@ -583,12 +493,7 @@
       "name": "getAndReturnWithMapOfMap - default",
       "request": {
         "urlPathTemplate": "/object/get-and-return-with-map-of-map",
-        "method": "POST",
-        "headers": {
-          "Authorization": {
-            "matches": "Bearer .+"
-          }
-        }
+        "method": "POST"
       },
       "response": {
         "status": 200,
@@ -614,12 +519,7 @@
       "name": "getAndReturnNestedWithOptionalField - default",
       "request": {
         "urlPathTemplate": "/object/get-and-return-nested-with-optional-field",
-        "method": "POST",
-        "headers": {
-          "Authorization": {
-            "matches": "Bearer .+"
-          }
-        }
+        "method": "POST"
       },
       "response": {
         "status": 200,
@@ -646,11 +546,6 @@
       "request": {
         "urlPathTemplate": "/object/get-and-return-nested-with-required-field/{string}",
         "method": "POST",
-        "headers": {
-          "Authorization": {
-            "matches": "Bearer .+"
-          }
-        },
         "pathParameters": {
           "string": {
             "equalTo": "string"
@@ -681,12 +576,7 @@
       "name": "getAndReturnNestedWithRequiredFieldAsList - default",
       "request": {
         "urlPathTemplate": "/object/get-and-return-nested-with-required-field-list",
-        "method": "POST",
-        "headers": {
-          "Authorization": {
-            "matches": "Bearer .+"
-          }
-        }
+        "method": "POST"
       },
       "response": {
         "status": 200,
@@ -712,12 +602,7 @@
       "name": "getAndReturnWithUnknownField - default",
       "request": {
         "urlPathTemplate": "/object/get-and-return-with-unknown-field",
-        "method": "POST",
-        "headers": {
-          "Authorization": {
-            "matches": "Bearer .+"
-          }
-        }
+        "method": "POST"
       },
       "response": {
         "status": 200,
@@ -743,12 +628,7 @@
       "name": "getAndReturnWithDocumentedUnknownType - default",
       "request": {
         "urlPathTemplate": "/object/get-and-return-with-documented-unknown-type",
-        "method": "POST",
-        "headers": {
-          "Authorization": {
-            "matches": "Bearer .+"
-          }
-        }
+        "method": "POST"
       },
       "response": {
         "status": 200,
@@ -774,12 +654,7 @@
       "name": "getAndReturnMapOfDocumentedUnknownType - default",
       "request": {
         "urlPathTemplate": "/object/get-and-return-map-of-documented-unknown-type",
-        "method": "POST",
-        "headers": {
-          "Authorization": {
-            "matches": "Bearer .+"
-          }
-        }
+        "method": "POST"
       },
       "response": {
         "status": 200,
@@ -805,12 +680,7 @@
       "name": "getAndReturnWithDatetimeLikeString - default",
       "request": {
         "urlPathTemplate": "/object/get-and-return-with-datetime-like-string",
-        "method": "POST",
-        "headers": {
-          "Authorization": {
-            "matches": "Bearer .+"
-          }
-        }
+        "method": "POST"
       },
       "response": {
         "status": 200,
@@ -837,11 +707,6 @@
       "request": {
         "urlPathTemplate": "/pagination",
         "method": "GET",
-        "headers": {
-          "Authorization": {
-            "matches": "Bearer .+"
-          }
-        },
         "queryParameters": {
           "cursor": {
             "equalTo": "cursor"
@@ -877,11 +742,6 @@
       "request": {
         "urlPathTemplate": "/params/path/{param}",
         "method": "GET",
-        "headers": {
-          "Authorization": {
-            "matches": "Bearer .+"
-          }
-        },
         "pathParameters": {
           "param": {
             "equalTo": "param"
@@ -913,11 +773,6 @@
       "request": {
         "urlPathTemplate": "/params/path/{param}",
         "method": "GET",
-        "headers": {
-          "Authorization": {
-            "matches": "Bearer .+"
-          }
-        },
         "pathParameters": {
           "param": {
             "equalTo": "param"
@@ -949,11 +804,6 @@
       "request": {
         "urlPathTemplate": "/params",
         "method": "GET",
-        "headers": {
-          "Authorization": {
-            "matches": "Bearer .+"
-          }
-        },
         "queryParameters": {
           "query": {
             "equalTo": "query"
@@ -989,11 +839,6 @@
       "request": {
         "urlPathTemplate": "/params",
         "method": "GET",
-        "headers": {
-          "Authorization": {
-            "matches": "Bearer .+"
-          }
-        },
         "queryParameters": {
           "query": {
             "equalTo": "query"
@@ -1029,11 +874,6 @@
       "request": {
         "urlPathTemplate": "/params/path-query/{param}",
         "method": "GET",
-        "headers": {
-          "Authorization": {
-            "matches": "Bearer .+"
-          }
-        },
         "pathParameters": {
           "param": {
             "equalTo": "param"
@@ -1070,11 +910,6 @@
       "request": {
         "urlPathTemplate": "/params/path-query/{param}",
         "method": "GET",
-        "headers": {
-          "Authorization": {
-            "matches": "Bearer .+"
-          }
-        },
         "pathParameters": {
           "param": {
             "equalTo": "param"
@@ -1111,11 +946,6 @@
       "request": {
         "urlPathTemplate": "/params/path/{param}",
         "method": "PUT",
-        "headers": {
-          "Authorization": {
-            "matches": "Bearer .+"
-          }
-        },
         "pathParameters": {
           "param": {
             "equalTo": "param"
@@ -1147,11 +977,6 @@
       "request": {
         "urlPathTemplate": "/params/path/{param}",
         "method": "PUT",
-        "headers": {
-          "Authorization": {
-            "matches": "Bearer .+"
-          }
-        },
         "pathParameters": {
           "param": {
             "equalTo": "param"
@@ -1183,11 +1008,6 @@
       "request": {
         "urlPathTemplate": "/params/path/{param}",
         "method": "GET",
-        "headers": {
-          "Authorization": {
-            "matches": "Bearer .+"
-          }
-        },
         "pathParameters": {
           "param": {
             "equalTo": "param"
@@ -1218,12 +1038,7 @@
       "name": "getAndReturnString - default",
       "request": {
         "urlPathTemplate": "/primitive/string",
-        "method": "POST",
-        "headers": {
-          "Authorization": {
-            "matches": "Bearer .+"
-          }
-        }
+        "method": "POST"
       },
       "response": {
         "status": 200,
@@ -1249,12 +1064,7 @@
       "name": "getAndReturnInt - default",
       "request": {
         "urlPathTemplate": "/primitive/integer",
-        "method": "POST",
-        "headers": {
-          "Authorization": {
-            "matches": "Bearer .+"
-          }
-        }
+        "method": "POST"
       },
       "response": {
         "status": 200,
@@ -1280,12 +1090,7 @@
       "name": "getAndReturnLong - default",
       "request": {
         "urlPathTemplate": "/primitive/long",
-        "method": "POST",
-        "headers": {
-          "Authorization": {
-            "matches": "Bearer .+"
-          }
-        }
+        "method": "POST"
       },
       "response": {
         "status": 200,
@@ -1311,12 +1116,7 @@
       "name": "getAndReturnDouble - default",
       "request": {
         "urlPathTemplate": "/primitive/double",
-        "method": "POST",
-        "headers": {
-          "Authorization": {
-            "matches": "Bearer .+"
-          }
-        }
+        "method": "POST"
       },
       "response": {
         "status": 200,
@@ -1342,12 +1142,7 @@
       "name": "getAndReturnBool - default",
       "request": {
         "urlPathTemplate": "/primitive/boolean",
-        "method": "POST",
-        "headers": {
-          "Authorization": {
-            "matches": "Bearer .+"
-          }
-        }
+        "method": "POST"
       },
       "response": {
         "status": 200,
@@ -1373,12 +1168,7 @@
       "name": "getAndReturnDatetime - default",
       "request": {
         "urlPathTemplate": "/primitive/datetime",
-        "method": "POST",
-        "headers": {
-          "Authorization": {
-            "matches": "Bearer .+"
-          }
-        }
+        "method": "POST"
       },
       "response": {
         "status": 200,
@@ -1404,12 +1194,7 @@
       "name": "getAndReturnDate - default",
       "request": {
         "urlPathTemplate": "/primitive/date",
-        "method": "POST",
-        "headers": {
-          "Authorization": {
-            "matches": "Bearer .+"
-          }
-        }
+        "method": "POST"
       },
       "response": {
         "status": 200,
@@ -1435,12 +1220,7 @@
       "name": "getAndReturnUUID - default",
       "request": {
         "urlPathTemplate": "/primitive/uuid",
-        "method": "POST",
-        "headers": {
-          "Authorization": {
-            "matches": "Bearer .+"
-          }
-        }
+        "method": "POST"
       },
       "response": {
         "status": 200,
@@ -1466,12 +1246,7 @@
       "name": "getAndReturnBase64 - default",
       "request": {
         "urlPathTemplate": "/primitive/base64",
-        "method": "POST",
-        "headers": {
-          "Authorization": {
-            "matches": "Bearer .+"
-          }
-        }
+        "method": "POST"
       },
       "response": {
         "status": 200,
@@ -1498,11 +1273,6 @@
       "request": {
         "urlPathTemplate": "/{id}",
         "method": "PUT",
-        "headers": {
-          "Authorization": {
-            "matches": "Bearer .+"
-          }
-        },
         "pathParameters": {
           "id": {
             "equalTo": "id"
@@ -1533,12 +1303,7 @@
       "name": "getAndReturnUnion - default",
       "request": {
         "urlPathTemplate": "/union",
-        "method": "POST",
-        "headers": {
-          "Authorization": {
-            "matches": "Bearer .+"
-          }
-        }
+        "method": "POST"
       },
       "response": {
         "status": 200,
@@ -1564,12 +1329,7 @@
       "name": "withMixedCase - default",
       "request": {
         "urlPathTemplate": "/urls/MixedCase",
-        "method": "GET",
-        "headers": {
-          "Authorization": {
-            "matches": "Bearer .+"
-          }
-        }
+        "method": "GET"
       },
       "response": {
         "status": 200,
@@ -1596,12 +1356,7 @@
       "name": "noEndingSlash - default",
       "request": {
         "urlPathTemplate": "/urls/no-ending-slash",
-        "method": "GET",
-        "headers": {
-          "Authorization": {
-            "matches": "Bearer .+"
-          }
-        }
+        "method": "GET"
       },
       "response": {
         "status": 200,
@@ -1628,12 +1383,7 @@
       "name": "withEndingSlash - default",
       "request": {
         "urlPathTemplate": "/urls/with-ending-slash/",
-        "method": "GET",
-        "headers": {
-          "Authorization": {
-            "matches": "Bearer .+"
-          }
-        }
+        "method": "GET"
       },
       "response": {
         "status": 200,
@@ -1660,12 +1410,7 @@
       "name": "withUnderscores - default",
       "request": {
         "urlPathTemplate": "/urls/with_underscores",
-        "method": "GET",
-        "headers": {
-          "Authorization": {
-            "matches": "Bearer .+"
-          }
-        }
+        "method": "GET"
       },
       "response": {
         "status": 200,
@@ -1744,12 +1489,7 @@
       "name": "getWithNoRequestBody - default",
       "request": {
         "urlPathTemplate": "/no-req-body",
-        "method": "GET",
-        "headers": {
-          "Authorization": {
-            "matches": "Bearer .+"
-          }
-        }
+        "method": "GET"
       },
       "response": {
         "status": 200,
@@ -1776,12 +1516,7 @@
       "name": "postWithNoRequestBody - default",
       "request": {
         "urlPathTemplate": "/no-req-body",
-        "method": "POST",
-        "headers": {
-          "Authorization": {
-            "matches": "Bearer .+"
-          }
-        }
+        "method": "POST"
       },
       "response": {
         "status": 200,
@@ -1807,12 +1542,7 @@
       "name": "getWithCustomHeader - default",
       "request": {
         "urlPathTemplate": "/test-headers/custom-header",
-        "method": "POST",
-        "headers": {
-          "Authorization": {
-            "matches": "Bearer .+"
-          }
-        }
+        "method": "POST"
       },
       "response": {
         "status": 200,

--- a/seed/go-sdk/go-deterministic-ordering/core/request_option.go
+++ b/seed/go-sdk/go-deterministic-ordering/core/request_option.go
@@ -17,14 +17,15 @@ type RequestOption interface {
 // This type is primarily used by the generated code and is not meant
 // to be used directly; use the option package instead.
 type RequestOptions struct {
-	BaseURL         string
-	HTTPClient      HTTPClient
-	HTTPHeader      http.Header
-	BodyProperties  map[string]interface{}
-	QueryParameters url.Values
-	MaxAttempts     uint
-	MaxBufSize      int
-	Token           string
+	BaseURL              string
+	HTTPClient           HTTPClient
+	HTTPHeader           http.Header
+	BodyProperties       map[string]interface{}
+	QueryParameters      url.Values
+	MaxAttempts          uint
+	MaxBufSize           int
+	MaxReconnectAttempts *int
+	Token                string
 }
 
 // NewRequestOptions returns a new *RequestOptions value.
@@ -123,6 +124,15 @@ type MaxBufSizeOption struct {
 
 func (m *MaxBufSizeOption) applyRequestOptions(opts *RequestOptions) {
 	opts.MaxBufSize = m.MaxBufSize
+}
+
+// MaxReconnectAttemptsOption implements the RequestOption interface.
+type MaxReconnectAttemptsOption struct {
+	MaxReconnectAttempts *int
+}
+
+func (m *MaxReconnectAttemptsOption) applyRequestOptions(opts *RequestOptions) {
+	opts.MaxReconnectAttempts = m.MaxReconnectAttempts
 }
 
 // TokenOption implements the RequestOption interface.

--- a/seed/go-sdk/go-deterministic-ordering/option/request_option.go
+++ b/seed/go-sdk/go-deterministic-ordering/option/request_option.go
@@ -72,6 +72,14 @@ func WithMaxStreamBufSize(size int) *core.MaxBufSizeOption {
 	}
 }
 
+// WithMaxReconnectAttempts configures the maximum number of reconnection
+// attempts for SSE streams. Default is 10. Set to 0 to disable auto-reconnection.
+func WithMaxReconnectAttempts(attempts int) *core.MaxReconnectAttemptsOption {
+	return &core.MaxReconnectAttemptsOption{
+		MaxReconnectAttempts: &attempts,
+	}
+}
+
 // WithToken sets the 'Authorization: Bearer <token>' request header.
 func WithToken(token string) *core.TokenOption {
 	return &core.TokenOption{

--- a/seed/go-sdk/go-deterministic-ordering/wiremock/wiremock-mappings.json
+++ b/seed/go-sdk/go-deterministic-ordering/wiremock/wiremock-mappings.json
@@ -5,12 +5,7 @@
       "name": "getAndReturnListOfPrimitives - default",
       "request": {
         "urlPathTemplate": "/container/list-of-primitives",
-        "method": "POST",
-        "headers": {
-          "Authorization": {
-            "matches": "Bearer .+"
-          }
-        }
+        "method": "POST"
       },
       "response": {
         "status": 200,
@@ -36,12 +31,7 @@
       "name": "getAndReturnListOfObjects - default",
       "request": {
         "urlPathTemplate": "/container/list-of-objects",
-        "method": "POST",
-        "headers": {
-          "Authorization": {
-            "matches": "Bearer .+"
-          }
-        }
+        "method": "POST"
       },
       "response": {
         "status": 200,
@@ -67,12 +57,7 @@
       "name": "getAndReturnSetOfPrimitives - default",
       "request": {
         "urlPathTemplate": "/container/set-of-primitives",
-        "method": "POST",
-        "headers": {
-          "Authorization": {
-            "matches": "Bearer .+"
-          }
-        }
+        "method": "POST"
       },
       "response": {
         "status": 200,
@@ -98,12 +83,7 @@
       "name": "getAndReturnSetOfObjects - default",
       "request": {
         "urlPathTemplate": "/container/set-of-objects",
-        "method": "POST",
-        "headers": {
-          "Authorization": {
-            "matches": "Bearer .+"
-          }
-        }
+        "method": "POST"
       },
       "response": {
         "status": 200,
@@ -129,12 +109,7 @@
       "name": "getAndReturnMapPrimToPrim - default",
       "request": {
         "urlPathTemplate": "/container/map-prim-to-prim",
-        "method": "POST",
-        "headers": {
-          "Authorization": {
-            "matches": "Bearer .+"
-          }
-        }
+        "method": "POST"
       },
       "response": {
         "status": 200,
@@ -160,12 +135,7 @@
       "name": "getAndReturnMapOfPrimToObject - default",
       "request": {
         "urlPathTemplate": "/container/map-prim-to-object",
-        "method": "POST",
-        "headers": {
-          "Authorization": {
-            "matches": "Bearer .+"
-          }
-        }
+        "method": "POST"
       },
       "response": {
         "status": 200,
@@ -191,12 +161,7 @@
       "name": "getAndReturnMapOfPrimToUndiscriminatedUnion - default",
       "request": {
         "urlPathTemplate": "/container/map-prim-to-union",
-        "method": "POST",
-        "headers": {
-          "Authorization": {
-            "matches": "Bearer .+"
-          }
-        }
+        "method": "POST"
       },
       "response": {
         "status": 200,
@@ -222,12 +187,7 @@
       "name": "getAndReturnOptional - default",
       "request": {
         "urlPathTemplate": "/container/opt-objects",
-        "method": "POST",
-        "headers": {
-          "Authorization": {
-            "matches": "Bearer .+"
-          }
-        }
+        "method": "POST"
       },
       "response": {
         "status": 200,
@@ -253,12 +213,7 @@
       "name": "postJsonPatchContentType - default",
       "request": {
         "urlPathTemplate": "/foo/bar",
-        "method": "POST",
-        "headers": {
-          "Authorization": {
-            "matches": "Bearer .+"
-          }
-        }
+        "method": "POST"
       },
       "response": {
         "status": 200,
@@ -284,12 +239,7 @@
       "name": "postJsonPatchContentWithCharsetType - default",
       "request": {
         "urlPathTemplate": "/foo/baz",
-        "method": "POST",
-        "headers": {
-          "Authorization": {
-            "matches": "Bearer .+"
-          }
-        }
+        "method": "POST"
       },
       "response": {
         "status": 200,
@@ -315,12 +265,7 @@
       "name": "create - default",
       "request": {
         "urlPathTemplate": "/duplicate-names-a",
-        "method": "POST",
-        "headers": {
-          "Authorization": {
-            "matches": "Bearer .+"
-          }
-        }
+        "method": "POST"
       },
       "response": {
         "status": 200,
@@ -347,11 +292,6 @@
       "request": {
         "urlPathTemplate": "/duplicate-names-a/{id}",
         "method": "GET",
-        "headers": {
-          "Authorization": {
-            "matches": "Bearer .+"
-          }
-        },
         "pathParameters": {
           "id": {
             "equalTo": "id"
@@ -388,11 +328,6 @@
       "request": {
         "urlPathTemplate": "/duplicate-names-a",
         "method": "GET",
-        "headers": {
-          "Authorization": {
-            "matches": "Bearer .+"
-          }
-        },
         "queryParameters": {
           "page": {
             "equalTo": "1"
@@ -427,12 +362,7 @@
       "name": "create - default",
       "request": {
         "urlPathTemplate": "/duplicate-names-b",
-        "method": "POST",
-        "headers": {
-          "Authorization": {
-            "matches": "Bearer .+"
-          }
-        }
+        "method": "POST"
       },
       "response": {
         "status": 200,
@@ -459,11 +389,6 @@
       "request": {
         "urlPathTemplate": "/duplicate-names-b/{id}",
         "method": "GET",
-        "headers": {
-          "Authorization": {
-            "matches": "Bearer .+"
-          }
-        },
         "pathParameters": {
           "id": {
             "equalTo": "id"
@@ -500,11 +425,6 @@
       "request": {
         "urlPathTemplate": "/duplicate-names-b",
         "method": "GET",
-        "headers": {
-          "Authorization": {
-            "matches": "Bearer .+"
-          }
-        },
         "queryParameters": {
           "cursor": {
             "equalTo": "cursor"
@@ -539,12 +459,7 @@
       "name": "create - default",
       "request": {
         "urlPathTemplate": "/duplicate-names-c",
-        "method": "POST",
-        "headers": {
-          "Authorization": {
-            "matches": "Bearer .+"
-          }
-        }
+        "method": "POST"
       },
       "response": {
         "status": 200,
@@ -571,11 +486,6 @@
       "request": {
         "urlPathTemplate": "/duplicate-names-c/{id}",
         "method": "GET",
-        "headers": {
-          "Authorization": {
-            "matches": "Bearer .+"
-          }
-        },
         "pathParameters": {
           "id": {
             "equalTo": "id"
@@ -612,11 +522,6 @@
       "request": {
         "urlPathTemplate": "/duplicate-names-c",
         "method": "GET",
-        "headers": {
-          "Authorization": {
-            "matches": "Bearer .+"
-          }
-        },
         "queryParameters": {
           "offset": {
             "equalTo": "1"
@@ -651,12 +556,7 @@
       "name": "getAndReturnEnum - default",
       "request": {
         "urlPathTemplate": "/enum",
-        "method": "POST",
-        "headers": {
-          "Authorization": {
-            "matches": "Bearer .+"
-          }
-        }
+        "method": "POST"
       },
       "response": {
         "status": 200,
@@ -683,11 +583,6 @@
       "request": {
         "urlPathTemplate": "/http-methods/{id}",
         "method": "GET",
-        "headers": {
-          "Authorization": {
-            "matches": "Bearer .+"
-          }
-        },
         "pathParameters": {
           "id": {
             "equalTo": "id"
@@ -718,12 +613,7 @@
       "name": "testPost - default",
       "request": {
         "urlPathTemplate": "/http-methods",
-        "method": "POST",
-        "headers": {
-          "Authorization": {
-            "matches": "Bearer .+"
-          }
-        }
+        "method": "POST"
       },
       "response": {
         "status": 200,
@@ -750,11 +640,6 @@
       "request": {
         "urlPathTemplate": "/http-methods/{id}",
         "method": "PUT",
-        "headers": {
-          "Authorization": {
-            "matches": "Bearer .+"
-          }
-        },
         "pathParameters": {
           "id": {
             "equalTo": "id"
@@ -786,11 +671,6 @@
       "request": {
         "urlPathTemplate": "/http-methods/{id}",
         "method": "PATCH",
-        "headers": {
-          "Authorization": {
-            "matches": "Bearer .+"
-          }
-        },
         "pathParameters": {
           "id": {
             "equalTo": "id"
@@ -822,11 +702,6 @@
       "request": {
         "urlPathTemplate": "/http-methods/{id}",
         "method": "DELETE",
-        "headers": {
-          "Authorization": {
-            "matches": "Bearer .+"
-          }
-        },
         "pathParameters": {
           "id": {
             "equalTo": "id"
@@ -857,12 +732,7 @@
       "name": "getAndReturnWithOptionalField - default",
       "request": {
         "urlPathTemplate": "/object/get-and-return-with-optional-field",
-        "method": "POST",
-        "headers": {
-          "Authorization": {
-            "matches": "Bearer .+"
-          }
-        }
+        "method": "POST"
       },
       "response": {
         "status": 200,
@@ -888,12 +758,7 @@
       "name": "getAndReturnWithRequiredField - default",
       "request": {
         "urlPathTemplate": "/object/get-and-return-with-required-field",
-        "method": "POST",
-        "headers": {
-          "Authorization": {
-            "matches": "Bearer .+"
-          }
-        }
+        "method": "POST"
       },
       "response": {
         "status": 200,
@@ -919,12 +784,7 @@
       "name": "getAndReturnWithMapOfMap - default",
       "request": {
         "urlPathTemplate": "/object/get-and-return-with-map-of-map",
-        "method": "POST",
-        "headers": {
-          "Authorization": {
-            "matches": "Bearer .+"
-          }
-        }
+        "method": "POST"
       },
       "response": {
         "status": 200,
@@ -950,12 +810,7 @@
       "name": "getAndReturnNestedWithOptionalField - default",
       "request": {
         "urlPathTemplate": "/object/get-and-return-nested-with-optional-field",
-        "method": "POST",
-        "headers": {
-          "Authorization": {
-            "matches": "Bearer .+"
-          }
-        }
+        "method": "POST"
       },
       "response": {
         "status": 200,
@@ -982,11 +837,6 @@
       "request": {
         "urlPathTemplate": "/object/get-and-return-nested-with-required-field/{string}",
         "method": "POST",
-        "headers": {
-          "Authorization": {
-            "matches": "Bearer .+"
-          }
-        },
         "pathParameters": {
           "string": {
             "equalTo": "string"
@@ -1017,12 +867,7 @@
       "name": "getAndReturnNestedWithRequiredFieldAsList - default",
       "request": {
         "urlPathTemplate": "/object/get-and-return-nested-with-required-field-list",
-        "method": "POST",
-        "headers": {
-          "Authorization": {
-            "matches": "Bearer .+"
-          }
-        }
+        "method": "POST"
       },
       "response": {
         "status": 200,
@@ -1048,12 +893,7 @@
       "name": "getAndReturnWithUnknownField - default",
       "request": {
         "urlPathTemplate": "/object/get-and-return-with-unknown-field",
-        "method": "POST",
-        "headers": {
-          "Authorization": {
-            "matches": "Bearer .+"
-          }
-        }
+        "method": "POST"
       },
       "response": {
         "status": 200,
@@ -1079,12 +919,7 @@
       "name": "getAndReturnWithDatetimeLikeString - default",
       "request": {
         "urlPathTemplate": "/object/get-and-return-with-datetime-like-string",
-        "method": "POST",
-        "headers": {
-          "Authorization": {
-            "matches": "Bearer .+"
-          }
-        }
+        "method": "POST"
       },
       "response": {
         "status": 200,
@@ -1111,11 +946,6 @@
       "request": {
         "urlPathTemplate": "/pagination",
         "method": "GET",
-        "headers": {
-          "Authorization": {
-            "matches": "Bearer .+"
-          }
-        },
         "queryParameters": {
           "cursor": {
             "equalTo": "cursor"
@@ -1151,11 +981,6 @@
       "request": {
         "urlPathTemplate": "/params/path/{param}",
         "method": "GET",
-        "headers": {
-          "Authorization": {
-            "matches": "Bearer .+"
-          }
-        },
         "pathParameters": {
           "param": {
             "equalTo": "param"
@@ -1187,11 +1012,6 @@
       "request": {
         "urlPathTemplate": "/params/path/{param}",
         "method": "GET",
-        "headers": {
-          "Authorization": {
-            "matches": "Bearer .+"
-          }
-        },
         "pathParameters": {
           "param": {
             "equalTo": "param"
@@ -1223,11 +1043,6 @@
       "request": {
         "urlPathTemplate": "/params",
         "method": "GET",
-        "headers": {
-          "Authorization": {
-            "matches": "Bearer .+"
-          }
-        },
         "queryParameters": {
           "query": {
             "equalTo": "query"
@@ -1263,11 +1078,6 @@
       "request": {
         "urlPathTemplate": "/params",
         "method": "GET",
-        "headers": {
-          "Authorization": {
-            "matches": "Bearer .+"
-          }
-        },
         "queryParameters": {
           "query": {
             "equalTo": "query"
@@ -1303,11 +1113,6 @@
       "request": {
         "urlPathTemplate": "/params/path-query/{param}",
         "method": "GET",
-        "headers": {
-          "Authorization": {
-            "matches": "Bearer .+"
-          }
-        },
         "pathParameters": {
           "param": {
             "equalTo": "param"
@@ -1344,11 +1149,6 @@
       "request": {
         "urlPathTemplate": "/params/path-query/{param}",
         "method": "GET",
-        "headers": {
-          "Authorization": {
-            "matches": "Bearer .+"
-          }
-        },
         "pathParameters": {
           "param": {
             "equalTo": "param"
@@ -1385,11 +1185,6 @@
       "request": {
         "urlPathTemplate": "/params/path/{param}",
         "method": "PUT",
-        "headers": {
-          "Authorization": {
-            "matches": "Bearer .+"
-          }
-        },
         "pathParameters": {
           "param": {
             "equalTo": "param"
@@ -1421,11 +1216,6 @@
       "request": {
         "urlPathTemplate": "/params/path/{param}",
         "method": "PUT",
-        "headers": {
-          "Authorization": {
-            "matches": "Bearer .+"
-          }
-        },
         "pathParameters": {
           "param": {
             "equalTo": "param"
@@ -1456,12 +1246,7 @@
       "name": "getAndReturnString - default",
       "request": {
         "urlPathTemplate": "/primitive/string",
-        "method": "POST",
-        "headers": {
-          "Authorization": {
-            "matches": "Bearer .+"
-          }
-        }
+        "method": "POST"
       },
       "response": {
         "status": 200,
@@ -1487,12 +1272,7 @@
       "name": "getAndReturnInt - default",
       "request": {
         "urlPathTemplate": "/primitive/integer",
-        "method": "POST",
-        "headers": {
-          "Authorization": {
-            "matches": "Bearer .+"
-          }
-        }
+        "method": "POST"
       },
       "response": {
         "status": 200,
@@ -1518,12 +1298,7 @@
       "name": "getAndReturnLong - default",
       "request": {
         "urlPathTemplate": "/primitive/long",
-        "method": "POST",
-        "headers": {
-          "Authorization": {
-            "matches": "Bearer .+"
-          }
-        }
+        "method": "POST"
       },
       "response": {
         "status": 200,
@@ -1549,12 +1324,7 @@
       "name": "getAndReturnDouble - default",
       "request": {
         "urlPathTemplate": "/primitive/double",
-        "method": "POST",
-        "headers": {
-          "Authorization": {
-            "matches": "Bearer .+"
-          }
-        }
+        "method": "POST"
       },
       "response": {
         "status": 200,
@@ -1580,12 +1350,7 @@
       "name": "getAndReturnBool - default",
       "request": {
         "urlPathTemplate": "/primitive/boolean",
-        "method": "POST",
-        "headers": {
-          "Authorization": {
-            "matches": "Bearer .+"
-          }
-        }
+        "method": "POST"
       },
       "response": {
         "status": 200,
@@ -1611,12 +1376,7 @@
       "name": "getAndReturnDatetime - default",
       "request": {
         "urlPathTemplate": "/primitive/datetime",
-        "method": "POST",
-        "headers": {
-          "Authorization": {
-            "matches": "Bearer .+"
-          }
-        }
+        "method": "POST"
       },
       "response": {
         "status": 200,
@@ -1642,12 +1402,7 @@
       "name": "getAndReturnDate - default",
       "request": {
         "urlPathTemplate": "/primitive/date",
-        "method": "POST",
-        "headers": {
-          "Authorization": {
-            "matches": "Bearer .+"
-          }
-        }
+        "method": "POST"
       },
       "response": {
         "status": 200,
@@ -1673,12 +1428,7 @@
       "name": "getAndReturnUUID - default",
       "request": {
         "urlPathTemplate": "/primitive/uuid",
-        "method": "POST",
-        "headers": {
-          "Authorization": {
-            "matches": "Bearer .+"
-          }
-        }
+        "method": "POST"
       },
       "response": {
         "status": 200,
@@ -1704,12 +1454,7 @@
       "name": "getAndReturnBase64 - default",
       "request": {
         "urlPathTemplate": "/primitive/base64",
-        "method": "POST",
-        "headers": {
-          "Authorization": {
-            "matches": "Bearer .+"
-          }
-        }
+        "method": "POST"
       },
       "response": {
         "status": 200,
@@ -1736,11 +1481,6 @@
       "request": {
         "urlPathTemplate": "/{id}",
         "method": "PUT",
-        "headers": {
-          "Authorization": {
-            "matches": "Bearer .+"
-          }
-        },
         "pathParameters": {
           "id": {
             "equalTo": "id"
@@ -1771,12 +1511,7 @@
       "name": "getAndReturnUnion - default",
       "request": {
         "urlPathTemplate": "/union",
-        "method": "POST",
-        "headers": {
-          "Authorization": {
-            "matches": "Bearer .+"
-          }
-        }
+        "method": "POST"
       },
       "response": {
         "status": 200,
@@ -1802,12 +1537,7 @@
       "name": "withMixedCase - default",
       "request": {
         "urlPathTemplate": "/urls/MixedCase",
-        "method": "GET",
-        "headers": {
-          "Authorization": {
-            "matches": "Bearer .+"
-          }
-        }
+        "method": "GET"
       },
       "response": {
         "status": 200,
@@ -1834,12 +1564,7 @@
       "name": "noEndingSlash - default",
       "request": {
         "urlPathTemplate": "/urls/no-ending-slash",
-        "method": "GET",
-        "headers": {
-          "Authorization": {
-            "matches": "Bearer .+"
-          }
-        }
+        "method": "GET"
       },
       "response": {
         "status": 200,
@@ -1866,12 +1591,7 @@
       "name": "withEndingSlash - default",
       "request": {
         "urlPathTemplate": "/urls/with-ending-slash/",
-        "method": "GET",
-        "headers": {
-          "Authorization": {
-            "matches": "Bearer .+"
-          }
-        }
+        "method": "GET"
       },
       "response": {
         "status": 200,
@@ -1898,12 +1618,7 @@
       "name": "withUnderscores - default",
       "request": {
         "urlPathTemplate": "/urls/with_underscores",
-        "method": "GET",
-        "headers": {
-          "Authorization": {
-            "matches": "Bearer .+"
-          }
-        }
+        "method": "GET"
       },
       "response": {
         "status": 200,
@@ -1982,12 +1697,7 @@
       "name": "getWithNoRequestBody - default",
       "request": {
         "urlPathTemplate": "/no-req-body",
-        "method": "GET",
-        "headers": {
-          "Authorization": {
-            "matches": "Bearer .+"
-          }
-        }
+        "method": "GET"
       },
       "response": {
         "status": 200,
@@ -2014,12 +1724,7 @@
       "name": "postWithNoRequestBody - default",
       "request": {
         "urlPathTemplate": "/no-req-body",
-        "method": "POST",
-        "headers": {
-          "Authorization": {
-            "matches": "Bearer .+"
-          }
-        }
+        "method": "POST"
       },
       "response": {
         "status": 200,
@@ -2045,12 +1750,7 @@
       "name": "getWithCustomHeader - default",
       "request": {
         "urlPathTemplate": "/test-headers/custom-header",
-        "method": "POST",
-        "headers": {
-          "Authorization": {
-            "matches": "Bearer .+"
-          }
-        }
+        "method": "POST"
       },
       "response": {
         "status": 200,


### PR DESCRIPTION
## Description
The fixtures `exhaustive/omit-empty-request-wrappers` and `go-deterministic-ordering` were failing on main because of a stale generation; this fixes that, plus adds an extra prophylactic change to `WireTestGenerator.ts` wherein actual auth options get generated when `endpoint.auth` is true.

## Testing
Tested that those two Go fixtures are indeed consistently failing on recent main runs (appears to have stemmed from here https://github.com/fern-api/fern/pull/14411, a PR that changed a shared util [packages/commons/mock-utils/index.ts](https://github.com/fern-api/fern/pull/14411/changes#diff-e750ff1687a2eb330dfb2f13b9a38fc7646c538e4ab100a8c8187896f60cb424) but didn't regenerate Go seed fixtures; and tested that this change fixes that.
- [X] Unit tests added/updated
- [X] Manual testing completed
