### PR TITLE
fix(internal): fetch remote branch before creating worktree

### DIFF
--- a/scripts/worktree-add.sh
+++ b/scripts/worktree-add.sh
@@ -31,9 +31,15 @@ if [ -z "$path" ]; then
     path="$WORKTREE_BASE/$branch"
 fi
 
+# Fetch the branch from origin if it exists remotely, so we track it
+# instead of creating a disconnected local branch.
+git fetch origin "$branch" 2>/dev/null || true
+
 # Create worktree — use -b if the branch doesn't exist yet
 if git show-ref --verify --quiet "refs/heads/$branch"; then
     git worktree add "$path" "$branch"
+elif git show-ref --verify --quiet "refs/remotes/origin/$branch"; then
+    git worktree add --track -b "$branch" "$path" "origin/$branch"
 else
     git worktree add -b "$branch" "$path"
 fi


### PR DESCRIPTION
## Summary
- Updated `scripts/worktree-add.sh` to `git fetch origin <branch>` before creating a worktree
- If the branch exists on the remote, the local branch is created with `--track` so it stays connected to `origin/<branch>`
- Prevents creating disconnected local branches when a remote branch with the same name already exists

## Test plan
- [ ] Run `pnpm worktree:add <existing-remote-branch>` and verify the local branch tracks the remote
- [ ] Run `pnpm worktree:add <new-branch-name>` and verify it still creates a fresh local branch
- [ ] Run `pnpm worktree:add <existing-local-branch>` and verify it uses the existing local branch
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/14772" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
