### PR TITLE
feat(csharp): expose metadata on paginated responses

### DIFF
--- a/generators/csharp/base/src/asIs/Page.Template.cs
+++ b/generators/csharp/base/src/asIs/Page.Template.cs
@@ -1,5 +1,6 @@
 using global::System.Collections;
 using global::System.Collections.ObjectModel;
+using global::System.Net;
 
 namespace <%= namespace%>;
 
@@ -20,9 +21,36 @@ public class Page<TItem> : IEnumerable<TItem>
     }
 
     /// <summary>
+    /// Creates a new <see cref="Page{TItem}"/> with the specified items and response metadata.
+    /// </summary>
+    public Page(IReadOnlyList<TItem> items, object? response, HttpStatusCode statusCode, ResponseHeaders? headers)
+    {
+        Items = items;
+        Response = response;
+        StatusCode = statusCode;
+        Headers = headers;
+    }
+
+    /// <summary>
     /// Gets the items in this <see cref="Page{TItem}"/>.
     /// </summary>
     public IReadOnlyList<TItem> Items { get; }
+
+    /// <summary>
+    /// The full API response object for this page. Cast to the endpoint's response
+    /// type to access fields beyond the paginated items (e.g., TotalCount, metadata).
+    /// </summary>
+    public object? Response { get; }
+
+    /// <summary>
+    /// The HTTP status code of the response that produced this page.
+    /// </summary>
+    public HttpStatusCode StatusCode { get; }
+
+    /// <summary>
+    /// The HTTP response headers from the response that produced this page.
+    /// </summary>
+    public ResponseHeaders? Headers { get; }
 
     /// <summary>
     /// Enumerate the items in this <see cref="Page{TItem}"/>.

--- a/generators/csharp/base/src/asIs/Pager.Template.cs
+++ b/generators/csharp/base/src/asIs/Pager.Template.cs
@@ -89,7 +89,7 @@ internal sealed class OffsetPager<TRequest, TRequestOptions, TResponse, TOffset,
     private readonly SendRequest _sendRequest;
     private readonly ParseApiCallDelegate _parseApiCall;
 
-    internal delegate global::System.Threading.Tasks.Task<TResponse> SendRequest(
+    internal delegate global::System.Threading.Tasks.Task<WithRawResponse<TResponse>> SendRequest(
         TRequest request,
         TRequestOptions? options,
         CancellationToken cancellationToken
@@ -109,7 +109,7 @@ internal sealed class OffsetPager<TRequest, TRequestOptions, TResponse, TOffset,
         TRequest? nextRequest,
         bool hasNextPage,
         Page<TItem> page
-    ) ParseApiCallDelegate(TRequest request, TResponse response);
+    ) ParseApiCallDelegate(TRequest request, WithRawResponse<TResponse> wrappedResponse);
 
     public Page<TItem> CurrentPage { get; private set; }
     public bool HasNextPage { get; private set; }
@@ -146,7 +146,7 @@ internal sealed class OffsetPager<TRequest, TRequestOptions, TResponse, TOffset,
     )
     {
         request ??= Activator.CreateInstance<TRequest>();
-        var response = await sendRequest(request, options, cancellationToken).ConfigureAwait(false);
+        var wrappedResponse = await sendRequest(request, options, cancellationToken).ConfigureAwait(false);
         var parseApiCall = CreateParseApiCallDelegate(
             getItems,
             getOffset,
@@ -154,7 +154,7 @@ internal sealed class OffsetPager<TRequest, TRequestOptions, TResponse, TOffset,
             getStep,
             getHasNextPage
         );
-        var (nextRequest, hasNextPage, page) = parseApiCall(request, response);
+        var (nextRequest, hasNextPage, page) = parseApiCall(request, wrappedResponse);
         return new OffsetPager<TRequest, TRequestOptions, TResponse, TOffset, TStep, TItem>(
             nextRequest,
             options,
@@ -173,10 +173,10 @@ internal sealed class OffsetPager<TRequest, TRequestOptions, TResponse, TOffset,
         GetHasNextPage? getHasNextPage
     )
     {
-        return (request, response) =>
+        return (request, wrappedResponse) =>
             ParseApiCall(
                 request,
-                response,
+                wrappedResponse,
                 getItems,
                 getOffset,
                 setOffset,
@@ -191,9 +191,9 @@ internal sealed class OffsetPager<TRequest, TRequestOptions, TResponse, TOffset,
         CancellationToken cancellationToken = default
     )
     {
-        var response = await _sendRequest(request, options, cancellationToken)
+        var wrappedResponse = await _sendRequest(request, options, cancellationToken)
             .ConfigureAwait(false);
-        var (nextRequest, hasNextPageFlag, page) = _parseApiCall(request, response);
+        var (nextRequest, hasNextPageFlag, page) = _parseApiCall(request, wrappedResponse);
         _request = nextRequest;
         HasNextPage = hasNextPageFlag;
         CurrentPage = page;
@@ -202,7 +202,7 @@ internal sealed class OffsetPager<TRequest, TRequestOptions, TResponse, TOffset,
 
     private static (TRequest? nextRequest, bool hasNextPage, Page<TItem> page) ParseApiCall(
         TRequest request,
-        TResponse response,
+        WithRawResponse<TResponse> wrappedResponse,
         GetItems getItems,
         GetOffset getOffset,
         SetOffset setOffset,
@@ -210,8 +210,11 @@ internal sealed class OffsetPager<TRequest, TRequestOptions, TResponse, TOffset,
         GetHasNextPage? getHasNextPage
     )
     {
+        var response = wrappedResponse.Data;
         var items = getItems(response);
-        var page = items is not null ? new Page<TItem>(items) : Page<TItem>.Empty;
+        var page = items is not null
+            ? new Page<TItem>(items, response, wrappedResponse.RawResponse.StatusCode, wrappedResponse.RawResponse.Headers)
+            : Page<TItem>.Empty;
         var offset = getOffset(request);
         var hasNextPage = getHasNextPage?.Invoke(response) ?? items?.Count > 0;
         if (!hasNextPage)
@@ -350,7 +353,7 @@ internal sealed class CursorPager<TRequest, TRequestOptions, TResponse, TCursor,
     /// <summary>
     /// Delegate for sending a request.
     /// </summary>
-    internal delegate global::System.Threading.Tasks.Task<TResponse> SendRequest(
+    internal delegate global::System.Threading.Tasks.Task<WithRawResponse<TResponse>> SendRequest(
         TRequest request,
         TRequestOptions? options,
         CancellationToken cancellationToken
@@ -375,7 +378,7 @@ internal sealed class CursorPager<TRequest, TRequestOptions, TResponse, TCursor,
         TRequest? nextRequest,
         bool hasNextPage,
         Page<TItem> page
-    ) ParseApiCallDelegate(TRequest request, TResponse response);
+    ) ParseApiCallDelegate(TRequest request, WithRawResponse<TResponse> wrappedResponse);
 
     /// <summary>
     /// The current <see cref="Page{TItem}"/>.
@@ -420,9 +423,9 @@ internal sealed class CursorPager<TRequest, TRequestOptions, TResponse, TCursor,
     )
     {
         request ??= Activator.CreateInstance<TRequest>();
-        var response = await sendRequest(request, options, cancellationToken).ConfigureAwait(false);
+        var wrappedResponse = await sendRequest(request, options, cancellationToken).ConfigureAwait(false);
         var parseApiCall = CreateParseApiCallDelegate(getItems, getNextCursor, setCursor);
-        var (nextRequest, hasNextPage, page) = parseApiCall(request, response);
+        var (nextRequest, hasNextPage, page) = parseApiCall(request, wrappedResponse);
         return new CursorPager<TRequest, TRequestOptions, TResponse, TCursor, TItem>(
             nextRequest,
             options,
@@ -439,13 +442,16 @@ internal sealed class CursorPager<TRequest, TRequestOptions, TResponse, TCursor,
         SetCursor setCursor
     )
     {
-        return (request, response) =>
+        return (request, wrappedResponse) =>
         {
+            var response = wrappedResponse.Data;
             var items = getItems(response);
-            var page = items is not null ? new Page<TItem>(items) : Page<TItem>.Empty;
+            var page = items is not null
+                ? new Page<TItem>(items, response, wrappedResponse.RawResponse.StatusCode, wrappedResponse.RawResponse.Headers)
+                : Page<TItem>.Empty;
             var cursor = getNextCursor(response);
             var hasNextPage = cursor switch
-            {   
+            {
                 null or "" => false,
                 _ => true
             };
@@ -465,9 +471,9 @@ internal sealed class CursorPager<TRequest, TRequestOptions, TResponse, TCursor,
         CancellationToken cancellationToken = default
     )
     {
-        var response = await _sendRequest(request, options, cancellationToken)
+        var wrappedResponse = await _sendRequest(request, options, cancellationToken)
             .ConfigureAwait(false);
-        var (nextRequest, hasNextPage, page) = _parseApiCall(request, response);
+        var (nextRequest, hasNextPage, page) = _parseApiCall(request, wrappedResponse);
         _request = nextRequest;
         HasNextPage = hasNextPage;
         CurrentPage = page;

--- a/generators/csharp/base/src/asIs/test/Pagination/GuidCursorTest.Template.cs
+++ b/generators/csharp/base/src/asIs/test/Pagination/GuidCursorTest.Template.cs
@@ -1,3 +1,4 @@
+using global::System.Net;
 using NUnit.Framework;
 using SystemTask = global::System.Threading.Tasks.Task;
 using <%= namespace%>.Core;
@@ -46,7 +47,7 @@ public class GuidCursorTest
             (_, _, _) =>
             {
                 responses.MoveNext();
-                return SystemTask.FromResult(responses.Current);
+                return SystemTask.FromResult(Wrap(responses.Current));
             },
             (request, cursor) =>
             {
@@ -101,4 +102,15 @@ public class GuidCursorTest
     {
         public required Guid? Next { get; set; }
     }
+
+    private static WithRawResponse<Response> Wrap(Response response) => new()
+    {
+        Data = response,
+        RawResponse = new RawResponse
+        {
+            StatusCode = HttpStatusCode.OK,
+            Url = new Uri("https://localhost"),
+            Headers = default,
+        },
+    };
 }

--- a/generators/csharp/base/src/asIs/test/Pagination/HasNextPageOffsetTest.Template.cs
+++ b/generators/csharp/base/src/asIs/test/Pagination/HasNextPageOffsetTest.Template.cs
@@ -1,3 +1,4 @@
+using global::System.Net;
 using NUnit.Framework;
 using SystemTask = global::System.Threading.Tasks.Task;
 using <%= namespace%>.Core;
@@ -41,7 +42,7 @@ public class HasNextPageOffsetTest
             (_, _, _) =>
             {
                 responses.MoveNext();
-                return SystemTask.FromResult(responses.Current);
+                return SystemTask.FromResult(Wrap(responses.Current));
             },
             request => request?.Pagination?.Page ?? 0,
             (request, offset) =>
@@ -89,4 +90,15 @@ public class HasNextPageOffsetTest
     {
         public IEnumerable<string>? Items { get; set; }
     }
+
+    private static WithRawResponse<Response> Wrap(Response response) => new()
+    {
+        Data = response,
+        RawResponse = new RawResponse
+        {
+            StatusCode = HttpStatusCode.OK,
+            Url = new Uri("https://localhost"),
+            Headers = default,
+        },
+    };
 }

--- a/generators/csharp/base/src/asIs/test/Pagination/IntOffsetTest.Template.cs
+++ b/generators/csharp/base/src/asIs/test/Pagination/IntOffsetTest.Template.cs
@@ -1,3 +1,4 @@
+using global::System.Net;
 using NUnit.Framework;
 using SystemTask = global::System.Threading.Tasks.Task;
 using <%= namespace%>.Core;
@@ -29,7 +30,7 @@ public class IntOffsetTest
             (_, _, _) =>
             {
                 responses.MoveNext();
-                return SystemTask.FromResult(responses.Current);
+                return SystemTask.FromResult(Wrap(responses.Current));
             },
             request => request?.Pagination?.Page ?? 0,
             (request, offset) =>
@@ -79,4 +80,15 @@ public class IntOffsetTest
     {
         public IEnumerable<string>? Items { get; set; }
     }
+
+    private static WithRawResponse<Response> Wrap(Response response) => new()
+    {
+        Data = response,
+        RawResponse = new RawResponse
+        {
+            StatusCode = HttpStatusCode.OK,
+            Url = new Uri("https://localhost"),
+            Headers = default,
+        },
+    };
 }

--- a/generators/csharp/base/src/asIs/test/Pagination/LongOffsetTest.Template.cs
+++ b/generators/csharp/base/src/asIs/test/Pagination/LongOffsetTest.Template.cs
@@ -1,3 +1,4 @@
+using global::System.Net;
 using NUnit.Framework;
 using SystemTask = global::System.Threading.Tasks.Task;
 using <%= namespace%>.Core;
@@ -29,7 +30,7 @@ public class LongOffsetTest
             (_, _, _) =>
             {
                 responses.MoveNext();
-                return SystemTask.FromResult(responses.Current);
+                return SystemTask.FromResult(Wrap(responses.Current));
             },
             request => request?.Pagination?.Page ?? 0,
             (request, offset) =>
@@ -76,4 +77,15 @@ public class LongOffsetTest
     {
         public IEnumerable<string>? Items { get; set; }
     }
+
+    private static WithRawResponse<Response> Wrap(Response response) => new()
+    {
+        Data = response,
+        RawResponse = new RawResponse
+        {
+            StatusCode = HttpStatusCode.OK,
+            Url = new Uri("https://localhost"),
+            Headers = default,
+        },
+    };
 }

--- a/generators/csharp/base/src/asIs/test/Pagination/NoRequestCursorTest.Template.cs
+++ b/generators/csharp/base/src/asIs/test/Pagination/NoRequestCursorTest.Template.cs
@@ -1,3 +1,4 @@
+using global::System.Net;
 using NUnit.Framework;
 using SystemTask = global::System.Threading.Tasks.Task;
 using <%= namespace%>.Core;
@@ -45,7 +46,7 @@ public class NoRequestCursorTest
             (_, _, _) =>
             {
                 responses.MoveNext();
-                return SystemTask.FromResult(responses.Current);
+                return SystemTask.FromResult(Wrap(responses.Current));
             },
             (request, cursor) =>
             {
@@ -103,4 +104,15 @@ public class NoRequestCursorTest
     {
         public required string? Next { get; set; }
     }
+
+    private static WithRawResponse<Response> Wrap(Response response) => new()
+    {
+        Data = response,
+        RawResponse = new RawResponse
+        {
+            StatusCode = HttpStatusCode.OK,
+            Url = new Uri("https://localhost"),
+            Headers = default,
+        },
+    };
 }

--- a/generators/csharp/base/src/asIs/test/Pagination/NoRequestOffsetTest.Template.cs
+++ b/generators/csharp/base/src/asIs/test/Pagination/NoRequestOffsetTest.Template.cs
@@ -1,3 +1,4 @@
+using global::System.Net;
 using NUnit.Framework;
 using SystemTask = global::System.Threading.Tasks.Task;
 using <%= namespace%>.Core;
@@ -29,7 +30,7 @@ public class NoRequestOffsetTest
             (_, _, _) =>
             {
                 responses.MoveNext();
-                return SystemTask.FromResult(responses.Current);
+                return SystemTask.FromResult(Wrap(responses.Current));
             },
             request => request?.Pagination?.Page ?? 0,
             (request, offset) =>
@@ -79,4 +80,15 @@ public class NoRequestOffsetTest
     {
         public IEnumerable<string>? Items { get; set; }
     }
+
+    private static WithRawResponse<Response> Wrap(Response response) => new()
+    {
+        Data = response,
+        RawResponse = new RawResponse
+        {
+            StatusCode = HttpStatusCode.OK,
+            Url = new Uri("https://localhost"),
+            Headers = default,
+        },
+    };
 }

--- a/generators/csharp/base/src/asIs/test/Pagination/StepOffsetTest.Template.cs
+++ b/generators/csharp/base/src/asIs/test/Pagination/StepOffsetTest.Template.cs
@@ -1,3 +1,4 @@
+using global::System.Net;
 using NUnit.Framework;
 using SystemTask = global::System.Threading.Tasks.Task;
 using <%= namespace%>.Core;
@@ -30,7 +31,7 @@ public class StepPageOffsetPaginationTest
             (_, _, _) =>
             {
                 responses.MoveNext();
-                return SystemTask.FromResult(responses.Current);
+                return SystemTask.FromResult(Wrap(responses.Current));
             },
             request => request?.Pagination?.ItemOffset ?? 0,
             (request, offset) =>
@@ -89,4 +90,15 @@ public class StepPageOffsetPaginationTest
     {
         public IEnumerable<string>? Items { get; set; }
     }
+
+    private static WithRawResponse<Response> Wrap(Response response) => new()
+    {
+        Data = response,
+        RawResponse = new RawResponse
+        {
+            StatusCode = HttpStatusCode.OK,
+            Url = new Uri("https://localhost"),
+            Headers = default,
+        },
+    };
 }

--- a/generators/csharp/base/src/asIs/test/Pagination/StringCursorTest.Template.cs
+++ b/generators/csharp/base/src/asIs/test/Pagination/StringCursorTest.Template.cs
@@ -1,3 +1,4 @@
+using global::System.Net;
 using NUnit.Framework;
 using SystemTask = global::System.Threading.Tasks.Task;
 using <%= namespace%>.Core;
@@ -47,7 +48,7 @@ public class StringCursorTest
             (_, _, _) =>
             {
                 responses.MoveNext();
-                return SystemTask.FromResult(responses.Current);
+                return SystemTask.FromResult(Wrap(responses.Current));
             },
             (request, cursor) =>
             {
@@ -116,7 +117,7 @@ public class StringCursorTest
             (_, _, _) =>
             {
                 responses.MoveNext();
-                return SystemTask.FromResult(responses.Current);
+                return SystemTask.FromResult(Wrap(responses.Current));
             },
             (request, cursor) =>
             {
@@ -165,4 +166,15 @@ public class StringCursorTest
     {
         public required string? Next { get; set; }
     }
+
+    private static WithRawResponse<Response> Wrap(Response response) => new()
+    {
+        Data = response,
+        RawResponse = new RawResponse
+        {
+            StatusCode = HttpStatusCode.OK,
+            Url = new Uri("https://localhost"),
+            Headers = default,
+        },
+    };
 }

--- a/generators/csharp/sdk/src/endpoint/AbstractEndpointGenerator.ts
+++ b/generators/csharp/sdk/src/endpoint/AbstractEndpointGenerator.ts
@@ -139,6 +139,32 @@ export abstract class AbstractEndpointGenerator extends WithGeneration {
         }
     }
 
+    /**
+     * Gets the base response type (unwrapped from WithRawResponseTask) for an endpoint.
+     * This is the inner T in WithRawResponseTask<T> or WithRawResponse<T>.
+     */
+    protected getBaseResponseType(endpoint: HttpEndpoint): ast.Type | undefined {
+        if (endpoint.response?.body == null) {
+            if (endpoint.method === FernIr.HttpMethod.Head) {
+                return this.System.Net.Http.HttpResponseHeaders;
+            }
+            return undefined;
+        }
+
+        return endpoint.response.body._visit<ast.Type | undefined>({
+            streaming: () => undefined, // Streaming endpoints don't use WithRawResponseTask
+            streamParameter: () => undefined,
+            fileDownload: () => this.System.IO.Stream.asFullyQualified(),
+            json: (reference) =>
+                this.context.csharpTypeMapper.convert({
+                    reference: reference.responseBodyType
+                }),
+            text: () => this.generation.Primitive.string,
+            bytes: () => undefined,
+            _other: () => undefined
+        });
+    }
+
     protected getPaginationItemType(endpoint: HttpEndpoint): ast.Type {
         this.assertHasPagination(endpoint);
         const listItemType = this.context.csharpTypeMapper.convert({

--- a/generators/csharp/sdk/src/endpoint/http/HttpEndpointGenerator.ts
+++ b/generators/csharp/sdk/src/endpoint/http/HttpEndpointGenerator.ts
@@ -354,32 +354,6 @@ export class HttpEndpointGenerator extends AbstractEndpointGenerator {
         writer.writeTextStatement("));");
     }
 
-    /**
-     * Gets the base response type (unwrapped from WithRawResponseTask) for an endpoint.
-     * This is the inner T in WithRawResponseTask<T> or WithRawResponse<T>.
-     */
-    private getBaseResponseType(endpoint: HttpEndpoint): ast.Type | undefined {
-        if (endpoint.response?.body == null) {
-            if (endpoint.method === FernIr.HttpMethod.Head) {
-                return this.System.Net.Http.HttpResponseHeaders;
-            }
-            return undefined;
-        }
-
-        return endpoint.response.body._visit<ast.Type | undefined>({
-            streaming: () => undefined, // Streaming endpoints don't use WithRawResponseTask
-            streamParameter: () => undefined,
-            fileDownload: () => this.System.IO.Stream.asFullyQualified(),
-            json: (reference) =>
-                this.context.csharpTypeMapper.convert({
-                    reference: reference.responseBodyType
-                }),
-            text: () => this.generation.Primitive.string,
-            bytes: () => undefined,
-            _other: () => undefined
-        });
-    }
-
     private writeWithRawResponseSuccessAndErrorHandling(endpoint: HttpEndpoint, writer: Writer) {
         // Generate success and error handling that returns WithRawResponse<T>
         // This is used inside the local async function for WithRawResponseTask methods
@@ -1335,20 +1309,19 @@ export class HttpEndpointGenerator extends AbstractEndpointGenerator {
             endpoint,
             requestParameter
         });
-        // For pagination, the pager expects a function that returns Task<T> (the unwrapped response type).
-        // Our unpaged methods return WithRawResponseTask<T>, which has an implicit conversion to Task<T>,
-        // but older .NET frameworks don't handle this well with delegate type inference.
-        // So we wrap the call in a lambda that uses the implicit conversion operator explicitly.
+        // The pager expects a function that returns Task<WithRawResponse<T>> so it can access
+        // both the deserialized response and HTTP metadata (status code, headers).
+        // We call .WithRawResponse() on the WithRawResponseTask<T> to get the full wrapper.
         return this.csharp.codeblock((writer) => {
             writer.write("async (request, options, cancellationToken) => ");
             if (pathParameters.length === 0) {
                 writer.write(
-                    `await ${this.getUnpagedEndpointMethodName(endpoint)}(request, options, cancellationToken)`
+                    `await ${this.getUnpagedEndpointMethodName(endpoint)}(request, options, cancellationToken).WithRawResponse()`
                 );
             } else {
+                writer.write("await ");
                 writer.writeNode(
                     this.csharp.invokeMethod({
-                        async: true,
                         method: this.getUnpagedEndpointMethodName(endpoint),
                         arguments_: [
                             ...pathParameters.map((parameter) => this.csharp.codeblock(parameter.name)),
@@ -1358,6 +1331,7 @@ export class HttpEndpointGenerator extends AbstractEndpointGenerator {
                         ]
                     })
                 );
+                writer.write(".WithRawResponse()");
             }
         });
     }

--- a/generators/csharp/sdk/versions.yml
+++ b/generators/csharp/sdk/versions.yml
@@ -1,4 +1,14 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 2.59.0
+  changelogEntry:
+    - summary: |
+        Expose HTTP response metadata on paginated endpoints. `Page<TItem>` now includes
+        `StatusCode`, `Headers`, and `Response` properties, giving users access to HTTP
+        status codes, response headers, and the full API response object for each page.
+      type: feat
+  createdAt: "2026-04-08"
+  irVersion: 66
+
 - version: 2.58.1
   changelogEntry:
     - summary: |

--- a/seed/csharp-sdk/exhaustive/explicit-namespaces/src/SeedExhaustive.Test/Core/Pagination/GuidCursorTest.cs
+++ b/seed/csharp-sdk/exhaustive/explicit-namespaces/src/SeedExhaustive.Test/Core/Pagination/GuidCursorTest.cs
@@ -1,3 +1,4 @@
+using global::System.Net;
 using NUnit.Framework;
 using SeedExhaustive.Core;
 using SystemTask = global::System.Threading.Tasks.Task;
@@ -45,7 +46,7 @@ public class GuidCursorTest
             (_, _, _) =>
             {
                 responses.MoveNext();
-                return SystemTask.FromResult(responses.Current);
+                return SystemTask.FromResult(Wrap(responses.Current));
             },
             (request, cursor) =>
             {
@@ -100,4 +101,16 @@ public class GuidCursorTest
     {
         public required Guid? Next { get; set; }
     }
+
+    private static WithRawResponse<Response> Wrap(Response response) =>
+        new()
+        {
+            Data = response,
+            RawResponse = new RawResponse
+            {
+                StatusCode = HttpStatusCode.OK,
+                Url = new Uri("https://localhost"),
+                Headers = default,
+            },
+        };
 }

--- a/seed/csharp-sdk/exhaustive/explicit-namespaces/src/SeedExhaustive.Test/Core/Pagination/HasNextPageOffsetTest.cs
+++ b/seed/csharp-sdk/exhaustive/explicit-namespaces/src/SeedExhaustive.Test/Core/Pagination/HasNextPageOffsetTest.cs
@@ -1,3 +1,4 @@
+using global::System.Net;
 using NUnit.Framework;
 using SeedExhaustive.Core;
 using SystemTask = global::System.Threading.Tasks.Task;
@@ -41,7 +42,7 @@ public class HasNextPageOffsetTest
             (_, _, _) =>
             {
                 responses.MoveNext();
-                return SystemTask.FromResult(responses.Current);
+                return SystemTask.FromResult(Wrap(responses.Current));
             },
             request => request?.Pagination?.Page ?? 0,
             (request, offset) =>
@@ -89,4 +90,16 @@ public class HasNextPageOffsetTest
     {
         public IEnumerable<string>? Items { get; set; }
     }
+
+    private static WithRawResponse<Response> Wrap(Response response) =>
+        new()
+        {
+            Data = response,
+            RawResponse = new RawResponse
+            {
+                StatusCode = HttpStatusCode.OK,
+                Url = new Uri("https://localhost"),
+                Headers = default,
+            },
+        };
 }

--- a/seed/csharp-sdk/exhaustive/explicit-namespaces/src/SeedExhaustive.Test/Core/Pagination/IntOffsetTest.cs
+++ b/seed/csharp-sdk/exhaustive/explicit-namespaces/src/SeedExhaustive.Test/Core/Pagination/IntOffsetTest.cs
@@ -1,3 +1,4 @@
+using global::System.Net;
 using NUnit.Framework;
 using SeedExhaustive.Core;
 using SystemTask = global::System.Threading.Tasks.Task;
@@ -29,7 +30,7 @@ public class IntOffsetTest
             (_, _, _) =>
             {
                 responses.MoveNext();
-                return SystemTask.FromResult(responses.Current);
+                return SystemTask.FromResult(Wrap(responses.Current));
             },
             request => request?.Pagination?.Page ?? 0,
             (request, offset) =>
@@ -79,4 +80,16 @@ public class IntOffsetTest
     {
         public IEnumerable<string>? Items { get; set; }
     }
+
+    private static WithRawResponse<Response> Wrap(Response response) =>
+        new()
+        {
+            Data = response,
+            RawResponse = new RawResponse
+            {
+                StatusCode = HttpStatusCode.OK,
+                Url = new Uri("https://localhost"),
+                Headers = default,
+            },
+        };
 }

--- a/seed/csharp-sdk/exhaustive/explicit-namespaces/src/SeedExhaustive.Test/Core/Pagination/LongOffsetTest.cs
+++ b/seed/csharp-sdk/exhaustive/explicit-namespaces/src/SeedExhaustive.Test/Core/Pagination/LongOffsetTest.cs
@@ -1,3 +1,4 @@
+using global::System.Net;
 using NUnit.Framework;
 using SeedExhaustive.Core;
 using SystemTask = global::System.Threading.Tasks.Task;
@@ -29,7 +30,7 @@ public class LongOffsetTest
             (_, _, _) =>
             {
                 responses.MoveNext();
-                return SystemTask.FromResult(responses.Current);
+                return SystemTask.FromResult(Wrap(responses.Current));
             },
             request => request?.Pagination?.Page ?? 0,
             (request, offset) =>
@@ -76,4 +77,16 @@ public class LongOffsetTest
     {
         public IEnumerable<string>? Items { get; set; }
     }
+
+    private static WithRawResponse<Response> Wrap(Response response) =>
+        new()
+        {
+            Data = response,
+            RawResponse = new RawResponse
+            {
+                StatusCode = HttpStatusCode.OK,
+                Url = new Uri("https://localhost"),
+                Headers = default,
+            },
+        };
 }

--- a/seed/csharp-sdk/exhaustive/explicit-namespaces/src/SeedExhaustive.Test/Core/Pagination/NoRequestCursorTest.cs
+++ b/seed/csharp-sdk/exhaustive/explicit-namespaces/src/SeedExhaustive.Test/Core/Pagination/NoRequestCursorTest.cs
@@ -1,3 +1,4 @@
+using global::System.Net;
 using NUnit.Framework;
 using SeedExhaustive.Core;
 using SystemTask = global::System.Threading.Tasks.Task;
@@ -45,7 +46,7 @@ public class NoRequestCursorTest
             (_, _, _) =>
             {
                 responses.MoveNext();
-                return SystemTask.FromResult(responses.Current);
+                return SystemTask.FromResult(Wrap(responses.Current));
             },
             (request, cursor) =>
             {
@@ -103,4 +104,16 @@ public class NoRequestCursorTest
     {
         public required string? Next { get; set; }
     }
+
+    private static WithRawResponse<Response> Wrap(Response response) =>
+        new()
+        {
+            Data = response,
+            RawResponse = new RawResponse
+            {
+                StatusCode = HttpStatusCode.OK,
+                Url = new Uri("https://localhost"),
+                Headers = default,
+            },
+        };
 }

--- a/seed/csharp-sdk/exhaustive/explicit-namespaces/src/SeedExhaustive.Test/Core/Pagination/NoRequestOffsetTest.cs
+++ b/seed/csharp-sdk/exhaustive/explicit-namespaces/src/SeedExhaustive.Test/Core/Pagination/NoRequestOffsetTest.cs
@@ -1,3 +1,4 @@
+using global::System.Net;
 using NUnit.Framework;
 using SeedExhaustive.Core;
 using SystemTask = global::System.Threading.Tasks.Task;
@@ -29,7 +30,7 @@ public class NoRequestOffsetTest
             (_, _, _) =>
             {
                 responses.MoveNext();
-                return SystemTask.FromResult(responses.Current);
+                return SystemTask.FromResult(Wrap(responses.Current));
             },
             request => request?.Pagination?.Page ?? 0,
             (request, offset) =>
@@ -79,4 +80,16 @@ public class NoRequestOffsetTest
     {
         public IEnumerable<string>? Items { get; set; }
     }
+
+    private static WithRawResponse<Response> Wrap(Response response) =>
+        new()
+        {
+            Data = response,
+            RawResponse = new RawResponse
+            {
+                StatusCode = HttpStatusCode.OK,
+                Url = new Uri("https://localhost"),
+                Headers = default,
+            },
+        };
 }

--- a/seed/csharp-sdk/exhaustive/explicit-namespaces/src/SeedExhaustive.Test/Core/Pagination/StepOffsetTest.cs
+++ b/seed/csharp-sdk/exhaustive/explicit-namespaces/src/SeedExhaustive.Test/Core/Pagination/StepOffsetTest.cs
@@ -1,3 +1,4 @@
+using global::System.Net;
 using NUnit.Framework;
 using SeedExhaustive.Core;
 using SystemTask = global::System.Threading.Tasks.Task;
@@ -30,7 +31,7 @@ public class StepPageOffsetPaginationTest
             (_, _, _) =>
             {
                 responses.MoveNext();
-                return SystemTask.FromResult(responses.Current);
+                return SystemTask.FromResult(Wrap(responses.Current));
             },
             request => request?.Pagination?.ItemOffset ?? 0,
             (request, offset) =>
@@ -89,4 +90,16 @@ public class StepPageOffsetPaginationTest
     {
         public IEnumerable<string>? Items { get; set; }
     }
+
+    private static WithRawResponse<Response> Wrap(Response response) =>
+        new()
+        {
+            Data = response,
+            RawResponse = new RawResponse
+            {
+                StatusCode = HttpStatusCode.OK,
+                Url = new Uri("https://localhost"),
+                Headers = default,
+            },
+        };
 }

--- a/seed/csharp-sdk/exhaustive/explicit-namespaces/src/SeedExhaustive.Test/Core/Pagination/StringCursorTest.cs
+++ b/seed/csharp-sdk/exhaustive/explicit-namespaces/src/SeedExhaustive.Test/Core/Pagination/StringCursorTest.cs
@@ -1,3 +1,4 @@
+using global::System.Net;
 using NUnit.Framework;
 using SeedExhaustive.Core;
 using SystemTask = global::System.Threading.Tasks.Task;
@@ -46,7 +47,7 @@ public class StringCursorTest
             (_, _, _) =>
             {
                 responses.MoveNext();
-                return SystemTask.FromResult(responses.Current);
+                return SystemTask.FromResult(Wrap(responses.Current));
             },
             (request, cursor) =>
             {
@@ -115,7 +116,7 @@ public class StringCursorTest
             (_, _, _) =>
             {
                 responses.MoveNext();
-                return SystemTask.FromResult(responses.Current);
+                return SystemTask.FromResult(Wrap(responses.Current));
             },
             (request, cursor) =>
             {
@@ -164,4 +165,16 @@ public class StringCursorTest
     {
         public required string? Next { get; set; }
     }
+
+    private static WithRawResponse<Response> Wrap(Response response) =>
+        new()
+        {
+            Data = response,
+            RawResponse = new RawResponse
+            {
+                StatusCode = HttpStatusCode.OK,
+                Url = new Uri("https://localhost"),
+                Headers = default,
+            },
+        };
 }

--- a/seed/csharp-sdk/exhaustive/explicit-namespaces/src/SeedExhaustive/Core/Page.cs
+++ b/seed/csharp-sdk/exhaustive/explicit-namespaces/src/SeedExhaustive/Core/Page.cs
@@ -1,5 +1,6 @@
 using global::System.Collections;
 using global::System.Collections.ObjectModel;
+using global::System.Net;
 
 namespace SeedExhaustive.Core;
 
@@ -20,9 +21,41 @@ public class Page<TItem> : IEnumerable<TItem>
     }
 
     /// <summary>
+    /// Creates a new <see cref="Page{TItem}"/> with the specified items and response metadata.
+    /// </summary>
+    public Page(
+        IReadOnlyList<TItem> items,
+        object? response,
+        HttpStatusCode statusCode,
+        ResponseHeaders? headers
+    )
+    {
+        Items = items;
+        Response = response;
+        StatusCode = statusCode;
+        Headers = headers;
+    }
+
+    /// <summary>
     /// Gets the items in this <see cref="Page{TItem}"/>.
     /// </summary>
     public IReadOnlyList<TItem> Items { get; }
+
+    /// <summary>
+    /// The full API response object for this page. Cast to the endpoint's response
+    /// type to access fields beyond the paginated items (e.g., TotalCount, metadata).
+    /// </summary>
+    public object? Response { get; }
+
+    /// <summary>
+    /// The HTTP status code of the response that produced this page.
+    /// </summary>
+    public HttpStatusCode StatusCode { get; }
+
+    /// <summary>
+    /// The HTTP response headers from the response that produced this page.
+    /// </summary>
+    public ResponseHeaders? Headers { get; }
 
     /// <summary>
     /// Enumerate the items in this <see cref="Page{TItem}"/>.

--- a/seed/csharp-sdk/exhaustive/explicit-namespaces/src/SeedExhaustive/Core/Pager.cs
+++ b/seed/csharp-sdk/exhaustive/explicit-namespaces/src/SeedExhaustive/Core/Pager.cs
@@ -95,7 +95,7 @@ internal sealed class OffsetPager<TRequest, TRequestOptions, TResponse, TOffset,
     private readonly SendRequest _sendRequest;
     private readonly ParseApiCallDelegate _parseApiCall;
 
-    internal delegate global::System.Threading.Tasks.Task<TResponse> SendRequest(
+    internal delegate global::System.Threading.Tasks.Task<WithRawResponse<TResponse>> SendRequest(
         TRequest request,
         TRequestOptions? options,
         CancellationToken cancellationToken
@@ -115,7 +115,7 @@ internal sealed class OffsetPager<TRequest, TRequestOptions, TResponse, TOffset,
         TRequest? nextRequest,
         bool hasNextPage,
         Page<TItem> page
-    ) ParseApiCallDelegate(TRequest request, TResponse response);
+    ) ParseApiCallDelegate(TRequest request, WithRawResponse<TResponse> wrappedResponse);
 
     public Page<TItem> CurrentPage { get; private set; }
     public bool HasNextPage { get; private set; }
@@ -152,7 +152,8 @@ internal sealed class OffsetPager<TRequest, TRequestOptions, TResponse, TOffset,
     )
     {
         request ??= Activator.CreateInstance<TRequest>();
-        var response = await sendRequest(request, options, cancellationToken).ConfigureAwait(false);
+        var wrappedResponse = await sendRequest(request, options, cancellationToken)
+            .ConfigureAwait(false);
         var parseApiCall = CreateParseApiCallDelegate(
             getItems,
             getOffset,
@@ -160,7 +161,7 @@ internal sealed class OffsetPager<TRequest, TRequestOptions, TResponse, TOffset,
             getStep,
             getHasNextPage
         );
-        var (nextRequest, hasNextPage, page) = parseApiCall(request, response);
+        var (nextRequest, hasNextPage, page) = parseApiCall(request, wrappedResponse);
         return new OffsetPager<TRequest, TRequestOptions, TResponse, TOffset, TStep, TItem>(
             nextRequest,
             options,
@@ -179,10 +180,10 @@ internal sealed class OffsetPager<TRequest, TRequestOptions, TResponse, TOffset,
         GetHasNextPage? getHasNextPage
     )
     {
-        return (request, response) =>
+        return (request, wrappedResponse) =>
             ParseApiCall(
                 request,
-                response,
+                wrappedResponse,
                 getItems,
                 getOffset,
                 setOffset,
@@ -197,9 +198,9 @@ internal sealed class OffsetPager<TRequest, TRequestOptions, TResponse, TOffset,
         CancellationToken cancellationToken = default
     )
     {
-        var response = await _sendRequest(request, options, cancellationToken)
+        var wrappedResponse = await _sendRequest(request, options, cancellationToken)
             .ConfigureAwait(false);
-        var (nextRequest, hasNextPageFlag, page) = _parseApiCall(request, response);
+        var (nextRequest, hasNextPageFlag, page) = _parseApiCall(request, wrappedResponse);
         _request = nextRequest;
         HasNextPage = hasNextPageFlag;
         CurrentPage = page;
@@ -208,7 +209,7 @@ internal sealed class OffsetPager<TRequest, TRequestOptions, TResponse, TOffset,
 
     private static (TRequest? nextRequest, bool hasNextPage, Page<TItem> page) ParseApiCall(
         TRequest request,
-        TResponse response,
+        WithRawResponse<TResponse> wrappedResponse,
         GetItems getItems,
         GetOffset getOffset,
         SetOffset setOffset,
@@ -216,8 +217,16 @@ internal sealed class OffsetPager<TRequest, TRequestOptions, TResponse, TOffset,
         GetHasNextPage? getHasNextPage
     )
     {
+        var response = wrappedResponse.Data;
         var items = getItems(response);
-        var page = items is not null ? new Page<TItem>(items) : Page<TItem>.Empty;
+        var page = items is not null
+            ? new Page<TItem>(
+                items,
+                response,
+                wrappedResponse.RawResponse.StatusCode,
+                wrappedResponse.RawResponse.Headers
+            )
+            : Page<TItem>.Empty;
         var offset = getOffset(request);
         var hasNextPage = getHasNextPage?.Invoke(response) ?? items?.Count > 0;
         if (!hasNextPage)
@@ -360,7 +369,7 @@ internal sealed class CursorPager<TRequest, TRequestOptions, TResponse, TCursor,
     /// <summary>
     /// Delegate for sending a request.
     /// </summary>
-    internal delegate global::System.Threading.Tasks.Task<TResponse> SendRequest(
+    internal delegate global::System.Threading.Tasks.Task<WithRawResponse<TResponse>> SendRequest(
         TRequest request,
         TRequestOptions? options,
         CancellationToken cancellationToken
@@ -385,7 +394,7 @@ internal sealed class CursorPager<TRequest, TRequestOptions, TResponse, TCursor,
         TRequest? nextRequest,
         bool hasNextPage,
         Page<TItem> page
-    ) ParseApiCallDelegate(TRequest request, TResponse response);
+    ) ParseApiCallDelegate(TRequest request, WithRawResponse<TResponse> wrappedResponse);
 
     /// <summary>
     /// The current <see cref="Page{TItem}"/>.
@@ -430,9 +439,10 @@ internal sealed class CursorPager<TRequest, TRequestOptions, TResponse, TCursor,
     )
     {
         request ??= Activator.CreateInstance<TRequest>();
-        var response = await sendRequest(request, options, cancellationToken).ConfigureAwait(false);
+        var wrappedResponse = await sendRequest(request, options, cancellationToken)
+            .ConfigureAwait(false);
         var parseApiCall = CreateParseApiCallDelegate(getItems, getNextCursor, setCursor);
-        var (nextRequest, hasNextPage, page) = parseApiCall(request, response);
+        var (nextRequest, hasNextPage, page) = parseApiCall(request, wrappedResponse);
         return new CursorPager<TRequest, TRequestOptions, TResponse, TCursor, TItem>(
             nextRequest,
             options,
@@ -449,10 +459,18 @@ internal sealed class CursorPager<TRequest, TRequestOptions, TResponse, TCursor,
         SetCursor setCursor
     )
     {
-        return (request, response) =>
+        return (request, wrappedResponse) =>
         {
+            var response = wrappedResponse.Data;
             var items = getItems(response);
-            var page = items is not null ? new Page<TItem>(items) : Page<TItem>.Empty;
+            var page = items is not null
+                ? new Page<TItem>(
+                    items,
+                    response,
+                    wrappedResponse.RawResponse.StatusCode,
+                    wrappedResponse.RawResponse.Headers
+                )
+                : Page<TItem>.Empty;
             var cursor = getNextCursor(response);
             var hasNextPage = cursor switch
             {
@@ -475,9 +493,9 @@ internal sealed class CursorPager<TRequest, TRequestOptions, TResponse, TCursor,
         CancellationToken cancellationToken = default
     )
     {
-        var response = await _sendRequest(request, options, cancellationToken)
+        var wrappedResponse = await _sendRequest(request, options, cancellationToken)
             .ConfigureAwait(false);
-        var (nextRequest, hasNextPage, page) = _parseApiCall(request, response);
+        var (nextRequest, hasNextPage, page) = _parseApiCall(request, wrappedResponse);
         _request = nextRequest;
         HasNextPage = hasNextPage;
         CurrentPage = page;

--- a/seed/csharp-sdk/exhaustive/explicit-namespaces/src/SeedExhaustive/Endpoints/Pagination/PaginationClient.cs
+++ b/seed/csharp-sdk/exhaustive/explicit-namespaces/src/SeedExhaustive/Endpoints/Pagination/PaginationClient.cs
@@ -128,7 +128,8 @@ public partial class PaginationClient : IPaginationClient
                 request,
                 options,
                 async (request, options, cancellationToken) =>
-                    await ListItemsInternalAsync(request, options, cancellationToken),
+                    await ListItemsInternalAsync(request, options, cancellationToken)
+                        .WithRawResponse(),
                 (request, cursor) =>
                 {
                     request.Cursor = cursor;

--- a/seed/csharp-sdk/exhaustive/include-exception-handler/src/SeedExhaustive.Test/Core/Pagination/GuidCursorTest.cs
+++ b/seed/csharp-sdk/exhaustive/include-exception-handler/src/SeedExhaustive.Test/Core/Pagination/GuidCursorTest.cs
@@ -1,3 +1,4 @@
+using global::System.Net;
 using NUnit.Framework;
 using SeedExhaustive.Core;
 using SystemTask = global::System.Threading.Tasks.Task;
@@ -45,7 +46,7 @@ public class GuidCursorTest
             (_, _, _) =>
             {
                 responses.MoveNext();
-                return SystemTask.FromResult(responses.Current);
+                return SystemTask.FromResult(Wrap(responses.Current));
             },
             (request, cursor) =>
             {
@@ -100,4 +101,16 @@ public class GuidCursorTest
     {
         public required Guid? Next { get; set; }
     }
+
+    private static WithRawResponse<Response> Wrap(Response response) =>
+        new()
+        {
+            Data = response,
+            RawResponse = new RawResponse
+            {
+                StatusCode = HttpStatusCode.OK,
+                Url = new Uri("https://localhost"),
+                Headers = default,
+            },
+        };
 }

--- a/seed/csharp-sdk/exhaustive/include-exception-handler/src/SeedExhaustive.Test/Core/Pagination/HasNextPageOffsetTest.cs
+++ b/seed/csharp-sdk/exhaustive/include-exception-handler/src/SeedExhaustive.Test/Core/Pagination/HasNextPageOffsetTest.cs
@@ -1,3 +1,4 @@
+using global::System.Net;
 using NUnit.Framework;
 using SeedExhaustive.Core;
 using SystemTask = global::System.Threading.Tasks.Task;
@@ -41,7 +42,7 @@ public class HasNextPageOffsetTest
             (_, _, _) =>
             {
                 responses.MoveNext();
-                return SystemTask.FromResult(responses.Current);
+                return SystemTask.FromResult(Wrap(responses.Current));
             },
             request => request?.Pagination?.Page ?? 0,
             (request, offset) =>
@@ -89,4 +90,16 @@ public class HasNextPageOffsetTest
     {
         public IEnumerable<string>? Items { get; set; }
     }
+
+    private static WithRawResponse<Response> Wrap(Response response) =>
+        new()
+        {
+            Data = response,
+            RawResponse = new RawResponse
+            {
+                StatusCode = HttpStatusCode.OK,
+                Url = new Uri("https://localhost"),
+                Headers = default,
+            },
+        };
 }

--- a/seed/csharp-sdk/exhaustive/include-exception-handler/src/SeedExhaustive.Test/Core/Pagination/IntOffsetTest.cs
+++ b/seed/csharp-sdk/exhaustive/include-exception-handler/src/SeedExhaustive.Test/Core/Pagination/IntOffsetTest.cs
@@ -1,3 +1,4 @@
+using global::System.Net;
 using NUnit.Framework;
 using SeedExhaustive.Core;
 using SystemTask = global::System.Threading.Tasks.Task;
@@ -29,7 +30,7 @@ public class IntOffsetTest
             (_, _, _) =>
             {
                 responses.MoveNext();
-                return SystemTask.FromResult(responses.Current);
+                return SystemTask.FromResult(Wrap(responses.Current));
             },
             request => request?.Pagination?.Page ?? 0,
             (request, offset) =>
@@ -79,4 +80,16 @@ public class IntOffsetTest
     {
         public IEnumerable<string>? Items { get; set; }
     }
+
+    private static WithRawResponse<Response> Wrap(Response response) =>
+        new()
+        {
+            Data = response,
+            RawResponse = new RawResponse
+            {
+                StatusCode = HttpStatusCode.OK,
+                Url = new Uri("https://localhost"),
+                Headers = default,
+            },
+        };
 }

--- a/seed/csharp-sdk/exhaustive/include-exception-handler/src/SeedExhaustive.Test/Core/Pagination/LongOffsetTest.cs
+++ b/seed/csharp-sdk/exhaustive/include-exception-handler/src/SeedExhaustive.Test/Core/Pagination/LongOffsetTest.cs
@@ -1,3 +1,4 @@
+using global::System.Net;
 using NUnit.Framework;
 using SeedExhaustive.Core;
 using SystemTask = global::System.Threading.Tasks.Task;
@@ -29,7 +30,7 @@ public class LongOffsetTest
             (_, _, _) =>
             {
                 responses.MoveNext();
-                return SystemTask.FromResult(responses.Current);
+                return SystemTask.FromResult(Wrap(responses.Current));
             },
             request => request?.Pagination?.Page ?? 0,
             (request, offset) =>
@@ -76,4 +77,16 @@ public class LongOffsetTest
     {
         public IEnumerable<string>? Items { get; set; }
     }
+
+    private static WithRawResponse<Response> Wrap(Response response) =>
+        new()
+        {
+            Data = response,
+            RawResponse = new RawResponse
+            {
+                StatusCode = HttpStatusCode.OK,
+                Url = new Uri("https://localhost"),
+                Headers = default,
+            },
+        };
 }

--- a/seed/csharp-sdk/exhaustive/include-exception-handler/src/SeedExhaustive.Test/Core/Pagination/NoRequestCursorTest.cs
+++ b/seed/csharp-sdk/exhaustive/include-exception-handler/src/SeedExhaustive.Test/Core/Pagination/NoRequestCursorTest.cs
@@ -1,3 +1,4 @@
+using global::System.Net;
 using NUnit.Framework;
 using SeedExhaustive.Core;
 using SystemTask = global::System.Threading.Tasks.Task;
@@ -45,7 +46,7 @@ public class NoRequestCursorTest
             (_, _, _) =>
             {
                 responses.MoveNext();
-                return SystemTask.FromResult(responses.Current);
+                return SystemTask.FromResult(Wrap(responses.Current));
             },
             (request, cursor) =>
             {
@@ -103,4 +104,16 @@ public class NoRequestCursorTest
     {
         public required string? Next { get; set; }
     }
+
+    private static WithRawResponse<Response> Wrap(Response response) =>
+        new()
+        {
+            Data = response,
+            RawResponse = new RawResponse
+            {
+                StatusCode = HttpStatusCode.OK,
+                Url = new Uri("https://localhost"),
+                Headers = default,
+            },
+        };
 }

--- a/seed/csharp-sdk/exhaustive/include-exception-handler/src/SeedExhaustive.Test/Core/Pagination/NoRequestOffsetTest.cs
+++ b/seed/csharp-sdk/exhaustive/include-exception-handler/src/SeedExhaustive.Test/Core/Pagination/NoRequestOffsetTest.cs
@@ -1,3 +1,4 @@
+using global::System.Net;
 using NUnit.Framework;
 using SeedExhaustive.Core;
 using SystemTask = global::System.Threading.Tasks.Task;
@@ -29,7 +30,7 @@ public class NoRequestOffsetTest
             (_, _, _) =>
             {
                 responses.MoveNext();
-                return SystemTask.FromResult(responses.Current);
+                return SystemTask.FromResult(Wrap(responses.Current));
             },
             request => request?.Pagination?.Page ?? 0,
             (request, offset) =>
@@ -79,4 +80,16 @@ public class NoRequestOffsetTest
     {
         public IEnumerable<string>? Items { get; set; }
     }
+
+    private static WithRawResponse<Response> Wrap(Response response) =>
+        new()
+        {
+            Data = response,
+            RawResponse = new RawResponse
+            {
+                StatusCode = HttpStatusCode.OK,
+                Url = new Uri("https://localhost"),
+                Headers = default,
+            },
+        };
 }

--- a/seed/csharp-sdk/exhaustive/include-exception-handler/src/SeedExhaustive.Test/Core/Pagination/StepOffsetTest.cs
+++ b/seed/csharp-sdk/exhaustive/include-exception-handler/src/SeedExhaustive.Test/Core/Pagination/StepOffsetTest.cs
@@ -1,3 +1,4 @@
+using global::System.Net;
 using NUnit.Framework;
 using SeedExhaustive.Core;
 using SystemTask = global::System.Threading.Tasks.Task;
@@ -30,7 +31,7 @@ public class StepPageOffsetPaginationTest
             (_, _, _) =>
             {
                 responses.MoveNext();
-                return SystemTask.FromResult(responses.Current);
+                return SystemTask.FromResult(Wrap(responses.Current));
             },
             request => request?.Pagination?.ItemOffset ?? 0,
             (request, offset) =>
@@ -89,4 +90,16 @@ public class StepPageOffsetPaginationTest
     {
         public IEnumerable<string>? Items { get; set; }
     }
+
+    private static WithRawResponse<Response> Wrap(Response response) =>
+        new()
+        {
+            Data = response,
+            RawResponse = new RawResponse
+            {
+                StatusCode = HttpStatusCode.OK,
+                Url = new Uri("https://localhost"),
+                Headers = default,
+            },
+        };
 }

--- a/seed/csharp-sdk/exhaustive/include-exception-handler/src/SeedExhaustive.Test/Core/Pagination/StringCursorTest.cs
+++ b/seed/csharp-sdk/exhaustive/include-exception-handler/src/SeedExhaustive.Test/Core/Pagination/StringCursorTest.cs
@@ -1,3 +1,4 @@
+using global::System.Net;
 using NUnit.Framework;
 using SeedExhaustive.Core;
 using SystemTask = global::System.Threading.Tasks.Task;
@@ -46,7 +47,7 @@ public class StringCursorTest
             (_, _, _) =>
             {
                 responses.MoveNext();
-                return SystemTask.FromResult(responses.Current);
+                return SystemTask.FromResult(Wrap(responses.Current));
             },
             (request, cursor) =>
             {
@@ -115,7 +116,7 @@ public class StringCursorTest
             (_, _, _) =>
             {
                 responses.MoveNext();
-                return SystemTask.FromResult(responses.Current);
+                return SystemTask.FromResult(Wrap(responses.Current));
             },
             (request, cursor) =>
             {
@@ -164,4 +165,16 @@ public class StringCursorTest
     {
         public required string? Next { get; set; }
     }
+
+    private static WithRawResponse<Response> Wrap(Response response) =>
+        new()
+        {
+            Data = response,
+            RawResponse = new RawResponse
+            {
+                StatusCode = HttpStatusCode.OK,
+                Url = new Uri("https://localhost"),
+                Headers = default,
+            },
+        };
 }

--- a/seed/csharp-sdk/exhaustive/include-exception-handler/src/SeedExhaustive/Core/Page.cs
+++ b/seed/csharp-sdk/exhaustive/include-exception-handler/src/SeedExhaustive/Core/Page.cs
@@ -1,5 +1,6 @@
 using global::System.Collections;
 using global::System.Collections.ObjectModel;
+using global::System.Net;
 
 namespace SeedExhaustive.Core;
 
@@ -20,9 +21,41 @@ public class Page<TItem> : IEnumerable<TItem>
     }
 
     /// <summary>
+    /// Creates a new <see cref="Page{TItem}"/> with the specified items and response metadata.
+    /// </summary>
+    public Page(
+        IReadOnlyList<TItem> items,
+        object? response,
+        HttpStatusCode statusCode,
+        ResponseHeaders? headers
+    )
+    {
+        Items = items;
+        Response = response;
+        StatusCode = statusCode;
+        Headers = headers;
+    }
+
+    /// <summary>
     /// Gets the items in this <see cref="Page{TItem}"/>.
     /// </summary>
     public IReadOnlyList<TItem> Items { get; }
+
+    /// <summary>
+    /// The full API response object for this page. Cast to the endpoint's response
+    /// type to access fields beyond the paginated items (e.g., TotalCount, metadata).
+    /// </summary>
+    public object? Response { get; }
+
+    /// <summary>
+    /// The HTTP status code of the response that produced this page.
+    /// </summary>
+    public HttpStatusCode StatusCode { get; }
+
+    /// <summary>
+    /// The HTTP response headers from the response that produced this page.
+    /// </summary>
+    public ResponseHeaders? Headers { get; }
 
     /// <summary>
     /// Enumerate the items in this <see cref="Page{TItem}"/>.

--- a/seed/csharp-sdk/exhaustive/include-exception-handler/src/SeedExhaustive/Core/Pager.cs
+++ b/seed/csharp-sdk/exhaustive/include-exception-handler/src/SeedExhaustive/Core/Pager.cs
@@ -95,7 +95,7 @@ internal sealed class OffsetPager<TRequest, TRequestOptions, TResponse, TOffset,
     private readonly SendRequest _sendRequest;
     private readonly ParseApiCallDelegate _parseApiCall;
 
-    internal delegate global::System.Threading.Tasks.Task<TResponse> SendRequest(
+    internal delegate global::System.Threading.Tasks.Task<WithRawResponse<TResponse>> SendRequest(
         TRequest request,
         TRequestOptions? options,
         CancellationToken cancellationToken
@@ -115,7 +115,7 @@ internal sealed class OffsetPager<TRequest, TRequestOptions, TResponse, TOffset,
         TRequest? nextRequest,
         bool hasNextPage,
         Page<TItem> page
-    ) ParseApiCallDelegate(TRequest request, TResponse response);
+    ) ParseApiCallDelegate(TRequest request, WithRawResponse<TResponse> wrappedResponse);
 
     public Page<TItem> CurrentPage { get; private set; }
     public bool HasNextPage { get; private set; }
@@ -152,7 +152,8 @@ internal sealed class OffsetPager<TRequest, TRequestOptions, TResponse, TOffset,
     )
     {
         request ??= Activator.CreateInstance<TRequest>();
-        var response = await sendRequest(request, options, cancellationToken).ConfigureAwait(false);
+        var wrappedResponse = await sendRequest(request, options, cancellationToken)
+            .ConfigureAwait(false);
         var parseApiCall = CreateParseApiCallDelegate(
             getItems,
             getOffset,
@@ -160,7 +161,7 @@ internal sealed class OffsetPager<TRequest, TRequestOptions, TResponse, TOffset,
             getStep,
             getHasNextPage
         );
-        var (nextRequest, hasNextPage, page) = parseApiCall(request, response);
+        var (nextRequest, hasNextPage, page) = parseApiCall(request, wrappedResponse);
         return new OffsetPager<TRequest, TRequestOptions, TResponse, TOffset, TStep, TItem>(
             nextRequest,
             options,
@@ -179,10 +180,10 @@ internal sealed class OffsetPager<TRequest, TRequestOptions, TResponse, TOffset,
         GetHasNextPage? getHasNextPage
     )
     {
-        return (request, response) =>
+        return (request, wrappedResponse) =>
             ParseApiCall(
                 request,
-                response,
+                wrappedResponse,
                 getItems,
                 getOffset,
                 setOffset,
@@ -197,9 +198,9 @@ internal sealed class OffsetPager<TRequest, TRequestOptions, TResponse, TOffset,
         CancellationToken cancellationToken = default
     )
     {
-        var response = await _sendRequest(request, options, cancellationToken)
+        var wrappedResponse = await _sendRequest(request, options, cancellationToken)
             .ConfigureAwait(false);
-        var (nextRequest, hasNextPageFlag, page) = _parseApiCall(request, response);
+        var (nextRequest, hasNextPageFlag, page) = _parseApiCall(request, wrappedResponse);
         _request = nextRequest;
         HasNextPage = hasNextPageFlag;
         CurrentPage = page;
@@ -208,7 +209,7 @@ internal sealed class OffsetPager<TRequest, TRequestOptions, TResponse, TOffset,
 
     private static (TRequest? nextRequest, bool hasNextPage, Page<TItem> page) ParseApiCall(
         TRequest request,
-        TResponse response,
+        WithRawResponse<TResponse> wrappedResponse,
         GetItems getItems,
         GetOffset getOffset,
         SetOffset setOffset,
@@ -216,8 +217,16 @@ internal sealed class OffsetPager<TRequest, TRequestOptions, TResponse, TOffset,
         GetHasNextPage? getHasNextPage
     )
     {
+        var response = wrappedResponse.Data;
         var items = getItems(response);
-        var page = items is not null ? new Page<TItem>(items) : Page<TItem>.Empty;
+        var page = items is not null
+            ? new Page<TItem>(
+                items,
+                response,
+                wrappedResponse.RawResponse.StatusCode,
+                wrappedResponse.RawResponse.Headers
+            )
+            : Page<TItem>.Empty;
         var offset = getOffset(request);
         var hasNextPage = getHasNextPage?.Invoke(response) ?? items?.Count > 0;
         if (!hasNextPage)
@@ -360,7 +369,7 @@ internal sealed class CursorPager<TRequest, TRequestOptions, TResponse, TCursor,
     /// <summary>
     /// Delegate for sending a request.
     /// </summary>
-    internal delegate global::System.Threading.Tasks.Task<TResponse> SendRequest(
+    internal delegate global::System.Threading.Tasks.Task<WithRawResponse<TResponse>> SendRequest(
         TRequest request,
         TRequestOptions? options,
         CancellationToken cancellationToken
@@ -385,7 +394,7 @@ internal sealed class CursorPager<TRequest, TRequestOptions, TResponse, TCursor,
         TRequest? nextRequest,
         bool hasNextPage,
         Page<TItem> page
-    ) ParseApiCallDelegate(TRequest request, TResponse response);
+    ) ParseApiCallDelegate(TRequest request, WithRawResponse<TResponse> wrappedResponse);
 
     /// <summary>
     /// The current <see cref="Page{TItem}"/>.
@@ -430,9 +439,10 @@ internal sealed class CursorPager<TRequest, TRequestOptions, TResponse, TCursor,
     )
     {
         request ??= Activator.CreateInstance<TRequest>();
-        var response = await sendRequest(request, options, cancellationToken).ConfigureAwait(false);
+        var wrappedResponse = await sendRequest(request, options, cancellationToken)
+            .ConfigureAwait(false);
         var parseApiCall = CreateParseApiCallDelegate(getItems, getNextCursor, setCursor);
-        var (nextRequest, hasNextPage, page) = parseApiCall(request, response);
+        var (nextRequest, hasNextPage, page) = parseApiCall(request, wrappedResponse);
         return new CursorPager<TRequest, TRequestOptions, TResponse, TCursor, TItem>(
             nextRequest,
             options,
@@ -449,10 +459,18 @@ internal sealed class CursorPager<TRequest, TRequestOptions, TResponse, TCursor,
         SetCursor setCursor
     )
     {
-        return (request, response) =>
+        return (request, wrappedResponse) =>
         {
+            var response = wrappedResponse.Data;
             var items = getItems(response);
-            var page = items is not null ? new Page<TItem>(items) : Page<TItem>.Empty;
+            var page = items is not null
+                ? new Page<TItem>(
+                    items,
+                    response,
+                    wrappedResponse.RawResponse.StatusCode,
+                    wrappedResponse.RawResponse.Headers
+                )
+                : Page<TItem>.Empty;
             var cursor = getNextCursor(response);
             var hasNextPage = cursor switch
             {
@@ -475,9 +493,9 @@ internal sealed class CursorPager<TRequest, TRequestOptions, TResponse, TCursor,
         CancellationToken cancellationToken = default
     )
     {
-        var response = await _sendRequest(request, options, cancellationToken)
+        var wrappedResponse = await _sendRequest(request, options, cancellationToken)
             .ConfigureAwait(false);
-        var (nextRequest, hasNextPage, page) = _parseApiCall(request, response);
+        var (nextRequest, hasNextPage, page) = _parseApiCall(request, wrappedResponse);
         _request = nextRequest;
         HasNextPage = hasNextPage;
         CurrentPage = page;

--- a/seed/csharp-sdk/exhaustive/include-exception-handler/src/SeedExhaustive/Endpoints/Pagination/PaginationClient.cs
+++ b/seed/csharp-sdk/exhaustive/include-exception-handler/src/SeedExhaustive/Endpoints/Pagination/PaginationClient.cs
@@ -146,7 +146,8 @@ public partial class PaginationClient : IPaginationClient
                         request,
                         options,
                         async (request, options, cancellationToken) =>
-                            await ListItemsInternalAsync(request, options, cancellationToken),
+                            await ListItemsInternalAsync(request, options, cancellationToken)
+                                .WithRawResponse(),
                         (request, cursor) =>
                         {
                             request.Cursor = cursor;

--- a/seed/csharp-sdk/exhaustive/no-generate-error-types/src/SeedExhaustive.Test/Core/Pagination/GuidCursorTest.cs
+++ b/seed/csharp-sdk/exhaustive/no-generate-error-types/src/SeedExhaustive.Test/Core/Pagination/GuidCursorTest.cs
@@ -1,3 +1,4 @@
+using global::System.Net;
 using NUnit.Framework;
 using SeedExhaustive.Core;
 using SystemTask = global::System.Threading.Tasks.Task;
@@ -45,7 +46,7 @@ public class GuidCursorTest
             (_, _, _) =>
             {
                 responses.MoveNext();
-                return SystemTask.FromResult(responses.Current);
+                return SystemTask.FromResult(Wrap(responses.Current));
             },
             (request, cursor) =>
             {
@@ -100,4 +101,16 @@ public class GuidCursorTest
     {
         public required Guid? Next { get; set; }
     }
+
+    private static WithRawResponse<Response> Wrap(Response response) =>
+        new()
+        {
+            Data = response,
+            RawResponse = new RawResponse
+            {
+                StatusCode = HttpStatusCode.OK,
+                Url = new Uri("https://localhost"),
+                Headers = default,
+            },
+        };
 }

--- a/seed/csharp-sdk/exhaustive/no-generate-error-types/src/SeedExhaustive.Test/Core/Pagination/HasNextPageOffsetTest.cs
+++ b/seed/csharp-sdk/exhaustive/no-generate-error-types/src/SeedExhaustive.Test/Core/Pagination/HasNextPageOffsetTest.cs
@@ -1,3 +1,4 @@
+using global::System.Net;
 using NUnit.Framework;
 using SeedExhaustive.Core;
 using SystemTask = global::System.Threading.Tasks.Task;
@@ -41,7 +42,7 @@ public class HasNextPageOffsetTest
             (_, _, _) =>
             {
                 responses.MoveNext();
-                return SystemTask.FromResult(responses.Current);
+                return SystemTask.FromResult(Wrap(responses.Current));
             },
             request => request?.Pagination?.Page ?? 0,
             (request, offset) =>
@@ -89,4 +90,16 @@ public class HasNextPageOffsetTest
     {
         public IEnumerable<string>? Items { get; set; }
     }
+
+    private static WithRawResponse<Response> Wrap(Response response) =>
+        new()
+        {
+            Data = response,
+            RawResponse = new RawResponse
+            {
+                StatusCode = HttpStatusCode.OK,
+                Url = new Uri("https://localhost"),
+                Headers = default,
+            },
+        };
 }

--- a/seed/csharp-sdk/exhaustive/no-generate-error-types/src/SeedExhaustive.Test/Core/Pagination/IntOffsetTest.cs
+++ b/seed/csharp-sdk/exhaustive/no-generate-error-types/src/SeedExhaustive.Test/Core/Pagination/IntOffsetTest.cs
@@ -1,3 +1,4 @@
+using global::System.Net;
 using NUnit.Framework;
 using SeedExhaustive.Core;
 using SystemTask = global::System.Threading.Tasks.Task;
@@ -29,7 +30,7 @@ public class IntOffsetTest
             (_, _, _) =>
             {
                 responses.MoveNext();
-                return SystemTask.FromResult(responses.Current);
+                return SystemTask.FromResult(Wrap(responses.Current));
             },
             request => request?.Pagination?.Page ?? 0,
             (request, offset) =>
@@ -79,4 +80,16 @@ public class IntOffsetTest
     {
         public IEnumerable<string>? Items { get; set; }
     }
+
+    private static WithRawResponse<Response> Wrap(Response response) =>
+        new()
+        {
+            Data = response,
+            RawResponse = new RawResponse
+            {
+                StatusCode = HttpStatusCode.OK,
+                Url = new Uri("https://localhost"),
+                Headers = default,
+            },
+        };
 }

--- a/seed/csharp-sdk/exhaustive/no-generate-error-types/src/SeedExhaustive.Test/Core/Pagination/LongOffsetTest.cs
+++ b/seed/csharp-sdk/exhaustive/no-generate-error-types/src/SeedExhaustive.Test/Core/Pagination/LongOffsetTest.cs
@@ -1,3 +1,4 @@
+using global::System.Net;
 using NUnit.Framework;
 using SeedExhaustive.Core;
 using SystemTask = global::System.Threading.Tasks.Task;
@@ -29,7 +30,7 @@ public class LongOffsetTest
             (_, _, _) =>
             {
                 responses.MoveNext();
-                return SystemTask.FromResult(responses.Current);
+                return SystemTask.FromResult(Wrap(responses.Current));
             },
             request => request?.Pagination?.Page ?? 0,
             (request, offset) =>
@@ -76,4 +77,16 @@ public class LongOffsetTest
     {
         public IEnumerable<string>? Items { get; set; }
     }
+
+    private static WithRawResponse<Response> Wrap(Response response) =>
+        new()
+        {
+            Data = response,
+            RawResponse = new RawResponse
+            {
+                StatusCode = HttpStatusCode.OK,
+                Url = new Uri("https://localhost"),
+                Headers = default,
+            },
+        };
 }

--- a/seed/csharp-sdk/exhaustive/no-generate-error-types/src/SeedExhaustive.Test/Core/Pagination/NoRequestCursorTest.cs
+++ b/seed/csharp-sdk/exhaustive/no-generate-error-types/src/SeedExhaustive.Test/Core/Pagination/NoRequestCursorTest.cs
@@ -1,3 +1,4 @@
+using global::System.Net;
 using NUnit.Framework;
 using SeedExhaustive.Core;
 using SystemTask = global::System.Threading.Tasks.Task;
@@ -45,7 +46,7 @@ public class NoRequestCursorTest
             (_, _, _) =>
             {
                 responses.MoveNext();
-                return SystemTask.FromResult(responses.Current);
+                return SystemTask.FromResult(Wrap(responses.Current));
             },
             (request, cursor) =>
             {
@@ -103,4 +104,16 @@ public class NoRequestCursorTest
     {
         public required string? Next { get; set; }
     }
+
+    private static WithRawResponse<Response> Wrap(Response response) =>
+        new()
+        {
+            Data = response,
+            RawResponse = new RawResponse
+            {
+                StatusCode = HttpStatusCode.OK,
+                Url = new Uri("https://localhost"),
+                Headers = default,
+            },
+        };
 }

--- a/seed/csharp-sdk/exhaustive/no-generate-error-types/src/SeedExhaustive.Test/Core/Pagination/NoRequestOffsetTest.cs
+++ b/seed/csharp-sdk/exhaustive/no-generate-error-types/src/SeedExhaustive.Test/Core/Pagination/NoRequestOffsetTest.cs
@@ -1,3 +1,4 @@
+using global::System.Net;
 using NUnit.Framework;
 using SeedExhaustive.Core;
 using SystemTask = global::System.Threading.Tasks.Task;
@@ -29,7 +30,7 @@ public class NoRequestOffsetTest
             (_, _, _) =>
             {
                 responses.MoveNext();
-                return SystemTask.FromResult(responses.Current);
+                return SystemTask.FromResult(Wrap(responses.Current));
             },
             request => request?.Pagination?.Page ?? 0,
             (request, offset) =>
@@ -79,4 +80,16 @@ public class NoRequestOffsetTest
     {
         public IEnumerable<string>? Items { get; set; }
     }
+
+    private static WithRawResponse<Response> Wrap(Response response) =>
+        new()
+        {
+            Data = response,
+            RawResponse = new RawResponse
+            {
+                StatusCode = HttpStatusCode.OK,
+                Url = new Uri("https://localhost"),
+                Headers = default,
+            },
+        };
 }

--- a/seed/csharp-sdk/exhaustive/no-generate-error-types/src/SeedExhaustive.Test/Core/Pagination/StepOffsetTest.cs
+++ b/seed/csharp-sdk/exhaustive/no-generate-error-types/src/SeedExhaustive.Test/Core/Pagination/StepOffsetTest.cs
@@ -1,3 +1,4 @@
+using global::System.Net;
 using NUnit.Framework;
 using SeedExhaustive.Core;
 using SystemTask = global::System.Threading.Tasks.Task;
@@ -30,7 +31,7 @@ public class StepPageOffsetPaginationTest
             (_, _, _) =>
             {
                 responses.MoveNext();
-                return SystemTask.FromResult(responses.Current);
+                return SystemTask.FromResult(Wrap(responses.Current));
             },
             request => request?.Pagination?.ItemOffset ?? 0,
             (request, offset) =>
@@ -89,4 +90,16 @@ public class StepPageOffsetPaginationTest
     {
         public IEnumerable<string>? Items { get; set; }
     }
+
+    private static WithRawResponse<Response> Wrap(Response response) =>
+        new()
+        {
+            Data = response,
+            RawResponse = new RawResponse
+            {
+                StatusCode = HttpStatusCode.OK,
+                Url = new Uri("https://localhost"),
+                Headers = default,
+            },
+        };
 }

--- a/seed/csharp-sdk/exhaustive/no-generate-error-types/src/SeedExhaustive.Test/Core/Pagination/StringCursorTest.cs
+++ b/seed/csharp-sdk/exhaustive/no-generate-error-types/src/SeedExhaustive.Test/Core/Pagination/StringCursorTest.cs
@@ -1,3 +1,4 @@
+using global::System.Net;
 using NUnit.Framework;
 using SeedExhaustive.Core;
 using SystemTask = global::System.Threading.Tasks.Task;
@@ -46,7 +47,7 @@ public class StringCursorTest
             (_, _, _) =>
             {
                 responses.MoveNext();
-                return SystemTask.FromResult(responses.Current);
+                return SystemTask.FromResult(Wrap(responses.Current));
             },
             (request, cursor) =>
             {
@@ -115,7 +116,7 @@ public class StringCursorTest
             (_, _, _) =>
             {
                 responses.MoveNext();
-                return SystemTask.FromResult(responses.Current);
+                return SystemTask.FromResult(Wrap(responses.Current));
             },
             (request, cursor) =>
             {
@@ -164,4 +165,16 @@ public class StringCursorTest
     {
         public required string? Next { get; set; }
     }
+
+    private static WithRawResponse<Response> Wrap(Response response) =>
+        new()
+        {
+            Data = response,
+            RawResponse = new RawResponse
+            {
+                StatusCode = HttpStatusCode.OK,
+                Url = new Uri("https://localhost"),
+                Headers = default,
+            },
+        };
 }

--- a/seed/csharp-sdk/exhaustive/no-generate-error-types/src/SeedExhaustive/Core/Page.cs
+++ b/seed/csharp-sdk/exhaustive/no-generate-error-types/src/SeedExhaustive/Core/Page.cs
@@ -1,5 +1,6 @@
 using global::System.Collections;
 using global::System.Collections.ObjectModel;
+using global::System.Net;
 
 namespace SeedExhaustive.Core;
 
@@ -20,9 +21,41 @@ public class Page<TItem> : IEnumerable<TItem>
     }
 
     /// <summary>
+    /// Creates a new <see cref="Page{TItem}"/> with the specified items and response metadata.
+    /// </summary>
+    public Page(
+        IReadOnlyList<TItem> items,
+        object? response,
+        HttpStatusCode statusCode,
+        ResponseHeaders? headers
+    )
+    {
+        Items = items;
+        Response = response;
+        StatusCode = statusCode;
+        Headers = headers;
+    }
+
+    /// <summary>
     /// Gets the items in this <see cref="Page{TItem}"/>.
     /// </summary>
     public IReadOnlyList<TItem> Items { get; }
+
+    /// <summary>
+    /// The full API response object for this page. Cast to the endpoint's response
+    /// type to access fields beyond the paginated items (e.g., TotalCount, metadata).
+    /// </summary>
+    public object? Response { get; }
+
+    /// <summary>
+    /// The HTTP status code of the response that produced this page.
+    /// </summary>
+    public HttpStatusCode StatusCode { get; }
+
+    /// <summary>
+    /// The HTTP response headers from the response that produced this page.
+    /// </summary>
+    public ResponseHeaders? Headers { get; }
 
     /// <summary>
     /// Enumerate the items in this <see cref="Page{TItem}"/>.

--- a/seed/csharp-sdk/exhaustive/no-generate-error-types/src/SeedExhaustive/Core/Pager.cs
+++ b/seed/csharp-sdk/exhaustive/no-generate-error-types/src/SeedExhaustive/Core/Pager.cs
@@ -95,7 +95,7 @@ internal sealed class OffsetPager<TRequest, TRequestOptions, TResponse, TOffset,
     private readonly SendRequest _sendRequest;
     private readonly ParseApiCallDelegate _parseApiCall;
 
-    internal delegate global::System.Threading.Tasks.Task<TResponse> SendRequest(
+    internal delegate global::System.Threading.Tasks.Task<WithRawResponse<TResponse>> SendRequest(
         TRequest request,
         TRequestOptions? options,
         CancellationToken cancellationToken
@@ -115,7 +115,7 @@ internal sealed class OffsetPager<TRequest, TRequestOptions, TResponse, TOffset,
         TRequest? nextRequest,
         bool hasNextPage,
         Page<TItem> page
-    ) ParseApiCallDelegate(TRequest request, TResponse response);
+    ) ParseApiCallDelegate(TRequest request, WithRawResponse<TResponse> wrappedResponse);
 
     public Page<TItem> CurrentPage { get; private set; }
     public bool HasNextPage { get; private set; }
@@ -152,7 +152,8 @@ internal sealed class OffsetPager<TRequest, TRequestOptions, TResponse, TOffset,
     )
     {
         request ??= Activator.CreateInstance<TRequest>();
-        var response = await sendRequest(request, options, cancellationToken).ConfigureAwait(false);
+        var wrappedResponse = await sendRequest(request, options, cancellationToken)
+            .ConfigureAwait(false);
         var parseApiCall = CreateParseApiCallDelegate(
             getItems,
             getOffset,
@@ -160,7 +161,7 @@ internal sealed class OffsetPager<TRequest, TRequestOptions, TResponse, TOffset,
             getStep,
             getHasNextPage
         );
-        var (nextRequest, hasNextPage, page) = parseApiCall(request, response);
+        var (nextRequest, hasNextPage, page) = parseApiCall(request, wrappedResponse);
         return new OffsetPager<TRequest, TRequestOptions, TResponse, TOffset, TStep, TItem>(
             nextRequest,
             options,
@@ -179,10 +180,10 @@ internal sealed class OffsetPager<TRequest, TRequestOptions, TResponse, TOffset,
         GetHasNextPage? getHasNextPage
     )
     {
-        return (request, response) =>
+        return (request, wrappedResponse) =>
             ParseApiCall(
                 request,
-                response,
+                wrappedResponse,
                 getItems,
                 getOffset,
                 setOffset,
@@ -197,9 +198,9 @@ internal sealed class OffsetPager<TRequest, TRequestOptions, TResponse, TOffset,
         CancellationToken cancellationToken = default
     )
     {
-        var response = await _sendRequest(request, options, cancellationToken)
+        var wrappedResponse = await _sendRequest(request, options, cancellationToken)
             .ConfigureAwait(false);
-        var (nextRequest, hasNextPageFlag, page) = _parseApiCall(request, response);
+        var (nextRequest, hasNextPageFlag, page) = _parseApiCall(request, wrappedResponse);
         _request = nextRequest;
         HasNextPage = hasNextPageFlag;
         CurrentPage = page;
@@ -208,7 +209,7 @@ internal sealed class OffsetPager<TRequest, TRequestOptions, TResponse, TOffset,
 
     private static (TRequest? nextRequest, bool hasNextPage, Page<TItem> page) ParseApiCall(
         TRequest request,
-        TResponse response,
+        WithRawResponse<TResponse> wrappedResponse,
         GetItems getItems,
         GetOffset getOffset,
         SetOffset setOffset,
@@ -216,8 +217,16 @@ internal sealed class OffsetPager<TRequest, TRequestOptions, TResponse, TOffset,
         GetHasNextPage? getHasNextPage
     )
     {
+        var response = wrappedResponse.Data;
         var items = getItems(response);
-        var page = items is not null ? new Page<TItem>(items) : Page<TItem>.Empty;
+        var page = items is not null
+            ? new Page<TItem>(
+                items,
+                response,
+                wrappedResponse.RawResponse.StatusCode,
+                wrappedResponse.RawResponse.Headers
+            )
+            : Page<TItem>.Empty;
         var offset = getOffset(request);
         var hasNextPage = getHasNextPage?.Invoke(response) ?? items?.Count > 0;
         if (!hasNextPage)
@@ -360,7 +369,7 @@ internal sealed class CursorPager<TRequest, TRequestOptions, TResponse, TCursor,
     /// <summary>
     /// Delegate for sending a request.
     /// </summary>
-    internal delegate global::System.Threading.Tasks.Task<TResponse> SendRequest(
+    internal delegate global::System.Threading.Tasks.Task<WithRawResponse<TResponse>> SendRequest(
         TRequest request,
         TRequestOptions? options,
         CancellationToken cancellationToken
@@ -385,7 +394,7 @@ internal sealed class CursorPager<TRequest, TRequestOptions, TResponse, TCursor,
         TRequest? nextRequest,
         bool hasNextPage,
         Page<TItem> page
-    ) ParseApiCallDelegate(TRequest request, TResponse response);
+    ) ParseApiCallDelegate(TRequest request, WithRawResponse<TResponse> wrappedResponse);
 
     /// <summary>
     /// The current <see cref="Page{TItem}"/>.
@@ -430,9 +439,10 @@ internal sealed class CursorPager<TRequest, TRequestOptions, TResponse, TCursor,
     )
     {
         request ??= Activator.CreateInstance<TRequest>();
-        var response = await sendRequest(request, options, cancellationToken).ConfigureAwait(false);
+        var wrappedResponse = await sendRequest(request, options, cancellationToken)
+            .ConfigureAwait(false);
         var parseApiCall = CreateParseApiCallDelegate(getItems, getNextCursor, setCursor);
-        var (nextRequest, hasNextPage, page) = parseApiCall(request, response);
+        var (nextRequest, hasNextPage, page) = parseApiCall(request, wrappedResponse);
         return new CursorPager<TRequest, TRequestOptions, TResponse, TCursor, TItem>(
             nextRequest,
             options,
@@ -449,10 +459,18 @@ internal sealed class CursorPager<TRequest, TRequestOptions, TResponse, TCursor,
         SetCursor setCursor
     )
     {
-        return (request, response) =>
+        return (request, wrappedResponse) =>
         {
+            var response = wrappedResponse.Data;
             var items = getItems(response);
-            var page = items is not null ? new Page<TItem>(items) : Page<TItem>.Empty;
+            var page = items is not null
+                ? new Page<TItem>(
+                    items,
+                    response,
+                    wrappedResponse.RawResponse.StatusCode,
+                    wrappedResponse.RawResponse.Headers
+                )
+                : Page<TItem>.Empty;
             var cursor = getNextCursor(response);
             var hasNextPage = cursor switch
             {
@@ -475,9 +493,9 @@ internal sealed class CursorPager<TRequest, TRequestOptions, TResponse, TCursor,
         CancellationToken cancellationToken = default
     )
     {
-        var response = await _sendRequest(request, options, cancellationToken)
+        var wrappedResponse = await _sendRequest(request, options, cancellationToken)
             .ConfigureAwait(false);
-        var (nextRequest, hasNextPage, page) = _parseApiCall(request, response);
+        var (nextRequest, hasNextPage, page) = _parseApiCall(request, wrappedResponse);
         _request = nextRequest;
         HasNextPage = hasNextPage;
         CurrentPage = page;

--- a/seed/csharp-sdk/exhaustive/no-generate-error-types/src/SeedExhaustive/Endpoints/Pagination/PaginationClient.cs
+++ b/seed/csharp-sdk/exhaustive/no-generate-error-types/src/SeedExhaustive/Endpoints/Pagination/PaginationClient.cs
@@ -128,7 +128,8 @@ public partial class PaginationClient : IPaginationClient
                 request,
                 options,
                 async (request, options, cancellationToken) =>
-                    await ListItemsInternalAsync(request, options, cancellationToken),
+                    await ListItemsInternalAsync(request, options, cancellationToken)
+                        .WithRawResponse(),
                 (request, cursor) =>
                 {
                     request.Cursor = cursor;

--- a/seed/csharp-sdk/exhaustive/no-root-namespace-for-core-classes/src/SeedExhaustive.Test/Core/Pagination/GuidCursorTest.cs
+++ b/seed/csharp-sdk/exhaustive/no-root-namespace-for-core-classes/src/SeedExhaustive.Test/Core/Pagination/GuidCursorTest.cs
@@ -1,3 +1,4 @@
+using global::System.Net;
 using NUnit.Framework;
 using SeedExhaustive.Core;
 using SystemTask = global::System.Threading.Tasks.Task;
@@ -45,7 +46,7 @@ public class GuidCursorTest
             (_, _, _) =>
             {
                 responses.MoveNext();
-                return SystemTask.FromResult(responses.Current);
+                return SystemTask.FromResult(Wrap(responses.Current));
             },
             (request, cursor) =>
             {
@@ -100,4 +101,16 @@ public class GuidCursorTest
     {
         public required Guid? Next { get; set; }
     }
+
+    private static WithRawResponse<Response> Wrap(Response response) =>
+        new()
+        {
+            Data = response,
+            RawResponse = new RawResponse
+            {
+                StatusCode = HttpStatusCode.OK,
+                Url = new Uri("https://localhost"),
+                Headers = default,
+            },
+        };
 }

--- a/seed/csharp-sdk/exhaustive/no-root-namespace-for-core-classes/src/SeedExhaustive.Test/Core/Pagination/HasNextPageOffsetTest.cs
+++ b/seed/csharp-sdk/exhaustive/no-root-namespace-for-core-classes/src/SeedExhaustive.Test/Core/Pagination/HasNextPageOffsetTest.cs
@@ -1,3 +1,4 @@
+using global::System.Net;
 using NUnit.Framework;
 using SeedExhaustive.Core;
 using SystemTask = global::System.Threading.Tasks.Task;
@@ -41,7 +42,7 @@ public class HasNextPageOffsetTest
             (_, _, _) =>
             {
                 responses.MoveNext();
-                return SystemTask.FromResult(responses.Current);
+                return SystemTask.FromResult(Wrap(responses.Current));
             },
             request => request?.Pagination?.Page ?? 0,
             (request, offset) =>
@@ -89,4 +90,16 @@ public class HasNextPageOffsetTest
     {
         public IEnumerable<string>? Items { get; set; }
     }
+
+    private static WithRawResponse<Response> Wrap(Response response) =>
+        new()
+        {
+            Data = response,
+            RawResponse = new RawResponse
+            {
+                StatusCode = HttpStatusCode.OK,
+                Url = new Uri("https://localhost"),
+                Headers = default,
+            },
+        };
 }

--- a/seed/csharp-sdk/exhaustive/no-root-namespace-for-core-classes/src/SeedExhaustive.Test/Core/Pagination/IntOffsetTest.cs
+++ b/seed/csharp-sdk/exhaustive/no-root-namespace-for-core-classes/src/SeedExhaustive.Test/Core/Pagination/IntOffsetTest.cs
@@ -1,3 +1,4 @@
+using global::System.Net;
 using NUnit.Framework;
 using SeedExhaustive.Core;
 using SystemTask = global::System.Threading.Tasks.Task;
@@ -29,7 +30,7 @@ public class IntOffsetTest
             (_, _, _) =>
             {
                 responses.MoveNext();
-                return SystemTask.FromResult(responses.Current);
+                return SystemTask.FromResult(Wrap(responses.Current));
             },
             request => request?.Pagination?.Page ?? 0,
             (request, offset) =>
@@ -79,4 +80,16 @@ public class IntOffsetTest
     {
         public IEnumerable<string>? Items { get; set; }
     }
+
+    private static WithRawResponse<Response> Wrap(Response response) =>
+        new()
+        {
+            Data = response,
+            RawResponse = new RawResponse
+            {
+                StatusCode = HttpStatusCode.OK,
+                Url = new Uri("https://localhost"),
+                Headers = default,
+            },
+        };
 }

--- a/seed/csharp-sdk/exhaustive/no-root-namespace-for-core-classes/src/SeedExhaustive.Test/Core/Pagination/LongOffsetTest.cs
+++ b/seed/csharp-sdk/exhaustive/no-root-namespace-for-core-classes/src/SeedExhaustive.Test/Core/Pagination/LongOffsetTest.cs
@@ -1,3 +1,4 @@
+using global::System.Net;
 using NUnit.Framework;
 using SeedExhaustive.Core;
 using SystemTask = global::System.Threading.Tasks.Task;
@@ -29,7 +30,7 @@ public class LongOffsetTest
             (_, _, _) =>
             {
                 responses.MoveNext();
-                return SystemTask.FromResult(responses.Current);
+                return SystemTask.FromResult(Wrap(responses.Current));
             },
             request => request?.Pagination?.Page ?? 0,
             (request, offset) =>
@@ -76,4 +77,16 @@ public class LongOffsetTest
     {
         public IEnumerable<string>? Items { get; set; }
     }
+
+    private static WithRawResponse<Response> Wrap(Response response) =>
+        new()
+        {
+            Data = response,
+            RawResponse = new RawResponse
+            {
+                StatusCode = HttpStatusCode.OK,
+                Url = new Uri("https://localhost"),
+                Headers = default,
+            },
+        };
 }

--- a/seed/csharp-sdk/exhaustive/no-root-namespace-for-core-classes/src/SeedExhaustive.Test/Core/Pagination/NoRequestCursorTest.cs
+++ b/seed/csharp-sdk/exhaustive/no-root-namespace-for-core-classes/src/SeedExhaustive.Test/Core/Pagination/NoRequestCursorTest.cs
@@ -1,3 +1,4 @@
+using global::System.Net;
 using NUnit.Framework;
 using SeedExhaustive.Core;
 using SystemTask = global::System.Threading.Tasks.Task;
@@ -45,7 +46,7 @@ public class NoRequestCursorTest
             (_, _, _) =>
             {
                 responses.MoveNext();
-                return SystemTask.FromResult(responses.Current);
+                return SystemTask.FromResult(Wrap(responses.Current));
             },
             (request, cursor) =>
             {
@@ -103,4 +104,16 @@ public class NoRequestCursorTest
     {
         public required string? Next { get; set; }
     }
+
+    private static WithRawResponse<Response> Wrap(Response response) =>
+        new()
+        {
+            Data = response,
+            RawResponse = new RawResponse
+            {
+                StatusCode = HttpStatusCode.OK,
+                Url = new Uri("https://localhost"),
+                Headers = default,
+            },
+        };
 }

--- a/seed/csharp-sdk/exhaustive/no-root-namespace-for-core-classes/src/SeedExhaustive.Test/Core/Pagination/NoRequestOffsetTest.cs
+++ b/seed/csharp-sdk/exhaustive/no-root-namespace-for-core-classes/src/SeedExhaustive.Test/Core/Pagination/NoRequestOffsetTest.cs
@@ -1,3 +1,4 @@
+using global::System.Net;
 using NUnit.Framework;
 using SeedExhaustive.Core;
 using SystemTask = global::System.Threading.Tasks.Task;
@@ -29,7 +30,7 @@ public class NoRequestOffsetTest
             (_, _, _) =>
             {
                 responses.MoveNext();
-                return SystemTask.FromResult(responses.Current);
+                return SystemTask.FromResult(Wrap(responses.Current));
             },
             request => request?.Pagination?.Page ?? 0,
             (request, offset) =>
@@ -79,4 +80,16 @@ public class NoRequestOffsetTest
     {
         public IEnumerable<string>? Items { get; set; }
     }
+
+    private static WithRawResponse<Response> Wrap(Response response) =>
+        new()
+        {
+            Data = response,
+            RawResponse = new RawResponse
+            {
+                StatusCode = HttpStatusCode.OK,
+                Url = new Uri("https://localhost"),
+                Headers = default,
+            },
+        };
 }

--- a/seed/csharp-sdk/exhaustive/no-root-namespace-for-core-classes/src/SeedExhaustive.Test/Core/Pagination/StepOffsetTest.cs
+++ b/seed/csharp-sdk/exhaustive/no-root-namespace-for-core-classes/src/SeedExhaustive.Test/Core/Pagination/StepOffsetTest.cs
@@ -1,3 +1,4 @@
+using global::System.Net;
 using NUnit.Framework;
 using SeedExhaustive.Core;
 using SystemTask = global::System.Threading.Tasks.Task;
@@ -30,7 +31,7 @@ public class StepPageOffsetPaginationTest
             (_, _, _) =>
             {
                 responses.MoveNext();
-                return SystemTask.FromResult(responses.Current);
+                return SystemTask.FromResult(Wrap(responses.Current));
             },
             request => request?.Pagination?.ItemOffset ?? 0,
             (request, offset) =>
@@ -89,4 +90,16 @@ public class StepPageOffsetPaginationTest
     {
         public IEnumerable<string>? Items { get; set; }
     }
+
+    private static WithRawResponse<Response> Wrap(Response response) =>
+        new()
+        {
+            Data = response,
+            RawResponse = new RawResponse
+            {
+                StatusCode = HttpStatusCode.OK,
+                Url = new Uri("https://localhost"),
+                Headers = default,
+            },
+        };
 }

--- a/seed/csharp-sdk/exhaustive/no-root-namespace-for-core-classes/src/SeedExhaustive.Test/Core/Pagination/StringCursorTest.cs
+++ b/seed/csharp-sdk/exhaustive/no-root-namespace-for-core-classes/src/SeedExhaustive.Test/Core/Pagination/StringCursorTest.cs
@@ -1,3 +1,4 @@
+using global::System.Net;
 using NUnit.Framework;
 using SeedExhaustive.Core;
 using SystemTask = global::System.Threading.Tasks.Task;
@@ -46,7 +47,7 @@ public class StringCursorTest
             (_, _, _) =>
             {
                 responses.MoveNext();
-                return SystemTask.FromResult(responses.Current);
+                return SystemTask.FromResult(Wrap(responses.Current));
             },
             (request, cursor) =>
             {
@@ -115,7 +116,7 @@ public class StringCursorTest
             (_, _, _) =>
             {
                 responses.MoveNext();
-                return SystemTask.FromResult(responses.Current);
+                return SystemTask.FromResult(Wrap(responses.Current));
             },
             (request, cursor) =>
             {
@@ -164,4 +165,16 @@ public class StringCursorTest
     {
         public required string? Next { get; set; }
     }
+
+    private static WithRawResponse<Response> Wrap(Response response) =>
+        new()
+        {
+            Data = response,
+            RawResponse = new RawResponse
+            {
+                StatusCode = HttpStatusCode.OK,
+                Url = new Uri("https://localhost"),
+                Headers = default,
+            },
+        };
 }

--- a/seed/csharp-sdk/exhaustive/no-root-namespace-for-core-classes/src/SeedExhaustive/Core/Page.cs
+++ b/seed/csharp-sdk/exhaustive/no-root-namespace-for-core-classes/src/SeedExhaustive/Core/Page.cs
@@ -1,5 +1,6 @@
 using global::System.Collections;
 using global::System.Collections.ObjectModel;
+using global::System.Net;
 
 namespace SeedExhaustive.Core;
 
@@ -20,9 +21,41 @@ public class Page<TItem> : IEnumerable<TItem>
     }
 
     /// <summary>
+    /// Creates a new <see cref="Page{TItem}"/> with the specified items and response metadata.
+    /// </summary>
+    public Page(
+        IReadOnlyList<TItem> items,
+        object? response,
+        HttpStatusCode statusCode,
+        ResponseHeaders? headers
+    )
+    {
+        Items = items;
+        Response = response;
+        StatusCode = statusCode;
+        Headers = headers;
+    }
+
+    /// <summary>
     /// Gets the items in this <see cref="Page{TItem}"/>.
     /// </summary>
     public IReadOnlyList<TItem> Items { get; }
+
+    /// <summary>
+    /// The full API response object for this page. Cast to the endpoint's response
+    /// type to access fields beyond the paginated items (e.g., TotalCount, metadata).
+    /// </summary>
+    public object? Response { get; }
+
+    /// <summary>
+    /// The HTTP status code of the response that produced this page.
+    /// </summary>
+    public HttpStatusCode StatusCode { get; }
+
+    /// <summary>
+    /// The HTTP response headers from the response that produced this page.
+    /// </summary>
+    public ResponseHeaders? Headers { get; }
 
     /// <summary>
     /// Enumerate the items in this <see cref="Page{TItem}"/>.

--- a/seed/csharp-sdk/exhaustive/no-root-namespace-for-core-classes/src/SeedExhaustive/Core/Pager.cs
+++ b/seed/csharp-sdk/exhaustive/no-root-namespace-for-core-classes/src/SeedExhaustive/Core/Pager.cs
@@ -95,7 +95,7 @@ internal sealed class OffsetPager<TRequest, TRequestOptions, TResponse, TOffset,
     private readonly SendRequest _sendRequest;
     private readonly ParseApiCallDelegate _parseApiCall;
 
-    internal delegate global::System.Threading.Tasks.Task<TResponse> SendRequest(
+    internal delegate global::System.Threading.Tasks.Task<WithRawResponse<TResponse>> SendRequest(
         TRequest request,
         TRequestOptions? options,
         CancellationToken cancellationToken
@@ -115,7 +115,7 @@ internal sealed class OffsetPager<TRequest, TRequestOptions, TResponse, TOffset,
         TRequest? nextRequest,
         bool hasNextPage,
         Page<TItem> page
-    ) ParseApiCallDelegate(TRequest request, TResponse response);
+    ) ParseApiCallDelegate(TRequest request, WithRawResponse<TResponse> wrappedResponse);
 
     public Page<TItem> CurrentPage { get; private set; }
     public bool HasNextPage { get; private set; }
@@ -152,7 +152,8 @@ internal sealed class OffsetPager<TRequest, TRequestOptions, TResponse, TOffset,
     )
     {
         request ??= Activator.CreateInstance<TRequest>();
-        var response = await sendRequest(request, options, cancellationToken).ConfigureAwait(false);
+        var wrappedResponse = await sendRequest(request, options, cancellationToken)
+            .ConfigureAwait(false);
         var parseApiCall = CreateParseApiCallDelegate(
             getItems,
             getOffset,
@@ -160,7 +161,7 @@ internal sealed class OffsetPager<TRequest, TRequestOptions, TResponse, TOffset,
             getStep,
             getHasNextPage
         );
-        var (nextRequest, hasNextPage, page) = parseApiCall(request, response);
+        var (nextRequest, hasNextPage, page) = parseApiCall(request, wrappedResponse);
         return new OffsetPager<TRequest, TRequestOptions, TResponse, TOffset, TStep, TItem>(
             nextRequest,
             options,
@@ -179,10 +180,10 @@ internal sealed class OffsetPager<TRequest, TRequestOptions, TResponse, TOffset,
         GetHasNextPage? getHasNextPage
     )
     {
-        return (request, response) =>
+        return (request, wrappedResponse) =>
             ParseApiCall(
                 request,
-                response,
+                wrappedResponse,
                 getItems,
                 getOffset,
                 setOffset,
@@ -197,9 +198,9 @@ internal sealed class OffsetPager<TRequest, TRequestOptions, TResponse, TOffset,
         CancellationToken cancellationToken = default
     )
     {
-        var response = await _sendRequest(request, options, cancellationToken)
+        var wrappedResponse = await _sendRequest(request, options, cancellationToken)
             .ConfigureAwait(false);
-        var (nextRequest, hasNextPageFlag, page) = _parseApiCall(request, response);
+        var (nextRequest, hasNextPageFlag, page) = _parseApiCall(request, wrappedResponse);
         _request = nextRequest;
         HasNextPage = hasNextPageFlag;
         CurrentPage = page;
@@ -208,7 +209,7 @@ internal sealed class OffsetPager<TRequest, TRequestOptions, TResponse, TOffset,
 
     private static (TRequest? nextRequest, bool hasNextPage, Page<TItem> page) ParseApiCall(
         TRequest request,
-        TResponse response,
+        WithRawResponse<TResponse> wrappedResponse,
         GetItems getItems,
         GetOffset getOffset,
         SetOffset setOffset,
@@ -216,8 +217,16 @@ internal sealed class OffsetPager<TRequest, TRequestOptions, TResponse, TOffset,
         GetHasNextPage? getHasNextPage
     )
     {
+        var response = wrappedResponse.Data;
         var items = getItems(response);
-        var page = items is not null ? new Page<TItem>(items) : Page<TItem>.Empty;
+        var page = items is not null
+            ? new Page<TItem>(
+                items,
+                response,
+                wrappedResponse.RawResponse.StatusCode,
+                wrappedResponse.RawResponse.Headers
+            )
+            : Page<TItem>.Empty;
         var offset = getOffset(request);
         var hasNextPage = getHasNextPage?.Invoke(response) ?? items?.Count > 0;
         if (!hasNextPage)
@@ -360,7 +369,7 @@ internal sealed class CursorPager<TRequest, TRequestOptions, TResponse, TCursor,
     /// <summary>
     /// Delegate for sending a request.
     /// </summary>
-    internal delegate global::System.Threading.Tasks.Task<TResponse> SendRequest(
+    internal delegate global::System.Threading.Tasks.Task<WithRawResponse<TResponse>> SendRequest(
         TRequest request,
         TRequestOptions? options,
         CancellationToken cancellationToken
@@ -385,7 +394,7 @@ internal sealed class CursorPager<TRequest, TRequestOptions, TResponse, TCursor,
         TRequest? nextRequest,
         bool hasNextPage,
         Page<TItem> page
-    ) ParseApiCallDelegate(TRequest request, TResponse response);
+    ) ParseApiCallDelegate(TRequest request, WithRawResponse<TResponse> wrappedResponse);
 
     /// <summary>
     /// The current <see cref="Page{TItem}"/>.
@@ -430,9 +439,10 @@ internal sealed class CursorPager<TRequest, TRequestOptions, TResponse, TCursor,
     )
     {
         request ??= Activator.CreateInstance<TRequest>();
-        var response = await sendRequest(request, options, cancellationToken).ConfigureAwait(false);
+        var wrappedResponse = await sendRequest(request, options, cancellationToken)
+            .ConfigureAwait(false);
         var parseApiCall = CreateParseApiCallDelegate(getItems, getNextCursor, setCursor);
-        var (nextRequest, hasNextPage, page) = parseApiCall(request, response);
+        var (nextRequest, hasNextPage, page) = parseApiCall(request, wrappedResponse);
         return new CursorPager<TRequest, TRequestOptions, TResponse, TCursor, TItem>(
             nextRequest,
             options,
@@ -449,10 +459,18 @@ internal sealed class CursorPager<TRequest, TRequestOptions, TResponse, TCursor,
         SetCursor setCursor
     )
     {
-        return (request, response) =>
+        return (request, wrappedResponse) =>
         {
+            var response = wrappedResponse.Data;
             var items = getItems(response);
-            var page = items is not null ? new Page<TItem>(items) : Page<TItem>.Empty;
+            var page = items is not null
+                ? new Page<TItem>(
+                    items,
+                    response,
+                    wrappedResponse.RawResponse.StatusCode,
+                    wrappedResponse.RawResponse.Headers
+                )
+                : Page<TItem>.Empty;
             var cursor = getNextCursor(response);
             var hasNextPage = cursor switch
             {
@@ -475,9 +493,9 @@ internal sealed class CursorPager<TRequest, TRequestOptions, TResponse, TCursor,
         CancellationToken cancellationToken = default
     )
     {
-        var response = await _sendRequest(request, options, cancellationToken)
+        var wrappedResponse = await _sendRequest(request, options, cancellationToken)
             .ConfigureAwait(false);
-        var (nextRequest, hasNextPage, page) = _parseApiCall(request, response);
+        var (nextRequest, hasNextPage, page) = _parseApiCall(request, wrappedResponse);
         _request = nextRequest;
         HasNextPage = hasNextPage;
         CurrentPage = page;

--- a/seed/csharp-sdk/exhaustive/no-root-namespace-for-core-classes/src/SeedExhaustive/Endpoints/Pagination/PaginationClient.cs
+++ b/seed/csharp-sdk/exhaustive/no-root-namespace-for-core-classes/src/SeedExhaustive/Endpoints/Pagination/PaginationClient.cs
@@ -128,7 +128,8 @@ public partial class PaginationClient : IPaginationClient
                 request,
                 options,
                 async (request, options, cancellationToken) =>
-                    await ListItemsInternalAsync(request, options, cancellationToken),
+                    await ListItemsInternalAsync(request, options, cancellationToken)
+                        .WithRawResponse(),
                 (request, cursor) =>
                 {
                     request.Cursor = cursor;

--- a/seed/csharp-sdk/exhaustive/redact-response-body-on-error/src/SeedExhaustive.Test/Core/Pagination/GuidCursorTest.cs
+++ b/seed/csharp-sdk/exhaustive/redact-response-body-on-error/src/SeedExhaustive.Test/Core/Pagination/GuidCursorTest.cs
@@ -1,3 +1,4 @@
+using global::System.Net;
 using NUnit.Framework;
 using SeedExhaustive.Core;
 using SystemTask = global::System.Threading.Tasks.Task;
@@ -45,7 +46,7 @@ public class GuidCursorTest
             (_, _, _) =>
             {
                 responses.MoveNext();
-                return SystemTask.FromResult(responses.Current);
+                return SystemTask.FromResult(Wrap(responses.Current));
             },
             (request, cursor) =>
             {
@@ -100,4 +101,16 @@ public class GuidCursorTest
     {
         public required Guid? Next { get; set; }
     }
+
+    private static WithRawResponse<Response> Wrap(Response response) =>
+        new()
+        {
+            Data = response,
+            RawResponse = new RawResponse
+            {
+                StatusCode = HttpStatusCode.OK,
+                Url = new Uri("https://localhost"),
+                Headers = default,
+            },
+        };
 }

--- a/seed/csharp-sdk/exhaustive/redact-response-body-on-error/src/SeedExhaustive.Test/Core/Pagination/HasNextPageOffsetTest.cs
+++ b/seed/csharp-sdk/exhaustive/redact-response-body-on-error/src/SeedExhaustive.Test/Core/Pagination/HasNextPageOffsetTest.cs
@@ -1,3 +1,4 @@
+using global::System.Net;
 using NUnit.Framework;
 using SeedExhaustive.Core;
 using SystemTask = global::System.Threading.Tasks.Task;
@@ -41,7 +42,7 @@ public class HasNextPageOffsetTest
             (_, _, _) =>
             {
                 responses.MoveNext();
-                return SystemTask.FromResult(responses.Current);
+                return SystemTask.FromResult(Wrap(responses.Current));
             },
             request => request?.Pagination?.Page ?? 0,
             (request, offset) =>
@@ -89,4 +90,16 @@ public class HasNextPageOffsetTest
     {
         public IEnumerable<string>? Items { get; set; }
     }
+
+    private static WithRawResponse<Response> Wrap(Response response) =>
+        new()
+        {
+            Data = response,
+            RawResponse = new RawResponse
+            {
+                StatusCode = HttpStatusCode.OK,
+                Url = new Uri("https://localhost"),
+                Headers = default,
+            },
+        };
 }

--- a/seed/csharp-sdk/exhaustive/redact-response-body-on-error/src/SeedExhaustive.Test/Core/Pagination/IntOffsetTest.cs
+++ b/seed/csharp-sdk/exhaustive/redact-response-body-on-error/src/SeedExhaustive.Test/Core/Pagination/IntOffsetTest.cs
@@ -1,3 +1,4 @@
+using global::System.Net;
 using NUnit.Framework;
 using SeedExhaustive.Core;
 using SystemTask = global::System.Threading.Tasks.Task;
@@ -29,7 +30,7 @@ public class IntOffsetTest
             (_, _, _) =>
             {
                 responses.MoveNext();
-                return SystemTask.FromResult(responses.Current);
+                return SystemTask.FromResult(Wrap(responses.Current));
             },
             request => request?.Pagination?.Page ?? 0,
             (request, offset) =>
@@ -79,4 +80,16 @@ public class IntOffsetTest
     {
         public IEnumerable<string>? Items { get; set; }
     }
+
+    private static WithRawResponse<Response> Wrap(Response response) =>
+        new()
+        {
+            Data = response,
+            RawResponse = new RawResponse
+            {
+                StatusCode = HttpStatusCode.OK,
+                Url = new Uri("https://localhost"),
+                Headers = default,
+            },
+        };
 }

--- a/seed/csharp-sdk/exhaustive/redact-response-body-on-error/src/SeedExhaustive.Test/Core/Pagination/LongOffsetTest.cs
+++ b/seed/csharp-sdk/exhaustive/redact-response-body-on-error/src/SeedExhaustive.Test/Core/Pagination/LongOffsetTest.cs
@@ -1,3 +1,4 @@
+using global::System.Net;
 using NUnit.Framework;
 using SeedExhaustive.Core;
 using SystemTask = global::System.Threading.Tasks.Task;
@@ -29,7 +30,7 @@ public class LongOffsetTest
             (_, _, _) =>
             {
                 responses.MoveNext();
-                return SystemTask.FromResult(responses.Current);
+                return SystemTask.FromResult(Wrap(responses.Current));
             },
             request => request?.Pagination?.Page ?? 0,
             (request, offset) =>
@@ -76,4 +77,16 @@ public class LongOffsetTest
     {
         public IEnumerable<string>? Items { get; set; }
     }
+
+    private static WithRawResponse<Response> Wrap(Response response) =>
+        new()
+        {
+            Data = response,
+            RawResponse = new RawResponse
+            {
+                StatusCode = HttpStatusCode.OK,
+                Url = new Uri("https://localhost"),
+                Headers = default,
+            },
+        };
 }

--- a/seed/csharp-sdk/exhaustive/redact-response-body-on-error/src/SeedExhaustive.Test/Core/Pagination/NoRequestCursorTest.cs
+++ b/seed/csharp-sdk/exhaustive/redact-response-body-on-error/src/SeedExhaustive.Test/Core/Pagination/NoRequestCursorTest.cs
@@ -1,3 +1,4 @@
+using global::System.Net;
 using NUnit.Framework;
 using SeedExhaustive.Core;
 using SystemTask = global::System.Threading.Tasks.Task;
@@ -45,7 +46,7 @@ public class NoRequestCursorTest
             (_, _, _) =>
             {
                 responses.MoveNext();
-                return SystemTask.FromResult(responses.Current);
+                return SystemTask.FromResult(Wrap(responses.Current));
             },
             (request, cursor) =>
             {
@@ -103,4 +104,16 @@ public class NoRequestCursorTest
     {
         public required string? Next { get; set; }
     }
+
+    private static WithRawResponse<Response> Wrap(Response response) =>
+        new()
+        {
+            Data = response,
+            RawResponse = new RawResponse
+            {
+                StatusCode = HttpStatusCode.OK,
+                Url = new Uri("https://localhost"),
+                Headers = default,
+            },
+        };
 }

--- a/seed/csharp-sdk/exhaustive/redact-response-body-on-error/src/SeedExhaustive.Test/Core/Pagination/NoRequestOffsetTest.cs
+++ b/seed/csharp-sdk/exhaustive/redact-response-body-on-error/src/SeedExhaustive.Test/Core/Pagination/NoRequestOffsetTest.cs
@@ -1,3 +1,4 @@
+using global::System.Net;
 using NUnit.Framework;
 using SeedExhaustive.Core;
 using SystemTask = global::System.Threading.Tasks.Task;
@@ -29,7 +30,7 @@ public class NoRequestOffsetTest
             (_, _, _) =>
             {
                 responses.MoveNext();
-                return SystemTask.FromResult(responses.Current);
+                return SystemTask.FromResult(Wrap(responses.Current));
             },
             request => request?.Pagination?.Page ?? 0,
             (request, offset) =>
@@ -79,4 +80,16 @@ public class NoRequestOffsetTest
     {
         public IEnumerable<string>? Items { get; set; }
     }
+
+    private static WithRawResponse<Response> Wrap(Response response) =>
+        new()
+        {
+            Data = response,
+            RawResponse = new RawResponse
+            {
+                StatusCode = HttpStatusCode.OK,
+                Url = new Uri("https://localhost"),
+                Headers = default,
+            },
+        };
 }

--- a/seed/csharp-sdk/exhaustive/redact-response-body-on-error/src/SeedExhaustive.Test/Core/Pagination/StepOffsetTest.cs
+++ b/seed/csharp-sdk/exhaustive/redact-response-body-on-error/src/SeedExhaustive.Test/Core/Pagination/StepOffsetTest.cs
@@ -1,3 +1,4 @@
+using global::System.Net;
 using NUnit.Framework;
 using SeedExhaustive.Core;
 using SystemTask = global::System.Threading.Tasks.Task;
@@ -30,7 +31,7 @@ public class StepPageOffsetPaginationTest
             (_, _, _) =>
             {
                 responses.MoveNext();
-                return SystemTask.FromResult(responses.Current);
+                return SystemTask.FromResult(Wrap(responses.Current));
             },
             request => request?.Pagination?.ItemOffset ?? 0,
             (request, offset) =>
@@ -89,4 +90,16 @@ public class StepPageOffsetPaginationTest
     {
         public IEnumerable<string>? Items { get; set; }
     }
+
+    private static WithRawResponse<Response> Wrap(Response response) =>
+        new()
+        {
+            Data = response,
+            RawResponse = new RawResponse
+            {
+                StatusCode = HttpStatusCode.OK,
+                Url = new Uri("https://localhost"),
+                Headers = default,
+            },
+        };
 }

--- a/seed/csharp-sdk/exhaustive/redact-response-body-on-error/src/SeedExhaustive.Test/Core/Pagination/StringCursorTest.cs
+++ b/seed/csharp-sdk/exhaustive/redact-response-body-on-error/src/SeedExhaustive.Test/Core/Pagination/StringCursorTest.cs
@@ -1,3 +1,4 @@
+using global::System.Net;
 using NUnit.Framework;
 using SeedExhaustive.Core;
 using SystemTask = global::System.Threading.Tasks.Task;
@@ -46,7 +47,7 @@ public class StringCursorTest
             (_, _, _) =>
             {
                 responses.MoveNext();
-                return SystemTask.FromResult(responses.Current);
+                return SystemTask.FromResult(Wrap(responses.Current));
             },
             (request, cursor) =>
             {
@@ -115,7 +116,7 @@ public class StringCursorTest
             (_, _, _) =>
             {
                 responses.MoveNext();
-                return SystemTask.FromResult(responses.Current);
+                return SystemTask.FromResult(Wrap(responses.Current));
             },
             (request, cursor) =>
             {
@@ -164,4 +165,16 @@ public class StringCursorTest
     {
         public required string? Next { get; set; }
     }
+
+    private static WithRawResponse<Response> Wrap(Response response) =>
+        new()
+        {
+            Data = response,
+            RawResponse = new RawResponse
+            {
+                StatusCode = HttpStatusCode.OK,
+                Url = new Uri("https://localhost"),
+                Headers = default,
+            },
+        };
 }

--- a/seed/csharp-sdk/exhaustive/redact-response-body-on-error/src/SeedExhaustive/Core/Page.cs
+++ b/seed/csharp-sdk/exhaustive/redact-response-body-on-error/src/SeedExhaustive/Core/Page.cs
@@ -1,5 +1,6 @@
 using global::System.Collections;
 using global::System.Collections.ObjectModel;
+using global::System.Net;
 
 namespace SeedExhaustive.Core;
 
@@ -20,9 +21,41 @@ public class Page<TItem> : IEnumerable<TItem>
     }
 
     /// <summary>
+    /// Creates a new <see cref="Page{TItem}"/> with the specified items and response metadata.
+    /// </summary>
+    public Page(
+        IReadOnlyList<TItem> items,
+        object? response,
+        HttpStatusCode statusCode,
+        ResponseHeaders? headers
+    )
+    {
+        Items = items;
+        Response = response;
+        StatusCode = statusCode;
+        Headers = headers;
+    }
+
+    /// <summary>
     /// Gets the items in this <see cref="Page{TItem}"/>.
     /// </summary>
     public IReadOnlyList<TItem> Items { get; }
+
+    /// <summary>
+    /// The full API response object for this page. Cast to the endpoint's response
+    /// type to access fields beyond the paginated items (e.g., TotalCount, metadata).
+    /// </summary>
+    public object? Response { get; }
+
+    /// <summary>
+    /// The HTTP status code of the response that produced this page.
+    /// </summary>
+    public HttpStatusCode StatusCode { get; }
+
+    /// <summary>
+    /// The HTTP response headers from the response that produced this page.
+    /// </summary>
+    public ResponseHeaders? Headers { get; }
 
     /// <summary>
     /// Enumerate the items in this <see cref="Page{TItem}"/>.

--- a/seed/csharp-sdk/exhaustive/redact-response-body-on-error/src/SeedExhaustive/Core/Pager.cs
+++ b/seed/csharp-sdk/exhaustive/redact-response-body-on-error/src/SeedExhaustive/Core/Pager.cs
@@ -95,7 +95,7 @@ internal sealed class OffsetPager<TRequest, TRequestOptions, TResponse, TOffset,
     private readonly SendRequest _sendRequest;
     private readonly ParseApiCallDelegate _parseApiCall;
 
-    internal delegate global::System.Threading.Tasks.Task<TResponse> SendRequest(
+    internal delegate global::System.Threading.Tasks.Task<WithRawResponse<TResponse>> SendRequest(
         TRequest request,
         TRequestOptions? options,
         CancellationToken cancellationToken
@@ -115,7 +115,7 @@ internal sealed class OffsetPager<TRequest, TRequestOptions, TResponse, TOffset,
         TRequest? nextRequest,
         bool hasNextPage,
         Page<TItem> page
-    ) ParseApiCallDelegate(TRequest request, TResponse response);
+    ) ParseApiCallDelegate(TRequest request, WithRawResponse<TResponse> wrappedResponse);
 
     public Page<TItem> CurrentPage { get; private set; }
     public bool HasNextPage { get; private set; }
@@ -152,7 +152,8 @@ internal sealed class OffsetPager<TRequest, TRequestOptions, TResponse, TOffset,
     )
     {
         request ??= Activator.CreateInstance<TRequest>();
-        var response = await sendRequest(request, options, cancellationToken).ConfigureAwait(false);
+        var wrappedResponse = await sendRequest(request, options, cancellationToken)
+            .ConfigureAwait(false);
         var parseApiCall = CreateParseApiCallDelegate(
             getItems,
             getOffset,
@@ -160,7 +161,7 @@ internal sealed class OffsetPager<TRequest, TRequestOptions, TResponse, TOffset,
             getStep,
             getHasNextPage
         );
-        var (nextRequest, hasNextPage, page) = parseApiCall(request, response);
+        var (nextRequest, hasNextPage, page) = parseApiCall(request, wrappedResponse);
         return new OffsetPager<TRequest, TRequestOptions, TResponse, TOffset, TStep, TItem>(
             nextRequest,
             options,
@@ -179,10 +180,10 @@ internal sealed class OffsetPager<TRequest, TRequestOptions, TResponse, TOffset,
         GetHasNextPage? getHasNextPage
     )
     {
-        return (request, response) =>
+        return (request, wrappedResponse) =>
             ParseApiCall(
                 request,
-                response,
+                wrappedResponse,
                 getItems,
                 getOffset,
                 setOffset,
@@ -197,9 +198,9 @@ internal sealed class OffsetPager<TRequest, TRequestOptions, TResponse, TOffset,
         CancellationToken cancellationToken = default
     )
     {
-        var response = await _sendRequest(request, options, cancellationToken)
+        var wrappedResponse = await _sendRequest(request, options, cancellationToken)
             .ConfigureAwait(false);
-        var (nextRequest, hasNextPageFlag, page) = _parseApiCall(request, response);
+        var (nextRequest, hasNextPageFlag, page) = _parseApiCall(request, wrappedResponse);
         _request = nextRequest;
         HasNextPage = hasNextPageFlag;
         CurrentPage = page;
@@ -208,7 +209,7 @@ internal sealed class OffsetPager<TRequest, TRequestOptions, TResponse, TOffset,
 
     private static (TRequest? nextRequest, bool hasNextPage, Page<TItem> page) ParseApiCall(
         TRequest request,
-        TResponse response,
+        WithRawResponse<TResponse> wrappedResponse,
         GetItems getItems,
         GetOffset getOffset,
         SetOffset setOffset,
@@ -216,8 +217,16 @@ internal sealed class OffsetPager<TRequest, TRequestOptions, TResponse, TOffset,
         GetHasNextPage? getHasNextPage
     )
     {
+        var response = wrappedResponse.Data;
         var items = getItems(response);
-        var page = items is not null ? new Page<TItem>(items) : Page<TItem>.Empty;
+        var page = items is not null
+            ? new Page<TItem>(
+                items,
+                response,
+                wrappedResponse.RawResponse.StatusCode,
+                wrappedResponse.RawResponse.Headers
+            )
+            : Page<TItem>.Empty;
         var offset = getOffset(request);
         var hasNextPage = getHasNextPage?.Invoke(response) ?? items?.Count > 0;
         if (!hasNextPage)
@@ -360,7 +369,7 @@ internal sealed class CursorPager<TRequest, TRequestOptions, TResponse, TCursor,
     /// <summary>
     /// Delegate for sending a request.
     /// </summary>
-    internal delegate global::System.Threading.Tasks.Task<TResponse> SendRequest(
+    internal delegate global::System.Threading.Tasks.Task<WithRawResponse<TResponse>> SendRequest(
         TRequest request,
         TRequestOptions? options,
         CancellationToken cancellationToken
@@ -385,7 +394,7 @@ internal sealed class CursorPager<TRequest, TRequestOptions, TResponse, TCursor,
         TRequest? nextRequest,
         bool hasNextPage,
         Page<TItem> page
-    ) ParseApiCallDelegate(TRequest request, TResponse response);
+    ) ParseApiCallDelegate(TRequest request, WithRawResponse<TResponse> wrappedResponse);
 
     /// <summary>
     /// The current <see cref="Page{TItem}"/>.
@@ -430,9 +439,10 @@ internal sealed class CursorPager<TRequest, TRequestOptions, TResponse, TCursor,
     )
     {
         request ??= Activator.CreateInstance<TRequest>();
-        var response = await sendRequest(request, options, cancellationToken).ConfigureAwait(false);
+        var wrappedResponse = await sendRequest(request, options, cancellationToken)
+            .ConfigureAwait(false);
         var parseApiCall = CreateParseApiCallDelegate(getItems, getNextCursor, setCursor);
-        var (nextRequest, hasNextPage, page) = parseApiCall(request, response);
+        var (nextRequest, hasNextPage, page) = parseApiCall(request, wrappedResponse);
         return new CursorPager<TRequest, TRequestOptions, TResponse, TCursor, TItem>(
             nextRequest,
             options,
@@ -449,10 +459,18 @@ internal sealed class CursorPager<TRequest, TRequestOptions, TResponse, TCursor,
         SetCursor setCursor
     )
     {
-        return (request, response) =>
+        return (request, wrappedResponse) =>
         {
+            var response = wrappedResponse.Data;
             var items = getItems(response);
-            var page = items is not null ? new Page<TItem>(items) : Page<TItem>.Empty;
+            var page = items is not null
+                ? new Page<TItem>(
+                    items,
+                    response,
+                    wrappedResponse.RawResponse.StatusCode,
+                    wrappedResponse.RawResponse.Headers
+                )
+                : Page<TItem>.Empty;
             var cursor = getNextCursor(response);
             var hasNextPage = cursor switch
             {
@@ -475,9 +493,9 @@ internal sealed class CursorPager<TRequest, TRequestOptions, TResponse, TCursor,
         CancellationToken cancellationToken = default
     )
     {
-        var response = await _sendRequest(request, options, cancellationToken)
+        var wrappedResponse = await _sendRequest(request, options, cancellationToken)
             .ConfigureAwait(false);
-        var (nextRequest, hasNextPage, page) = _parseApiCall(request, response);
+        var (nextRequest, hasNextPage, page) = _parseApiCall(request, wrappedResponse);
         _request = nextRequest;
         HasNextPage = hasNextPage;
         CurrentPage = page;

--- a/seed/csharp-sdk/exhaustive/redact-response-body-on-error/src/SeedExhaustive/Endpoints/Pagination/PaginationClient.cs
+++ b/seed/csharp-sdk/exhaustive/redact-response-body-on-error/src/SeedExhaustive/Endpoints/Pagination/PaginationClient.cs
@@ -128,7 +128,8 @@ public partial class PaginationClient : IPaginationClient
                 request,
                 options,
                 async (request, options, cancellationToken) =>
-                    await ListItemsInternalAsync(request, options, cancellationToken),
+                    await ListItemsInternalAsync(request, options, cancellationToken)
+                        .WithRawResponse(),
                 (request, cursor) =>
                 {
                     request.Cursor = cursor;

--- a/seed/csharp-sdk/exhaustive/use-undiscriminated-unions/src/SeedExhaustive.Test/Core/Pagination/GuidCursorTest.cs
+++ b/seed/csharp-sdk/exhaustive/use-undiscriminated-unions/src/SeedExhaustive.Test/Core/Pagination/GuidCursorTest.cs
@@ -1,3 +1,4 @@
+using global::System.Net;
 using NUnit.Framework;
 using SeedExhaustive.Core;
 using SystemTask = global::System.Threading.Tasks.Task;
@@ -45,7 +46,7 @@ public class GuidCursorTest
             (_, _, _) =>
             {
                 responses.MoveNext();
-                return SystemTask.FromResult(responses.Current);
+                return SystemTask.FromResult(Wrap(responses.Current));
             },
             (request, cursor) =>
             {
@@ -100,4 +101,16 @@ public class GuidCursorTest
     {
         public required Guid? Next { get; set; }
     }
+
+    private static WithRawResponse<Response> Wrap(Response response) =>
+        new()
+        {
+            Data = response,
+            RawResponse = new RawResponse
+            {
+                StatusCode = HttpStatusCode.OK,
+                Url = new Uri("https://localhost"),
+                Headers = default,
+            },
+        };
 }

--- a/seed/csharp-sdk/exhaustive/use-undiscriminated-unions/src/SeedExhaustive.Test/Core/Pagination/HasNextPageOffsetTest.cs
+++ b/seed/csharp-sdk/exhaustive/use-undiscriminated-unions/src/SeedExhaustive.Test/Core/Pagination/HasNextPageOffsetTest.cs
@@ -1,3 +1,4 @@
+using global::System.Net;
 using NUnit.Framework;
 using SeedExhaustive.Core;
 using SystemTask = global::System.Threading.Tasks.Task;
@@ -41,7 +42,7 @@ public class HasNextPageOffsetTest
             (_, _, _) =>
             {
                 responses.MoveNext();
-                return SystemTask.FromResult(responses.Current);
+                return SystemTask.FromResult(Wrap(responses.Current));
             },
             request => request?.Pagination?.Page ?? 0,
             (request, offset) =>
@@ -89,4 +90,16 @@ public class HasNextPageOffsetTest
     {
         public IEnumerable<string>? Items { get; set; }
     }
+
+    private static WithRawResponse<Response> Wrap(Response response) =>
+        new()
+        {
+            Data = response,
+            RawResponse = new RawResponse
+            {
+                StatusCode = HttpStatusCode.OK,
+                Url = new Uri("https://localhost"),
+                Headers = default,
+            },
+        };
 }

--- a/seed/csharp-sdk/exhaustive/use-undiscriminated-unions/src/SeedExhaustive.Test/Core/Pagination/IntOffsetTest.cs
+++ b/seed/csharp-sdk/exhaustive/use-undiscriminated-unions/src/SeedExhaustive.Test/Core/Pagination/IntOffsetTest.cs
@@ -1,3 +1,4 @@
+using global::System.Net;
 using NUnit.Framework;
 using SeedExhaustive.Core;
 using SystemTask = global::System.Threading.Tasks.Task;
@@ -29,7 +30,7 @@ public class IntOffsetTest
             (_, _, _) =>
             {
                 responses.MoveNext();
-                return SystemTask.FromResult(responses.Current);
+                return SystemTask.FromResult(Wrap(responses.Current));
             },
             request => request?.Pagination?.Page ?? 0,
             (request, offset) =>
@@ -79,4 +80,16 @@ public class IntOffsetTest
     {
         public IEnumerable<string>? Items { get; set; }
     }
+
+    private static WithRawResponse<Response> Wrap(Response response) =>
+        new()
+        {
+            Data = response,
+            RawResponse = new RawResponse
+            {
+                StatusCode = HttpStatusCode.OK,
+                Url = new Uri("https://localhost"),
+                Headers = default,
+            },
+        };
 }

--- a/seed/csharp-sdk/exhaustive/use-undiscriminated-unions/src/SeedExhaustive.Test/Core/Pagination/LongOffsetTest.cs
+++ b/seed/csharp-sdk/exhaustive/use-undiscriminated-unions/src/SeedExhaustive.Test/Core/Pagination/LongOffsetTest.cs
@@ -1,3 +1,4 @@
+using global::System.Net;
 using NUnit.Framework;
 using SeedExhaustive.Core;
 using SystemTask = global::System.Threading.Tasks.Task;
@@ -29,7 +30,7 @@ public class LongOffsetTest
             (_, _, _) =>
             {
                 responses.MoveNext();
-                return SystemTask.FromResult(responses.Current);
+                return SystemTask.FromResult(Wrap(responses.Current));
             },
             request => request?.Pagination?.Page ?? 0,
             (request, offset) =>
@@ -76,4 +77,16 @@ public class LongOffsetTest
     {
         public IEnumerable<string>? Items { get; set; }
     }
+
+    private static WithRawResponse<Response> Wrap(Response response) =>
+        new()
+        {
+            Data = response,
+            RawResponse = new RawResponse
+            {
+                StatusCode = HttpStatusCode.OK,
+                Url = new Uri("https://localhost"),
+                Headers = default,
+            },
+        };
 }

--- a/seed/csharp-sdk/exhaustive/use-undiscriminated-unions/src/SeedExhaustive.Test/Core/Pagination/NoRequestCursorTest.cs
+++ b/seed/csharp-sdk/exhaustive/use-undiscriminated-unions/src/SeedExhaustive.Test/Core/Pagination/NoRequestCursorTest.cs
@@ -1,3 +1,4 @@
+using global::System.Net;
 using NUnit.Framework;
 using SeedExhaustive.Core;
 using SystemTask = global::System.Threading.Tasks.Task;
@@ -45,7 +46,7 @@ public class NoRequestCursorTest
             (_, _, _) =>
             {
                 responses.MoveNext();
-                return SystemTask.FromResult(responses.Current);
+                return SystemTask.FromResult(Wrap(responses.Current));
             },
             (request, cursor) =>
             {
@@ -103,4 +104,16 @@ public class NoRequestCursorTest
     {
         public required string? Next { get; set; }
     }
+
+    private static WithRawResponse<Response> Wrap(Response response) =>
+        new()
+        {
+            Data = response,
+            RawResponse = new RawResponse
+            {
+                StatusCode = HttpStatusCode.OK,
+                Url = new Uri("https://localhost"),
+                Headers = default,
+            },
+        };
 }

--- a/seed/csharp-sdk/exhaustive/use-undiscriminated-unions/src/SeedExhaustive.Test/Core/Pagination/NoRequestOffsetTest.cs
+++ b/seed/csharp-sdk/exhaustive/use-undiscriminated-unions/src/SeedExhaustive.Test/Core/Pagination/NoRequestOffsetTest.cs
@@ -1,3 +1,4 @@
+using global::System.Net;
 using NUnit.Framework;
 using SeedExhaustive.Core;
 using SystemTask = global::System.Threading.Tasks.Task;
@@ -29,7 +30,7 @@ public class NoRequestOffsetTest
             (_, _, _) =>
             {
                 responses.MoveNext();
-                return SystemTask.FromResult(responses.Current);
+                return SystemTask.FromResult(Wrap(responses.Current));
             },
             request => request?.Pagination?.Page ?? 0,
             (request, offset) =>
@@ -79,4 +80,16 @@ public class NoRequestOffsetTest
     {
         public IEnumerable<string>? Items { get; set; }
     }
+
+    private static WithRawResponse<Response> Wrap(Response response) =>
+        new()
+        {
+            Data = response,
+            RawResponse = new RawResponse
+            {
+                StatusCode = HttpStatusCode.OK,
+                Url = new Uri("https://localhost"),
+                Headers = default,
+            },
+        };
 }

--- a/seed/csharp-sdk/exhaustive/use-undiscriminated-unions/src/SeedExhaustive.Test/Core/Pagination/StepOffsetTest.cs
+++ b/seed/csharp-sdk/exhaustive/use-undiscriminated-unions/src/SeedExhaustive.Test/Core/Pagination/StepOffsetTest.cs
@@ -1,3 +1,4 @@
+using global::System.Net;
 using NUnit.Framework;
 using SeedExhaustive.Core;
 using SystemTask = global::System.Threading.Tasks.Task;
@@ -30,7 +31,7 @@ public class StepPageOffsetPaginationTest
             (_, _, _) =>
             {
                 responses.MoveNext();
-                return SystemTask.FromResult(responses.Current);
+                return SystemTask.FromResult(Wrap(responses.Current));
             },
             request => request?.Pagination?.ItemOffset ?? 0,
             (request, offset) =>
@@ -89,4 +90,16 @@ public class StepPageOffsetPaginationTest
     {
         public IEnumerable<string>? Items { get; set; }
     }
+
+    private static WithRawResponse<Response> Wrap(Response response) =>
+        new()
+        {
+            Data = response,
+            RawResponse = new RawResponse
+            {
+                StatusCode = HttpStatusCode.OK,
+                Url = new Uri("https://localhost"),
+                Headers = default,
+            },
+        };
 }

--- a/seed/csharp-sdk/exhaustive/use-undiscriminated-unions/src/SeedExhaustive.Test/Core/Pagination/StringCursorTest.cs
+++ b/seed/csharp-sdk/exhaustive/use-undiscriminated-unions/src/SeedExhaustive.Test/Core/Pagination/StringCursorTest.cs
@@ -1,3 +1,4 @@
+using global::System.Net;
 using NUnit.Framework;
 using SeedExhaustive.Core;
 using SystemTask = global::System.Threading.Tasks.Task;
@@ -46,7 +47,7 @@ public class StringCursorTest
             (_, _, _) =>
             {
                 responses.MoveNext();
-                return SystemTask.FromResult(responses.Current);
+                return SystemTask.FromResult(Wrap(responses.Current));
             },
             (request, cursor) =>
             {
@@ -115,7 +116,7 @@ public class StringCursorTest
             (_, _, _) =>
             {
                 responses.MoveNext();
-                return SystemTask.FromResult(responses.Current);
+                return SystemTask.FromResult(Wrap(responses.Current));
             },
             (request, cursor) =>
             {
@@ -164,4 +165,16 @@ public class StringCursorTest
     {
         public required string? Next { get; set; }
     }
+
+    private static WithRawResponse<Response> Wrap(Response response) =>
+        new()
+        {
+            Data = response,
+            RawResponse = new RawResponse
+            {
+                StatusCode = HttpStatusCode.OK,
+                Url = new Uri("https://localhost"),
+                Headers = default,
+            },
+        };
 }

--- a/seed/csharp-sdk/exhaustive/use-undiscriminated-unions/src/SeedExhaustive/Core/Page.cs
+++ b/seed/csharp-sdk/exhaustive/use-undiscriminated-unions/src/SeedExhaustive/Core/Page.cs
@@ -1,5 +1,6 @@
 using global::System.Collections;
 using global::System.Collections.ObjectModel;
+using global::System.Net;
 
 namespace SeedExhaustive.Core;
 
@@ -20,9 +21,41 @@ public class Page<TItem> : IEnumerable<TItem>
     }
 
     /// <summary>
+    /// Creates a new <see cref="Page{TItem}"/> with the specified items and response metadata.
+    /// </summary>
+    public Page(
+        IReadOnlyList<TItem> items,
+        object? response,
+        HttpStatusCode statusCode,
+        ResponseHeaders? headers
+    )
+    {
+        Items = items;
+        Response = response;
+        StatusCode = statusCode;
+        Headers = headers;
+    }
+
+    /// <summary>
     /// Gets the items in this <see cref="Page{TItem}"/>.
     /// </summary>
     public IReadOnlyList<TItem> Items { get; }
+
+    /// <summary>
+    /// The full API response object for this page. Cast to the endpoint's response
+    /// type to access fields beyond the paginated items (e.g., TotalCount, metadata).
+    /// </summary>
+    public object? Response { get; }
+
+    /// <summary>
+    /// The HTTP status code of the response that produced this page.
+    /// </summary>
+    public HttpStatusCode StatusCode { get; }
+
+    /// <summary>
+    /// The HTTP response headers from the response that produced this page.
+    /// </summary>
+    public ResponseHeaders? Headers { get; }
 
     /// <summary>
     /// Enumerate the items in this <see cref="Page{TItem}"/>.

--- a/seed/csharp-sdk/exhaustive/use-undiscriminated-unions/src/SeedExhaustive/Core/Pager.cs
+++ b/seed/csharp-sdk/exhaustive/use-undiscriminated-unions/src/SeedExhaustive/Core/Pager.cs
@@ -95,7 +95,7 @@ internal sealed class OffsetPager<TRequest, TRequestOptions, TResponse, TOffset,
     private readonly SendRequest _sendRequest;
     private readonly ParseApiCallDelegate _parseApiCall;
 
-    internal delegate global::System.Threading.Tasks.Task<TResponse> SendRequest(
+    internal delegate global::System.Threading.Tasks.Task<WithRawResponse<TResponse>> SendRequest(
         TRequest request,
         TRequestOptions? options,
         CancellationToken cancellationToken
@@ -115,7 +115,7 @@ internal sealed class OffsetPager<TRequest, TRequestOptions, TResponse, TOffset,
         TRequest? nextRequest,
         bool hasNextPage,
         Page<TItem> page
-    ) ParseApiCallDelegate(TRequest request, TResponse response);
+    ) ParseApiCallDelegate(TRequest request, WithRawResponse<TResponse> wrappedResponse);
 
     public Page<TItem> CurrentPage { get; private set; }
     public bool HasNextPage { get; private set; }
@@ -152,7 +152,8 @@ internal sealed class OffsetPager<TRequest, TRequestOptions, TResponse, TOffset,
     )
     {
         request ??= Activator.CreateInstance<TRequest>();
-        var response = await sendRequest(request, options, cancellationToken).ConfigureAwait(false);
+        var wrappedResponse = await sendRequest(request, options, cancellationToken)
+            .ConfigureAwait(false);
         var parseApiCall = CreateParseApiCallDelegate(
             getItems,
             getOffset,
@@ -160,7 +161,7 @@ internal sealed class OffsetPager<TRequest, TRequestOptions, TResponse, TOffset,
             getStep,
             getHasNextPage
         );
-        var (nextRequest, hasNextPage, page) = parseApiCall(request, response);
+        var (nextRequest, hasNextPage, page) = parseApiCall(request, wrappedResponse);
         return new OffsetPager<TRequest, TRequestOptions, TResponse, TOffset, TStep, TItem>(
             nextRequest,
             options,
@@ -179,10 +180,10 @@ internal sealed class OffsetPager<TRequest, TRequestOptions, TResponse, TOffset,
         GetHasNextPage? getHasNextPage
     )
     {
-        return (request, response) =>
+        return (request, wrappedResponse) =>
             ParseApiCall(
                 request,
-                response,
+                wrappedResponse,
                 getItems,
                 getOffset,
                 setOffset,
@@ -197,9 +198,9 @@ internal sealed class OffsetPager<TRequest, TRequestOptions, TResponse, TOffset,
         CancellationToken cancellationToken = default
     )
     {
-        var response = await _sendRequest(request, options, cancellationToken)
+        var wrappedResponse = await _sendRequest(request, options, cancellationToken)
             .ConfigureAwait(false);
-        var (nextRequest, hasNextPageFlag, page) = _parseApiCall(request, response);
+        var (nextRequest, hasNextPageFlag, page) = _parseApiCall(request, wrappedResponse);
         _request = nextRequest;
         HasNextPage = hasNextPageFlag;
         CurrentPage = page;
@@ -208,7 +209,7 @@ internal sealed class OffsetPager<TRequest, TRequestOptions, TResponse, TOffset,
 
     private static (TRequest? nextRequest, bool hasNextPage, Page<TItem> page) ParseApiCall(
         TRequest request,
-        TResponse response,
+        WithRawResponse<TResponse> wrappedResponse,
         GetItems getItems,
         GetOffset getOffset,
         SetOffset setOffset,
@@ -216,8 +217,16 @@ internal sealed class OffsetPager<TRequest, TRequestOptions, TResponse, TOffset,
         GetHasNextPage? getHasNextPage
     )
     {
+        var response = wrappedResponse.Data;
         var items = getItems(response);
-        var page = items is not null ? new Page<TItem>(items) : Page<TItem>.Empty;
+        var page = items is not null
+            ? new Page<TItem>(
+                items,
+                response,
+                wrappedResponse.RawResponse.StatusCode,
+                wrappedResponse.RawResponse.Headers
+            )
+            : Page<TItem>.Empty;
         var offset = getOffset(request);
         var hasNextPage = getHasNextPage?.Invoke(response) ?? items?.Count > 0;
         if (!hasNextPage)
@@ -360,7 +369,7 @@ internal sealed class CursorPager<TRequest, TRequestOptions, TResponse, TCursor,
     /// <summary>
     /// Delegate for sending a request.
     /// </summary>
-    internal delegate global::System.Threading.Tasks.Task<TResponse> SendRequest(
+    internal delegate global::System.Threading.Tasks.Task<WithRawResponse<TResponse>> SendRequest(
         TRequest request,
         TRequestOptions? options,
         CancellationToken cancellationToken
@@ -385,7 +394,7 @@ internal sealed class CursorPager<TRequest, TRequestOptions, TResponse, TCursor,
         TRequest? nextRequest,
         bool hasNextPage,
         Page<TItem> page
-    ) ParseApiCallDelegate(TRequest request, TResponse response);
+    ) ParseApiCallDelegate(TRequest request, WithRawResponse<TResponse> wrappedResponse);
 
     /// <summary>
     /// The current <see cref="Page{TItem}"/>.
@@ -430,9 +439,10 @@ internal sealed class CursorPager<TRequest, TRequestOptions, TResponse, TCursor,
     )
     {
         request ??= Activator.CreateInstance<TRequest>();
-        var response = await sendRequest(request, options, cancellationToken).ConfigureAwait(false);
+        var wrappedResponse = await sendRequest(request, options, cancellationToken)
+            .ConfigureAwait(false);
         var parseApiCall = CreateParseApiCallDelegate(getItems, getNextCursor, setCursor);
-        var (nextRequest, hasNextPage, page) = parseApiCall(request, response);
+        var (nextRequest, hasNextPage, page) = parseApiCall(request, wrappedResponse);
         return new CursorPager<TRequest, TRequestOptions, TResponse, TCursor, TItem>(
             nextRequest,
             options,
@@ -449,10 +459,18 @@ internal sealed class CursorPager<TRequest, TRequestOptions, TResponse, TCursor,
         SetCursor setCursor
     )
     {
-        return (request, response) =>
+        return (request, wrappedResponse) =>
         {
+            var response = wrappedResponse.Data;
             var items = getItems(response);
-            var page = items is not null ? new Page<TItem>(items) : Page<TItem>.Empty;
+            var page = items is not null
+                ? new Page<TItem>(
+                    items,
+                    response,
+                    wrappedResponse.RawResponse.StatusCode,
+                    wrappedResponse.RawResponse.Headers
+                )
+                : Page<TItem>.Empty;
             var cursor = getNextCursor(response);
             var hasNextPage = cursor switch
             {
@@ -475,9 +493,9 @@ internal sealed class CursorPager<TRequest, TRequestOptions, TResponse, TCursor,
         CancellationToken cancellationToken = default
     )
     {
-        var response = await _sendRequest(request, options, cancellationToken)
+        var wrappedResponse = await _sendRequest(request, options, cancellationToken)
             .ConfigureAwait(false);
-        var (nextRequest, hasNextPage, page) = _parseApiCall(request, response);
+        var (nextRequest, hasNextPage, page) = _parseApiCall(request, wrappedResponse);
         _request = nextRequest;
         HasNextPage = hasNextPage;
         CurrentPage = page;

--- a/seed/csharp-sdk/exhaustive/use-undiscriminated-unions/src/SeedExhaustive/Endpoints/Pagination/PaginationClient.cs
+++ b/seed/csharp-sdk/exhaustive/use-undiscriminated-unions/src/SeedExhaustive/Endpoints/Pagination/PaginationClient.cs
@@ -128,7 +128,8 @@ public partial class PaginationClient : IPaginationClient
                 request,
                 options,
                 async (request, options, cancellationToken) =>
-                    await ListItemsInternalAsync(request, options, cancellationToken),
+                    await ListItemsInternalAsync(request, options, cancellationToken)
+                        .WithRawResponse(),
                 (request, cursor) =>
                 {
                     request.Cursor = cursor;

--- a/seed/csharp-sdk/pagination-custom/src/SeedPagination.Test/Core/Pagination/GuidCursorTest.cs
+++ b/seed/csharp-sdk/pagination-custom/src/SeedPagination.Test/Core/Pagination/GuidCursorTest.cs
@@ -1,3 +1,4 @@
+using global::System.Net;
 using NUnit.Framework;
 using SeedPagination.Core;
 using SystemTask = global::System.Threading.Tasks.Task;
@@ -45,7 +46,7 @@ public class GuidCursorTest
             (_, _, _) =>
             {
                 responses.MoveNext();
-                return SystemTask.FromResult(responses.Current);
+                return SystemTask.FromResult(Wrap(responses.Current));
             },
             (request, cursor) =>
             {
@@ -100,4 +101,16 @@ public class GuidCursorTest
     {
         public required Guid? Next { get; set; }
     }
+
+    private static WithRawResponse<Response> Wrap(Response response) =>
+        new()
+        {
+            Data = response,
+            RawResponse = new RawResponse
+            {
+                StatusCode = HttpStatusCode.OK,
+                Url = new Uri("https://localhost"),
+                Headers = default,
+            },
+        };
 }

--- a/seed/csharp-sdk/pagination-custom/src/SeedPagination.Test/Core/Pagination/HasNextPageOffsetTest.cs
+++ b/seed/csharp-sdk/pagination-custom/src/SeedPagination.Test/Core/Pagination/HasNextPageOffsetTest.cs
@@ -1,3 +1,4 @@
+using global::System.Net;
 using NUnit.Framework;
 using SeedPagination.Core;
 using SystemTask = global::System.Threading.Tasks.Task;
@@ -41,7 +42,7 @@ public class HasNextPageOffsetTest
             (_, _, _) =>
             {
                 responses.MoveNext();
-                return SystemTask.FromResult(responses.Current);
+                return SystemTask.FromResult(Wrap(responses.Current));
             },
             request => request?.Pagination?.Page ?? 0,
             (request, offset) =>
@@ -89,4 +90,16 @@ public class HasNextPageOffsetTest
     {
         public IEnumerable<string>? Items { get; set; }
     }
+
+    private static WithRawResponse<Response> Wrap(Response response) =>
+        new()
+        {
+            Data = response,
+            RawResponse = new RawResponse
+            {
+                StatusCode = HttpStatusCode.OK,
+                Url = new Uri("https://localhost"),
+                Headers = default,
+            },
+        };
 }

--- a/seed/csharp-sdk/pagination-custom/src/SeedPagination.Test/Core/Pagination/IntOffsetTest.cs
+++ b/seed/csharp-sdk/pagination-custom/src/SeedPagination.Test/Core/Pagination/IntOffsetTest.cs
@@ -1,3 +1,4 @@
+using global::System.Net;
 using NUnit.Framework;
 using SeedPagination.Core;
 using SystemTask = global::System.Threading.Tasks.Task;
@@ -29,7 +30,7 @@ public class IntOffsetTest
             (_, _, _) =>
             {
                 responses.MoveNext();
-                return SystemTask.FromResult(responses.Current);
+                return SystemTask.FromResult(Wrap(responses.Current));
             },
             request => request?.Pagination?.Page ?? 0,
             (request, offset) =>
@@ -79,4 +80,16 @@ public class IntOffsetTest
     {
         public IEnumerable<string>? Items { get; set; }
     }
+
+    private static WithRawResponse<Response> Wrap(Response response) =>
+        new()
+        {
+            Data = response,
+            RawResponse = new RawResponse
+            {
+                StatusCode = HttpStatusCode.OK,
+                Url = new Uri("https://localhost"),
+                Headers = default,
+            },
+        };
 }

--- a/seed/csharp-sdk/pagination-custom/src/SeedPagination.Test/Core/Pagination/LongOffsetTest.cs
+++ b/seed/csharp-sdk/pagination-custom/src/SeedPagination.Test/Core/Pagination/LongOffsetTest.cs
@@ -1,3 +1,4 @@
+using global::System.Net;
 using NUnit.Framework;
 using SeedPagination.Core;
 using SystemTask = global::System.Threading.Tasks.Task;
@@ -29,7 +30,7 @@ public class LongOffsetTest
             (_, _, _) =>
             {
                 responses.MoveNext();
-                return SystemTask.FromResult(responses.Current);
+                return SystemTask.FromResult(Wrap(responses.Current));
             },
             request => request?.Pagination?.Page ?? 0,
             (request, offset) =>
@@ -76,4 +77,16 @@ public class LongOffsetTest
     {
         public IEnumerable<string>? Items { get; set; }
     }
+
+    private static WithRawResponse<Response> Wrap(Response response) =>
+        new()
+        {
+            Data = response,
+            RawResponse = new RawResponse
+            {
+                StatusCode = HttpStatusCode.OK,
+                Url = new Uri("https://localhost"),
+                Headers = default,
+            },
+        };
 }

--- a/seed/csharp-sdk/pagination-custom/src/SeedPagination.Test/Core/Pagination/NoRequestCursorTest.cs
+++ b/seed/csharp-sdk/pagination-custom/src/SeedPagination.Test/Core/Pagination/NoRequestCursorTest.cs
@@ -1,3 +1,4 @@
+using global::System.Net;
 using NUnit.Framework;
 using SeedPagination.Core;
 using SystemTask = global::System.Threading.Tasks.Task;
@@ -45,7 +46,7 @@ public class NoRequestCursorTest
             (_, _, _) =>
             {
                 responses.MoveNext();
-                return SystemTask.FromResult(responses.Current);
+                return SystemTask.FromResult(Wrap(responses.Current));
             },
             (request, cursor) =>
             {
@@ -103,4 +104,16 @@ public class NoRequestCursorTest
     {
         public required string? Next { get; set; }
     }
+
+    private static WithRawResponse<Response> Wrap(Response response) =>
+        new()
+        {
+            Data = response,
+            RawResponse = new RawResponse
+            {
+                StatusCode = HttpStatusCode.OK,
+                Url = new Uri("https://localhost"),
+                Headers = default,
+            },
+        };
 }

--- a/seed/csharp-sdk/pagination-custom/src/SeedPagination.Test/Core/Pagination/NoRequestOffsetTest.cs
+++ b/seed/csharp-sdk/pagination-custom/src/SeedPagination.Test/Core/Pagination/NoRequestOffsetTest.cs
@@ -1,3 +1,4 @@
+using global::System.Net;
 using NUnit.Framework;
 using SeedPagination.Core;
 using SystemTask = global::System.Threading.Tasks.Task;
@@ -29,7 +30,7 @@ public class NoRequestOffsetTest
             (_, _, _) =>
             {
                 responses.MoveNext();
-                return SystemTask.FromResult(responses.Current);
+                return SystemTask.FromResult(Wrap(responses.Current));
             },
             request => request?.Pagination?.Page ?? 0,
             (request, offset) =>
@@ -79,4 +80,16 @@ public class NoRequestOffsetTest
     {
         public IEnumerable<string>? Items { get; set; }
     }
+
+    private static WithRawResponse<Response> Wrap(Response response) =>
+        new()
+        {
+            Data = response,
+            RawResponse = new RawResponse
+            {
+                StatusCode = HttpStatusCode.OK,
+                Url = new Uri("https://localhost"),
+                Headers = default,
+            },
+        };
 }

--- a/seed/csharp-sdk/pagination-custom/src/SeedPagination.Test/Core/Pagination/StepOffsetTest.cs
+++ b/seed/csharp-sdk/pagination-custom/src/SeedPagination.Test/Core/Pagination/StepOffsetTest.cs
@@ -1,3 +1,4 @@
+using global::System.Net;
 using NUnit.Framework;
 using SeedPagination.Core;
 using SystemTask = global::System.Threading.Tasks.Task;
@@ -30,7 +31,7 @@ public class StepPageOffsetPaginationTest
             (_, _, _) =>
             {
                 responses.MoveNext();
-                return SystemTask.FromResult(responses.Current);
+                return SystemTask.FromResult(Wrap(responses.Current));
             },
             request => request?.Pagination?.ItemOffset ?? 0,
             (request, offset) =>
@@ -89,4 +90,16 @@ public class StepPageOffsetPaginationTest
     {
         public IEnumerable<string>? Items { get; set; }
     }
+
+    private static WithRawResponse<Response> Wrap(Response response) =>
+        new()
+        {
+            Data = response,
+            RawResponse = new RawResponse
+            {
+                StatusCode = HttpStatusCode.OK,
+                Url = new Uri("https://localhost"),
+                Headers = default,
+            },
+        };
 }

--- a/seed/csharp-sdk/pagination-custom/src/SeedPagination.Test/Core/Pagination/StringCursorTest.cs
+++ b/seed/csharp-sdk/pagination-custom/src/SeedPagination.Test/Core/Pagination/StringCursorTest.cs
@@ -1,3 +1,4 @@
+using global::System.Net;
 using NUnit.Framework;
 using SeedPagination.Core;
 using SystemTask = global::System.Threading.Tasks.Task;
@@ -46,7 +47,7 @@ public class StringCursorTest
             (_, _, _) =>
             {
                 responses.MoveNext();
-                return SystemTask.FromResult(responses.Current);
+                return SystemTask.FromResult(Wrap(responses.Current));
             },
             (request, cursor) =>
             {
@@ -115,7 +116,7 @@ public class StringCursorTest
             (_, _, _) =>
             {
                 responses.MoveNext();
-                return SystemTask.FromResult(responses.Current);
+                return SystemTask.FromResult(Wrap(responses.Current));
             },
             (request, cursor) =>
             {
@@ -164,4 +165,16 @@ public class StringCursorTest
     {
         public required string? Next { get; set; }
     }
+
+    private static WithRawResponse<Response> Wrap(Response response) =>
+        new()
+        {
+            Data = response,
+            RawResponse = new RawResponse
+            {
+                StatusCode = HttpStatusCode.OK,
+                Url = new Uri("https://localhost"),
+                Headers = default,
+            },
+        };
 }

--- a/seed/csharp-sdk/pagination-custom/src/SeedPagination/Core/Page.cs
+++ b/seed/csharp-sdk/pagination-custom/src/SeedPagination/Core/Page.cs
@@ -1,5 +1,6 @@
 using global::System.Collections;
 using global::System.Collections.ObjectModel;
+using global::System.Net;
 
 namespace SeedPagination.Core;
 
@@ -20,9 +21,41 @@ public class Page<TItem> : IEnumerable<TItem>
     }
 
     /// <summary>
+    /// Creates a new <see cref="Page{TItem}"/> with the specified items and response metadata.
+    /// </summary>
+    public Page(
+        IReadOnlyList<TItem> items,
+        object? response,
+        HttpStatusCode statusCode,
+        ResponseHeaders? headers
+    )
+    {
+        Items = items;
+        Response = response;
+        StatusCode = statusCode;
+        Headers = headers;
+    }
+
+    /// <summary>
     /// Gets the items in this <see cref="Page{TItem}"/>.
     /// </summary>
     public IReadOnlyList<TItem> Items { get; }
+
+    /// <summary>
+    /// The full API response object for this page. Cast to the endpoint's response
+    /// type to access fields beyond the paginated items (e.g., TotalCount, metadata).
+    /// </summary>
+    public object? Response { get; }
+
+    /// <summary>
+    /// The HTTP status code of the response that produced this page.
+    /// </summary>
+    public HttpStatusCode StatusCode { get; }
+
+    /// <summary>
+    /// The HTTP response headers from the response that produced this page.
+    /// </summary>
+    public ResponseHeaders? Headers { get; }
 
     /// <summary>
     /// Enumerate the items in this <see cref="Page{TItem}"/>.

--- a/seed/csharp-sdk/pagination-custom/src/SeedPagination/Core/Pager.cs
+++ b/seed/csharp-sdk/pagination-custom/src/SeedPagination/Core/Pager.cs
@@ -95,7 +95,7 @@ internal sealed class OffsetPager<TRequest, TRequestOptions, TResponse, TOffset,
     private readonly SendRequest _sendRequest;
     private readonly ParseApiCallDelegate _parseApiCall;
 
-    internal delegate global::System.Threading.Tasks.Task<TResponse> SendRequest(
+    internal delegate global::System.Threading.Tasks.Task<WithRawResponse<TResponse>> SendRequest(
         TRequest request,
         TRequestOptions? options,
         CancellationToken cancellationToken
@@ -115,7 +115,7 @@ internal sealed class OffsetPager<TRequest, TRequestOptions, TResponse, TOffset,
         TRequest? nextRequest,
         bool hasNextPage,
         Page<TItem> page
-    ) ParseApiCallDelegate(TRequest request, TResponse response);
+    ) ParseApiCallDelegate(TRequest request, WithRawResponse<TResponse> wrappedResponse);
 
     public Page<TItem> CurrentPage { get; private set; }
     public bool HasNextPage { get; private set; }
@@ -152,7 +152,8 @@ internal sealed class OffsetPager<TRequest, TRequestOptions, TResponse, TOffset,
     )
     {
         request ??= Activator.CreateInstance<TRequest>();
-        var response = await sendRequest(request, options, cancellationToken).ConfigureAwait(false);
+        var wrappedResponse = await sendRequest(request, options, cancellationToken)
+            .ConfigureAwait(false);
         var parseApiCall = CreateParseApiCallDelegate(
             getItems,
             getOffset,
@@ -160,7 +161,7 @@ internal sealed class OffsetPager<TRequest, TRequestOptions, TResponse, TOffset,
             getStep,
             getHasNextPage
         );
-        var (nextRequest, hasNextPage, page) = parseApiCall(request, response);
+        var (nextRequest, hasNextPage, page) = parseApiCall(request, wrappedResponse);
         return new OffsetPager<TRequest, TRequestOptions, TResponse, TOffset, TStep, TItem>(
             nextRequest,
             options,
@@ -179,10 +180,10 @@ internal sealed class OffsetPager<TRequest, TRequestOptions, TResponse, TOffset,
         GetHasNextPage? getHasNextPage
     )
     {
-        return (request, response) =>
+        return (request, wrappedResponse) =>
             ParseApiCall(
                 request,
-                response,
+                wrappedResponse,
                 getItems,
                 getOffset,
                 setOffset,
@@ -197,9 +198,9 @@ internal sealed class OffsetPager<TRequest, TRequestOptions, TResponse, TOffset,
         CancellationToken cancellationToken = default
     )
     {
-        var response = await _sendRequest(request, options, cancellationToken)
+        var wrappedResponse = await _sendRequest(request, options, cancellationToken)
             .ConfigureAwait(false);
-        var (nextRequest, hasNextPageFlag, page) = _parseApiCall(request, response);
+        var (nextRequest, hasNextPageFlag, page) = _parseApiCall(request, wrappedResponse);
         _request = nextRequest;
         HasNextPage = hasNextPageFlag;
         CurrentPage = page;
@@ -208,7 +209,7 @@ internal sealed class OffsetPager<TRequest, TRequestOptions, TResponse, TOffset,
 
     private static (TRequest? nextRequest, bool hasNextPage, Page<TItem> page) ParseApiCall(
         TRequest request,
-        TResponse response,
+        WithRawResponse<TResponse> wrappedResponse,
         GetItems getItems,
         GetOffset getOffset,
         SetOffset setOffset,
@@ -216,8 +217,16 @@ internal sealed class OffsetPager<TRequest, TRequestOptions, TResponse, TOffset,
         GetHasNextPage? getHasNextPage
     )
     {
+        var response = wrappedResponse.Data;
         var items = getItems(response);
-        var page = items is not null ? new Page<TItem>(items) : Page<TItem>.Empty;
+        var page = items is not null
+            ? new Page<TItem>(
+                items,
+                response,
+                wrappedResponse.RawResponse.StatusCode,
+                wrappedResponse.RawResponse.Headers
+            )
+            : Page<TItem>.Empty;
         var offset = getOffset(request);
         var hasNextPage = getHasNextPage?.Invoke(response) ?? items?.Count > 0;
         if (!hasNextPage)
@@ -360,7 +369,7 @@ internal sealed class CursorPager<TRequest, TRequestOptions, TResponse, TCursor,
     /// <summary>
     /// Delegate for sending a request.
     /// </summary>
-    internal delegate global::System.Threading.Tasks.Task<TResponse> SendRequest(
+    internal delegate global::System.Threading.Tasks.Task<WithRawResponse<TResponse>> SendRequest(
         TRequest request,
         TRequestOptions? options,
         CancellationToken cancellationToken
@@ -385,7 +394,7 @@ internal sealed class CursorPager<TRequest, TRequestOptions, TResponse, TCursor,
         TRequest? nextRequest,
         bool hasNextPage,
         Page<TItem> page
-    ) ParseApiCallDelegate(TRequest request, TResponse response);
+    ) ParseApiCallDelegate(TRequest request, WithRawResponse<TResponse> wrappedResponse);
 
     /// <summary>
     /// The current <see cref="Page{TItem}"/>.
@@ -430,9 +439,10 @@ internal sealed class CursorPager<TRequest, TRequestOptions, TResponse, TCursor,
     )
     {
         request ??= Activator.CreateInstance<TRequest>();
-        var response = await sendRequest(request, options, cancellationToken).ConfigureAwait(false);
+        var wrappedResponse = await sendRequest(request, options, cancellationToken)
+            .ConfigureAwait(false);
         var parseApiCall = CreateParseApiCallDelegate(getItems, getNextCursor, setCursor);
-        var (nextRequest, hasNextPage, page) = parseApiCall(request, response);
+        var (nextRequest, hasNextPage, page) = parseApiCall(request, wrappedResponse);
         return new CursorPager<TRequest, TRequestOptions, TResponse, TCursor, TItem>(
             nextRequest,
             options,
@@ -449,10 +459,18 @@ internal sealed class CursorPager<TRequest, TRequestOptions, TResponse, TCursor,
         SetCursor setCursor
     )
     {
-        return (request, response) =>
+        return (request, wrappedResponse) =>
         {
+            var response = wrappedResponse.Data;
             var items = getItems(response);
-            var page = items is not null ? new Page<TItem>(items) : Page<TItem>.Empty;
+            var page = items is not null
+                ? new Page<TItem>(
+                    items,
+                    response,
+                    wrappedResponse.RawResponse.StatusCode,
+                    wrappedResponse.RawResponse.Headers
+                )
+                : Page<TItem>.Empty;
             var cursor = getNextCursor(response);
             var hasNextPage = cursor switch
             {
@@ -475,9 +493,9 @@ internal sealed class CursorPager<TRequest, TRequestOptions, TResponse, TCursor,
         CancellationToken cancellationToken = default
     )
     {
-        var response = await _sendRequest(request, options, cancellationToken)
+        var wrappedResponse = await _sendRequest(request, options, cancellationToken)
             .ConfigureAwait(false);
-        var (nextRequest, hasNextPage, page) = _parseApiCall(request, response);
+        var (nextRequest, hasNextPage, page) = _parseApiCall(request, wrappedResponse);
         _request = nextRequest;
         HasNextPage = hasNextPage;
         CurrentPage = page;

--- a/seed/csharp-sdk/pagination-uri-path/src/SeedPaginationUriPath.Test/Core/Pagination/GuidCursorTest.cs
+++ b/seed/csharp-sdk/pagination-uri-path/src/SeedPaginationUriPath.Test/Core/Pagination/GuidCursorTest.cs
@@ -1,3 +1,4 @@
+using global::System.Net;
 using NUnit.Framework;
 using SeedPaginationUriPath.Core;
 using SystemTask = global::System.Threading.Tasks.Task;
@@ -45,7 +46,7 @@ public class GuidCursorTest
             (_, _, _) =>
             {
                 responses.MoveNext();
-                return SystemTask.FromResult(responses.Current);
+                return SystemTask.FromResult(Wrap(responses.Current));
             },
             (request, cursor) =>
             {
@@ -100,4 +101,16 @@ public class GuidCursorTest
     {
         public required Guid? Next { get; set; }
     }
+
+    private static WithRawResponse<Response> Wrap(Response response) =>
+        new()
+        {
+            Data = response,
+            RawResponse = new RawResponse
+            {
+                StatusCode = HttpStatusCode.OK,
+                Url = new Uri("https://localhost"),
+                Headers = default,
+            },
+        };
 }

--- a/seed/csharp-sdk/pagination-uri-path/src/SeedPaginationUriPath.Test/Core/Pagination/HasNextPageOffsetTest.cs
+++ b/seed/csharp-sdk/pagination-uri-path/src/SeedPaginationUriPath.Test/Core/Pagination/HasNextPageOffsetTest.cs
@@ -1,3 +1,4 @@
+using global::System.Net;
 using NUnit.Framework;
 using SeedPaginationUriPath.Core;
 using SystemTask = global::System.Threading.Tasks.Task;
@@ -41,7 +42,7 @@ public class HasNextPageOffsetTest
             (_, _, _) =>
             {
                 responses.MoveNext();
-                return SystemTask.FromResult(responses.Current);
+                return SystemTask.FromResult(Wrap(responses.Current));
             },
             request => request?.Pagination?.Page ?? 0,
             (request, offset) =>
@@ -89,4 +90,16 @@ public class HasNextPageOffsetTest
     {
         public IEnumerable<string>? Items { get; set; }
     }
+
+    private static WithRawResponse<Response> Wrap(Response response) =>
+        new()
+        {
+            Data = response,
+            RawResponse = new RawResponse
+            {
+                StatusCode = HttpStatusCode.OK,
+                Url = new Uri("https://localhost"),
+                Headers = default,
+            },
+        };
 }

--- a/seed/csharp-sdk/pagination-uri-path/src/SeedPaginationUriPath.Test/Core/Pagination/IntOffsetTest.cs
+++ b/seed/csharp-sdk/pagination-uri-path/src/SeedPaginationUriPath.Test/Core/Pagination/IntOffsetTest.cs
@@ -1,3 +1,4 @@
+using global::System.Net;
 using NUnit.Framework;
 using SeedPaginationUriPath.Core;
 using SystemTask = global::System.Threading.Tasks.Task;
@@ -29,7 +30,7 @@ public class IntOffsetTest
             (_, _, _) =>
             {
                 responses.MoveNext();
-                return SystemTask.FromResult(responses.Current);
+                return SystemTask.FromResult(Wrap(responses.Current));
             },
             request => request?.Pagination?.Page ?? 0,
             (request, offset) =>
@@ -79,4 +80,16 @@ public class IntOffsetTest
     {
         public IEnumerable<string>? Items { get; set; }
     }
+
+    private static WithRawResponse<Response> Wrap(Response response) =>
+        new()
+        {
+            Data = response,
+            RawResponse = new RawResponse
+            {
+                StatusCode = HttpStatusCode.OK,
+                Url = new Uri("https://localhost"),
+                Headers = default,
+            },
+        };
 }

--- a/seed/csharp-sdk/pagination-uri-path/src/SeedPaginationUriPath.Test/Core/Pagination/LongOffsetTest.cs
+++ b/seed/csharp-sdk/pagination-uri-path/src/SeedPaginationUriPath.Test/Core/Pagination/LongOffsetTest.cs
@@ -1,3 +1,4 @@
+using global::System.Net;
 using NUnit.Framework;
 using SeedPaginationUriPath.Core;
 using SystemTask = global::System.Threading.Tasks.Task;
@@ -29,7 +30,7 @@ public class LongOffsetTest
             (_, _, _) =>
             {
                 responses.MoveNext();
-                return SystemTask.FromResult(responses.Current);
+                return SystemTask.FromResult(Wrap(responses.Current));
             },
             request => request?.Pagination?.Page ?? 0,
             (request, offset) =>
@@ -76,4 +77,16 @@ public class LongOffsetTest
     {
         public IEnumerable<string>? Items { get; set; }
     }
+
+    private static WithRawResponse<Response> Wrap(Response response) =>
+        new()
+        {
+            Data = response,
+            RawResponse = new RawResponse
+            {
+                StatusCode = HttpStatusCode.OK,
+                Url = new Uri("https://localhost"),
+                Headers = default,
+            },
+        };
 }

--- a/seed/csharp-sdk/pagination-uri-path/src/SeedPaginationUriPath.Test/Core/Pagination/NoRequestCursorTest.cs
+++ b/seed/csharp-sdk/pagination-uri-path/src/SeedPaginationUriPath.Test/Core/Pagination/NoRequestCursorTest.cs
@@ -1,3 +1,4 @@
+using global::System.Net;
 using NUnit.Framework;
 using SeedPaginationUriPath.Core;
 using SystemTask = global::System.Threading.Tasks.Task;
@@ -45,7 +46,7 @@ public class NoRequestCursorTest
             (_, _, _) =>
             {
                 responses.MoveNext();
-                return SystemTask.FromResult(responses.Current);
+                return SystemTask.FromResult(Wrap(responses.Current));
             },
             (request, cursor) =>
             {
@@ -103,4 +104,16 @@ public class NoRequestCursorTest
     {
         public required string? Next { get; set; }
     }
+
+    private static WithRawResponse<Response> Wrap(Response response) =>
+        new()
+        {
+            Data = response,
+            RawResponse = new RawResponse
+            {
+                StatusCode = HttpStatusCode.OK,
+                Url = new Uri("https://localhost"),
+                Headers = default,
+            },
+        };
 }

--- a/seed/csharp-sdk/pagination-uri-path/src/SeedPaginationUriPath.Test/Core/Pagination/NoRequestOffsetTest.cs
+++ b/seed/csharp-sdk/pagination-uri-path/src/SeedPaginationUriPath.Test/Core/Pagination/NoRequestOffsetTest.cs
@@ -1,3 +1,4 @@
+using global::System.Net;
 using NUnit.Framework;
 using SeedPaginationUriPath.Core;
 using SystemTask = global::System.Threading.Tasks.Task;
@@ -29,7 +30,7 @@ public class NoRequestOffsetTest
             (_, _, _) =>
             {
                 responses.MoveNext();
-                return SystemTask.FromResult(responses.Current);
+                return SystemTask.FromResult(Wrap(responses.Current));
             },
             request => request?.Pagination?.Page ?? 0,
             (request, offset) =>
@@ -79,4 +80,16 @@ public class NoRequestOffsetTest
     {
         public IEnumerable<string>? Items { get; set; }
     }
+
+    private static WithRawResponse<Response> Wrap(Response response) =>
+        new()
+        {
+            Data = response,
+            RawResponse = new RawResponse
+            {
+                StatusCode = HttpStatusCode.OK,
+                Url = new Uri("https://localhost"),
+                Headers = default,
+            },
+        };
 }

--- a/seed/csharp-sdk/pagination-uri-path/src/SeedPaginationUriPath.Test/Core/Pagination/StepOffsetTest.cs
+++ b/seed/csharp-sdk/pagination-uri-path/src/SeedPaginationUriPath.Test/Core/Pagination/StepOffsetTest.cs
@@ -1,3 +1,4 @@
+using global::System.Net;
 using NUnit.Framework;
 using SeedPaginationUriPath.Core;
 using SystemTask = global::System.Threading.Tasks.Task;
@@ -30,7 +31,7 @@ public class StepPageOffsetPaginationTest
             (_, _, _) =>
             {
                 responses.MoveNext();
-                return SystemTask.FromResult(responses.Current);
+                return SystemTask.FromResult(Wrap(responses.Current));
             },
             request => request?.Pagination?.ItemOffset ?? 0,
             (request, offset) =>
@@ -89,4 +90,16 @@ public class StepPageOffsetPaginationTest
     {
         public IEnumerable<string>? Items { get; set; }
     }
+
+    private static WithRawResponse<Response> Wrap(Response response) =>
+        new()
+        {
+            Data = response,
+            RawResponse = new RawResponse
+            {
+                StatusCode = HttpStatusCode.OK,
+                Url = new Uri("https://localhost"),
+                Headers = default,
+            },
+        };
 }

--- a/seed/csharp-sdk/pagination-uri-path/src/SeedPaginationUriPath.Test/Core/Pagination/StringCursorTest.cs
+++ b/seed/csharp-sdk/pagination-uri-path/src/SeedPaginationUriPath.Test/Core/Pagination/StringCursorTest.cs
@@ -1,3 +1,4 @@
+using global::System.Net;
 using NUnit.Framework;
 using SeedPaginationUriPath.Core;
 using SystemTask = global::System.Threading.Tasks.Task;
@@ -46,7 +47,7 @@ public class StringCursorTest
             (_, _, _) =>
             {
                 responses.MoveNext();
-                return SystemTask.FromResult(responses.Current);
+                return SystemTask.FromResult(Wrap(responses.Current));
             },
             (request, cursor) =>
             {
@@ -115,7 +116,7 @@ public class StringCursorTest
             (_, _, _) =>
             {
                 responses.MoveNext();
-                return SystemTask.FromResult(responses.Current);
+                return SystemTask.FromResult(Wrap(responses.Current));
             },
             (request, cursor) =>
             {
@@ -164,4 +165,16 @@ public class StringCursorTest
     {
         public required string? Next { get; set; }
     }
+
+    private static WithRawResponse<Response> Wrap(Response response) =>
+        new()
+        {
+            Data = response,
+            RawResponse = new RawResponse
+            {
+                StatusCode = HttpStatusCode.OK,
+                Url = new Uri("https://localhost"),
+                Headers = default,
+            },
+        };
 }

--- a/seed/csharp-sdk/pagination-uri-path/src/SeedPaginationUriPath/Core/Page.cs
+++ b/seed/csharp-sdk/pagination-uri-path/src/SeedPaginationUriPath/Core/Page.cs
@@ -1,5 +1,6 @@
 using global::System.Collections;
 using global::System.Collections.ObjectModel;
+using global::System.Net;
 
 namespace SeedPaginationUriPath.Core;
 
@@ -20,9 +21,41 @@ public class Page<TItem> : IEnumerable<TItem>
     }
 
     /// <summary>
+    /// Creates a new <see cref="Page{TItem}"/> with the specified items and response metadata.
+    /// </summary>
+    public Page(
+        IReadOnlyList<TItem> items,
+        object? response,
+        HttpStatusCode statusCode,
+        ResponseHeaders? headers
+    )
+    {
+        Items = items;
+        Response = response;
+        StatusCode = statusCode;
+        Headers = headers;
+    }
+
+    /// <summary>
     /// Gets the items in this <see cref="Page{TItem}"/>.
     /// </summary>
     public IReadOnlyList<TItem> Items { get; }
+
+    /// <summary>
+    /// The full API response object for this page. Cast to the endpoint's response
+    /// type to access fields beyond the paginated items (e.g., TotalCount, metadata).
+    /// </summary>
+    public object? Response { get; }
+
+    /// <summary>
+    /// The HTTP status code of the response that produced this page.
+    /// </summary>
+    public HttpStatusCode StatusCode { get; }
+
+    /// <summary>
+    /// The HTTP response headers from the response that produced this page.
+    /// </summary>
+    public ResponseHeaders? Headers { get; }
 
     /// <summary>
     /// Enumerate the items in this <see cref="Page{TItem}"/>.

--- a/seed/csharp-sdk/pagination-uri-path/src/SeedPaginationUriPath/Core/Pager.cs
+++ b/seed/csharp-sdk/pagination-uri-path/src/SeedPaginationUriPath/Core/Pager.cs
@@ -95,7 +95,7 @@ internal sealed class OffsetPager<TRequest, TRequestOptions, TResponse, TOffset,
     private readonly SendRequest _sendRequest;
     private readonly ParseApiCallDelegate _parseApiCall;
 
-    internal delegate global::System.Threading.Tasks.Task<TResponse> SendRequest(
+    internal delegate global::System.Threading.Tasks.Task<WithRawResponse<TResponse>> SendRequest(
         TRequest request,
         TRequestOptions? options,
         CancellationToken cancellationToken
@@ -115,7 +115,7 @@ internal sealed class OffsetPager<TRequest, TRequestOptions, TResponse, TOffset,
         TRequest? nextRequest,
         bool hasNextPage,
         Page<TItem> page
-    ) ParseApiCallDelegate(TRequest request, TResponse response);
+    ) ParseApiCallDelegate(TRequest request, WithRawResponse<TResponse> wrappedResponse);
 
     public Page<TItem> CurrentPage { get; private set; }
     public bool HasNextPage { get; private set; }
@@ -152,7 +152,8 @@ internal sealed class OffsetPager<TRequest, TRequestOptions, TResponse, TOffset,
     )
     {
         request ??= Activator.CreateInstance<TRequest>();
-        var response = await sendRequest(request, options, cancellationToken).ConfigureAwait(false);
+        var wrappedResponse = await sendRequest(request, options, cancellationToken)
+            .ConfigureAwait(false);
         var parseApiCall = CreateParseApiCallDelegate(
             getItems,
             getOffset,
@@ -160,7 +161,7 @@ internal sealed class OffsetPager<TRequest, TRequestOptions, TResponse, TOffset,
             getStep,
             getHasNextPage
         );
-        var (nextRequest, hasNextPage, page) = parseApiCall(request, response);
+        var (nextRequest, hasNextPage, page) = parseApiCall(request, wrappedResponse);
         return new OffsetPager<TRequest, TRequestOptions, TResponse, TOffset, TStep, TItem>(
             nextRequest,
             options,
@@ -179,10 +180,10 @@ internal sealed class OffsetPager<TRequest, TRequestOptions, TResponse, TOffset,
         GetHasNextPage? getHasNextPage
     )
     {
-        return (request, response) =>
+        return (request, wrappedResponse) =>
             ParseApiCall(
                 request,
-                response,
+                wrappedResponse,
                 getItems,
                 getOffset,
                 setOffset,
@@ -197,9 +198,9 @@ internal sealed class OffsetPager<TRequest, TRequestOptions, TResponse, TOffset,
         CancellationToken cancellationToken = default
     )
     {
-        var response = await _sendRequest(request, options, cancellationToken)
+        var wrappedResponse = await _sendRequest(request, options, cancellationToken)
             .ConfigureAwait(false);
-        var (nextRequest, hasNextPageFlag, page) = _parseApiCall(request, response);
+        var (nextRequest, hasNextPageFlag, page) = _parseApiCall(request, wrappedResponse);
         _request = nextRequest;
         HasNextPage = hasNextPageFlag;
         CurrentPage = page;
@@ -208,7 +209,7 @@ internal sealed class OffsetPager<TRequest, TRequestOptions, TResponse, TOffset,
 
     private static (TRequest? nextRequest, bool hasNextPage, Page<TItem> page) ParseApiCall(
         TRequest request,
-        TResponse response,
+        WithRawResponse<TResponse> wrappedResponse,
         GetItems getItems,
         GetOffset getOffset,
         SetOffset setOffset,
@@ -216,8 +217,16 @@ internal sealed class OffsetPager<TRequest, TRequestOptions, TResponse, TOffset,
         GetHasNextPage? getHasNextPage
     )
     {
+        var response = wrappedResponse.Data;
         var items = getItems(response);
-        var page = items is not null ? new Page<TItem>(items) : Page<TItem>.Empty;
+        var page = items is not null
+            ? new Page<TItem>(
+                items,
+                response,
+                wrappedResponse.RawResponse.StatusCode,
+                wrappedResponse.RawResponse.Headers
+            )
+            : Page<TItem>.Empty;
         var offset = getOffset(request);
         var hasNextPage = getHasNextPage?.Invoke(response) ?? items?.Count > 0;
         if (!hasNextPage)
@@ -360,7 +369,7 @@ internal sealed class CursorPager<TRequest, TRequestOptions, TResponse, TCursor,
     /// <summary>
     /// Delegate for sending a request.
     /// </summary>
-    internal delegate global::System.Threading.Tasks.Task<TResponse> SendRequest(
+    internal delegate global::System.Threading.Tasks.Task<WithRawResponse<TResponse>> SendRequest(
         TRequest request,
         TRequestOptions? options,
         CancellationToken cancellationToken
@@ -385,7 +394,7 @@ internal sealed class CursorPager<TRequest, TRequestOptions, TResponse, TCursor,
         TRequest? nextRequest,
         bool hasNextPage,
         Page<TItem> page
-    ) ParseApiCallDelegate(TRequest request, TResponse response);
+    ) ParseApiCallDelegate(TRequest request, WithRawResponse<TResponse> wrappedResponse);
 
     /// <summary>
     /// The current <see cref="Page{TItem}"/>.
@@ -430,9 +439,10 @@ internal sealed class CursorPager<TRequest, TRequestOptions, TResponse, TCursor,
     )
     {
         request ??= Activator.CreateInstance<TRequest>();
-        var response = await sendRequest(request, options, cancellationToken).ConfigureAwait(false);
+        var wrappedResponse = await sendRequest(request, options, cancellationToken)
+            .ConfigureAwait(false);
         var parseApiCall = CreateParseApiCallDelegate(getItems, getNextCursor, setCursor);
-        var (nextRequest, hasNextPage, page) = parseApiCall(request, response);
+        var (nextRequest, hasNextPage, page) = parseApiCall(request, wrappedResponse);
         return new CursorPager<TRequest, TRequestOptions, TResponse, TCursor, TItem>(
             nextRequest,
             options,
@@ -449,10 +459,18 @@ internal sealed class CursorPager<TRequest, TRequestOptions, TResponse, TCursor,
         SetCursor setCursor
     )
     {
-        return (request, response) =>
+        return (request, wrappedResponse) =>
         {
+            var response = wrappedResponse.Data;
             var items = getItems(response);
-            var page = items is not null ? new Page<TItem>(items) : Page<TItem>.Empty;
+            var page = items is not null
+                ? new Page<TItem>(
+                    items,
+                    response,
+                    wrappedResponse.RawResponse.StatusCode,
+                    wrappedResponse.RawResponse.Headers
+                )
+                : Page<TItem>.Empty;
             var cursor = getNextCursor(response);
             var hasNextPage = cursor switch
             {
@@ -475,9 +493,9 @@ internal sealed class CursorPager<TRequest, TRequestOptions, TResponse, TCursor,
         CancellationToken cancellationToken = default
     )
     {
-        var response = await _sendRequest(request, options, cancellationToken)
+        var wrappedResponse = await _sendRequest(request, options, cancellationToken)
             .ConfigureAwait(false);
-        var (nextRequest, hasNextPage, page) = _parseApiCall(request, response);
+        var (nextRequest, hasNextPage, page) = _parseApiCall(request, wrappedResponse);
         _request = nextRequest;
         HasNextPage = hasNextPage;
         CurrentPage = page;

--- a/seed/csharp-sdk/pagination/custom-pager-with-exception-handler/src/SeedPagination.Test/Core/Pagination/GuidCursorTest.cs
+++ b/seed/csharp-sdk/pagination/custom-pager-with-exception-handler/src/SeedPagination.Test/Core/Pagination/GuidCursorTest.cs
@@ -1,3 +1,4 @@
+using global::System.Net;
 using NUnit.Framework;
 using SeedPagination.Core;
 using SystemTask = global::System.Threading.Tasks.Task;
@@ -45,7 +46,7 @@ public class GuidCursorTest
             (_, _, _) =>
             {
                 responses.MoveNext();
-                return SystemTask.FromResult(responses.Current);
+                return SystemTask.FromResult(Wrap(responses.Current));
             },
             (request, cursor) =>
             {
@@ -100,4 +101,16 @@ public class GuidCursorTest
     {
         public required Guid? Next { get; set; }
     }
+
+    private static WithRawResponse<Response> Wrap(Response response) =>
+        new()
+        {
+            Data = response,
+            RawResponse = new RawResponse
+            {
+                StatusCode = HttpStatusCode.OK,
+                Url = new Uri("https://localhost"),
+                Headers = default,
+            },
+        };
 }

--- a/seed/csharp-sdk/pagination/custom-pager-with-exception-handler/src/SeedPagination.Test/Core/Pagination/HasNextPageOffsetTest.cs
+++ b/seed/csharp-sdk/pagination/custom-pager-with-exception-handler/src/SeedPagination.Test/Core/Pagination/HasNextPageOffsetTest.cs
@@ -1,3 +1,4 @@
+using global::System.Net;
 using NUnit.Framework;
 using SeedPagination.Core;
 using SystemTask = global::System.Threading.Tasks.Task;
@@ -41,7 +42,7 @@ public class HasNextPageOffsetTest
             (_, _, _) =>
             {
                 responses.MoveNext();
-                return SystemTask.FromResult(responses.Current);
+                return SystemTask.FromResult(Wrap(responses.Current));
             },
             request => request?.Pagination?.Page ?? 0,
             (request, offset) =>
@@ -89,4 +90,16 @@ public class HasNextPageOffsetTest
     {
         public IEnumerable<string>? Items { get; set; }
     }
+
+    private static WithRawResponse<Response> Wrap(Response response) =>
+        new()
+        {
+            Data = response,
+            RawResponse = new RawResponse
+            {
+                StatusCode = HttpStatusCode.OK,
+                Url = new Uri("https://localhost"),
+                Headers = default,
+            },
+        };
 }

--- a/seed/csharp-sdk/pagination/custom-pager-with-exception-handler/src/SeedPagination.Test/Core/Pagination/IntOffsetTest.cs
+++ b/seed/csharp-sdk/pagination/custom-pager-with-exception-handler/src/SeedPagination.Test/Core/Pagination/IntOffsetTest.cs
@@ -1,3 +1,4 @@
+using global::System.Net;
 using NUnit.Framework;
 using SeedPagination.Core;
 using SystemTask = global::System.Threading.Tasks.Task;
@@ -29,7 +30,7 @@ public class IntOffsetTest
             (_, _, _) =>
             {
                 responses.MoveNext();
-                return SystemTask.FromResult(responses.Current);
+                return SystemTask.FromResult(Wrap(responses.Current));
             },
             request => request?.Pagination?.Page ?? 0,
             (request, offset) =>
@@ -79,4 +80,16 @@ public class IntOffsetTest
     {
         public IEnumerable<string>? Items { get; set; }
     }
+
+    private static WithRawResponse<Response> Wrap(Response response) =>
+        new()
+        {
+            Data = response,
+            RawResponse = new RawResponse
+            {
+                StatusCode = HttpStatusCode.OK,
+                Url = new Uri("https://localhost"),
+                Headers = default,
+            },
+        };
 }

--- a/seed/csharp-sdk/pagination/custom-pager-with-exception-handler/src/SeedPagination.Test/Core/Pagination/LongOffsetTest.cs
+++ b/seed/csharp-sdk/pagination/custom-pager-with-exception-handler/src/SeedPagination.Test/Core/Pagination/LongOffsetTest.cs
@@ -1,3 +1,4 @@
+using global::System.Net;
 using NUnit.Framework;
 using SeedPagination.Core;
 using SystemTask = global::System.Threading.Tasks.Task;
@@ -29,7 +30,7 @@ public class LongOffsetTest
             (_, _, _) =>
             {
                 responses.MoveNext();
-                return SystemTask.FromResult(responses.Current);
+                return SystemTask.FromResult(Wrap(responses.Current));
             },
             request => request?.Pagination?.Page ?? 0,
             (request, offset) =>
@@ -76,4 +77,16 @@ public class LongOffsetTest
     {
         public IEnumerable<string>? Items { get; set; }
     }
+
+    private static WithRawResponse<Response> Wrap(Response response) =>
+        new()
+        {
+            Data = response,
+            RawResponse = new RawResponse
+            {
+                StatusCode = HttpStatusCode.OK,
+                Url = new Uri("https://localhost"),
+                Headers = default,
+            },
+        };
 }

--- a/seed/csharp-sdk/pagination/custom-pager-with-exception-handler/src/SeedPagination.Test/Core/Pagination/NoRequestCursorTest.cs
+++ b/seed/csharp-sdk/pagination/custom-pager-with-exception-handler/src/SeedPagination.Test/Core/Pagination/NoRequestCursorTest.cs
@@ -1,3 +1,4 @@
+using global::System.Net;
 using NUnit.Framework;
 using SeedPagination.Core;
 using SystemTask = global::System.Threading.Tasks.Task;
@@ -45,7 +46,7 @@ public class NoRequestCursorTest
             (_, _, _) =>
             {
                 responses.MoveNext();
-                return SystemTask.FromResult(responses.Current);
+                return SystemTask.FromResult(Wrap(responses.Current));
             },
             (request, cursor) =>
             {
@@ -103,4 +104,16 @@ public class NoRequestCursorTest
     {
         public required string? Next { get; set; }
     }
+
+    private static WithRawResponse<Response> Wrap(Response response) =>
+        new()
+        {
+            Data = response,
+            RawResponse = new RawResponse
+            {
+                StatusCode = HttpStatusCode.OK,
+                Url = new Uri("https://localhost"),
+                Headers = default,
+            },
+        };
 }

--- a/seed/csharp-sdk/pagination/custom-pager-with-exception-handler/src/SeedPagination.Test/Core/Pagination/NoRequestOffsetTest.cs
+++ b/seed/csharp-sdk/pagination/custom-pager-with-exception-handler/src/SeedPagination.Test/Core/Pagination/NoRequestOffsetTest.cs
@@ -1,3 +1,4 @@
+using global::System.Net;
 using NUnit.Framework;
 using SeedPagination.Core;
 using SystemTask = global::System.Threading.Tasks.Task;
@@ -29,7 +30,7 @@ public class NoRequestOffsetTest
             (_, _, _) =>
             {
                 responses.MoveNext();
-                return SystemTask.FromResult(responses.Current);
+                return SystemTask.FromResult(Wrap(responses.Current));
             },
             request => request?.Pagination?.Page ?? 0,
             (request, offset) =>
@@ -79,4 +80,16 @@ public class NoRequestOffsetTest
     {
         public IEnumerable<string>? Items { get; set; }
     }
+
+    private static WithRawResponse<Response> Wrap(Response response) =>
+        new()
+        {
+            Data = response,
+            RawResponse = new RawResponse
+            {
+                StatusCode = HttpStatusCode.OK,
+                Url = new Uri("https://localhost"),
+                Headers = default,
+            },
+        };
 }

--- a/seed/csharp-sdk/pagination/custom-pager-with-exception-handler/src/SeedPagination.Test/Core/Pagination/StepOffsetTest.cs
+++ b/seed/csharp-sdk/pagination/custom-pager-with-exception-handler/src/SeedPagination.Test/Core/Pagination/StepOffsetTest.cs
@@ -1,3 +1,4 @@
+using global::System.Net;
 using NUnit.Framework;
 using SeedPagination.Core;
 using SystemTask = global::System.Threading.Tasks.Task;
@@ -30,7 +31,7 @@ public class StepPageOffsetPaginationTest
             (_, _, _) =>
             {
                 responses.MoveNext();
-                return SystemTask.FromResult(responses.Current);
+                return SystemTask.FromResult(Wrap(responses.Current));
             },
             request => request?.Pagination?.ItemOffset ?? 0,
             (request, offset) =>
@@ -89,4 +90,16 @@ public class StepPageOffsetPaginationTest
     {
         public IEnumerable<string>? Items { get; set; }
     }
+
+    private static WithRawResponse<Response> Wrap(Response response) =>
+        new()
+        {
+            Data = response,
+            RawResponse = new RawResponse
+            {
+                StatusCode = HttpStatusCode.OK,
+                Url = new Uri("https://localhost"),
+                Headers = default,
+            },
+        };
 }

--- a/seed/csharp-sdk/pagination/custom-pager-with-exception-handler/src/SeedPagination.Test/Core/Pagination/StringCursorTest.cs
+++ b/seed/csharp-sdk/pagination/custom-pager-with-exception-handler/src/SeedPagination.Test/Core/Pagination/StringCursorTest.cs
@@ -1,3 +1,4 @@
+using global::System.Net;
 using NUnit.Framework;
 using SeedPagination.Core;
 using SystemTask = global::System.Threading.Tasks.Task;
@@ -46,7 +47,7 @@ public class StringCursorTest
             (_, _, _) =>
             {
                 responses.MoveNext();
-                return SystemTask.FromResult(responses.Current);
+                return SystemTask.FromResult(Wrap(responses.Current));
             },
             (request, cursor) =>
             {
@@ -115,7 +116,7 @@ public class StringCursorTest
             (_, _, _) =>
             {
                 responses.MoveNext();
-                return SystemTask.FromResult(responses.Current);
+                return SystemTask.FromResult(Wrap(responses.Current));
             },
             (request, cursor) =>
             {
@@ -164,4 +165,16 @@ public class StringCursorTest
     {
         public required string? Next { get; set; }
     }
+
+    private static WithRawResponse<Response> Wrap(Response response) =>
+        new()
+        {
+            Data = response,
+            RawResponse = new RawResponse
+            {
+                StatusCode = HttpStatusCode.OK,
+                Url = new Uri("https://localhost"),
+                Headers = default,
+            },
+        };
 }

--- a/seed/csharp-sdk/pagination/custom-pager-with-exception-handler/src/SeedPagination/Complex/ComplexClient.cs
+++ b/seed/csharp-sdk/pagination/custom-pager-with-exception-handler/src/SeedPagination/Complex/ComplexClient.cs
@@ -153,7 +153,7 @@ public partial class ComplexClient : IComplexClient
                         options,
                         async (request, options, cancellationToken) =>
                             await SearchInternalAsync(index, request, options, cancellationToken)
-                                .ConfigureAwait(false),
+                                .WithRawResponse(),
                         (request, cursor) =>
                         {
                             request.Pagination ??= new StartingAfterPaging() { PerPage = 0 };

--- a/seed/csharp-sdk/pagination/custom-pager-with-exception-handler/src/SeedPagination/Core/Page.cs
+++ b/seed/csharp-sdk/pagination/custom-pager-with-exception-handler/src/SeedPagination/Core/Page.cs
@@ -1,5 +1,6 @@
 using global::System.Collections;
 using global::System.Collections.ObjectModel;
+using global::System.Net;
 
 namespace SeedPagination.Core;
 
@@ -20,9 +21,41 @@ public class Page<TItem> : IEnumerable<TItem>
     }
 
     /// <summary>
+    /// Creates a new <see cref="Page{TItem}"/> with the specified items and response metadata.
+    /// </summary>
+    public Page(
+        IReadOnlyList<TItem> items,
+        object? response,
+        HttpStatusCode statusCode,
+        ResponseHeaders? headers
+    )
+    {
+        Items = items;
+        Response = response;
+        StatusCode = statusCode;
+        Headers = headers;
+    }
+
+    /// <summary>
     /// Gets the items in this <see cref="Page{TItem}"/>.
     /// </summary>
     public IReadOnlyList<TItem> Items { get; }
+
+    /// <summary>
+    /// The full API response object for this page. Cast to the endpoint's response
+    /// type to access fields beyond the paginated items (e.g., TotalCount, metadata).
+    /// </summary>
+    public object? Response { get; }
+
+    /// <summary>
+    /// The HTTP status code of the response that produced this page.
+    /// </summary>
+    public HttpStatusCode StatusCode { get; }
+
+    /// <summary>
+    /// The HTTP response headers from the response that produced this page.
+    /// </summary>
+    public ResponseHeaders? Headers { get; }
 
     /// <summary>
     /// Enumerate the items in this <see cref="Page{TItem}"/>.

--- a/seed/csharp-sdk/pagination/custom-pager-with-exception-handler/src/SeedPagination/Core/Pager.cs
+++ b/seed/csharp-sdk/pagination/custom-pager-with-exception-handler/src/SeedPagination/Core/Pager.cs
@@ -95,7 +95,7 @@ internal sealed class OffsetPager<TRequest, TRequestOptions, TResponse, TOffset,
     private readonly SendRequest _sendRequest;
     private readonly ParseApiCallDelegate _parseApiCall;
 
-    internal delegate global::System.Threading.Tasks.Task<TResponse> SendRequest(
+    internal delegate global::System.Threading.Tasks.Task<WithRawResponse<TResponse>> SendRequest(
         TRequest request,
         TRequestOptions? options,
         CancellationToken cancellationToken
@@ -115,7 +115,7 @@ internal sealed class OffsetPager<TRequest, TRequestOptions, TResponse, TOffset,
         TRequest? nextRequest,
         bool hasNextPage,
         Page<TItem> page
-    ) ParseApiCallDelegate(TRequest request, TResponse response);
+    ) ParseApiCallDelegate(TRequest request, WithRawResponse<TResponse> wrappedResponse);
 
     public Page<TItem> CurrentPage { get; private set; }
     public bool HasNextPage { get; private set; }
@@ -152,7 +152,8 @@ internal sealed class OffsetPager<TRequest, TRequestOptions, TResponse, TOffset,
     )
     {
         request ??= Activator.CreateInstance<TRequest>();
-        var response = await sendRequest(request, options, cancellationToken).ConfigureAwait(false);
+        var wrappedResponse = await sendRequest(request, options, cancellationToken)
+            .ConfigureAwait(false);
         var parseApiCall = CreateParseApiCallDelegate(
             getItems,
             getOffset,
@@ -160,7 +161,7 @@ internal sealed class OffsetPager<TRequest, TRequestOptions, TResponse, TOffset,
             getStep,
             getHasNextPage
         );
-        var (nextRequest, hasNextPage, page) = parseApiCall(request, response);
+        var (nextRequest, hasNextPage, page) = parseApiCall(request, wrappedResponse);
         return new OffsetPager<TRequest, TRequestOptions, TResponse, TOffset, TStep, TItem>(
             nextRequest,
             options,
@@ -179,10 +180,10 @@ internal sealed class OffsetPager<TRequest, TRequestOptions, TResponse, TOffset,
         GetHasNextPage? getHasNextPage
     )
     {
-        return (request, response) =>
+        return (request, wrappedResponse) =>
             ParseApiCall(
                 request,
-                response,
+                wrappedResponse,
                 getItems,
                 getOffset,
                 setOffset,
@@ -197,9 +198,9 @@ internal sealed class OffsetPager<TRequest, TRequestOptions, TResponse, TOffset,
         CancellationToken cancellationToken = default
     )
     {
-        var response = await _sendRequest(request, options, cancellationToken)
+        var wrappedResponse = await _sendRequest(request, options, cancellationToken)
             .ConfigureAwait(false);
-        var (nextRequest, hasNextPageFlag, page) = _parseApiCall(request, response);
+        var (nextRequest, hasNextPageFlag, page) = _parseApiCall(request, wrappedResponse);
         _request = nextRequest;
         HasNextPage = hasNextPageFlag;
         CurrentPage = page;
@@ -208,7 +209,7 @@ internal sealed class OffsetPager<TRequest, TRequestOptions, TResponse, TOffset,
 
     private static (TRequest? nextRequest, bool hasNextPage, Page<TItem> page) ParseApiCall(
         TRequest request,
-        TResponse response,
+        WithRawResponse<TResponse> wrappedResponse,
         GetItems getItems,
         GetOffset getOffset,
         SetOffset setOffset,
@@ -216,8 +217,16 @@ internal sealed class OffsetPager<TRequest, TRequestOptions, TResponse, TOffset,
         GetHasNextPage? getHasNextPage
     )
     {
+        var response = wrappedResponse.Data;
         var items = getItems(response);
-        var page = items is not null ? new Page<TItem>(items) : Page<TItem>.Empty;
+        var page = items is not null
+            ? new Page<TItem>(
+                items,
+                response,
+                wrappedResponse.RawResponse.StatusCode,
+                wrappedResponse.RawResponse.Headers
+            )
+            : Page<TItem>.Empty;
         var offset = getOffset(request);
         var hasNextPage = getHasNextPage?.Invoke(response) ?? items?.Count > 0;
         if (!hasNextPage)
@@ -360,7 +369,7 @@ internal sealed class CursorPager<TRequest, TRequestOptions, TResponse, TCursor,
     /// <summary>
     /// Delegate for sending a request.
     /// </summary>
-    internal delegate global::System.Threading.Tasks.Task<TResponse> SendRequest(
+    internal delegate global::System.Threading.Tasks.Task<WithRawResponse<TResponse>> SendRequest(
         TRequest request,
         TRequestOptions? options,
         CancellationToken cancellationToken
@@ -385,7 +394,7 @@ internal sealed class CursorPager<TRequest, TRequestOptions, TResponse, TCursor,
         TRequest? nextRequest,
         bool hasNextPage,
         Page<TItem> page
-    ) ParseApiCallDelegate(TRequest request, TResponse response);
+    ) ParseApiCallDelegate(TRequest request, WithRawResponse<TResponse> wrappedResponse);
 
     /// <summary>
     /// The current <see cref="Page{TItem}"/>.
@@ -430,9 +439,10 @@ internal sealed class CursorPager<TRequest, TRequestOptions, TResponse, TCursor,
     )
     {
         request ??= Activator.CreateInstance<TRequest>();
-        var response = await sendRequest(request, options, cancellationToken).ConfigureAwait(false);
+        var wrappedResponse = await sendRequest(request, options, cancellationToken)
+            .ConfigureAwait(false);
         var parseApiCall = CreateParseApiCallDelegate(getItems, getNextCursor, setCursor);
-        var (nextRequest, hasNextPage, page) = parseApiCall(request, response);
+        var (nextRequest, hasNextPage, page) = parseApiCall(request, wrappedResponse);
         return new CursorPager<TRequest, TRequestOptions, TResponse, TCursor, TItem>(
             nextRequest,
             options,
@@ -449,10 +459,18 @@ internal sealed class CursorPager<TRequest, TRequestOptions, TResponse, TCursor,
         SetCursor setCursor
     )
     {
-        return (request, response) =>
+        return (request, wrappedResponse) =>
         {
+            var response = wrappedResponse.Data;
             var items = getItems(response);
-            var page = items is not null ? new Page<TItem>(items) : Page<TItem>.Empty;
+            var page = items is not null
+                ? new Page<TItem>(
+                    items,
+                    response,
+                    wrappedResponse.RawResponse.StatusCode,
+                    wrappedResponse.RawResponse.Headers
+                )
+                : Page<TItem>.Empty;
             var cursor = getNextCursor(response);
             var hasNextPage = cursor switch
             {
@@ -475,9 +493,9 @@ internal sealed class CursorPager<TRequest, TRequestOptions, TResponse, TCursor,
         CancellationToken cancellationToken = default
     )
     {
-        var response = await _sendRequest(request, options, cancellationToken)
+        var wrappedResponse = await _sendRequest(request, options, cancellationToken)
             .ConfigureAwait(false);
-        var (nextRequest, hasNextPage, page) = _parseApiCall(request, response);
+        var (nextRequest, hasNextPage, page) = _parseApiCall(request, wrappedResponse);
         _request = nextRequest;
         HasNextPage = hasNextPage;
         CurrentPage = page;

--- a/seed/csharp-sdk/pagination/custom-pager-with-exception-handler/src/SeedPagination/InlineUsers/InlineUsers/InlineUsersClient_.cs
+++ b/seed/csharp-sdk/pagination/custom-pager-with-exception-handler/src/SeedPagination/InlineUsers/InlineUsers/InlineUsersClient_.cs
@@ -1168,10 +1168,11 @@ public partial class InlineUsersClient_ : IInlineUsersClient_
                         options,
                         async (request, options, cancellationToken) =>
                             await ListWithCursorPaginationInternalAsync(
-                                request,
-                                options,
-                                cancellationToken
-                            ),
+                                    request,
+                                    options,
+                                    cancellationToken
+                                )
+                                .WithRawResponse(),
                         (request, cursor) =>
                         {
                             request.StartingAfter = cursor;
@@ -1216,10 +1217,11 @@ public partial class InlineUsersClient_ : IInlineUsersClient_
                         options,
                         async (request, options, cancellationToken) =>
                             await ListWithMixedTypeCursorPaginationInternalAsync(
-                                request,
-                                options,
-                                cancellationToken
-                            ),
+                                    request,
+                                    options,
+                                    cancellationToken
+                                )
+                                .WithRawResponse(),
                         (request, cursor) =>
                         {
                             request.Cursor = cursor;
@@ -1267,10 +1269,11 @@ public partial class InlineUsersClient_ : IInlineUsersClient_
                         options,
                         async (request, options, cancellationToken) =>
                             await ListWithBodyCursorPaginationInternalAsync(
-                                request,
-                                options,
-                                cancellationToken
-                            ),
+                                    request,
+                                    options,
+                                    cancellationToken
+                                )
+                                .WithRawResponse(),
                         (request, cursor) =>
                         {
                             request.Pagination ??= new WithCursor();
@@ -1320,10 +1323,11 @@ public partial class InlineUsersClient_ : IInlineUsersClient_
                         options,
                         async (request, options, cancellationToken) =>
                             await ListWithOffsetPaginationInternalAsync(
-                                request,
-                                options,
-                                cancellationToken
-                            ),
+                                    request,
+                                    options,
+                                    cancellationToken
+                                )
+                                .WithRawResponse(),
                         request => request.Page ?? 0,
                         (request, offset) =>
                         {
@@ -1374,10 +1378,11 @@ public partial class InlineUsersClient_ : IInlineUsersClient_
                         options,
                         async (request, options, cancellationToken) =>
                             await ListWithDoubleOffsetPaginationInternalAsync(
-                                request,
-                                options,
-                                cancellationToken
-                            ),
+                                    request,
+                                    options,
+                                    cancellationToken
+                                )
+                                .WithRawResponse(),
                         request => request.Page ?? 0,
                         (request, offset) =>
                         {
@@ -1425,10 +1430,11 @@ public partial class InlineUsersClient_ : IInlineUsersClient_
                         options,
                         async (request, options, cancellationToken) =>
                             await ListWithBodyOffsetPaginationInternalAsync(
-                                request,
-                                options,
-                                cancellationToken
-                            ),
+                                    request,
+                                    options,
+                                    cancellationToken
+                                )
+                                .WithRawResponse(),
                         request => request.Pagination?.Page ?? 0,
                         (request, offset) =>
                         {
@@ -1479,10 +1485,11 @@ public partial class InlineUsersClient_ : IInlineUsersClient_
                         options,
                         async (request, options, cancellationToken) =>
                             await ListWithOffsetStepPaginationInternalAsync(
-                                request,
-                                options,
-                                cancellationToken
-                            ),
+                                    request,
+                                    options,
+                                    cancellationToken
+                                )
+                                .WithRawResponse(),
                         request => request.Page ?? 0,
                         (request, offset) =>
                         {
@@ -1532,10 +1539,11 @@ public partial class InlineUsersClient_ : IInlineUsersClient_
                         options,
                         async (request, options, cancellationToken) =>
                             await ListWithOffsetPaginationHasNextPageInternalAsync(
-                                request,
-                                options,
-                                cancellationToken
-                            ),
+                                    request,
+                                    options,
+                                    cancellationToken
+                                )
+                                .WithRawResponse(),
                         request => request.Page ?? 0,
                         (request, offset) =>
                         {
@@ -1585,10 +1593,11 @@ public partial class InlineUsersClient_ : IInlineUsersClient_
                         options,
                         async (request, options, cancellationToken) =>
                             await ListWithExtendedResultsInternalAsync(
-                                request,
-                                options,
-                                cancellationToken
-                            ),
+                                    request,
+                                    options,
+                                    cancellationToken
+                                )
+                                .WithRawResponse(),
                         (request, cursor) =>
                         {
                             request.Cursor = cursor;
@@ -1636,10 +1645,11 @@ public partial class InlineUsersClient_ : IInlineUsersClient_
                         options,
                         async (request, options, cancellationToken) =>
                             await ListWithExtendedResultsAndOptionalDataInternalAsync(
-                                request,
-                                options,
-                                cancellationToken
-                            ),
+                                    request,
+                                    options,
+                                    cancellationToken
+                                )
+                                .WithRawResponse(),
                         (request, cursor) =>
                         {
                             request.Cursor = cursor;
@@ -1683,7 +1693,8 @@ public partial class InlineUsersClient_ : IInlineUsersClient_
                         request,
                         options,
                         async (request, options, cancellationToken) =>
-                            await ListUsernamesInternalAsync(request, options, cancellationToken),
+                            await ListUsernamesInternalAsync(request, options, cancellationToken)
+                                .WithRawResponse(),
                         (request, cursor) =>
                         {
                             request.StartingAfter = cursor;
@@ -1726,10 +1737,11 @@ public partial class InlineUsersClient_ : IInlineUsersClient_
                         options,
                         async (request, options, cancellationToken) =>
                             await ListWithGlobalConfigInternalAsync(
-                                request,
-                                options,
-                                cancellationToken
-                            ),
+                                    request,
+                                    options,
+                                    cancellationToken
+                                )
+                                .WithRawResponse(),
                         request => request.Offset ?? 0,
                         (request, offset) =>
                         {

--- a/seed/csharp-sdk/pagination/custom-pager-with-exception-handler/src/SeedPagination/Users/UsersClient.cs
+++ b/seed/csharp-sdk/pagination/custom-pager-with-exception-handler/src/SeedPagination/Users/UsersClient.cs
@@ -1543,10 +1543,11 @@ public partial class UsersClient : IUsersClient
                         options,
                         async (request, options, cancellationToken) =>
                             await ListWithCursorPaginationInternalAsync(
-                                request,
-                                options,
-                                cancellationToken
-                            ),
+                                    request,
+                                    options,
+                                    cancellationToken
+                                )
+                                .WithRawResponse(),
                         (request, cursor) =>
                         {
                             request.StartingAfter = cursor;
@@ -1591,10 +1592,11 @@ public partial class UsersClient : IUsersClient
                         options,
                         async (request, options, cancellationToken) =>
                             await ListWithMixedTypeCursorPaginationInternalAsync(
-                                request,
-                                options,
-                                cancellationToken
-                            ),
+                                    request,
+                                    options,
+                                    cancellationToken
+                                )
+                                .WithRawResponse(),
                         (request, cursor) =>
                         {
                             request.Cursor = cursor;
@@ -1642,10 +1644,11 @@ public partial class UsersClient : IUsersClient
                         options,
                         async (request, options, cancellationToken) =>
                             await ListWithBodyCursorPaginationInternalAsync(
-                                request,
-                                options,
-                                cancellationToken
-                            ),
+                                    request,
+                                    options,
+                                    cancellationToken
+                                )
+                                .WithRawResponse(),
                         (request, cursor) =>
                         {
                             request.Pagination ??= new WithCursor();
@@ -1700,10 +1703,11 @@ public partial class UsersClient : IUsersClient
                         options,
                         async (request, options, cancellationToken) =>
                             await ListWithTopLevelBodyCursorPaginationInternalAsync(
-                                request,
-                                options,
-                                cancellationToken
-                            ),
+                                    request,
+                                    options,
+                                    cancellationToken
+                                )
+                                .WithRawResponse(),
                         (request, cursor) =>
                         {
                             request.Cursor = cursor;
@@ -1752,10 +1756,11 @@ public partial class UsersClient : IUsersClient
                         options,
                         async (request, options, cancellationToken) =>
                             await ListWithOffsetPaginationInternalAsync(
-                                request,
-                                options,
-                                cancellationToken
-                            ),
+                                    request,
+                                    options,
+                                    cancellationToken
+                                )
+                                .WithRawResponse(),
                         request => request.Page ?? 0,
                         (request, offset) =>
                         {
@@ -1806,10 +1811,11 @@ public partial class UsersClient : IUsersClient
                         options,
                         async (request, options, cancellationToken) =>
                             await ListWithDoubleOffsetPaginationInternalAsync(
-                                request,
-                                options,
-                                cancellationToken
-                            ),
+                                    request,
+                                    options,
+                                    cancellationToken
+                                )
+                                .WithRawResponse(),
                         request => request.Page ?? 0,
                         (request, offset) =>
                         {
@@ -1857,10 +1863,11 @@ public partial class UsersClient : IUsersClient
                         options,
                         async (request, options, cancellationToken) =>
                             await ListWithBodyOffsetPaginationInternalAsync(
-                                request,
-                                options,
-                                cancellationToken
-                            ),
+                                    request,
+                                    options,
+                                    cancellationToken
+                                )
+                                .WithRawResponse(),
                         request => request.Pagination?.Page ?? 0,
                         (request, offset) =>
                         {
@@ -1911,10 +1918,11 @@ public partial class UsersClient : IUsersClient
                         options,
                         async (request, options, cancellationToken) =>
                             await ListWithOffsetStepPaginationInternalAsync(
-                                request,
-                                options,
-                                cancellationToken
-                            ),
+                                    request,
+                                    options,
+                                    cancellationToken
+                                )
+                                .WithRawResponse(),
                         request => request.Page ?? 0,
                         (request, offset) =>
                         {
@@ -1964,10 +1972,11 @@ public partial class UsersClient : IUsersClient
                         options,
                         async (request, options, cancellationToken) =>
                             await ListWithOffsetPaginationHasNextPageInternalAsync(
-                                request,
-                                options,
-                                cancellationToken
-                            ),
+                                    request,
+                                    options,
+                                    cancellationToken
+                                )
+                                .WithRawResponse(),
                         request => request.Page ?? 0,
                         (request, offset) =>
                         {
@@ -2014,10 +2023,11 @@ public partial class UsersClient : IUsersClient
                         options,
                         async (request, options, cancellationToken) =>
                             await ListWithExtendedResultsInternalAsync(
-                                request,
-                                options,
-                                cancellationToken
-                            ),
+                                    request,
+                                    options,
+                                    cancellationToken
+                                )
+                                .WithRawResponse(),
                         (request, cursor) =>
                         {
                             request.Cursor = cursor;
@@ -2065,10 +2075,11 @@ public partial class UsersClient : IUsersClient
                         options,
                         async (request, options, cancellationToken) =>
                             await ListWithExtendedResultsAndOptionalDataInternalAsync(
-                                request,
-                                options,
-                                cancellationToken
-                            ),
+                                    request,
+                                    options,
+                                    cancellationToken
+                                )
+                                .WithRawResponse(),
                         (request, cursor) =>
                         {
                             request.Cursor = cursor;
@@ -2112,7 +2123,8 @@ public partial class UsersClient : IUsersClient
                         request,
                         options,
                         async (request, options, cancellationToken) =>
-                            await ListUsernamesInternalAsync(request, options, cancellationToken),
+                            await ListUsernamesInternalAsync(request, options, cancellationToken)
+                                .WithRawResponse(),
                         (request, cursor) =>
                         {
                             request.StartingAfter = cursor;
@@ -2157,10 +2169,11 @@ public partial class UsersClient : IUsersClient
                         options,
                         async (request, options, cancellationToken) =>
                             await ListUsernamesWithOptionalResponseInternalAsync(
-                                request,
-                                options,
-                                cancellationToken
-                            ),
+                                    request,
+                                    options,
+                                    cancellationToken
+                                )
+                                .WithRawResponse(),
                         (request, cursor) =>
                         {
                             request.StartingAfter = cursor;
@@ -2203,10 +2216,11 @@ public partial class UsersClient : IUsersClient
                         options,
                         async (request, options, cancellationToken) =>
                             await ListWithGlobalConfigInternalAsync(
-                                request,
-                                options,
-                                cancellationToken
-                            ),
+                                    request,
+                                    options,
+                                    cancellationToken
+                                )
+                                .WithRawResponse(),
                         request => request.Offset ?? 0,
                         (request, offset) =>
                         {
@@ -2249,10 +2263,11 @@ public partial class UsersClient : IUsersClient
                         options,
                         async (request, options, cancellationToken) =>
                             await ListWithOptionalDataInternalAsync(
-                                request,
-                                options,
-                                cancellationToken
-                            ),
+                                    request,
+                                    options,
+                                    cancellationToken
+                                )
+                                .WithRawResponse(),
                         request => request.Page ?? 0,
                         (request, offset) =>
                         {
@@ -2304,10 +2319,11 @@ public partial class UsersClient : IUsersClient
                         options,
                         async (request, options, cancellationToken) =>
                             await ListWithAliasedDataInternalAsync(
-                                request,
-                                options,
-                                cancellationToken
-                            ),
+                                    request,
+                                    options,
+                                    cancellationToken
+                                )
+                                .WithRawResponse(),
                         (request, cursor) =>
                         {
                             request.StartingAfter = cursor;

--- a/seed/csharp-sdk/pagination/custom-pager/src/SeedPagination.Test/Core/Pagination/GuidCursorTest.cs
+++ b/seed/csharp-sdk/pagination/custom-pager/src/SeedPagination.Test/Core/Pagination/GuidCursorTest.cs
@@ -1,3 +1,4 @@
+using global::System.Net;
 using NUnit.Framework;
 using SeedPagination.Core;
 using SystemTask = global::System.Threading.Tasks.Task;
@@ -45,7 +46,7 @@ public class GuidCursorTest
             (_, _, _) =>
             {
                 responses.MoveNext();
-                return SystemTask.FromResult(responses.Current);
+                return SystemTask.FromResult(Wrap(responses.Current));
             },
             (request, cursor) =>
             {
@@ -100,4 +101,16 @@ public class GuidCursorTest
     {
         public required Guid? Next { get; set; }
     }
+
+    private static WithRawResponse<Response> Wrap(Response response) =>
+        new()
+        {
+            Data = response,
+            RawResponse = new RawResponse
+            {
+                StatusCode = HttpStatusCode.OK,
+                Url = new Uri("https://localhost"),
+                Headers = default,
+            },
+        };
 }

--- a/seed/csharp-sdk/pagination/custom-pager/src/SeedPagination.Test/Core/Pagination/HasNextPageOffsetTest.cs
+++ b/seed/csharp-sdk/pagination/custom-pager/src/SeedPagination.Test/Core/Pagination/HasNextPageOffsetTest.cs
@@ -1,3 +1,4 @@
+using global::System.Net;
 using NUnit.Framework;
 using SeedPagination.Core;
 using SystemTask = global::System.Threading.Tasks.Task;
@@ -41,7 +42,7 @@ public class HasNextPageOffsetTest
             (_, _, _) =>
             {
                 responses.MoveNext();
-                return SystemTask.FromResult(responses.Current);
+                return SystemTask.FromResult(Wrap(responses.Current));
             },
             request => request?.Pagination?.Page ?? 0,
             (request, offset) =>
@@ -89,4 +90,16 @@ public class HasNextPageOffsetTest
     {
         public IEnumerable<string>? Items { get; set; }
     }
+
+    private static WithRawResponse<Response> Wrap(Response response) =>
+        new()
+        {
+            Data = response,
+            RawResponse = new RawResponse
+            {
+                StatusCode = HttpStatusCode.OK,
+                Url = new Uri("https://localhost"),
+                Headers = default,
+            },
+        };
 }

--- a/seed/csharp-sdk/pagination/custom-pager/src/SeedPagination.Test/Core/Pagination/IntOffsetTest.cs
+++ b/seed/csharp-sdk/pagination/custom-pager/src/SeedPagination.Test/Core/Pagination/IntOffsetTest.cs
@@ -1,3 +1,4 @@
+using global::System.Net;
 using NUnit.Framework;
 using SeedPagination.Core;
 using SystemTask = global::System.Threading.Tasks.Task;
@@ -29,7 +30,7 @@ public class IntOffsetTest
             (_, _, _) =>
             {
                 responses.MoveNext();
-                return SystemTask.FromResult(responses.Current);
+                return SystemTask.FromResult(Wrap(responses.Current));
             },
             request => request?.Pagination?.Page ?? 0,
             (request, offset) =>
@@ -79,4 +80,16 @@ public class IntOffsetTest
     {
         public IEnumerable<string>? Items { get; set; }
     }
+
+    private static WithRawResponse<Response> Wrap(Response response) =>
+        new()
+        {
+            Data = response,
+            RawResponse = new RawResponse
+            {
+                StatusCode = HttpStatusCode.OK,
+                Url = new Uri("https://localhost"),
+                Headers = default,
+            },
+        };
 }

--- a/seed/csharp-sdk/pagination/custom-pager/src/SeedPagination.Test/Core/Pagination/LongOffsetTest.cs
+++ b/seed/csharp-sdk/pagination/custom-pager/src/SeedPagination.Test/Core/Pagination/LongOffsetTest.cs
@@ -1,3 +1,4 @@
+using global::System.Net;
 using NUnit.Framework;
 using SeedPagination.Core;
 using SystemTask = global::System.Threading.Tasks.Task;
@@ -29,7 +30,7 @@ public class LongOffsetTest
             (_, _, _) =>
             {
                 responses.MoveNext();
-                return SystemTask.FromResult(responses.Current);
+                return SystemTask.FromResult(Wrap(responses.Current));
             },
             request => request?.Pagination?.Page ?? 0,
             (request, offset) =>
@@ -76,4 +77,16 @@ public class LongOffsetTest
     {
         public IEnumerable<string>? Items { get; set; }
     }
+
+    private static WithRawResponse<Response> Wrap(Response response) =>
+        new()
+        {
+            Data = response,
+            RawResponse = new RawResponse
+            {
+                StatusCode = HttpStatusCode.OK,
+                Url = new Uri("https://localhost"),
+                Headers = default,
+            },
+        };
 }

--- a/seed/csharp-sdk/pagination/custom-pager/src/SeedPagination.Test/Core/Pagination/NoRequestCursorTest.cs
+++ b/seed/csharp-sdk/pagination/custom-pager/src/SeedPagination.Test/Core/Pagination/NoRequestCursorTest.cs
@@ -1,3 +1,4 @@
+using global::System.Net;
 using NUnit.Framework;
 using SeedPagination.Core;
 using SystemTask = global::System.Threading.Tasks.Task;
@@ -45,7 +46,7 @@ public class NoRequestCursorTest
             (_, _, _) =>
             {
                 responses.MoveNext();
-                return SystemTask.FromResult(responses.Current);
+                return SystemTask.FromResult(Wrap(responses.Current));
             },
             (request, cursor) =>
             {
@@ -103,4 +104,16 @@ public class NoRequestCursorTest
     {
         public required string? Next { get; set; }
     }
+
+    private static WithRawResponse<Response> Wrap(Response response) =>
+        new()
+        {
+            Data = response,
+            RawResponse = new RawResponse
+            {
+                StatusCode = HttpStatusCode.OK,
+                Url = new Uri("https://localhost"),
+                Headers = default,
+            },
+        };
 }

--- a/seed/csharp-sdk/pagination/custom-pager/src/SeedPagination.Test/Core/Pagination/NoRequestOffsetTest.cs
+++ b/seed/csharp-sdk/pagination/custom-pager/src/SeedPagination.Test/Core/Pagination/NoRequestOffsetTest.cs
@@ -1,3 +1,4 @@
+using global::System.Net;
 using NUnit.Framework;
 using SeedPagination.Core;
 using SystemTask = global::System.Threading.Tasks.Task;
@@ -29,7 +30,7 @@ public class NoRequestOffsetTest
             (_, _, _) =>
             {
                 responses.MoveNext();
-                return SystemTask.FromResult(responses.Current);
+                return SystemTask.FromResult(Wrap(responses.Current));
             },
             request => request?.Pagination?.Page ?? 0,
             (request, offset) =>
@@ -79,4 +80,16 @@ public class NoRequestOffsetTest
     {
         public IEnumerable<string>? Items { get; set; }
     }
+
+    private static WithRawResponse<Response> Wrap(Response response) =>
+        new()
+        {
+            Data = response,
+            RawResponse = new RawResponse
+            {
+                StatusCode = HttpStatusCode.OK,
+                Url = new Uri("https://localhost"),
+                Headers = default,
+            },
+        };
 }

--- a/seed/csharp-sdk/pagination/custom-pager/src/SeedPagination.Test/Core/Pagination/StepOffsetTest.cs
+++ b/seed/csharp-sdk/pagination/custom-pager/src/SeedPagination.Test/Core/Pagination/StepOffsetTest.cs
@@ -1,3 +1,4 @@
+using global::System.Net;
 using NUnit.Framework;
 using SeedPagination.Core;
 using SystemTask = global::System.Threading.Tasks.Task;
@@ -30,7 +31,7 @@ public class StepPageOffsetPaginationTest
             (_, _, _) =>
             {
                 responses.MoveNext();
-                return SystemTask.FromResult(responses.Current);
+                return SystemTask.FromResult(Wrap(responses.Current));
             },
             request => request?.Pagination?.ItemOffset ?? 0,
             (request, offset) =>
@@ -89,4 +90,16 @@ public class StepPageOffsetPaginationTest
     {
         public IEnumerable<string>? Items { get; set; }
     }
+
+    private static WithRawResponse<Response> Wrap(Response response) =>
+        new()
+        {
+            Data = response,
+            RawResponse = new RawResponse
+            {
+                StatusCode = HttpStatusCode.OK,
+                Url = new Uri("https://localhost"),
+                Headers = default,
+            },
+        };
 }

--- a/seed/csharp-sdk/pagination/custom-pager/src/SeedPagination.Test/Core/Pagination/StringCursorTest.cs
+++ b/seed/csharp-sdk/pagination/custom-pager/src/SeedPagination.Test/Core/Pagination/StringCursorTest.cs
@@ -1,3 +1,4 @@
+using global::System.Net;
 using NUnit.Framework;
 using SeedPagination.Core;
 using SystemTask = global::System.Threading.Tasks.Task;
@@ -46,7 +47,7 @@ public class StringCursorTest
             (_, _, _) =>
             {
                 responses.MoveNext();
-                return SystemTask.FromResult(responses.Current);
+                return SystemTask.FromResult(Wrap(responses.Current));
             },
             (request, cursor) =>
             {
@@ -115,7 +116,7 @@ public class StringCursorTest
             (_, _, _) =>
             {
                 responses.MoveNext();
-                return SystemTask.FromResult(responses.Current);
+                return SystemTask.FromResult(Wrap(responses.Current));
             },
             (request, cursor) =>
             {
@@ -164,4 +165,16 @@ public class StringCursorTest
     {
         public required string? Next { get; set; }
     }
+
+    private static WithRawResponse<Response> Wrap(Response response) =>
+        new()
+        {
+            Data = response,
+            RawResponse = new RawResponse
+            {
+                StatusCode = HttpStatusCode.OK,
+                Url = new Uri("https://localhost"),
+                Headers = default,
+            },
+        };
 }

--- a/seed/csharp-sdk/pagination/custom-pager/src/SeedPagination/Complex/ComplexClient.cs
+++ b/seed/csharp-sdk/pagination/custom-pager/src/SeedPagination/Complex/ComplexClient.cs
@@ -135,7 +135,7 @@ public partial class ComplexClient : IComplexClient
                 options,
                 async (request, options, cancellationToken) =>
                     await SearchInternalAsync(index, request, options, cancellationToken)
-                        .ConfigureAwait(false),
+                        .WithRawResponse(),
                 (request, cursor) =>
                 {
                     request.Pagination ??= new StartingAfterPaging() { PerPage = 0 };

--- a/seed/csharp-sdk/pagination/custom-pager/src/SeedPagination/Core/Page.cs
+++ b/seed/csharp-sdk/pagination/custom-pager/src/SeedPagination/Core/Page.cs
@@ -1,5 +1,6 @@
 using global::System.Collections;
 using global::System.Collections.ObjectModel;
+using global::System.Net;
 
 namespace SeedPagination.Core;
 
@@ -20,9 +21,41 @@ public class Page<TItem> : IEnumerable<TItem>
     }
 
     /// <summary>
+    /// Creates a new <see cref="Page{TItem}"/> with the specified items and response metadata.
+    /// </summary>
+    public Page(
+        IReadOnlyList<TItem> items,
+        object? response,
+        HttpStatusCode statusCode,
+        ResponseHeaders? headers
+    )
+    {
+        Items = items;
+        Response = response;
+        StatusCode = statusCode;
+        Headers = headers;
+    }
+
+    /// <summary>
     /// Gets the items in this <see cref="Page{TItem}"/>.
     /// </summary>
     public IReadOnlyList<TItem> Items { get; }
+
+    /// <summary>
+    /// The full API response object for this page. Cast to the endpoint's response
+    /// type to access fields beyond the paginated items (e.g., TotalCount, metadata).
+    /// </summary>
+    public object? Response { get; }
+
+    /// <summary>
+    /// The HTTP status code of the response that produced this page.
+    /// </summary>
+    public HttpStatusCode StatusCode { get; }
+
+    /// <summary>
+    /// The HTTP response headers from the response that produced this page.
+    /// </summary>
+    public ResponseHeaders? Headers { get; }
 
     /// <summary>
     /// Enumerate the items in this <see cref="Page{TItem}"/>.

--- a/seed/csharp-sdk/pagination/custom-pager/src/SeedPagination/Core/Pager.cs
+++ b/seed/csharp-sdk/pagination/custom-pager/src/SeedPagination/Core/Pager.cs
@@ -95,7 +95,7 @@ internal sealed class OffsetPager<TRequest, TRequestOptions, TResponse, TOffset,
     private readonly SendRequest _sendRequest;
     private readonly ParseApiCallDelegate _parseApiCall;
 
-    internal delegate global::System.Threading.Tasks.Task<TResponse> SendRequest(
+    internal delegate global::System.Threading.Tasks.Task<WithRawResponse<TResponse>> SendRequest(
         TRequest request,
         TRequestOptions? options,
         CancellationToken cancellationToken
@@ -115,7 +115,7 @@ internal sealed class OffsetPager<TRequest, TRequestOptions, TResponse, TOffset,
         TRequest? nextRequest,
         bool hasNextPage,
         Page<TItem> page
-    ) ParseApiCallDelegate(TRequest request, TResponse response);
+    ) ParseApiCallDelegate(TRequest request, WithRawResponse<TResponse> wrappedResponse);
 
     public Page<TItem> CurrentPage { get; private set; }
     public bool HasNextPage { get; private set; }
@@ -152,7 +152,8 @@ internal sealed class OffsetPager<TRequest, TRequestOptions, TResponse, TOffset,
     )
     {
         request ??= Activator.CreateInstance<TRequest>();
-        var response = await sendRequest(request, options, cancellationToken).ConfigureAwait(false);
+        var wrappedResponse = await sendRequest(request, options, cancellationToken)
+            .ConfigureAwait(false);
         var parseApiCall = CreateParseApiCallDelegate(
             getItems,
             getOffset,
@@ -160,7 +161,7 @@ internal sealed class OffsetPager<TRequest, TRequestOptions, TResponse, TOffset,
             getStep,
             getHasNextPage
         );
-        var (nextRequest, hasNextPage, page) = parseApiCall(request, response);
+        var (nextRequest, hasNextPage, page) = parseApiCall(request, wrappedResponse);
         return new OffsetPager<TRequest, TRequestOptions, TResponse, TOffset, TStep, TItem>(
             nextRequest,
             options,
@@ -179,10 +180,10 @@ internal sealed class OffsetPager<TRequest, TRequestOptions, TResponse, TOffset,
         GetHasNextPage? getHasNextPage
     )
     {
-        return (request, response) =>
+        return (request, wrappedResponse) =>
             ParseApiCall(
                 request,
-                response,
+                wrappedResponse,
                 getItems,
                 getOffset,
                 setOffset,
@@ -197,9 +198,9 @@ internal sealed class OffsetPager<TRequest, TRequestOptions, TResponse, TOffset,
         CancellationToken cancellationToken = default
     )
     {
-        var response = await _sendRequest(request, options, cancellationToken)
+        var wrappedResponse = await _sendRequest(request, options, cancellationToken)
             .ConfigureAwait(false);
-        var (nextRequest, hasNextPageFlag, page) = _parseApiCall(request, response);
+        var (nextRequest, hasNextPageFlag, page) = _parseApiCall(request, wrappedResponse);
         _request = nextRequest;
         HasNextPage = hasNextPageFlag;
         CurrentPage = page;
@@ -208,7 +209,7 @@ internal sealed class OffsetPager<TRequest, TRequestOptions, TResponse, TOffset,
 
     private static (TRequest? nextRequest, bool hasNextPage, Page<TItem> page) ParseApiCall(
         TRequest request,
-        TResponse response,
+        WithRawResponse<TResponse> wrappedResponse,
         GetItems getItems,
         GetOffset getOffset,
         SetOffset setOffset,
@@ -216,8 +217,16 @@ internal sealed class OffsetPager<TRequest, TRequestOptions, TResponse, TOffset,
         GetHasNextPage? getHasNextPage
     )
     {
+        var response = wrappedResponse.Data;
         var items = getItems(response);
-        var page = items is not null ? new Page<TItem>(items) : Page<TItem>.Empty;
+        var page = items is not null
+            ? new Page<TItem>(
+                items,
+                response,
+                wrappedResponse.RawResponse.StatusCode,
+                wrappedResponse.RawResponse.Headers
+            )
+            : Page<TItem>.Empty;
         var offset = getOffset(request);
         var hasNextPage = getHasNextPage?.Invoke(response) ?? items?.Count > 0;
         if (!hasNextPage)
@@ -360,7 +369,7 @@ internal sealed class CursorPager<TRequest, TRequestOptions, TResponse, TCursor,
     /// <summary>
     /// Delegate for sending a request.
     /// </summary>
-    internal delegate global::System.Threading.Tasks.Task<TResponse> SendRequest(
+    internal delegate global::System.Threading.Tasks.Task<WithRawResponse<TResponse>> SendRequest(
         TRequest request,
         TRequestOptions? options,
         CancellationToken cancellationToken
@@ -385,7 +394,7 @@ internal sealed class CursorPager<TRequest, TRequestOptions, TResponse, TCursor,
         TRequest? nextRequest,
         bool hasNextPage,
         Page<TItem> page
-    ) ParseApiCallDelegate(TRequest request, TResponse response);
+    ) ParseApiCallDelegate(TRequest request, WithRawResponse<TResponse> wrappedResponse);
 
     /// <summary>
     /// The current <see cref="Page{TItem}"/>.
@@ -430,9 +439,10 @@ internal sealed class CursorPager<TRequest, TRequestOptions, TResponse, TCursor,
     )
     {
         request ??= Activator.CreateInstance<TRequest>();
-        var response = await sendRequest(request, options, cancellationToken).ConfigureAwait(false);
+        var wrappedResponse = await sendRequest(request, options, cancellationToken)
+            .ConfigureAwait(false);
         var parseApiCall = CreateParseApiCallDelegate(getItems, getNextCursor, setCursor);
-        var (nextRequest, hasNextPage, page) = parseApiCall(request, response);
+        var (nextRequest, hasNextPage, page) = parseApiCall(request, wrappedResponse);
         return new CursorPager<TRequest, TRequestOptions, TResponse, TCursor, TItem>(
             nextRequest,
             options,
@@ -449,10 +459,18 @@ internal sealed class CursorPager<TRequest, TRequestOptions, TResponse, TCursor,
         SetCursor setCursor
     )
     {
-        return (request, response) =>
+        return (request, wrappedResponse) =>
         {
+            var response = wrappedResponse.Data;
             var items = getItems(response);
-            var page = items is not null ? new Page<TItem>(items) : Page<TItem>.Empty;
+            var page = items is not null
+                ? new Page<TItem>(
+                    items,
+                    response,
+                    wrappedResponse.RawResponse.StatusCode,
+                    wrappedResponse.RawResponse.Headers
+                )
+                : Page<TItem>.Empty;
             var cursor = getNextCursor(response);
             var hasNextPage = cursor switch
             {
@@ -475,9 +493,9 @@ internal sealed class CursorPager<TRequest, TRequestOptions, TResponse, TCursor,
         CancellationToken cancellationToken = default
     )
     {
-        var response = await _sendRequest(request, options, cancellationToken)
+        var wrappedResponse = await _sendRequest(request, options, cancellationToken)
             .ConfigureAwait(false);
-        var (nextRequest, hasNextPage, page) = _parseApiCall(request, response);
+        var (nextRequest, hasNextPage, page) = _parseApiCall(request, wrappedResponse);
         _request = nextRequest;
         HasNextPage = hasNextPage;
         CurrentPage = page;

--- a/seed/csharp-sdk/pagination/custom-pager/src/SeedPagination/InlineUsers/InlineUsers/InlineUsersClient_.cs
+++ b/seed/csharp-sdk/pagination/custom-pager/src/SeedPagination/InlineUsers/InlineUsers/InlineUsersClient_.cs
@@ -1068,11 +1068,8 @@ public partial class InlineUsersClient_ : IInlineUsersClient_
                 request,
                 options,
                 async (request, options, cancellationToken) =>
-                    await ListWithCursorPaginationInternalAsync(
-                        request,
-                        options,
-                        cancellationToken
-                    ),
+                    await ListWithCursorPaginationInternalAsync(request, options, cancellationToken)
+                        .WithRawResponse(),
                 (request, cursor) =>
                 {
                     request.StartingAfter = cursor;
@@ -1112,10 +1109,11 @@ public partial class InlineUsersClient_ : IInlineUsersClient_
                 options,
                 async (request, options, cancellationToken) =>
                     await ListWithMixedTypeCursorPaginationInternalAsync(
-                        request,
-                        options,
-                        cancellationToken
-                    ),
+                            request,
+                            options,
+                            cancellationToken
+                        )
+                        .WithRawResponse(),
                 (request, cursor) =>
                 {
                     request.Cursor = cursor;
@@ -1158,10 +1156,11 @@ public partial class InlineUsersClient_ : IInlineUsersClient_
                 options,
                 async (request, options, cancellationToken) =>
                     await ListWithBodyCursorPaginationInternalAsync(
-                        request,
-                        options,
-                        cancellationToken
-                    ),
+                            request,
+                            options,
+                            cancellationToken
+                        )
+                        .WithRawResponse(),
                 (request, cursor) =>
                 {
                     request.Pagination ??= new WithCursor();
@@ -1205,11 +1204,8 @@ public partial class InlineUsersClient_ : IInlineUsersClient_
                 request,
                 options,
                 async (request, options, cancellationToken) =>
-                    await ListWithOffsetPaginationInternalAsync(
-                        request,
-                        options,
-                        cancellationToken
-                    ),
+                    await ListWithOffsetPaginationInternalAsync(request, options, cancellationToken)
+                        .WithRawResponse(),
                 request => request.Page ?? 0,
                 (request, offset) =>
                 {
@@ -1255,10 +1251,11 @@ public partial class InlineUsersClient_ : IInlineUsersClient_
                 options,
                 async (request, options, cancellationToken) =>
                     await ListWithDoubleOffsetPaginationInternalAsync(
-                        request,
-                        options,
-                        cancellationToken
-                    ),
+                            request,
+                            options,
+                            cancellationToken
+                        )
+                        .WithRawResponse(),
                 request => request.Page ?? 0,
                 (request, offset) =>
                 {
@@ -1301,10 +1298,11 @@ public partial class InlineUsersClient_ : IInlineUsersClient_
                 options,
                 async (request, options, cancellationToken) =>
                     await ListWithBodyOffsetPaginationInternalAsync(
-                        request,
-                        options,
-                        cancellationToken
-                    ),
+                            request,
+                            options,
+                            cancellationToken
+                        )
+                        .WithRawResponse(),
                 request => request.Pagination?.Page ?? 0,
                 (request, offset) =>
                 {
@@ -1350,10 +1348,11 @@ public partial class InlineUsersClient_ : IInlineUsersClient_
                 options,
                 async (request, options, cancellationToken) =>
                     await ListWithOffsetStepPaginationInternalAsync(
-                        request,
-                        options,
-                        cancellationToken
-                    ),
+                            request,
+                            options,
+                            cancellationToken
+                        )
+                        .WithRawResponse(),
                 request => request.Page ?? 0,
                 (request, offset) =>
                 {
@@ -1398,10 +1397,11 @@ public partial class InlineUsersClient_ : IInlineUsersClient_
                 options,
                 async (request, options, cancellationToken) =>
                     await ListWithOffsetPaginationHasNextPageInternalAsync(
-                        request,
-                        options,
-                        cancellationToken
-                    ),
+                            request,
+                            options,
+                            cancellationToken
+                        )
+                        .WithRawResponse(),
                 request => request.Page ?? 0,
                 (request, offset) =>
                 {
@@ -1445,7 +1445,8 @@ public partial class InlineUsersClient_ : IInlineUsersClient_
                 request,
                 options,
                 async (request, options, cancellationToken) =>
-                    await ListWithExtendedResultsInternalAsync(request, options, cancellationToken),
+                    await ListWithExtendedResultsInternalAsync(request, options, cancellationToken)
+                        .WithRawResponse(),
                 (request, cursor) =>
                 {
                     request.Cursor = cursor;
@@ -1488,10 +1489,11 @@ public partial class InlineUsersClient_ : IInlineUsersClient_
                 options,
                 async (request, options, cancellationToken) =>
                     await ListWithExtendedResultsAndOptionalDataInternalAsync(
-                        request,
-                        options,
-                        cancellationToken
-                    ),
+                            request,
+                            options,
+                            cancellationToken
+                        )
+                        .WithRawResponse(),
                 (request, cursor) =>
                 {
                     request.Cursor = cursor;
@@ -1530,7 +1532,8 @@ public partial class InlineUsersClient_ : IInlineUsersClient_
                 request,
                 options,
                 async (request, options, cancellationToken) =>
-                    await ListUsernamesInternalAsync(request, options, cancellationToken),
+                    await ListUsernamesInternalAsync(request, options, cancellationToken)
+                        .WithRawResponse(),
                 (request, cursor) =>
                 {
                     request.StartingAfter = cursor;
@@ -1567,7 +1570,8 @@ public partial class InlineUsersClient_ : IInlineUsersClient_
                 request,
                 options,
                 async (request, options, cancellationToken) =>
-                    await ListWithGlobalConfigInternalAsync(request, options, cancellationToken),
+                    await ListWithGlobalConfigInternalAsync(request, options, cancellationToken)
+                        .WithRawResponse(),
                 request => request.Offset ?? 0,
                 (request, offset) =>
                 {

--- a/seed/csharp-sdk/pagination/custom-pager/src/SeedPagination/Users/UsersClient.cs
+++ b/seed/csharp-sdk/pagination/custom-pager/src/SeedPagination/Users/UsersClient.cs
@@ -1412,11 +1412,8 @@ public partial class UsersClient : IUsersClient
                 request,
                 options,
                 async (request, options, cancellationToken) =>
-                    await ListWithCursorPaginationInternalAsync(
-                        request,
-                        options,
-                        cancellationToken
-                    ),
+                    await ListWithCursorPaginationInternalAsync(request, options, cancellationToken)
+                        .WithRawResponse(),
                 (request, cursor) =>
                 {
                     request.StartingAfter = cursor;
@@ -1456,10 +1453,11 @@ public partial class UsersClient : IUsersClient
                 options,
                 async (request, options, cancellationToken) =>
                     await ListWithMixedTypeCursorPaginationInternalAsync(
-                        request,
-                        options,
-                        cancellationToken
-                    ),
+                            request,
+                            options,
+                            cancellationToken
+                        )
+                        .WithRawResponse(),
                 (request, cursor) =>
                 {
                     request.Cursor = cursor;
@@ -1502,10 +1500,11 @@ public partial class UsersClient : IUsersClient
                 options,
                 async (request, options, cancellationToken) =>
                     await ListWithBodyCursorPaginationInternalAsync(
-                        request,
-                        options,
-                        cancellationToken
-                    ),
+                            request,
+                            options,
+                            cancellationToken
+                        )
+                        .WithRawResponse(),
                 (request, cursor) =>
                 {
                     request.Pagination ??= new WithCursor();
@@ -1555,10 +1554,11 @@ public partial class UsersClient : IUsersClient
                 options,
                 async (request, options, cancellationToken) =>
                     await ListWithTopLevelBodyCursorPaginationInternalAsync(
-                        request,
-                        options,
-                        cancellationToken
-                    ),
+                            request,
+                            options,
+                            cancellationToken
+                        )
+                        .WithRawResponse(),
                 (request, cursor) =>
                 {
                     request.Cursor = cursor;
@@ -1601,11 +1601,8 @@ public partial class UsersClient : IUsersClient
                 request,
                 options,
                 async (request, options, cancellationToken) =>
-                    await ListWithOffsetPaginationInternalAsync(
-                        request,
-                        options,
-                        cancellationToken
-                    ),
+                    await ListWithOffsetPaginationInternalAsync(request, options, cancellationToken)
+                        .WithRawResponse(),
                 request => request.Page ?? 0,
                 (request, offset) =>
                 {
@@ -1651,10 +1648,11 @@ public partial class UsersClient : IUsersClient
                 options,
                 async (request, options, cancellationToken) =>
                     await ListWithDoubleOffsetPaginationInternalAsync(
-                        request,
-                        options,
-                        cancellationToken
-                    ),
+                            request,
+                            options,
+                            cancellationToken
+                        )
+                        .WithRawResponse(),
                 request => request.Page ?? 0,
                 (request, offset) =>
                 {
@@ -1697,10 +1695,11 @@ public partial class UsersClient : IUsersClient
                 options,
                 async (request, options, cancellationToken) =>
                     await ListWithBodyOffsetPaginationInternalAsync(
-                        request,
-                        options,
-                        cancellationToken
-                    ),
+                            request,
+                            options,
+                            cancellationToken
+                        )
+                        .WithRawResponse(),
                 request => request.Pagination?.Page ?? 0,
                 (request, offset) =>
                 {
@@ -1746,10 +1745,11 @@ public partial class UsersClient : IUsersClient
                 options,
                 async (request, options, cancellationToken) =>
                     await ListWithOffsetStepPaginationInternalAsync(
-                        request,
-                        options,
-                        cancellationToken
-                    ),
+                            request,
+                            options,
+                            cancellationToken
+                        )
+                        .WithRawResponse(),
                 request => request.Page ?? 0,
                 (request, offset) =>
                 {
@@ -1794,10 +1794,11 @@ public partial class UsersClient : IUsersClient
                 options,
                 async (request, options, cancellationToken) =>
                     await ListWithOffsetPaginationHasNextPageInternalAsync(
-                        request,
-                        options,
-                        cancellationToken
-                    ),
+                            request,
+                            options,
+                            cancellationToken
+                        )
+                        .WithRawResponse(),
                 request => request.Page ?? 0,
                 (request, offset) =>
                 {
@@ -1838,7 +1839,8 @@ public partial class UsersClient : IUsersClient
                 request,
                 options,
                 async (request, options, cancellationToken) =>
-                    await ListWithExtendedResultsInternalAsync(request, options, cancellationToken),
+                    await ListWithExtendedResultsInternalAsync(request, options, cancellationToken)
+                        .WithRawResponse(),
                 (request, cursor) =>
                 {
                     request.Cursor = cursor;
@@ -1881,10 +1883,11 @@ public partial class UsersClient : IUsersClient
                 options,
                 async (request, options, cancellationToken) =>
                     await ListWithExtendedResultsAndOptionalDataInternalAsync(
-                        request,
-                        options,
-                        cancellationToken
-                    ),
+                            request,
+                            options,
+                            cancellationToken
+                        )
+                        .WithRawResponse(),
                 (request, cursor) =>
                 {
                     request.Cursor = cursor;
@@ -1923,7 +1926,8 @@ public partial class UsersClient : IUsersClient
                 request,
                 options,
                 async (request, options, cancellationToken) =>
-                    await ListUsernamesInternalAsync(request, options, cancellationToken),
+                    await ListUsernamesInternalAsync(request, options, cancellationToken)
+                        .WithRawResponse(),
                 (request, cursor) =>
                 {
                     request.StartingAfter = cursor;
@@ -1963,10 +1967,11 @@ public partial class UsersClient : IUsersClient
                 options,
                 async (request, options, cancellationToken) =>
                     await ListUsernamesWithOptionalResponseInternalAsync(
-                        request,
-                        options,
-                        cancellationToken
-                    ),
+                            request,
+                            options,
+                            cancellationToken
+                        )
+                        .WithRawResponse(),
                 (request, cursor) =>
                 {
                     request.StartingAfter = cursor;
@@ -2003,7 +2008,8 @@ public partial class UsersClient : IUsersClient
                 request,
                 options,
                 async (request, options, cancellationToken) =>
-                    await ListWithGlobalConfigInternalAsync(request, options, cancellationToken),
+                    await ListWithGlobalConfigInternalAsync(request, options, cancellationToken)
+                        .WithRawResponse(),
                 request => request.Offset ?? 0,
                 (request, offset) =>
                 {
@@ -2040,7 +2046,8 @@ public partial class UsersClient : IUsersClient
                 request,
                 options,
                 async (request, options, cancellationToken) =>
-                    await ListWithOptionalDataInternalAsync(request, options, cancellationToken),
+                    await ListWithOptionalDataInternalAsync(request, options, cancellationToken)
+                        .WithRawResponse(),
                 request => request.Page ?? 0,
                 (request, offset) =>
                 {
@@ -2086,7 +2093,8 @@ public partial class UsersClient : IUsersClient
                 request,
                 options,
                 async (request, options, cancellationToken) =>
-                    await ListWithAliasedDataInternalAsync(request, options, cancellationToken),
+                    await ListWithAliasedDataInternalAsync(request, options, cancellationToken)
+                        .WithRawResponse(),
                 (request, cursor) =>
                 {
                     request.StartingAfter = cursor;

--- a/seed/csharp-sdk/pagination/no-custom-config/src/SeedPagination.Test/Core/Pagination/GuidCursorTest.cs
+++ b/seed/csharp-sdk/pagination/no-custom-config/src/SeedPagination.Test/Core/Pagination/GuidCursorTest.cs
@@ -1,3 +1,4 @@
+using global::System.Net;
 using NUnit.Framework;
 using SeedPagination.Core;
 using SystemTask = global::System.Threading.Tasks.Task;
@@ -45,7 +46,7 @@ public class GuidCursorTest
             (_, _, _) =>
             {
                 responses.MoveNext();
-                return SystemTask.FromResult(responses.Current);
+                return SystemTask.FromResult(Wrap(responses.Current));
             },
             (request, cursor) =>
             {
@@ -100,4 +101,16 @@ public class GuidCursorTest
     {
         public required Guid? Next { get; set; }
     }
+
+    private static WithRawResponse<Response> Wrap(Response response) =>
+        new()
+        {
+            Data = response,
+            RawResponse = new RawResponse
+            {
+                StatusCode = HttpStatusCode.OK,
+                Url = new Uri("https://localhost"),
+                Headers = default,
+            },
+        };
 }

--- a/seed/csharp-sdk/pagination/no-custom-config/src/SeedPagination.Test/Core/Pagination/HasNextPageOffsetTest.cs
+++ b/seed/csharp-sdk/pagination/no-custom-config/src/SeedPagination.Test/Core/Pagination/HasNextPageOffsetTest.cs
@@ -1,3 +1,4 @@
+using global::System.Net;
 using NUnit.Framework;
 using SeedPagination.Core;
 using SystemTask = global::System.Threading.Tasks.Task;
@@ -41,7 +42,7 @@ public class HasNextPageOffsetTest
             (_, _, _) =>
             {
                 responses.MoveNext();
-                return SystemTask.FromResult(responses.Current);
+                return SystemTask.FromResult(Wrap(responses.Current));
             },
             request => request?.Pagination?.Page ?? 0,
             (request, offset) =>
@@ -89,4 +90,16 @@ public class HasNextPageOffsetTest
     {
         public IEnumerable<string>? Items { get; set; }
     }
+
+    private static WithRawResponse<Response> Wrap(Response response) =>
+        new()
+        {
+            Data = response,
+            RawResponse = new RawResponse
+            {
+                StatusCode = HttpStatusCode.OK,
+                Url = new Uri("https://localhost"),
+                Headers = default,
+            },
+        };
 }

--- a/seed/csharp-sdk/pagination/no-custom-config/src/SeedPagination.Test/Core/Pagination/IntOffsetTest.cs
+++ b/seed/csharp-sdk/pagination/no-custom-config/src/SeedPagination.Test/Core/Pagination/IntOffsetTest.cs
@@ -1,3 +1,4 @@
+using global::System.Net;
 using NUnit.Framework;
 using SeedPagination.Core;
 using SystemTask = global::System.Threading.Tasks.Task;
@@ -29,7 +30,7 @@ public class IntOffsetTest
             (_, _, _) =>
             {
                 responses.MoveNext();
-                return SystemTask.FromResult(responses.Current);
+                return SystemTask.FromResult(Wrap(responses.Current));
             },
             request => request?.Pagination?.Page ?? 0,
             (request, offset) =>
@@ -79,4 +80,16 @@ public class IntOffsetTest
     {
         public IEnumerable<string>? Items { get; set; }
     }
+
+    private static WithRawResponse<Response> Wrap(Response response) =>
+        new()
+        {
+            Data = response,
+            RawResponse = new RawResponse
+            {
+                StatusCode = HttpStatusCode.OK,
+                Url = new Uri("https://localhost"),
+                Headers = default,
+            },
+        };
 }

--- a/seed/csharp-sdk/pagination/no-custom-config/src/SeedPagination.Test/Core/Pagination/LongOffsetTest.cs
+++ b/seed/csharp-sdk/pagination/no-custom-config/src/SeedPagination.Test/Core/Pagination/LongOffsetTest.cs
@@ -1,3 +1,4 @@
+using global::System.Net;
 using NUnit.Framework;
 using SeedPagination.Core;
 using SystemTask = global::System.Threading.Tasks.Task;
@@ -29,7 +30,7 @@ public class LongOffsetTest
             (_, _, _) =>
             {
                 responses.MoveNext();
-                return SystemTask.FromResult(responses.Current);
+                return SystemTask.FromResult(Wrap(responses.Current));
             },
             request => request?.Pagination?.Page ?? 0,
             (request, offset) =>
@@ -76,4 +77,16 @@ public class LongOffsetTest
     {
         public IEnumerable<string>? Items { get; set; }
     }
+
+    private static WithRawResponse<Response> Wrap(Response response) =>
+        new()
+        {
+            Data = response,
+            RawResponse = new RawResponse
+            {
+                StatusCode = HttpStatusCode.OK,
+                Url = new Uri("https://localhost"),
+                Headers = default,
+            },
+        };
 }

--- a/seed/csharp-sdk/pagination/no-custom-config/src/SeedPagination.Test/Core/Pagination/NoRequestCursorTest.cs
+++ b/seed/csharp-sdk/pagination/no-custom-config/src/SeedPagination.Test/Core/Pagination/NoRequestCursorTest.cs
@@ -1,3 +1,4 @@
+using global::System.Net;
 using NUnit.Framework;
 using SeedPagination.Core;
 using SystemTask = global::System.Threading.Tasks.Task;
@@ -45,7 +46,7 @@ public class NoRequestCursorTest
             (_, _, _) =>
             {
                 responses.MoveNext();
-                return SystemTask.FromResult(responses.Current);
+                return SystemTask.FromResult(Wrap(responses.Current));
             },
             (request, cursor) =>
             {
@@ -103,4 +104,16 @@ public class NoRequestCursorTest
     {
         public required string? Next { get; set; }
     }
+
+    private static WithRawResponse<Response> Wrap(Response response) =>
+        new()
+        {
+            Data = response,
+            RawResponse = new RawResponse
+            {
+                StatusCode = HttpStatusCode.OK,
+                Url = new Uri("https://localhost"),
+                Headers = default,
+            },
+        };
 }

--- a/seed/csharp-sdk/pagination/no-custom-config/src/SeedPagination.Test/Core/Pagination/NoRequestOffsetTest.cs
+++ b/seed/csharp-sdk/pagination/no-custom-config/src/SeedPagination.Test/Core/Pagination/NoRequestOffsetTest.cs
@@ -1,3 +1,4 @@
+using global::System.Net;
 using NUnit.Framework;
 using SeedPagination.Core;
 using SystemTask = global::System.Threading.Tasks.Task;
@@ -29,7 +30,7 @@ public class NoRequestOffsetTest
             (_, _, _) =>
             {
                 responses.MoveNext();
-                return SystemTask.FromResult(responses.Current);
+                return SystemTask.FromResult(Wrap(responses.Current));
             },
             request => request?.Pagination?.Page ?? 0,
             (request, offset) =>
@@ -79,4 +80,16 @@ public class NoRequestOffsetTest
     {
         public IEnumerable<string>? Items { get; set; }
     }
+
+    private static WithRawResponse<Response> Wrap(Response response) =>
+        new()
+        {
+            Data = response,
+            RawResponse = new RawResponse
+            {
+                StatusCode = HttpStatusCode.OK,
+                Url = new Uri("https://localhost"),
+                Headers = default,
+            },
+        };
 }

--- a/seed/csharp-sdk/pagination/no-custom-config/src/SeedPagination.Test/Core/Pagination/StepOffsetTest.cs
+++ b/seed/csharp-sdk/pagination/no-custom-config/src/SeedPagination.Test/Core/Pagination/StepOffsetTest.cs
@@ -1,3 +1,4 @@
+using global::System.Net;
 using NUnit.Framework;
 using SeedPagination.Core;
 using SystemTask = global::System.Threading.Tasks.Task;
@@ -30,7 +31,7 @@ public class StepPageOffsetPaginationTest
             (_, _, _) =>
             {
                 responses.MoveNext();
-                return SystemTask.FromResult(responses.Current);
+                return SystemTask.FromResult(Wrap(responses.Current));
             },
             request => request?.Pagination?.ItemOffset ?? 0,
             (request, offset) =>
@@ -89,4 +90,16 @@ public class StepPageOffsetPaginationTest
     {
         public IEnumerable<string>? Items { get; set; }
     }
+
+    private static WithRawResponse<Response> Wrap(Response response) =>
+        new()
+        {
+            Data = response,
+            RawResponse = new RawResponse
+            {
+                StatusCode = HttpStatusCode.OK,
+                Url = new Uri("https://localhost"),
+                Headers = default,
+            },
+        };
 }

--- a/seed/csharp-sdk/pagination/no-custom-config/src/SeedPagination.Test/Core/Pagination/StringCursorTest.cs
+++ b/seed/csharp-sdk/pagination/no-custom-config/src/SeedPagination.Test/Core/Pagination/StringCursorTest.cs
@@ -1,3 +1,4 @@
+using global::System.Net;
 using NUnit.Framework;
 using SeedPagination.Core;
 using SystemTask = global::System.Threading.Tasks.Task;
@@ -46,7 +47,7 @@ public class StringCursorTest
             (_, _, _) =>
             {
                 responses.MoveNext();
-                return SystemTask.FromResult(responses.Current);
+                return SystemTask.FromResult(Wrap(responses.Current));
             },
             (request, cursor) =>
             {
@@ -115,7 +116,7 @@ public class StringCursorTest
             (_, _, _) =>
             {
                 responses.MoveNext();
-                return SystemTask.FromResult(responses.Current);
+                return SystemTask.FromResult(Wrap(responses.Current));
             },
             (request, cursor) =>
             {
@@ -164,4 +165,16 @@ public class StringCursorTest
     {
         public required string? Next { get; set; }
     }
+
+    private static WithRawResponse<Response> Wrap(Response response) =>
+        new()
+        {
+            Data = response,
+            RawResponse = new RawResponse
+            {
+                StatusCode = HttpStatusCode.OK,
+                Url = new Uri("https://localhost"),
+                Headers = default,
+            },
+        };
 }

--- a/seed/csharp-sdk/pagination/no-custom-config/src/SeedPagination/Complex/ComplexClient.cs
+++ b/seed/csharp-sdk/pagination/no-custom-config/src/SeedPagination/Complex/ComplexClient.cs
@@ -135,7 +135,7 @@ public partial class ComplexClient : IComplexClient
                 options,
                 async (request, options, cancellationToken) =>
                     await SearchInternalAsync(index, request, options, cancellationToken)
-                        .ConfigureAwait(false),
+                        .WithRawResponse(),
                 (request, cursor) =>
                 {
                     request.Pagination ??= new StartingAfterPaging() { PerPage = 0 };

--- a/seed/csharp-sdk/pagination/no-custom-config/src/SeedPagination/Core/Page.cs
+++ b/seed/csharp-sdk/pagination/no-custom-config/src/SeedPagination/Core/Page.cs
@@ -1,5 +1,6 @@
 using global::System.Collections;
 using global::System.Collections.ObjectModel;
+using global::System.Net;
 
 namespace SeedPagination.Core;
 
@@ -20,9 +21,41 @@ public class Page<TItem> : IEnumerable<TItem>
     }
 
     /// <summary>
+    /// Creates a new <see cref="Page{TItem}"/> with the specified items and response metadata.
+    /// </summary>
+    public Page(
+        IReadOnlyList<TItem> items,
+        object? response,
+        HttpStatusCode statusCode,
+        ResponseHeaders? headers
+    )
+    {
+        Items = items;
+        Response = response;
+        StatusCode = statusCode;
+        Headers = headers;
+    }
+
+    /// <summary>
     /// Gets the items in this <see cref="Page{TItem}"/>.
     /// </summary>
     public IReadOnlyList<TItem> Items { get; }
+
+    /// <summary>
+    /// The full API response object for this page. Cast to the endpoint's response
+    /// type to access fields beyond the paginated items (e.g., TotalCount, metadata).
+    /// </summary>
+    public object? Response { get; }
+
+    /// <summary>
+    /// The HTTP status code of the response that produced this page.
+    /// </summary>
+    public HttpStatusCode StatusCode { get; }
+
+    /// <summary>
+    /// The HTTP response headers from the response that produced this page.
+    /// </summary>
+    public ResponseHeaders? Headers { get; }
 
     /// <summary>
     /// Enumerate the items in this <see cref="Page{TItem}"/>.

--- a/seed/csharp-sdk/pagination/no-custom-config/src/SeedPagination/Core/Pager.cs
+++ b/seed/csharp-sdk/pagination/no-custom-config/src/SeedPagination/Core/Pager.cs
@@ -95,7 +95,7 @@ internal sealed class OffsetPager<TRequest, TRequestOptions, TResponse, TOffset,
     private readonly SendRequest _sendRequest;
     private readonly ParseApiCallDelegate _parseApiCall;
 
-    internal delegate global::System.Threading.Tasks.Task<TResponse> SendRequest(
+    internal delegate global::System.Threading.Tasks.Task<WithRawResponse<TResponse>> SendRequest(
         TRequest request,
         TRequestOptions? options,
         CancellationToken cancellationToken
@@ -115,7 +115,7 @@ internal sealed class OffsetPager<TRequest, TRequestOptions, TResponse, TOffset,
         TRequest? nextRequest,
         bool hasNextPage,
         Page<TItem> page
-    ) ParseApiCallDelegate(TRequest request, TResponse response);
+    ) ParseApiCallDelegate(TRequest request, WithRawResponse<TResponse> wrappedResponse);
 
     public Page<TItem> CurrentPage { get; private set; }
     public bool HasNextPage { get; private set; }
@@ -152,7 +152,8 @@ internal sealed class OffsetPager<TRequest, TRequestOptions, TResponse, TOffset,
     )
     {
         request ??= Activator.CreateInstance<TRequest>();
-        var response = await sendRequest(request, options, cancellationToken).ConfigureAwait(false);
+        var wrappedResponse = await sendRequest(request, options, cancellationToken)
+            .ConfigureAwait(false);
         var parseApiCall = CreateParseApiCallDelegate(
             getItems,
             getOffset,
@@ -160,7 +161,7 @@ internal sealed class OffsetPager<TRequest, TRequestOptions, TResponse, TOffset,
             getStep,
             getHasNextPage
         );
-        var (nextRequest, hasNextPage, page) = parseApiCall(request, response);
+        var (nextRequest, hasNextPage, page) = parseApiCall(request, wrappedResponse);
         return new OffsetPager<TRequest, TRequestOptions, TResponse, TOffset, TStep, TItem>(
             nextRequest,
             options,
@@ -179,10 +180,10 @@ internal sealed class OffsetPager<TRequest, TRequestOptions, TResponse, TOffset,
         GetHasNextPage? getHasNextPage
     )
     {
-        return (request, response) =>
+        return (request, wrappedResponse) =>
             ParseApiCall(
                 request,
-                response,
+                wrappedResponse,
                 getItems,
                 getOffset,
                 setOffset,
@@ -197,9 +198,9 @@ internal sealed class OffsetPager<TRequest, TRequestOptions, TResponse, TOffset,
         CancellationToken cancellationToken = default
     )
     {
-        var response = await _sendRequest(request, options, cancellationToken)
+        var wrappedResponse = await _sendRequest(request, options, cancellationToken)
             .ConfigureAwait(false);
-        var (nextRequest, hasNextPageFlag, page) = _parseApiCall(request, response);
+        var (nextRequest, hasNextPageFlag, page) = _parseApiCall(request, wrappedResponse);
         _request = nextRequest;
         HasNextPage = hasNextPageFlag;
         CurrentPage = page;
@@ -208,7 +209,7 @@ internal sealed class OffsetPager<TRequest, TRequestOptions, TResponse, TOffset,
 
     private static (TRequest? nextRequest, bool hasNextPage, Page<TItem> page) ParseApiCall(
         TRequest request,
-        TResponse response,
+        WithRawResponse<TResponse> wrappedResponse,
         GetItems getItems,
         GetOffset getOffset,
         SetOffset setOffset,
@@ -216,8 +217,16 @@ internal sealed class OffsetPager<TRequest, TRequestOptions, TResponse, TOffset,
         GetHasNextPage? getHasNextPage
     )
     {
+        var response = wrappedResponse.Data;
         var items = getItems(response);
-        var page = items is not null ? new Page<TItem>(items) : Page<TItem>.Empty;
+        var page = items is not null
+            ? new Page<TItem>(
+                items,
+                response,
+                wrappedResponse.RawResponse.StatusCode,
+                wrappedResponse.RawResponse.Headers
+            )
+            : Page<TItem>.Empty;
         var offset = getOffset(request);
         var hasNextPage = getHasNextPage?.Invoke(response) ?? items?.Count > 0;
         if (!hasNextPage)
@@ -360,7 +369,7 @@ internal sealed class CursorPager<TRequest, TRequestOptions, TResponse, TCursor,
     /// <summary>
     /// Delegate for sending a request.
     /// </summary>
-    internal delegate global::System.Threading.Tasks.Task<TResponse> SendRequest(
+    internal delegate global::System.Threading.Tasks.Task<WithRawResponse<TResponse>> SendRequest(
         TRequest request,
         TRequestOptions? options,
         CancellationToken cancellationToken
@@ -385,7 +394,7 @@ internal sealed class CursorPager<TRequest, TRequestOptions, TResponse, TCursor,
         TRequest? nextRequest,
         bool hasNextPage,
         Page<TItem> page
-    ) ParseApiCallDelegate(TRequest request, TResponse response);
+    ) ParseApiCallDelegate(TRequest request, WithRawResponse<TResponse> wrappedResponse);
 
     /// <summary>
     /// The current <see cref="Page{TItem}"/>.
@@ -430,9 +439,10 @@ internal sealed class CursorPager<TRequest, TRequestOptions, TResponse, TCursor,
     )
     {
         request ??= Activator.CreateInstance<TRequest>();
-        var response = await sendRequest(request, options, cancellationToken).ConfigureAwait(false);
+        var wrappedResponse = await sendRequest(request, options, cancellationToken)
+            .ConfigureAwait(false);
         var parseApiCall = CreateParseApiCallDelegate(getItems, getNextCursor, setCursor);
-        var (nextRequest, hasNextPage, page) = parseApiCall(request, response);
+        var (nextRequest, hasNextPage, page) = parseApiCall(request, wrappedResponse);
         return new CursorPager<TRequest, TRequestOptions, TResponse, TCursor, TItem>(
             nextRequest,
             options,
@@ -449,10 +459,18 @@ internal sealed class CursorPager<TRequest, TRequestOptions, TResponse, TCursor,
         SetCursor setCursor
     )
     {
-        return (request, response) =>
+        return (request, wrappedResponse) =>
         {
+            var response = wrappedResponse.Data;
             var items = getItems(response);
-            var page = items is not null ? new Page<TItem>(items) : Page<TItem>.Empty;
+            var page = items is not null
+                ? new Page<TItem>(
+                    items,
+                    response,
+                    wrappedResponse.RawResponse.StatusCode,
+                    wrappedResponse.RawResponse.Headers
+                )
+                : Page<TItem>.Empty;
             var cursor = getNextCursor(response);
             var hasNextPage = cursor switch
             {
@@ -475,9 +493,9 @@ internal sealed class CursorPager<TRequest, TRequestOptions, TResponse, TCursor,
         CancellationToken cancellationToken = default
     )
     {
-        var response = await _sendRequest(request, options, cancellationToken)
+        var wrappedResponse = await _sendRequest(request, options, cancellationToken)
             .ConfigureAwait(false);
-        var (nextRequest, hasNextPage, page) = _parseApiCall(request, response);
+        var (nextRequest, hasNextPage, page) = _parseApiCall(request, wrappedResponse);
         _request = nextRequest;
         HasNextPage = hasNextPage;
         CurrentPage = page;

--- a/seed/csharp-sdk/pagination/no-custom-config/src/SeedPagination/InlineUsers/InlineUsers/InlineUsersClient_.cs
+++ b/seed/csharp-sdk/pagination/no-custom-config/src/SeedPagination/InlineUsers/InlineUsers/InlineUsersClient_.cs
@@ -1068,11 +1068,8 @@ public partial class InlineUsersClient_ : IInlineUsersClient_
                 request,
                 options,
                 async (request, options, cancellationToken) =>
-                    await ListWithCursorPaginationInternalAsync(
-                        request,
-                        options,
-                        cancellationToken
-                    ),
+                    await ListWithCursorPaginationInternalAsync(request, options, cancellationToken)
+                        .WithRawResponse(),
                 (request, cursor) =>
                 {
                     request.StartingAfter = cursor;
@@ -1112,10 +1109,11 @@ public partial class InlineUsersClient_ : IInlineUsersClient_
                 options,
                 async (request, options, cancellationToken) =>
                     await ListWithMixedTypeCursorPaginationInternalAsync(
-                        request,
-                        options,
-                        cancellationToken
-                    ),
+                            request,
+                            options,
+                            cancellationToken
+                        )
+                        .WithRawResponse(),
                 (request, cursor) =>
                 {
                     request.Cursor = cursor;
@@ -1158,10 +1156,11 @@ public partial class InlineUsersClient_ : IInlineUsersClient_
                 options,
                 async (request, options, cancellationToken) =>
                     await ListWithBodyCursorPaginationInternalAsync(
-                        request,
-                        options,
-                        cancellationToken
-                    ),
+                            request,
+                            options,
+                            cancellationToken
+                        )
+                        .WithRawResponse(),
                 (request, cursor) =>
                 {
                     request.Pagination ??= new WithCursor();
@@ -1205,11 +1204,8 @@ public partial class InlineUsersClient_ : IInlineUsersClient_
                 request,
                 options,
                 async (request, options, cancellationToken) =>
-                    await ListWithOffsetPaginationInternalAsync(
-                        request,
-                        options,
-                        cancellationToken
-                    ),
+                    await ListWithOffsetPaginationInternalAsync(request, options, cancellationToken)
+                        .WithRawResponse(),
                 request => request.Page ?? 0,
                 (request, offset) =>
                 {
@@ -1255,10 +1251,11 @@ public partial class InlineUsersClient_ : IInlineUsersClient_
                 options,
                 async (request, options, cancellationToken) =>
                     await ListWithDoubleOffsetPaginationInternalAsync(
-                        request,
-                        options,
-                        cancellationToken
-                    ),
+                            request,
+                            options,
+                            cancellationToken
+                        )
+                        .WithRawResponse(),
                 request => request.Page ?? 0,
                 (request, offset) =>
                 {
@@ -1301,10 +1298,11 @@ public partial class InlineUsersClient_ : IInlineUsersClient_
                 options,
                 async (request, options, cancellationToken) =>
                     await ListWithBodyOffsetPaginationInternalAsync(
-                        request,
-                        options,
-                        cancellationToken
-                    ),
+                            request,
+                            options,
+                            cancellationToken
+                        )
+                        .WithRawResponse(),
                 request => request.Pagination?.Page ?? 0,
                 (request, offset) =>
                 {
@@ -1350,10 +1348,11 @@ public partial class InlineUsersClient_ : IInlineUsersClient_
                 options,
                 async (request, options, cancellationToken) =>
                     await ListWithOffsetStepPaginationInternalAsync(
-                        request,
-                        options,
-                        cancellationToken
-                    ),
+                            request,
+                            options,
+                            cancellationToken
+                        )
+                        .WithRawResponse(),
                 request => request.Page ?? 0,
                 (request, offset) =>
                 {
@@ -1398,10 +1397,11 @@ public partial class InlineUsersClient_ : IInlineUsersClient_
                 options,
                 async (request, options, cancellationToken) =>
                     await ListWithOffsetPaginationHasNextPageInternalAsync(
-                        request,
-                        options,
-                        cancellationToken
-                    ),
+                            request,
+                            options,
+                            cancellationToken
+                        )
+                        .WithRawResponse(),
                 request => request.Page ?? 0,
                 (request, offset) =>
                 {
@@ -1445,7 +1445,8 @@ public partial class InlineUsersClient_ : IInlineUsersClient_
                 request,
                 options,
                 async (request, options, cancellationToken) =>
-                    await ListWithExtendedResultsInternalAsync(request, options, cancellationToken),
+                    await ListWithExtendedResultsInternalAsync(request, options, cancellationToken)
+                        .WithRawResponse(),
                 (request, cursor) =>
                 {
                     request.Cursor = cursor;
@@ -1488,10 +1489,11 @@ public partial class InlineUsersClient_ : IInlineUsersClient_
                 options,
                 async (request, options, cancellationToken) =>
                     await ListWithExtendedResultsAndOptionalDataInternalAsync(
-                        request,
-                        options,
-                        cancellationToken
-                    ),
+                            request,
+                            options,
+                            cancellationToken
+                        )
+                        .WithRawResponse(),
                 (request, cursor) =>
                 {
                     request.Cursor = cursor;
@@ -1530,7 +1532,8 @@ public partial class InlineUsersClient_ : IInlineUsersClient_
                 request,
                 options,
                 async (request, options, cancellationToken) =>
-                    await ListUsernamesInternalAsync(request, options, cancellationToken),
+                    await ListUsernamesInternalAsync(request, options, cancellationToken)
+                        .WithRawResponse(),
                 (request, cursor) =>
                 {
                     request.StartingAfter = cursor;
@@ -1567,7 +1570,8 @@ public partial class InlineUsersClient_ : IInlineUsersClient_
                 request,
                 options,
                 async (request, options, cancellationToken) =>
-                    await ListWithGlobalConfigInternalAsync(request, options, cancellationToken),
+                    await ListWithGlobalConfigInternalAsync(request, options, cancellationToken)
+                        .WithRawResponse(),
                 request => request.Offset ?? 0,
                 (request, offset) =>
                 {

--- a/seed/csharp-sdk/pagination/no-custom-config/src/SeedPagination/Users/UsersClient.cs
+++ b/seed/csharp-sdk/pagination/no-custom-config/src/SeedPagination/Users/UsersClient.cs
@@ -1412,11 +1412,8 @@ public partial class UsersClient : IUsersClient
                 request,
                 options,
                 async (request, options, cancellationToken) =>
-                    await ListWithCursorPaginationInternalAsync(
-                        request,
-                        options,
-                        cancellationToken
-                    ),
+                    await ListWithCursorPaginationInternalAsync(request, options, cancellationToken)
+                        .WithRawResponse(),
                 (request, cursor) =>
                 {
                     request.StartingAfter = cursor;
@@ -1456,10 +1453,11 @@ public partial class UsersClient : IUsersClient
                 options,
                 async (request, options, cancellationToken) =>
                     await ListWithMixedTypeCursorPaginationInternalAsync(
-                        request,
-                        options,
-                        cancellationToken
-                    ),
+                            request,
+                            options,
+                            cancellationToken
+                        )
+                        .WithRawResponse(),
                 (request, cursor) =>
                 {
                     request.Cursor = cursor;
@@ -1502,10 +1500,11 @@ public partial class UsersClient : IUsersClient
                 options,
                 async (request, options, cancellationToken) =>
                     await ListWithBodyCursorPaginationInternalAsync(
-                        request,
-                        options,
-                        cancellationToken
-                    ),
+                            request,
+                            options,
+                            cancellationToken
+                        )
+                        .WithRawResponse(),
                 (request, cursor) =>
                 {
                     request.Pagination ??= new WithCursor();
@@ -1555,10 +1554,11 @@ public partial class UsersClient : IUsersClient
                 options,
                 async (request, options, cancellationToken) =>
                     await ListWithTopLevelBodyCursorPaginationInternalAsync(
-                        request,
-                        options,
-                        cancellationToken
-                    ),
+                            request,
+                            options,
+                            cancellationToken
+                        )
+                        .WithRawResponse(),
                 (request, cursor) =>
                 {
                     request.Cursor = cursor;
@@ -1601,11 +1601,8 @@ public partial class UsersClient : IUsersClient
                 request,
                 options,
                 async (request, options, cancellationToken) =>
-                    await ListWithOffsetPaginationInternalAsync(
-                        request,
-                        options,
-                        cancellationToken
-                    ),
+                    await ListWithOffsetPaginationInternalAsync(request, options, cancellationToken)
+                        .WithRawResponse(),
                 request => request.Page ?? 0,
                 (request, offset) =>
                 {
@@ -1651,10 +1648,11 @@ public partial class UsersClient : IUsersClient
                 options,
                 async (request, options, cancellationToken) =>
                     await ListWithDoubleOffsetPaginationInternalAsync(
-                        request,
-                        options,
-                        cancellationToken
-                    ),
+                            request,
+                            options,
+                            cancellationToken
+                        )
+                        .WithRawResponse(),
                 request => request.Page ?? 0,
                 (request, offset) =>
                 {
@@ -1697,10 +1695,11 @@ public partial class UsersClient : IUsersClient
                 options,
                 async (request, options, cancellationToken) =>
                     await ListWithBodyOffsetPaginationInternalAsync(
-                        request,
-                        options,
-                        cancellationToken
-                    ),
+                            request,
+                            options,
+                            cancellationToken
+                        )
+                        .WithRawResponse(),
                 request => request.Pagination?.Page ?? 0,
                 (request, offset) =>
                 {
@@ -1746,10 +1745,11 @@ public partial class UsersClient : IUsersClient
                 options,
                 async (request, options, cancellationToken) =>
                     await ListWithOffsetStepPaginationInternalAsync(
-                        request,
-                        options,
-                        cancellationToken
-                    ),
+                            request,
+                            options,
+                            cancellationToken
+                        )
+                        .WithRawResponse(),
                 request => request.Page ?? 0,
                 (request, offset) =>
                 {
@@ -1794,10 +1794,11 @@ public partial class UsersClient : IUsersClient
                 options,
                 async (request, options, cancellationToken) =>
                     await ListWithOffsetPaginationHasNextPageInternalAsync(
-                        request,
-                        options,
-                        cancellationToken
-                    ),
+                            request,
+                            options,
+                            cancellationToken
+                        )
+                        .WithRawResponse(),
                 request => request.Page ?? 0,
                 (request, offset) =>
                 {
@@ -1838,7 +1839,8 @@ public partial class UsersClient : IUsersClient
                 request,
                 options,
                 async (request, options, cancellationToken) =>
-                    await ListWithExtendedResultsInternalAsync(request, options, cancellationToken),
+                    await ListWithExtendedResultsInternalAsync(request, options, cancellationToken)
+                        .WithRawResponse(),
                 (request, cursor) =>
                 {
                     request.Cursor = cursor;
@@ -1881,10 +1883,11 @@ public partial class UsersClient : IUsersClient
                 options,
                 async (request, options, cancellationToken) =>
                     await ListWithExtendedResultsAndOptionalDataInternalAsync(
-                        request,
-                        options,
-                        cancellationToken
-                    ),
+                            request,
+                            options,
+                            cancellationToken
+                        )
+                        .WithRawResponse(),
                 (request, cursor) =>
                 {
                     request.Cursor = cursor;
@@ -1923,7 +1926,8 @@ public partial class UsersClient : IUsersClient
                 request,
                 options,
                 async (request, options, cancellationToken) =>
-                    await ListUsernamesInternalAsync(request, options, cancellationToken),
+                    await ListUsernamesInternalAsync(request, options, cancellationToken)
+                        .WithRawResponse(),
                 (request, cursor) =>
                 {
                     request.StartingAfter = cursor;
@@ -1963,10 +1967,11 @@ public partial class UsersClient : IUsersClient
                 options,
                 async (request, options, cancellationToken) =>
                     await ListUsernamesWithOptionalResponseInternalAsync(
-                        request,
-                        options,
-                        cancellationToken
-                    ),
+                            request,
+                            options,
+                            cancellationToken
+                        )
+                        .WithRawResponse(),
                 (request, cursor) =>
                 {
                     request.StartingAfter = cursor;
@@ -2003,7 +2008,8 @@ public partial class UsersClient : IUsersClient
                 request,
                 options,
                 async (request, options, cancellationToken) =>
-                    await ListWithGlobalConfigInternalAsync(request, options, cancellationToken),
+                    await ListWithGlobalConfigInternalAsync(request, options, cancellationToken)
+                        .WithRawResponse(),
                 request => request.Offset ?? 0,
                 (request, offset) =>
                 {
@@ -2040,7 +2046,8 @@ public partial class UsersClient : IUsersClient
                 request,
                 options,
                 async (request, options, cancellationToken) =>
-                    await ListWithOptionalDataInternalAsync(request, options, cancellationToken),
+                    await ListWithOptionalDataInternalAsync(request, options, cancellationToken)
+                        .WithRawResponse(),
                 request => request.Page ?? 0,
                 (request, offset) =>
                 {
@@ -2086,7 +2093,8 @@ public partial class UsersClient : IUsersClient
                 request,
                 options,
                 async (request, options, cancellationToken) =>
-                    await ListWithAliasedDataInternalAsync(request, options, cancellationToken),
+                    await ListWithAliasedDataInternalAsync(request, options, cancellationToken)
+                        .WithRawResponse(),
                 (request, cursor) =>
                 {
                     request.StartingAfter = cursor;


### PR DESCRIPTION
## Description
Equivalent of https://github.com/fern-api/fern/pull/10629 in C#.

Added three new properties to `Page<TItem>`:
- `Response` (`object?`), the full deserialized API response object
- StatusCode (`HttpStatusCode`), the HTTP status code
- Headers (`ResponseHeaders?`), the HTTP response headers

Pager now explicitly calls `.WithRawResponse()` so `Page` can have `Response`. There was a somewhat suboptimal design decision made here to avoid a breaking change; namely, I'd rather have expanded the interface of `Pager` to `Pager<TResponse, TItem>` so users wouldn't have to cast `Response` to the correct type to use it, but that would break any code that implemented the interface. I'd theoretically be alright with this since getting the raw response here is a relatively fringe use case compared to the status code or headers, but it's still a compromise.

Code example:
```csharp
  var pager = await client.Users.ListAsync(request);
  await foreach (var page in pager.AsPagesAsync())
  {
      // HTTP metadata
      Console.WriteLine(page.StatusCode);   // e.g., HttpStatusCode.OK
      Console.WriteLine(page.Headers);      // ResponseHeaders

      // Full response (cast to access non-item fields)
      var response = (ListUsersPaginationResponse)page.Response!;
      Console.WriteLine(response.TotalCount);
  }
```

## Testing
Regeneration of all pagination fixtures.
- [X] Unit tests added/updated
- [X] Manual testing completed
