### PR TITLE
fix(go): fix dynamic snippet import paths with empty/invalid version strings

### DIFF
--- a/generators/go-v2/ast/src/utils/resolveRootImportPath.ts
+++ b/generators/go-v2/ast/src/utils/resolveRootImportPath.ts
@@ -62,11 +62,11 @@ function getMajorVersionSuffix({ config }: { config: FernGeneratorExec.config.Ge
 // prefix, e.g. "v0", "v1", "v2", etc.
 function parseMajorVersion({ config }: { config: FernGeneratorExec.config.GeneratorConfig }): string | undefined {
     const version = getVersion(config);
-    if (version == null) {
+    if (version == null || version === "") {
         return undefined;
     }
     const split = version.split(".");
-    if (split[0] == null) {
+    if (split[0] == null || split[0] === "" || split[0] === "v") {
         return undefined;
     }
     const majorVersion = split[0];

--- a/generators/go/sdk/versions.yml
+++ b/generators/go/sdk/versions.yml
@@ -1,4 +1,15 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 1.33.5
+  changelogEntry:
+    - summary: |
+        Fix dynamic snippet import paths receiving a spurious `/v` suffix when
+        the SDK version is empty or invalid (e.g. `""`). The major-version
+        parser now returns `undefined` for empty and bare-`v` version strings
+        instead of producing an erroneous `v` suffix.
+      type: fix
+  createdAt: "2026-04-08"
+  irVersion: 61
+
 - version: 1.33.4
   changelogEntry:
     - summary: |


### PR DESCRIPTION
## Description

Fixes Go dynamic snippet generation producing incorrect import paths with a spurious `/v` suffix (e.g. `github.com/payroc/papi-sdk-go/v` instead of `github.com/payroc/papi-sdk-go`) when the SDK version is empty or invalid.

## Changes Made

- Added guards in `parseMajorVersion` (`generators/go-v2/ast/src/utils/resolveRootImportPath.ts`) to return `undefined` for:
  - Empty string versions (`""`)
  - Bare `"v"` major version (from splitting `""` or `"v"` on `.`)
- Added changelog entry (v1.33.5) in `generators/go/sdk/versions.yml`

**Root cause:** When the version string is `""`, `"".split(".")` produces `[""]`. The old code didn't guard against `""` in `split[0]`, so it fell through to `return \`v${""}\`` → `"v"`. `getMajorVersionSuffix` only filtered `"v0"` and `"v1"`, so the bare `"v"` was appended to the import path. The Go v1 generator avoids this because it uses Go's `semver.Major()` which returns `""` for invalid inputs.

## Testing

- [ ] Unit tests added/updated — **no new tests added**; existing tests still pass
- [ ] Manual testing completed — verified fix logic against edge cases: `""`, `"v"`, `undefined`, `"v1.0.0"`, `"v2.0.0"`, `"v3.1.2"`

## Review Checklist

- Verify the `split[0] === "v"` guard doesn't accidentally reject valid versions like `"v2.0.0"` (it shouldn't — `split[0]` would be `"v2"`, not `"v"`)
- Consider whether a unit test should be added in `resolveRootImportPath` for these edge cases

Link to Devin session: https://app.devin.ai/sessions/da475ac82f754e50b67b0d219f6bb052
Requested by: @iamnamananand996