### PR TITLE
fix(python): filter `nop` vals from objects in wire tests

### DIFF
--- a/generators/python-v2/dynamic-snippets/src/context/DynamicTypeLiteralMapper.ts
+++ b/generators/python-v2/dynamic-snippets/src/context/DynamicTypeLiteralMapper.ts
@@ -384,7 +384,9 @@ export class DynamicTypeLiteralMapper {
             }
         }
 
-        return result;
+        // Filter out nop entries (e.g. literal types that produce no output) to avoid
+        // generating invalid syntax like `strategy=,`.
+        return result.filter((entry) => !python.TypeInstantiation.isNop(entry.value));
     }
 
     private convertObject({

--- a/generators/python/sdk/versions.yml
+++ b/generators/python/sdk/versions.yml
@@ -1,5 +1,15 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 # For unreleased changes, use unreleased.yml
+- version: 5.3.5
+  changelogEntry:
+    - summary: |
+        Fix wire test generation producing invalid syntax (e.g. `strategy=,`) for object
+        properties with literal/const types. Literal properties that resolve to nop values
+        are now filtered out of generated constructor arguments.
+      type: fix
+  createdAt: "2026-04-09"
+  irVersion: 65
+
 - version: 5.3.4
   changelogEntry:
     - summary: |


### PR DESCRIPTION
## Description
When an object property has a literal/const type (e.g. `strategy` with `const: "adfs"`), `convertObjectEntries` in `DynamicTypeLiteralMapper` includes it in the result even when `convert()` returns a `nop()`. Since `nop()` renders as empty string, this produces invalid Python syntax like `strategy=,`. Now `nop`s are filtered before returning from `convertObjectEntries`.

## Testing
On Auth0's MyOrg API.
- [X] Unit tests added/updated
- [X] Manual testing completed
