### PR TITLE
feat(cli): detect Postman deploy source from git commit message

### DIFF
--- a/packages/cli/cli/src/utils/environment.ts
+++ b/packages/cli/cli/src/utils/environment.ts
@@ -6,6 +6,7 @@ export interface CISource {
     commitSha?: string;
     branch?: string;
     actor?: string;
+    deploySource?: string;
 }
 
 /**
@@ -13,6 +14,8 @@ export interface CISource {
  * Returns undefined when not running in a recognized CI environment.
  */
 export function detectCISource(): CISource | undefined {
+    const deploySource = nonEmpty(process.env.FERN_DEPLOY_SOURCE);
+
     if (process.env.GITHUB_ACTIONS === "true") {
         const repo = process.env.GITHUB_REPOSITORY;
         const serverUrl = process.env.GITHUB_SERVER_URL ?? "https://github.com";
@@ -24,7 +27,8 @@ export function detectCISource(): CISource | undefined {
             runUrl: repo && runId ? `${serverUrl}/${repo}/actions/runs/${runId}` : undefined,
             commitSha: process.env.GITHUB_SHA,
             branch: process.env.GITHUB_REF_NAME,
-            actor: process.env.GITHUB_ACTOR
+            actor: process.env.GITHUB_ACTOR,
+            ...(deploySource != null && { deploySource })
         };
     }
     if (process.env.GITLAB_CI === "true") {
@@ -35,7 +39,8 @@ export function detectCISource(): CISource | undefined {
             runUrl: process.env.CI_PIPELINE_URL,
             commitSha: process.env.CI_COMMIT_SHA,
             branch: process.env.CI_COMMIT_REF_NAME,
-            actor: process.env.GITLAB_USER_LOGIN
+            actor: process.env.GITLAB_USER_LOGIN,
+            ...(deploySource != null && { deploySource })
         };
     }
     if (process.env.BITBUCKET_BUILD_NUMBER != null) {
@@ -51,7 +56,8 @@ export function detectCISource(): CISource | undefined {
                     ? `https://bitbucket.org/${workspace}/${repoSlug}/pipelines/results/${buildNumber}`
                     : undefined,
             commitSha: process.env.BITBUCKET_COMMIT,
-            branch: process.env.BITBUCKET_BRANCH
+            branch: process.env.BITBUCKET_BRANCH,
+            ...(deploySource != null && { deploySource })
         };
     }
     return undefined;

--- a/packages/cli/cli/src/utils/environment.ts
+++ b/packages/cli/cli/src/utils/environment.ts
@@ -1,3 +1,5 @@
+import { execSync } from "child_process";
+
 export interface CISource {
     type: "github" | "gitlab" | "bitbucket";
     repo?: string;
@@ -14,7 +16,7 @@ export interface CISource {
  * Returns undefined when not running in a recognized CI environment.
  */
 export function detectCISource(): CISource | undefined {
-    const deploySource = nonEmpty(process.env.FERN_DEPLOY_SOURCE);
+    const deploySource = detectDeploySource();
 
     if (process.env.GITHUB_ACTIONS === "true") {
         const repo = process.env.GITHUB_REPOSITORY;
@@ -59,6 +61,23 @@ export function detectCISource(): CISource | undefined {
             branch: process.env.BITBUCKET_BRANCH,
             ...(deploySource != null && { deploySource })
         };
+    }
+    return undefined;
+}
+
+/**
+ * Detects the deploy source by inspecting the current git commit message.
+ * If the commit subject contains `[source:postman]`, returns `"postman"`.
+ * Returns undefined when the marker is absent or git is unavailable.
+ */
+function detectDeploySource(): string | undefined {
+    try {
+        const subject = execSync("git log -1 --format=%s", { encoding: "utf-8", timeout: 5000 }).trim();
+        if (subject.includes("[source:postman]")) {
+            return "postman";
+        }
+    } catch {
+        // git not available or not in a repo — skip silently
     }
     return undefined;
 }

--- a/packages/cli/cli/src/utils/environment.ts
+++ b/packages/cli/cli/src/utils/environment.ts
@@ -72,7 +72,7 @@ export function detectCISource(): CISource | undefined {
  */
 function detectDeploySource(): string | undefined {
     try {
-        const subject = execSync("git log -1 --format=%s", { encoding: "utf-8", timeout: 5000 }).trim();
+        const subject = execSync("git log -1 --format=%s", { encoding: "utf-8", timeout: 5000, stdio: "pipe" }).trim();
         if (subject.includes("[source:postman]")) {
             return "postman";
         }

--- a/packages/cli/cli/src/utils/environment.ts
+++ b/packages/cli/cli/src/utils/environment.ts
@@ -78,7 +78,7 @@ function detectDeploySource(): string | undefined {
         }
     } catch (error) {
         // git not available or not in a repo — log at debug level and continue
-        // eslint-disable-next-line no-console
+        // biome-ignore lint/suspicious/noConsole: allow console
         console.debug("detectDeploySource: git log failed", error);
     }
     return undefined;

--- a/packages/cli/cli/src/utils/environment.ts
+++ b/packages/cli/cli/src/utils/environment.ts
@@ -16,40 +16,36 @@ export interface CISource {
  * Returns undefined when not running in a recognized CI environment.
  */
 export function detectCISource(): CISource | undefined {
-    const deploySource = detectDeploySource();
+    let source: CISource | undefined;
 
     if (process.env.GITHUB_ACTIONS === "true") {
         const repo = process.env.GITHUB_REPOSITORY;
         const serverUrl = process.env.GITHUB_SERVER_URL ?? "https://github.com";
         const runId = process.env.GITHUB_RUN_ID;
-        return {
+        source = {
             type: "github",
             repo,
             runId,
             runUrl: repo && runId ? `${serverUrl}/${repo}/actions/runs/${runId}` : undefined,
             commitSha: process.env.GITHUB_SHA,
             branch: process.env.GITHUB_REF_NAME,
-            actor: process.env.GITHUB_ACTOR,
-            ...(deploySource != null && { deploySource })
+            actor: process.env.GITHUB_ACTOR
         };
-    }
-    if (process.env.GITLAB_CI === "true") {
-        return {
+    } else if (process.env.GITLAB_CI === "true") {
+        source = {
             type: "gitlab",
             repo: process.env.CI_PROJECT_PATH,
             runId: process.env.CI_PIPELINE_ID,
             runUrl: process.env.CI_PIPELINE_URL,
             commitSha: process.env.CI_COMMIT_SHA,
             branch: process.env.CI_COMMIT_REF_NAME,
-            actor: process.env.GITLAB_USER_LOGIN,
-            ...(deploySource != null && { deploySource })
+            actor: process.env.GITLAB_USER_LOGIN
         };
-    }
-    if (process.env.BITBUCKET_BUILD_NUMBER != null) {
+    } else if (process.env.BITBUCKET_BUILD_NUMBER != null) {
         const workspace = process.env.BITBUCKET_WORKSPACE;
         const repoSlug = process.env.BITBUCKET_REPO_SLUG;
         const buildNumber = process.env.BITBUCKET_BUILD_NUMBER;
-        return {
+        source = {
             type: "bitbucket",
             repo: workspace && repoSlug ? `${workspace}/${repoSlug}` : undefined,
             runId: buildNumber,
@@ -58,11 +54,18 @@ export function detectCISource(): CISource | undefined {
                     ? `https://bitbucket.org/${workspace}/${repoSlug}/pipelines/results/${buildNumber}`
                     : undefined,
             commitSha: process.env.BITBUCKET_COMMIT,
-            branch: process.env.BITBUCKET_BRANCH,
-            ...(deploySource != null && { deploySource })
+            branch: process.env.BITBUCKET_BRANCH
         };
     }
-    return undefined;
+
+    if (source != null) {
+        const deploySource = detectDeploySource();
+        if (deploySource != null) {
+            source.deploySource = deploySource;
+        }
+    }
+
+    return source;
 }
 
 /**

--- a/packages/cli/cli/src/utils/environment.ts
+++ b/packages/cli/cli/src/utils/environment.ts
@@ -76,8 +76,10 @@ function detectDeploySource(): string | undefined {
         if (subject.includes("[source:postman]")) {
             return "postman";
         }
-    } catch {
-        // git not available or not in a repo — skip silently
+    } catch (error) {
+        // git not available or not in a repo — log at debug level and continue
+        // eslint-disable-next-line no-console
+        console.debug("detectDeploySource: git log failed", error);
     }
     return undefined;
 }

--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -12,6 +12,17 @@
   createdAt: "2026-04-08"
   irVersion: 66
 
+- version: 4.67.0
+  changelogEntry:
+    - summary: |
+        Detect `[source:postman]` marker in the git commit message and include
+        `deploySource` in the `X-CI-Source` header sent to FDR during docs
+        publishing. This allows Postman-triggered deployments to be identified
+        in the dashboard activity log without requiring workflow template changes.
+      type: feat
+  createdAt: "2026-04-08"
+  irVersion: 66
+
 - version: 4.66.0
   changelogEntry:
     - summary: |

--- a/packages/cli/generation/remote-generation/remote-workspace-runner/src/publishDocs.ts
+++ b/packages/cli/generation/remote-generation/remote-workspace-runner/src/publishDocs.ts
@@ -108,6 +108,7 @@ interface CISource {
     commitSha?: string;
     branch?: string;
     actor?: string;
+    deploySource?: string;
 }
 
 export async function publishDocs({

--- a/packages/cli/generation/remote-generation/remote-workspace-runner/src/runRemoteGenerationForDocsWorkspace.ts
+++ b/packages/cli/generation/remote-generation/remote-workspace-runner/src/runRemoteGenerationForDocsWorkspace.ts
@@ -19,6 +19,7 @@ export interface CISource {
     commitSha?: string;
     branch?: string;
     actor?: string;
+    deploySource?: string;
 }
 
 export async function runRemoteGenerationForDocsWorkspace({


### PR DESCRIPTION
## Description

Refs fern-api/fern-platform#9560 (companion PR)

Adds support for detecting when a docs deployment was triggered by a Postman collection update, by inspecting the git commit message for a `[source:postman]` marker. When found, the CLI includes `deploySource: "postman"` in the `X-CI-Source` JSON header sent to FDR during docs publishing, so the dashboard can show a Postman indicator in the deployment activity log.

This approach detects the source directly from the commit message rather than requiring a custom workflow step to set an env var — meaning it works for all existing Postman-integrated repos on day one without any workflow template changes.

## Changes Made

- Added `deploySource?: string` field to the `CISource` interface (in all three locations where it's defined)
- Added `detectDeploySource()` helper that runs `git log -1 --format=%s` and checks for `[source:postman]` in the commit subject
- `detectCISource()` now calls `detectDeploySource()` **only after a CI environment is confirmed** — the git exec is never spawned on local dev machines
- Refactored `detectCISource()` from separate `if` blocks with early returns to an `if/else if` chain that builds a `source` object, then conditionally enriches it with `deploySource`
- The git call is wrapped in try/catch with a 5s timeout and `stdio: "pipe"` to prevent stderr from leaking to the user's terminal when git is unavailable
- Errors are logged at `console.debug` level for diagnosability
- Added `versions.yml` entry for v4.67.0 (minor bump for feat)

## Testing

- [ ] Unit tests added/updated
- [x] Lint passes (`pnpm run check`)
- [x] Biome passes (`pnpm check:biome`)
- [ ] Manual testing completed

## Reviewer Checklist

- **Synchronous shell exec**: `detectDeploySource()` uses `execSync` which blocks the event loop. The 5s timeout bounds the worst case, and this only runs once per CLI invocation and only when already inside a recognized CI environment. Worth confirming this is acceptable.
- **Commit message detection scope**: `git log -1 --format=%s` reads the HEAD commit subject. For merge commits or squash merges, verify the `[source:postman]` marker propagates to the final commit subject (the fern-platform companion PR controls the commit message format).
- **Three `CISource` interfaces**: The field was added to all three duplicate definitions (`environment.ts`, `publishDocs.ts`, `runRemoteGenerationForDocsWorkspace.ts`). The duplication is pre-existing.
- **No unit tests**: `detectDeploySource()` shells out to git so it's not easily unit-testable without mocking `execSync`. The function is small and defensive (try/catch + timeout). Consider whether integration coverage is sufficient.
- **Backward-compatible**: The field is optional and only included when the marker is detected, so existing deployments are unaffected.
- **FDR compatibility**: `deploySource` is a new non-URL string field in the `X-CI-Source` JSON. FDR's `sanitizeCiSource` only strips URL fields (`runUrl`), so this passes through untouched. No FDR changes needed.

## Updates since last revision

- **Deferred `detectDeploySource()`**: Moved the `execSync` git call so it only runs after a CI environment (GitHub/GitLab/Bitbucket) has been confirmed. Previously it ran unconditionally at the top of `detectCISource()`, which could block local dev machines for up to 5s with no benefit.
- **Refactored control flow**: Changed `detectCISource()` from separate `if` blocks with early returns to `if/else if` chain, building a `source` variable that gets enriched with `deploySource` before returning.
- **Version bumped to 4.67.0**: Main branch added its own 4.66.0 entry, so our entry is now 4.67.0.

Link to Devin session: https://app.devin.ai/sessions/9b2a038d4ebb47039520482f78e4a254
Requested by: @matlegault
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/14768" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
