### PR TITLE
fix(seed): eliminate spurious docker tag errors in seed run

### DIFF
--- a/packages/seed/src/commands/test/test-runner/ContainerTestRunner.ts
+++ b/packages/seed/src/commands/test/test-runner/ContainerTestRunner.ts
@@ -46,6 +46,12 @@ export class ContainerTestRunner extends TestRunner {
     }
 
     public async build(): Promise<void> {
+        // Guard against redundant builds (e.g., when build() is called directly
+        // before TestRunner.run() which also triggers a build via buildInvocation)
+        if (this.reusableContainer != null) {
+            return;
+        }
+
         const testConfig =
             this.runner === "podman" && this.generator.workspaceConfig.test.podman != null
                 ? this.generator.workspaceConfig.test.podman
@@ -59,6 +65,7 @@ export class ContainerTestRunner extends TestRunner {
         // Rewrite -t flags in build commands to use :local (or :local-wt-<suffix>) tags.
         // This handles direct `docker build` / `podman build` commands.
         const namespacedCommands = containerCommands.map((cmd) => this.rewriteDockerBuildTag(cmd));
+        const rewriteApplied = namespacedCommands.some((cmd, i) => cmd !== containerCommands[i]);
 
         if (!this.shouldPipeOutput()) {
             CONSOLE_LOGGER.info(`Building container for ${this.generator.workspaceName}...`);
@@ -76,24 +83,21 @@ export class ContainerTestRunner extends TestRunner {
         // For turbo-wrapped or other indirect build commands that may have built
         // the image under its original tag (e.g. :latest), create a :local alias
         // so downstream consumers can find the image.
-        const originalImage = this.getOriginalImageFromConfig();
-        const localImage = this.getContainerImageName();
-        if (originalImage !== localImage) {
-            try {
-                await loggingExeca(undefined, this.runner, ["tag", originalImage, localImage], {
-                    doNotPipeOutput: !this.shouldPipeOutput()
-                });
-            } catch (error) {
-                // tag may fail if the rewrite already produced the :local image directly
-                CONSOLE_LOGGER.debug(
-                    `docker tag failed (expected if image was built with local tag directly): ${error}`
-                );
+        // Skip this when build commands were already rewritten to use :local directly.
+        if (!rewriteApplied) {
+            const originalImage = this.getOriginalImageFromConfig();
+            const localImage = this.getContainerImageName();
+            if (originalImage !== localImage) {
+                try {
+                    await loggingExeca(undefined, this.runner, ["tag", originalImage, localImage], {
+                        doNotPipeOutput: !this.shouldPipeOutput()
+                    });
+                } catch (error) {
+                    CONSOLE_LOGGER.debug(
+                        `docker tag failed (expected if image was built with local tag directly): ${error}`
+                    );
+                }
             }
-        }
-
-        // Start a reusable long-lived container for generation (guard against double build() calls)
-        if (this.reusableContainer != null) {
-            return;
         }
         this.reusableContainer = new ReusableContainerExecutionEnvironment({
             imageName: this.getContainerImageName(),


### PR DESCRIPTION
## Description

Fixes confusing `docker tag failed` / `No such image` error messages that appear when running `seed run` against a custom fixture.

## Changes Made

Two issues in `ContainerTestRunner.build()`:

1. **Double build**: `runWithCustomFixture.ts` calls `testRunner.build()` directly, then `testRunner.run()` calls it again internally (via `buildInvocation`). The existing `reusableContainer != null` guard was placed *after* the docker build and tag commands, so both ran twice on every `seed run` invocation. **Fix**: moved the guard to the top of `build()`.

2. **Unnecessary `docker tag` attempt**: When `rewriteDockerBuildTag` successfully rewrites `-t image:latest` → `-t image:local` in the build command, the image is built directly with the `:local` tag. The subsequent `docker tag image:latest image:local` always fails because `:latest` was never created. This error was caught and logged via `CONSOLE_LOGGER.debug()`, but Node.js `console.debug()` prints to stdout regardless of log level, so users see alarming error messages. **Fix**: track whether the rewrite was applied and skip the fallback `docker tag` when it was (the tag fallback is only needed for turbo-wrapped/indirect builds where the rewrite can't apply).

## Review Checklist
- [ ] Verify the `rewriteApplied` comparison logic: `rewriteDockerBuildTag` returns the same string *reference* for non-build commands and a new string from `.replace()` for build commands, so `!==` reference comparison is valid here
- [ ] Confirm moving the guard to the top of `build()` doesn't break the `seed test` path (which uses `buildInvocation` in `TestRunner.run()` to deduplicate)

## Testing
- [ ] Manual testing with `seed run --generator python-sdk` against a custom fixture
- [x] Lint passes (`pnpm run check`)

Link to Devin session: https://app.devin.ai/sessions/83293bc9f63341228287bc5f07a297b2
Requested by: @jsklan
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/14773" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
