### PR TITLE
fix(cli): fallback to sole generator when snippet config package name doesn't match

### DIFF
--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -1,5 +1,18 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 
+- version: 4.63.3
+  changelogEntry:
+    - summary: |
+        Fix dynamic snippet generation falling back to raw HTTP code when the
+        snippet config package name in `docs.yml` does not exactly match the
+        generator output in `generators.yml`. When a language has a snippet
+        config but no exact package match, the CLI now falls back to the sole
+        generator for that language (if exactly one exists), ensuring SDK-
+        idiomatic snippets are generated instead of raw HTTP code.
+      type: fix
+  createdAt: "2026-04-08"
+  irVersion: 66
+
 - version: 4.63.2
   changelogEntry:
     - summary: |

--- a/packages/cli/generation/remote-generation/remote-workspace-runner/src/publishDocs.ts
+++ b/packages/cli/generation/remote-generation/remote-workspace-runner/src/publishDocs.ts
@@ -5,6 +5,7 @@ import { createFdrService } from "@fern-api/core";
 import { MediaType, replaceEnvVariables } from "@fern-api/core-utils";
 import { DocsDefinitionResolver, UploadedFile, wrapWithHttps } from "@fern-api/docs-resolver";
 import { APIV1Write, FdrAPI as CjsFdrSdk, DocsV1Write, DocsV2Write, FdrClient } from "@fern-api/fdr-sdk";
+import { dynamic } from "@fern-api/ir-sdk";
 
 type DynamicIr = APIV1Write.DynamicIr;
 type DynamicIrUpload = APIV1Write.DynamicIrUpload;
@@ -1173,6 +1174,16 @@ async function generateLanguageSpecificDynamicIRs({
         rust: snippetsConfig.rustSdk?.package
     };
 
+    // Build a map of generator invocations per language for fallback matching
+    const generatorsByLanguage: Record<
+        string,
+        Array<{
+            invocation: generatorsYml.GeneratorInvocation;
+            config: dynamic.GeneratorConfig | undefined;
+            packageName: string;
+        }>
+    > = {};
+
     if (workspace.generatorsConfiguration?.groups) {
         for (const group of workspace.generatorsConfiguration.groups) {
             for (const generatorInvocation of group.generators) {
@@ -1226,6 +1237,16 @@ async function generateLanguageSpecificDynamicIRs({
                     continue;
                 }
 
+                // Track generators by language for fallback matching
+                if (!generatorsByLanguage[generatorInvocation.language]) {
+                    generatorsByLanguage[generatorInvocation.language] = [];
+                }
+                generatorsByLanguage[generatorInvocation.language].push({
+                    invocation: generatorInvocation,
+                    config: dynamicGeneratorConfig,
+                    packageName
+                });
+
                 // Skip languages that already have SDK dynamic IRs
                 if (skipLanguages.has(generatorInvocation.language)) {
                     context.logger.debug(
@@ -1277,6 +1298,59 @@ async function generateLanguageSpecificDynamicIRs({
                         context.logger.debug(`Failed to create dynamic IR for ${generatorInvocation.language}`);
                     }
                 }
+            }
+        }
+    }
+
+    // Fallback: for languages that have a snippet config but no exact package name match,
+    // use the sole generator for that language if there is exactly one. This handles cases
+    // where docs.yml snippet config doesn't exactly match the generators.yml value (e.g.
+    // a mismatched Go GitHub repo URL).
+    for (const [language, configuredPackageName] of Object.entries(snippetConfiguration)) {
+        if (!configuredPackageName || languageSpecificIRs[language] || skipLanguages.has(language)) {
+            continue;
+        }
+        const generators = generatorsByLanguage[language];
+        if (generators && generators.length === 1) {
+            const { invocation, config, packageName } = generators[0];
+            context.logger.warn(
+                `Snippet config for ${language} specifies \`${configuredPackageName}\` but generator publishes \`${packageName}\`. Using generator config as fallback.`
+            );
+            const irForDynamicSnippets = generateIntermediateRepresentation({
+                workspace,
+                generationLanguage: invocation.language,
+                keywords: undefined,
+                smartCasing: invocation.smartCasing,
+                exampleGeneration: {
+                    disabled: true,
+                    skipAutogenerationIfManualExamplesExist: true,
+                    skipErrorAutogenerationIfManualErrorExamplesExist: true
+                },
+                audiences: {
+                    type: "all"
+                },
+                readme: undefined,
+                packageName: packageName,
+                version: undefined,
+                context,
+                sourceResolver: new SourceResolverImpl(context, workspace),
+                dynamicGeneratorConfig: config
+            });
+
+            const dynamicIR = convertIrToDynamicSnippetsIr({
+                ir: irForDynamicSnippets,
+                disableExamples: true,
+                smartCasing: invocation.smartCasing,
+                generationLanguage: invocation.language,
+                generatorConfig: config
+            });
+
+            if (dynamicIR) {
+                languageSpecificIRs[language] = {
+                    dynamicIR
+                };
+            } else {
+                context.logger.debug(`Failed to create dynamic IR for ${language} (fallback)`);
             }
         }
     }


### PR DESCRIPTION
## Description

Refs: Follow-up to #14754

After merging the Go package name normalization fix (#14754), dynamic snippet generation was **still** falling back to raw HTTP code for customers whose `docs.yml` snippet config specifies a different package/repo name than what's in `generators.yml`. For example:

- `docs.yml`: `go: https://github.com/payroc/payroc-sdk-go`
- `generators.yml`: `github.repository: payroc/papi-sdk-go`

The exact-match comparison at the core of `generateLanguageSpecificDynamicIRs` fails because these are simply different strings, so no dynamic IR is generated and docs fall back to `httpsnippet-lite` raw HTTP code.

## Changes Made

- **Added fallback matching in `generateLanguageSpecificDynamicIRs`**: After the first pass through generators fails to produce a match for a language, a second pass checks if there is exactly one generator configured for that language. If so, it uses that generator's config to produce the dynamic IR, logging a warning about the package name mismatch.
- **Tracks generators by language** via a `generatorsByLanguage` map built during the first pass.
- Added `versions.yml` entry for v4.63.3.

## Testing

- [ ] Unit tests added/updated
- [x] Lint passes (`pnpm run check`)
- [ ] Manual testing completed (requires `fern docs publish` with FDR auth — not feasible locally)

## ⚠️ Key review points

1. **Fallback applies to all languages, not just Go/Swift.** If a customer has a typo in their TypeScript snippet config but exactly one TS generator, the fallback will silently use it. The warning log helps surface this, but consider whether the fallback should be scoped to only URL-based package names (Go, Swift).
2. **Code duplication**: The `generateIntermediateRepresentation` + `convertIrToDynamicSnippetsIr` block is duplicated from the exact-match path. Could be extracted into a helper to reduce drift risk.
3. **Fallback uses the generator's `packageName`**, not the `configuredPackageName` from `docs.yml` — this is intentional (use what the generator actually publishes).

Link to Devin session: https://app.devin.ai/sessions/97992dbbc8c7438bbdf2c381765313d1
Requested by: @iamnamananand996