### PR TITLE
fix(typescript): use raw response body as expected in wire tests when noSerdeLayer is enabled

### DIFF
--- a/generators/typescript/sdk/generator/src/test-generator/TestGenerator.ts
+++ b/generators/typescript/sdk/generator/src/test-generator/TestGenerator.ts
@@ -1196,23 +1196,12 @@ describe("${serviceName}", () => {
 
         const willThrowError = responseStatusCode >= 400 && this.neverThrowErrors === false;
 
-        // When noSerdeLayer is enabled, the SDK returns raw JSON without transformation,
-        // so the expected response should match the raw response body exactly.
-        const expected =
-            !context.includeSerdeLayer && rawResponseBody != null && responseStatusCode < 400
-                ? this.neverThrowErrors
-                    ? code`{
-                        body: rawResponseBody,
-                        ok: true,
-                        headers: expect.any(Object),
-                        rawResponse: expect.any(Object),
-                    }`
-                    : code`rawResponseBody`
-                : getExpectedResponse({
-                      response: example.response,
-                      context,
-                      neverThrowErrors: this.neverThrowErrors
-                  });
+        const expected = getExpectedResponse({
+            response: example.response,
+            context,
+            neverThrowErrors: this.neverThrowErrors,
+            rawResponseBody
+        });
 
         const sseExpectedEvents: Code | undefined = isSSEStreaming
             ? this.getSseExpectedEvents({ endpoint, example, context })
@@ -2149,11 +2138,13 @@ function getUnusedPropertiesFromJsonExample(
 function getExpectedResponse({
     response,
     context,
-    neverThrowErrors
+    neverThrowErrors,
+    rawResponseBody
 }: {
     response: FernIr.ExampleResponse;
     context: FileContext;
     neverThrowErrors: boolean;
+    rawResponseBody?: Code;
 }): Code {
     return response._visit({
         ok: (response) => {
@@ -2161,6 +2152,10 @@ function getExpectedResponse({
                 body: (value) => {
                     if (!value) {
                         return code`undefined`;
+                    }
+                    // When noSerdeLayer is enabled, use the raw response body directly
+                    if (!context.includeSerdeLayer && rawResponseBody != null) {
+                        return code`rawResponseBody`;
                     }
                     const example = context.type.getGeneratedExample(value).build(context, {
                         isForSnippet: true,

--- a/generators/typescript/sdk/generator/src/test-generator/TestGenerator.ts
+++ b/generators/typescript/sdk/generator/src/test-generator/TestGenerator.ts
@@ -1196,11 +1196,23 @@ describe("${serviceName}", () => {
 
         const willThrowError = responseStatusCode >= 400 && this.neverThrowErrors === false;
 
-        const expected = getExpectedResponse({
-            response: example.response,
-            context,
-            neverThrowErrors: this.neverThrowErrors
-        });
+        // When noSerdeLayer is enabled, the SDK returns raw JSON without transformation,
+        // so the expected response should match the raw response body exactly.
+        const expected =
+            !context.includeSerdeLayer && rawResponseBody != null && responseStatusCode < 400
+                ? this.neverThrowErrors
+                    ? code`{
+                        body: rawResponseBody,
+                        ok: true,
+                        headers: expect.any(Object),
+                        rawResponse: expect.any(Object),
+                    }`
+                    : code`rawResponseBody`
+                : getExpectedResponse({
+                      response: example.response,
+                      context,
+                      neverThrowErrors: this.neverThrowErrors
+                  });
 
         const sseExpectedEvents: Code | undefined = isSSEStreaming
             ? this.getSseExpectedEvents({ endpoint, example, context })

--- a/generators/typescript/sdk/versions.yml
+++ b/generators/typescript/sdk/versions.yml
@@ -1,4 +1,17 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 3.63.1
+  changelogEntry:
+    - summary: |
+        Fix wire test expected response mismatch when `noSerdeLayer` is enabled and
+        the IR example shape contains fewer properties than the JSON example (e.g. for
+        inline types). The mock server sends the full raw JSON body, but the expected
+        assertion was built from the typed example which only included a subset of
+        properties. The test generator now uses the raw response body as the expected
+        value when `noSerdeLayer` is enabled, matching the SDK's pass-through behavior.
+      type: fix
+  createdAt: "2026-04-08"
+  irVersion: 66
+
 - version: 3.63.0
   changelogEntry:
     - summary: |

--- a/seed/ts-sdk/exhaustive/allow-extra-fields/tests/wire/endpoints/container.test.ts
+++ b/seed/ts-sdk/exhaustive/allow-extra-fields/tests/wire/endpoints/container.test.ts
@@ -20,7 +20,7 @@ describe("ContainerClient", () => {
             .build();
 
         const response = await client.endpoints.container.getAndReturnListOfPrimitives(["string", "string"]);
-        expect(response).toEqual(["string", "string"]);
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnListOfObjects", async () => {
@@ -46,14 +46,7 @@ describe("ContainerClient", () => {
                 string: "string",
             },
         ]);
-        expect(response).toEqual([
-            {
-                string: "string",
-            },
-            {
-                string: "string",
-            },
-        ]);
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnSetOfPrimitives", async () => {
@@ -72,7 +65,7 @@ describe("ContainerClient", () => {
             .build();
 
         const response = await client.endpoints.container.getAndReturnSetOfPrimitives(["string"]);
-        expect(response).toEqual(["string"]);
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnSetOfObjects", async () => {
@@ -95,11 +88,7 @@ describe("ContainerClient", () => {
                 string: "string",
             },
         ]);
-        expect(response).toEqual([
-            {
-                string: "string",
-            },
-        ]);
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnMapPrimToPrim", async () => {
@@ -120,9 +109,7 @@ describe("ContainerClient", () => {
         const response = await client.endpoints.container.getAndReturnMapPrimToPrim({
             string: "string",
         });
-        expect(response).toEqual({
-            string: "string",
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnMapOfPrimToObject", async () => {
@@ -145,11 +132,7 @@ describe("ContainerClient", () => {
                 string: "string",
             },
         });
-        expect(response).toEqual({
-            string: {
-                string: "string",
-            },
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnMapOfPrimToUndiscriminatedUnion", async () => {
@@ -170,9 +153,7 @@ describe("ContainerClient", () => {
         const response = await client.endpoints.container.getAndReturnMapOfPrimToUndiscriminatedUnion({
             string: 1.1,
         });
-        expect(response).toEqual({
-            string: 1.1,
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnOptional", async () => {
@@ -193,8 +174,6 @@ describe("ContainerClient", () => {
         const response = await client.endpoints.container.getAndReturnOptional({
             string: "string",
         });
-        expect(response).toEqual({
-            string: "string",
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 });

--- a/seed/ts-sdk/exhaustive/allow-extra-fields/tests/wire/endpoints/enum.test.ts
+++ b/seed/ts-sdk/exhaustive/allow-extra-fields/tests/wire/endpoints/enum.test.ts
@@ -20,6 +20,6 @@ describe("EnumClient", () => {
             .build();
 
         const response = await client.endpoints.enum.getAndReturnEnum("SUNNY");
-        expect(response).toEqual("SUNNY");
+        expect(response).toEqual(rawResponseBody);
     });
 });

--- a/seed/ts-sdk/exhaustive/allow-extra-fields/tests/wire/endpoints/httpMethods.test.ts
+++ b/seed/ts-sdk/exhaustive/allow-extra-fields/tests/wire/endpoints/httpMethods.test.ts
@@ -13,7 +13,7 @@ describe("HttpMethodsClient", () => {
         server.mockEndpoint().get("/http-methods/id").respondWith().statusCode(200).jsonBody(rawResponseBody).build();
 
         const response = await client.endpoints.httpMethods.testGet("id");
-        expect(response).toEqual("string");
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("testPost", async () => {
@@ -48,23 +48,7 @@ describe("HttpMethodsClient", () => {
         const response = await client.endpoints.httpMethods.testPost({
             string: "string",
         });
-        expect(response).toEqual({
-            string: "string",
-            integer: 1,
-            long: 1000000,
-            double: 1.1,
-            bool: true,
-            datetime: "2024-01-15T09:30:00Z",
-            date: "2023-01-15",
-            uuid: "d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32",
-            base64: "SGVsbG8gd29ybGQh",
-            list: ["list", "list"],
-            set: ["set"],
-            map: {
-                1: "map",
-            },
-            bigint: "1000000",
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("testPut", async () => {
@@ -99,23 +83,7 @@ describe("HttpMethodsClient", () => {
         const response = await client.endpoints.httpMethods.testPut("id", {
             string: "string",
         });
-        expect(response).toEqual({
-            string: "string",
-            integer: 1,
-            long: 1000000,
-            double: 1.1,
-            bool: true,
-            datetime: "2024-01-15T09:30:00Z",
-            date: "2023-01-15",
-            uuid: "d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32",
-            base64: "SGVsbG8gd29ybGQh",
-            list: ["list", "list"],
-            set: ["set"],
-            map: {
-                1: "map",
-            },
-            bigint: "1000000",
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("testPatch", async () => {
@@ -178,23 +146,7 @@ describe("HttpMethodsClient", () => {
             },
             bigint: "1000000",
         });
-        expect(response).toEqual({
-            string: "string",
-            integer: 1,
-            long: 1000000,
-            double: 1.1,
-            bool: true,
-            datetime: "2024-01-15T09:30:00Z",
-            date: "2023-01-15",
-            uuid: "d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32",
-            base64: "SGVsbG8gd29ybGQh",
-            list: ["list", "list"],
-            set: ["set"],
-            map: {
-                1: "map",
-            },
-            bigint: "1000000",
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("testDelete", async () => {
@@ -212,6 +164,6 @@ describe("HttpMethodsClient", () => {
             .build();
 
         const response = await client.endpoints.httpMethods.testDelete("id");
-        expect(response).toEqual(true);
+        expect(response).toEqual(rawResponseBody);
     });
 });

--- a/seed/ts-sdk/exhaustive/allow-extra-fields/tests/wire/endpoints/object.test.ts
+++ b/seed/ts-sdk/exhaustive/allow-extra-fields/tests/wire/endpoints/object.test.ts
@@ -64,23 +64,7 @@ describe("ObjectClient", () => {
             },
             bigint: "1000000",
         });
-        expect(response).toEqual({
-            string: "string",
-            integer: 1,
-            long: 1000000,
-            double: 1.1,
-            bool: true,
-            datetime: "2024-01-15T09:30:00Z",
-            date: "2023-01-15",
-            uuid: "d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32",
-            base64: "SGVsbG8gd29ybGQh",
-            list: ["list", "list"],
-            set: ["set"],
-            map: {
-                1: "map",
-            },
-            bigint: "1000000",
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnWithRequiredField", async () => {
@@ -101,9 +85,7 @@ describe("ObjectClient", () => {
         const response = await client.endpoints.object.getAndReturnWithRequiredField({
             string: "string",
         });
-        expect(response).toEqual({
-            string: "string",
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnWithMapOfMap", async () => {
@@ -128,13 +110,7 @@ describe("ObjectClient", () => {
                 },
             },
         });
-        expect(response).toEqual({
-            map: {
-                map: {
-                    map: "map",
-                },
-            },
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnNestedWithOptionalField", async () => {
@@ -206,26 +182,7 @@ describe("ObjectClient", () => {
                 bigint: "1000000",
             },
         });
-        expect(response).toEqual({
-            string: "string",
-            NestedObject: {
-                string: "string",
-                integer: 1,
-                long: 1000000,
-                double: 1.1,
-                bool: true,
-                datetime: "2024-01-15T09:30:00Z",
-                date: "2023-01-15",
-                uuid: "d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32",
-                base64: "SGVsbG8gd29ybGQh",
-                list: ["list", "list"],
-                set: ["set"],
-                map: {
-                    1: "map",
-                },
-                bigint: "1000000",
-            },
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnNestedWithRequiredField", async () => {
@@ -297,26 +254,7 @@ describe("ObjectClient", () => {
                 bigint: "1000000",
             },
         });
-        expect(response).toEqual({
-            string: "string",
-            NestedObject: {
-                string: "string",
-                integer: 1,
-                long: 1000000,
-                double: 1.1,
-                bool: true,
-                datetime: "2024-01-15T09:30:00Z",
-                date: "2023-01-15",
-                uuid: "d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32",
-                base64: "SGVsbG8gd29ybGQh",
-                list: ["list", "list"],
-                set: ["set"],
-                map: {
-                    1: "map",
-                },
-                bigint: "1000000",
-            },
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnNestedWithRequiredFieldAsList", async () => {
@@ -430,26 +368,7 @@ describe("ObjectClient", () => {
                 },
             },
         ]);
-        expect(response).toEqual({
-            string: "string",
-            NestedObject: {
-                string: "string",
-                integer: 1,
-                long: 1000000,
-                double: 1.1,
-                bool: true,
-                datetime: "2024-01-15T09:30:00Z",
-                date: "2023-01-15",
-                uuid: "d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32",
-                base64: "SGVsbG8gd29ybGQh",
-                list: ["list", "list"],
-                set: ["set"],
-                map: {
-                    1: "map",
-                },
-                bigint: "1000000",
-            },
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnWithUnknownField", async () => {
@@ -472,11 +391,7 @@ describe("ObjectClient", () => {
                 $ref: "https://example.com/schema",
             },
         });
-        expect(response).toEqual({
-            unknown: {
-                $ref: "https://example.com/schema",
-            },
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnWithDocumentedUnknownType", async () => {
@@ -499,11 +414,7 @@ describe("ObjectClient", () => {
                 key: "value",
             },
         });
-        expect(response).toEqual({
-            documentedUnknownType: {
-                key: "value",
-            },
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnMapOfDocumentedUnknownType", async () => {
@@ -526,11 +437,7 @@ describe("ObjectClient", () => {
                 key: "value",
             },
         });
-        expect(response).toEqual({
-            string: {
-                key: "value",
-            },
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnWithDatetimeLikeString", async () => {
@@ -552,9 +459,6 @@ describe("ObjectClient", () => {
             datetimeLikeString: "2023-08-31T14:15:22Z",
             actualDatetime: "2023-08-31T14:15:22Z",
         });
-        expect(response).toEqual({
-            datetimeLikeString: "2023-08-31T14:15:22Z",
-            actualDatetime: "2023-08-31T14:15:22Z",
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 });

--- a/seed/ts-sdk/exhaustive/allow-extra-fields/tests/wire/endpoints/pagination.test.ts
+++ b/seed/ts-sdk/exhaustive/allow-extra-fields/tests/wire/endpoints/pagination.test.ts
@@ -18,17 +18,7 @@ describe("PaginationClient", () => {
             .jsonBody(rawResponseBody)
             .build();
 
-        const expected = {
-            items: [
-                {
-                    string: "string",
-                },
-                {
-                    string: "string",
-                },
-            ],
-            next: "next",
-        };
+        const expected = rawResponseBody;
         const page = await client.endpoints.pagination.listItems({
             cursor: "cursor",
             limit: 1,

--- a/seed/ts-sdk/exhaustive/allow-extra-fields/tests/wire/endpoints/params.test.ts
+++ b/seed/ts-sdk/exhaustive/allow-extra-fields/tests/wire/endpoints/params.test.ts
@@ -14,7 +14,7 @@ describe("ParamsClient", () => {
         server.mockEndpoint().get("/params/path/param").respondWith().statusCode(200).jsonBody(rawResponseBody).build();
 
         const response = await client.endpoints.params.getWithPath("param");
-        expect(response).toEqual("string");
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getWithInlinePath", async () => {
@@ -28,7 +28,7 @@ describe("ParamsClient", () => {
         const response = await client.endpoints.params.getWithInlinePath({
             param: "param",
         });
-        expect(response).toEqual("string");
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getWithQuery", async () => {
@@ -98,7 +98,7 @@ describe("ParamsClient", () => {
             .build();
 
         const response = await client.endpoints.params.modifyWithPath("param", "string");
-        expect(response).toEqual("string");
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("modifyWithInlinePath", async () => {
@@ -120,7 +120,7 @@ describe("ParamsClient", () => {
             param: "param",
             body: "string",
         });
-        expect(response).toEqual("string");
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getWithPathAndErrors (1)", async () => {
@@ -132,7 +132,7 @@ describe("ParamsClient", () => {
         server.mockEndpoint().get("/params/path/param").respondWith().statusCode(200).jsonBody(rawResponseBody).build();
 
         const response = await client.endpoints.params.getWithPathAndErrors("param");
-        expect(response).toEqual("string");
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getWithPathAndErrors (2)", async () => {

--- a/seed/ts-sdk/exhaustive/allow-extra-fields/tests/wire/endpoints/primitive.test.ts
+++ b/seed/ts-sdk/exhaustive/allow-extra-fields/tests/wire/endpoints/primitive.test.ts
@@ -20,7 +20,7 @@ describe("PrimitiveClient", () => {
             .build();
 
         const response = await client.endpoints.primitive.getAndReturnString("string");
-        expect(response).toEqual("string");
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnInt", async () => {
@@ -39,7 +39,7 @@ describe("PrimitiveClient", () => {
             .build();
 
         const response = await client.endpoints.primitive.getAndReturnInt(1);
-        expect(response).toEqual(1);
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnLong", async () => {
@@ -58,7 +58,7 @@ describe("PrimitiveClient", () => {
             .build();
 
         const response = await client.endpoints.primitive.getAndReturnLong(1000000);
-        expect(response).toEqual(1000000);
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnDouble", async () => {
@@ -77,7 +77,7 @@ describe("PrimitiveClient", () => {
             .build();
 
         const response = await client.endpoints.primitive.getAndReturnDouble(1.1);
-        expect(response).toEqual(1.1);
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnBool", async () => {
@@ -96,7 +96,7 @@ describe("PrimitiveClient", () => {
             .build();
 
         const response = await client.endpoints.primitive.getAndReturnBool(true);
-        expect(response).toEqual(true);
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnDatetime", async () => {
@@ -115,7 +115,7 @@ describe("PrimitiveClient", () => {
             .build();
 
         const response = await client.endpoints.primitive.getAndReturnDatetime("2024-01-15T09:30:00Z");
-        expect(response).toEqual("2024-01-15T09:30:00Z");
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnDate", async () => {
@@ -134,7 +134,7 @@ describe("PrimitiveClient", () => {
             .build();
 
         const response = await client.endpoints.primitive.getAndReturnDate("2023-01-15");
-        expect(response).toEqual("2023-01-15");
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnUUID", async () => {
@@ -153,7 +153,7 @@ describe("PrimitiveClient", () => {
             .build();
 
         const response = await client.endpoints.primitive.getAndReturnUuid("d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32");
-        expect(response).toEqual("d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32");
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnBase64", async () => {
@@ -172,6 +172,6 @@ describe("PrimitiveClient", () => {
             .build();
 
         const response = await client.endpoints.primitive.getAndReturnBase64("SGVsbG8gd29ybGQh");
-        expect(response).toEqual("SGVsbG8gd29ybGQh");
+        expect(response).toEqual(rawResponseBody);
     });
 });

--- a/seed/ts-sdk/exhaustive/allow-extra-fields/tests/wire/endpoints/put.test.ts
+++ b/seed/ts-sdk/exhaustive/allow-extra-fields/tests/wire/endpoints/put.test.ts
@@ -20,21 +20,6 @@ describe("PutClient", () => {
         const response = await client.endpoints.put.add({
             id: "id",
         });
-        expect(response).toEqual({
-            errors: [
-                {
-                    category: "API_ERROR",
-                    code: "INTERNAL_SERVER_ERROR",
-                    detail: "detail",
-                    field: "field",
-                },
-                {
-                    category: "API_ERROR",
-                    code: "INTERNAL_SERVER_ERROR",
-                    detail: "detail",
-                    field: "field",
-                },
-            ],
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 });

--- a/seed/ts-sdk/exhaustive/allow-extra-fields/tests/wire/endpoints/union.test.ts
+++ b/seed/ts-sdk/exhaustive/allow-extra-fields/tests/wire/endpoints/union.test.ts
@@ -24,10 +24,6 @@ describe("UnionClient", () => {
             name: "name",
             likesToWoof: true,
         });
-        expect(response).toEqual({
-            animal: "dog",
-            name: "name",
-            likesToWoof: true,
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 });

--- a/seed/ts-sdk/exhaustive/allow-extra-fields/tests/wire/endpoints/urls.test.ts
+++ b/seed/ts-sdk/exhaustive/allow-extra-fields/tests/wire/endpoints/urls.test.ts
@@ -13,7 +13,7 @@ describe("UrlsClient", () => {
         server.mockEndpoint().get("/urls/MixedCase").respondWith().statusCode(200).jsonBody(rawResponseBody).build();
 
         const response = await client.endpoints.urls.withMixedCase();
-        expect(response).toEqual("string");
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("noEndingSlash", async () => {
@@ -31,7 +31,7 @@ describe("UrlsClient", () => {
             .build();
 
         const response = await client.endpoints.urls.noEndingSlash();
-        expect(response).toEqual("string");
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("withEndingSlash", async () => {
@@ -49,7 +49,7 @@ describe("UrlsClient", () => {
             .build();
 
         const response = await client.endpoints.urls.withEndingSlash();
-        expect(response).toEqual("string");
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("withUnderscores", async () => {
@@ -67,6 +67,6 @@ describe("UrlsClient", () => {
             .build();
 
         const response = await client.endpoints.urls.withUnderscores();
-        expect(response).toEqual("string");
+        expect(response).toEqual(rawResponseBody);
     });
 });

--- a/seed/ts-sdk/exhaustive/allow-extra-fields/tests/wire/inlinedRequests.test.ts
+++ b/seed/ts-sdk/exhaustive/allow-extra-fields/tests/wire/inlinedRequests.test.ts
@@ -73,23 +73,7 @@ describe("InlinedRequestsClient", () => {
                 bigint: "1000000",
             },
         });
-        expect(response).toEqual({
-            string: "string",
-            integer: 1,
-            long: 1000000,
-            double: 1.1,
-            bool: true,
-            datetime: "2024-01-15T09:30:00Z",
-            date: "2023-01-15",
-            uuid: "d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32",
-            base64: "SGVsbG8gd29ybGQh",
-            list: ["list", "list"],
-            set: ["set"],
-            map: {
-                1: "map",
-            },
-            bigint: "1000000",
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("postWithObjectBodyandResponse (2)", async () => {

--- a/seed/ts-sdk/exhaustive/allow-extra-fields/tests/wire/noAuth.test.ts
+++ b/seed/ts-sdk/exhaustive/allow-extra-fields/tests/wire/noAuth.test.ts
@@ -23,7 +23,7 @@ describe("NoAuthClient", () => {
         const response = await client.noAuth.postWithNoAuth({
             key: "value",
         });
-        expect(response).toEqual(true);
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("postWithNoAuth (2)", async () => {

--- a/seed/ts-sdk/exhaustive/allow-extra-fields/tests/wire/noReqBody.test.ts
+++ b/seed/ts-sdk/exhaustive/allow-extra-fields/tests/wire/noReqBody.test.ts
@@ -27,23 +27,7 @@ describe("NoReqBodyClient", () => {
         server.mockEndpoint().get("/no-req-body").respondWith().statusCode(200).jsonBody(rawResponseBody).build();
 
         const response = await client.noReqBody.getWithNoRequestBody();
-        expect(response).toEqual({
-            string: "string",
-            integer: 1,
-            long: 1000000,
-            double: 1.1,
-            bool: true,
-            datetime: "2024-01-15T09:30:00Z",
-            date: "2023-01-15",
-            uuid: "d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32",
-            base64: "SGVsbG8gd29ybGQh",
-            list: ["list", "list"],
-            set: ["set"],
-            map: {
-                1: "map",
-            },
-            bigint: "1000000",
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("postWithNoRequestBody", async () => {
@@ -55,6 +39,6 @@ describe("NoReqBodyClient", () => {
         server.mockEndpoint().post("/no-req-body").respondWith().statusCode(200).jsonBody(rawResponseBody).build();
 
         const response = await client.noReqBody.postWithNoRequestBody();
-        expect(response).toEqual("string");
+        expect(response).toEqual(rawResponseBody);
     });
 });

--- a/seed/ts-sdk/exhaustive/bigint/tests/wire/endpoints/container.test.ts
+++ b/seed/ts-sdk/exhaustive/bigint/tests/wire/endpoints/container.test.ts
@@ -20,7 +20,7 @@ describe("ContainerClient", () => {
             .build();
 
         const response = await client.endpoints.container.getAndReturnListOfPrimitives(["string", "string"]);
-        expect(response).toEqual(["string", "string"]);
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnListOfObjects", async () => {
@@ -46,14 +46,7 @@ describe("ContainerClient", () => {
                 string: "string",
             },
         ]);
-        expect(response).toEqual([
-            {
-                string: "string",
-            },
-            {
-                string: "string",
-            },
-        ]);
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnSetOfPrimitives", async () => {
@@ -72,7 +65,7 @@ describe("ContainerClient", () => {
             .build();
 
         const response = await client.endpoints.container.getAndReturnSetOfPrimitives(["string"]);
-        expect(response).toEqual(["string"]);
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnSetOfObjects", async () => {
@@ -95,11 +88,7 @@ describe("ContainerClient", () => {
                 string: "string",
             },
         ]);
-        expect(response).toEqual([
-            {
-                string: "string",
-            },
-        ]);
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnMapPrimToPrim", async () => {
@@ -120,9 +109,7 @@ describe("ContainerClient", () => {
         const response = await client.endpoints.container.getAndReturnMapPrimToPrim({
             string: "string",
         });
-        expect(response).toEqual({
-            string: "string",
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnMapOfPrimToObject", async () => {
@@ -145,11 +132,7 @@ describe("ContainerClient", () => {
                 string: "string",
             },
         });
-        expect(response).toEqual({
-            string: {
-                string: "string",
-            },
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnMapOfPrimToUndiscriminatedUnion", async () => {
@@ -170,9 +153,7 @@ describe("ContainerClient", () => {
         const response = await client.endpoints.container.getAndReturnMapOfPrimToUndiscriminatedUnion({
             string: 1.1,
         });
-        expect(response).toEqual({
-            string: 1.1,
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnOptional", async () => {
@@ -193,8 +174,6 @@ describe("ContainerClient", () => {
         const response = await client.endpoints.container.getAndReturnOptional({
             string: "string",
         });
-        expect(response).toEqual({
-            string: "string",
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 });

--- a/seed/ts-sdk/exhaustive/bigint/tests/wire/endpoints/enum.test.ts
+++ b/seed/ts-sdk/exhaustive/bigint/tests/wire/endpoints/enum.test.ts
@@ -20,6 +20,6 @@ describe("EnumClient", () => {
             .build();
 
         const response = await client.endpoints.enum.getAndReturnEnum("SUNNY");
-        expect(response).toEqual("SUNNY");
+        expect(response).toEqual(rawResponseBody);
     });
 });

--- a/seed/ts-sdk/exhaustive/bigint/tests/wire/endpoints/httpMethods.test.ts
+++ b/seed/ts-sdk/exhaustive/bigint/tests/wire/endpoints/httpMethods.test.ts
@@ -13,7 +13,7 @@ describe("HttpMethodsClient", () => {
         server.mockEndpoint().get("/http-methods/id").respondWith().statusCode(200).jsonBody(rawResponseBody).build();
 
         const response = await client.endpoints.httpMethods.testGet("id");
-        expect(response).toEqual("string");
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("testPost", async () => {
@@ -48,23 +48,7 @@ describe("HttpMethodsClient", () => {
         const response = await client.endpoints.httpMethods.testPost({
             string: "string",
         });
-        expect(response).toEqual({
-            string: "string",
-            integer: 1,
-            long: BigInt("1000000"),
-            double: 1.1,
-            bool: true,
-            datetime: "2024-01-15T09:30:00Z",
-            date: "2023-01-15",
-            uuid: "d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32",
-            base64: "SGVsbG8gd29ybGQh",
-            list: ["list", "list"],
-            set: ["set"],
-            map: {
-                1: "map",
-            },
-            bigint: BigInt("1000000"),
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("testPut", async () => {
@@ -99,23 +83,7 @@ describe("HttpMethodsClient", () => {
         const response = await client.endpoints.httpMethods.testPut("id", {
             string: "string",
         });
-        expect(response).toEqual({
-            string: "string",
-            integer: 1,
-            long: BigInt("1000000"),
-            double: 1.1,
-            bool: true,
-            datetime: "2024-01-15T09:30:00Z",
-            date: "2023-01-15",
-            uuid: "d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32",
-            base64: "SGVsbG8gd29ybGQh",
-            list: ["list", "list"],
-            set: ["set"],
-            map: {
-                1: "map",
-            },
-            bigint: BigInt("1000000"),
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("testPatch", async () => {
@@ -178,23 +146,7 @@ describe("HttpMethodsClient", () => {
             },
             bigint: BigInt("1000000"),
         });
-        expect(response).toEqual({
-            string: "string",
-            integer: 1,
-            long: BigInt("1000000"),
-            double: 1.1,
-            bool: true,
-            datetime: "2024-01-15T09:30:00Z",
-            date: "2023-01-15",
-            uuid: "d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32",
-            base64: "SGVsbG8gd29ybGQh",
-            list: ["list", "list"],
-            set: ["set"],
-            map: {
-                1: "map",
-            },
-            bigint: BigInt("1000000"),
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("testDelete", async () => {
@@ -212,6 +164,6 @@ describe("HttpMethodsClient", () => {
             .build();
 
         const response = await client.endpoints.httpMethods.testDelete("id");
-        expect(response).toEqual(true);
+        expect(response).toEqual(rawResponseBody);
     });
 });

--- a/seed/ts-sdk/exhaustive/bigint/tests/wire/endpoints/object.test.ts
+++ b/seed/ts-sdk/exhaustive/bigint/tests/wire/endpoints/object.test.ts
@@ -64,23 +64,7 @@ describe("ObjectClient", () => {
             },
             bigint: BigInt("1000000"),
         });
-        expect(response).toEqual({
-            string: "string",
-            integer: 1,
-            long: BigInt("1000000"),
-            double: 1.1,
-            bool: true,
-            datetime: "2024-01-15T09:30:00Z",
-            date: "2023-01-15",
-            uuid: "d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32",
-            base64: "SGVsbG8gd29ybGQh",
-            list: ["list", "list"],
-            set: ["set"],
-            map: {
-                1: "map",
-            },
-            bigint: BigInt("1000000"),
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnWithRequiredField", async () => {
@@ -101,9 +85,7 @@ describe("ObjectClient", () => {
         const response = await client.endpoints.object.getAndReturnWithRequiredField({
             string: "string",
         });
-        expect(response).toEqual({
-            string: "string",
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnWithMapOfMap", async () => {
@@ -128,13 +110,7 @@ describe("ObjectClient", () => {
                 },
             },
         });
-        expect(response).toEqual({
-            map: {
-                map: {
-                    map: "map",
-                },
-            },
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnNestedWithOptionalField", async () => {
@@ -206,26 +182,7 @@ describe("ObjectClient", () => {
                 bigint: BigInt("1000000"),
             },
         });
-        expect(response).toEqual({
-            string: "string",
-            NestedObject: {
-                string: "string",
-                integer: 1,
-                long: BigInt("1000000"),
-                double: 1.1,
-                bool: true,
-                datetime: "2024-01-15T09:30:00Z",
-                date: "2023-01-15",
-                uuid: "d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32",
-                base64: "SGVsbG8gd29ybGQh",
-                list: ["list", "list"],
-                set: ["set"],
-                map: {
-                    1: "map",
-                },
-                bigint: BigInt("1000000"),
-            },
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnNestedWithRequiredField", async () => {
@@ -297,26 +254,7 @@ describe("ObjectClient", () => {
                 bigint: BigInt("1000000"),
             },
         });
-        expect(response).toEqual({
-            string: "string",
-            NestedObject: {
-                string: "string",
-                integer: 1,
-                long: BigInt("1000000"),
-                double: 1.1,
-                bool: true,
-                datetime: "2024-01-15T09:30:00Z",
-                date: "2023-01-15",
-                uuid: "d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32",
-                base64: "SGVsbG8gd29ybGQh",
-                list: ["list", "list"],
-                set: ["set"],
-                map: {
-                    1: "map",
-                },
-                bigint: BigInt("1000000"),
-            },
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnNestedWithRequiredFieldAsList", async () => {
@@ -430,26 +368,7 @@ describe("ObjectClient", () => {
                 },
             },
         ]);
-        expect(response).toEqual({
-            string: "string",
-            NestedObject: {
-                string: "string",
-                integer: 1,
-                long: BigInt("1000000"),
-                double: 1.1,
-                bool: true,
-                datetime: "2024-01-15T09:30:00Z",
-                date: "2023-01-15",
-                uuid: "d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32",
-                base64: "SGVsbG8gd29ybGQh",
-                list: ["list", "list"],
-                set: ["set"],
-                map: {
-                    1: "map",
-                },
-                bigint: BigInt("1000000"),
-            },
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnWithUnknownField", async () => {
@@ -472,11 +391,7 @@ describe("ObjectClient", () => {
                 $ref: "https://example.com/schema",
             },
         });
-        expect(response).toEqual({
-            unknown: {
-                $ref: "https://example.com/schema",
-            },
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnWithDocumentedUnknownType", async () => {
@@ -499,11 +414,7 @@ describe("ObjectClient", () => {
                 key: "value",
             },
         });
-        expect(response).toEqual({
-            documentedUnknownType: {
-                key: "value",
-            },
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnMapOfDocumentedUnknownType", async () => {
@@ -526,11 +437,7 @@ describe("ObjectClient", () => {
                 key: "value",
             },
         });
-        expect(response).toEqual({
-            string: {
-                key: "value",
-            },
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnWithDatetimeLikeString", async () => {
@@ -552,9 +459,6 @@ describe("ObjectClient", () => {
             datetimeLikeString: "2023-08-31T14:15:22Z",
             actualDatetime: "2023-08-31T14:15:22Z",
         });
-        expect(response).toEqual({
-            datetimeLikeString: "2023-08-31T14:15:22Z",
-            actualDatetime: "2023-08-31T14:15:22Z",
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 });

--- a/seed/ts-sdk/exhaustive/bigint/tests/wire/endpoints/pagination.test.ts
+++ b/seed/ts-sdk/exhaustive/bigint/tests/wire/endpoints/pagination.test.ts
@@ -18,17 +18,7 @@ describe("PaginationClient", () => {
             .jsonBody(rawResponseBody)
             .build();
 
-        const expected = {
-            items: [
-                {
-                    string: "string",
-                },
-                {
-                    string: "string",
-                },
-            ],
-            next: "next",
-        };
+        const expected = rawResponseBody;
         const page = await client.endpoints.pagination.listItems({
             cursor: "cursor",
             limit: 1,

--- a/seed/ts-sdk/exhaustive/bigint/tests/wire/endpoints/params.test.ts
+++ b/seed/ts-sdk/exhaustive/bigint/tests/wire/endpoints/params.test.ts
@@ -14,7 +14,7 @@ describe("ParamsClient", () => {
         server.mockEndpoint().get("/params/path/param").respondWith().statusCode(200).jsonBody(rawResponseBody).build();
 
         const response = await client.endpoints.params.getWithPath("param");
-        expect(response).toEqual("string");
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getWithInlinePath", async () => {
@@ -28,7 +28,7 @@ describe("ParamsClient", () => {
         const response = await client.endpoints.params.getWithInlinePath({
             param: "param",
         });
-        expect(response).toEqual("string");
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getWithQuery", async () => {
@@ -98,7 +98,7 @@ describe("ParamsClient", () => {
             .build();
 
         const response = await client.endpoints.params.modifyWithPath("param", "string");
-        expect(response).toEqual("string");
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("modifyWithInlinePath", async () => {
@@ -120,7 +120,7 @@ describe("ParamsClient", () => {
             param: "param",
             body: "string",
         });
-        expect(response).toEqual("string");
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getWithPathAndErrors (1)", async () => {
@@ -132,7 +132,7 @@ describe("ParamsClient", () => {
         server.mockEndpoint().get("/params/path/param").respondWith().statusCode(200).jsonBody(rawResponseBody).build();
 
         const response = await client.endpoints.params.getWithPathAndErrors("param");
-        expect(response).toEqual("string");
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getWithPathAndErrors (2)", async () => {

--- a/seed/ts-sdk/exhaustive/bigint/tests/wire/endpoints/primitive.test.ts
+++ b/seed/ts-sdk/exhaustive/bigint/tests/wire/endpoints/primitive.test.ts
@@ -20,7 +20,7 @@ describe("PrimitiveClient", () => {
             .build();
 
         const response = await client.endpoints.primitive.getAndReturnString("string");
-        expect(response).toEqual("string");
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnInt", async () => {
@@ -39,7 +39,7 @@ describe("PrimitiveClient", () => {
             .build();
 
         const response = await client.endpoints.primitive.getAndReturnInt(1);
-        expect(response).toEqual(1);
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnLong", async () => {
@@ -58,7 +58,7 @@ describe("PrimitiveClient", () => {
             .build();
 
         const response = await client.endpoints.primitive.getAndReturnLong(BigInt("1000000"));
-        expect(response).toEqual(BigInt("1000000"));
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnDouble", async () => {
@@ -77,7 +77,7 @@ describe("PrimitiveClient", () => {
             .build();
 
         const response = await client.endpoints.primitive.getAndReturnDouble(1.1);
-        expect(response).toEqual(1.1);
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnBool", async () => {
@@ -96,7 +96,7 @@ describe("PrimitiveClient", () => {
             .build();
 
         const response = await client.endpoints.primitive.getAndReturnBool(true);
-        expect(response).toEqual(true);
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnDatetime", async () => {
@@ -115,7 +115,7 @@ describe("PrimitiveClient", () => {
             .build();
 
         const response = await client.endpoints.primitive.getAndReturnDatetime("2024-01-15T09:30:00Z");
-        expect(response).toEqual("2024-01-15T09:30:00Z");
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnDate", async () => {
@@ -134,7 +134,7 @@ describe("PrimitiveClient", () => {
             .build();
 
         const response = await client.endpoints.primitive.getAndReturnDate("2023-01-15");
-        expect(response).toEqual("2023-01-15");
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnUUID", async () => {
@@ -153,7 +153,7 @@ describe("PrimitiveClient", () => {
             .build();
 
         const response = await client.endpoints.primitive.getAndReturnUuid("d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32");
-        expect(response).toEqual("d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32");
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnBase64", async () => {
@@ -172,6 +172,6 @@ describe("PrimitiveClient", () => {
             .build();
 
         const response = await client.endpoints.primitive.getAndReturnBase64("SGVsbG8gd29ybGQh");
-        expect(response).toEqual("SGVsbG8gd29ybGQh");
+        expect(response).toEqual(rawResponseBody);
     });
 });

--- a/seed/ts-sdk/exhaustive/bigint/tests/wire/endpoints/put.test.ts
+++ b/seed/ts-sdk/exhaustive/bigint/tests/wire/endpoints/put.test.ts
@@ -20,21 +20,6 @@ describe("PutClient", () => {
         const response = await client.endpoints.put.add({
             id: "id",
         });
-        expect(response).toEqual({
-            errors: [
-                {
-                    category: "API_ERROR",
-                    code: "INTERNAL_SERVER_ERROR",
-                    detail: "detail",
-                    field: "field",
-                },
-                {
-                    category: "API_ERROR",
-                    code: "INTERNAL_SERVER_ERROR",
-                    detail: "detail",
-                    field: "field",
-                },
-            ],
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 });

--- a/seed/ts-sdk/exhaustive/bigint/tests/wire/endpoints/union.test.ts
+++ b/seed/ts-sdk/exhaustive/bigint/tests/wire/endpoints/union.test.ts
@@ -24,10 +24,6 @@ describe("UnionClient", () => {
             name: "name",
             likesToWoof: true,
         });
-        expect(response).toEqual({
-            animal: "dog",
-            name: "name",
-            likesToWoof: true,
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 });

--- a/seed/ts-sdk/exhaustive/bigint/tests/wire/endpoints/urls.test.ts
+++ b/seed/ts-sdk/exhaustive/bigint/tests/wire/endpoints/urls.test.ts
@@ -13,7 +13,7 @@ describe("UrlsClient", () => {
         server.mockEndpoint().get("/urls/MixedCase").respondWith().statusCode(200).jsonBody(rawResponseBody).build();
 
         const response = await client.endpoints.urls.withMixedCase();
-        expect(response).toEqual("string");
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("noEndingSlash", async () => {
@@ -31,7 +31,7 @@ describe("UrlsClient", () => {
             .build();
 
         const response = await client.endpoints.urls.noEndingSlash();
-        expect(response).toEqual("string");
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("withEndingSlash", async () => {
@@ -49,7 +49,7 @@ describe("UrlsClient", () => {
             .build();
 
         const response = await client.endpoints.urls.withEndingSlash();
-        expect(response).toEqual("string");
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("withUnderscores", async () => {
@@ -67,6 +67,6 @@ describe("UrlsClient", () => {
             .build();
 
         const response = await client.endpoints.urls.withUnderscores();
-        expect(response).toEqual("string");
+        expect(response).toEqual(rawResponseBody);
     });
 });

--- a/seed/ts-sdk/exhaustive/bigint/tests/wire/inlinedRequests.test.ts
+++ b/seed/ts-sdk/exhaustive/bigint/tests/wire/inlinedRequests.test.ts
@@ -73,23 +73,7 @@ describe("InlinedRequestsClient", () => {
                 bigint: BigInt("1000000"),
             },
         });
-        expect(response).toEqual({
-            string: "string",
-            integer: 1,
-            long: BigInt("1000000"),
-            double: 1.1,
-            bool: true,
-            datetime: "2024-01-15T09:30:00Z",
-            date: "2023-01-15",
-            uuid: "d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32",
-            base64: "SGVsbG8gd29ybGQh",
-            list: ["list", "list"],
-            set: ["set"],
-            map: {
-                1: "map",
-            },
-            bigint: BigInt("1000000"),
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("postWithObjectBodyandResponse (2)", async () => {

--- a/seed/ts-sdk/exhaustive/bigint/tests/wire/noAuth.test.ts
+++ b/seed/ts-sdk/exhaustive/bigint/tests/wire/noAuth.test.ts
@@ -23,7 +23,7 @@ describe("NoAuthClient", () => {
         const response = await client.noAuth.postWithNoAuth({
             key: "value",
         });
-        expect(response).toEqual(true);
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("postWithNoAuth (2)", async () => {

--- a/seed/ts-sdk/exhaustive/bigint/tests/wire/noReqBody.test.ts
+++ b/seed/ts-sdk/exhaustive/bigint/tests/wire/noReqBody.test.ts
@@ -27,23 +27,7 @@ describe("NoReqBodyClient", () => {
         server.mockEndpoint().get("/no-req-body").respondWith().statusCode(200).jsonBody(rawResponseBody).build();
 
         const response = await client.noReqBody.getWithNoRequestBody();
-        expect(response).toEqual({
-            string: "string",
-            integer: 1,
-            long: BigInt("1000000"),
-            double: 1.1,
-            bool: true,
-            datetime: "2024-01-15T09:30:00Z",
-            date: "2023-01-15",
-            uuid: "d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32",
-            base64: "SGVsbG8gd29ybGQh",
-            list: ["list", "list"],
-            set: ["set"],
-            map: {
-                1: "map",
-            },
-            bigint: BigInt("1000000"),
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("postWithNoRequestBody", async () => {
@@ -55,6 +39,6 @@ describe("NoReqBodyClient", () => {
         server.mockEndpoint().post("/no-req-body").respondWith().statusCode(200).jsonBody(rawResponseBody).build();
 
         const response = await client.noReqBody.postWithNoRequestBody();
-        expect(response).toEqual("string");
+        expect(response).toEqual(rawResponseBody);
     });
 });

--- a/seed/ts-sdk/exhaustive/consolidate-type-files/tests/wire/endpoints/container.test.ts
+++ b/seed/ts-sdk/exhaustive/consolidate-type-files/tests/wire/endpoints/container.test.ts
@@ -20,7 +20,7 @@ describe("ContainerClient", () => {
             .build();
 
         const response = await client.endpoints.container.getAndReturnListOfPrimitives(["string", "string"]);
-        expect(response).toEqual(["string", "string"]);
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnListOfObjects", async () => {
@@ -46,14 +46,7 @@ describe("ContainerClient", () => {
                 string: "string",
             },
         ]);
-        expect(response).toEqual([
-            {
-                string: "string",
-            },
-            {
-                string: "string",
-            },
-        ]);
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnSetOfPrimitives", async () => {
@@ -72,7 +65,7 @@ describe("ContainerClient", () => {
             .build();
 
         const response = await client.endpoints.container.getAndReturnSetOfPrimitives(["string"]);
-        expect(response).toEqual(["string"]);
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnSetOfObjects", async () => {
@@ -95,11 +88,7 @@ describe("ContainerClient", () => {
                 string: "string",
             },
         ]);
-        expect(response).toEqual([
-            {
-                string: "string",
-            },
-        ]);
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnMapPrimToPrim", async () => {
@@ -120,9 +109,7 @@ describe("ContainerClient", () => {
         const response = await client.endpoints.container.getAndReturnMapPrimToPrim({
             string: "string",
         });
-        expect(response).toEqual({
-            string: "string",
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnMapOfPrimToObject", async () => {
@@ -145,11 +132,7 @@ describe("ContainerClient", () => {
                 string: "string",
             },
         });
-        expect(response).toEqual({
-            string: {
-                string: "string",
-            },
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnMapOfPrimToUndiscriminatedUnion", async () => {
@@ -170,9 +153,7 @@ describe("ContainerClient", () => {
         const response = await client.endpoints.container.getAndReturnMapOfPrimToUndiscriminatedUnion({
             string: 1.1,
         });
-        expect(response).toEqual({
-            string: 1.1,
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnOptional", async () => {
@@ -193,8 +174,6 @@ describe("ContainerClient", () => {
         const response = await client.endpoints.container.getAndReturnOptional({
             string: "string",
         });
-        expect(response).toEqual({
-            string: "string",
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 });

--- a/seed/ts-sdk/exhaustive/consolidate-type-files/tests/wire/endpoints/enum.test.ts
+++ b/seed/ts-sdk/exhaustive/consolidate-type-files/tests/wire/endpoints/enum.test.ts
@@ -20,6 +20,6 @@ describe("EnumClient", () => {
             .build();
 
         const response = await client.endpoints.enum.getAndReturnEnum("SUNNY");
-        expect(response).toEqual("SUNNY");
+        expect(response).toEqual(rawResponseBody);
     });
 });

--- a/seed/ts-sdk/exhaustive/consolidate-type-files/tests/wire/endpoints/httpMethods.test.ts
+++ b/seed/ts-sdk/exhaustive/consolidate-type-files/tests/wire/endpoints/httpMethods.test.ts
@@ -13,7 +13,7 @@ describe("HttpMethodsClient", () => {
         server.mockEndpoint().get("/http-methods/id").respondWith().statusCode(200).jsonBody(rawResponseBody).build();
 
         const response = await client.endpoints.httpMethods.testGet("id");
-        expect(response).toEqual("string");
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("testPost", async () => {
@@ -48,23 +48,7 @@ describe("HttpMethodsClient", () => {
         const response = await client.endpoints.httpMethods.testPost({
             string: "string",
         });
-        expect(response).toEqual({
-            string: "string",
-            integer: 1,
-            long: 1000000,
-            double: 1.1,
-            bool: true,
-            datetime: "2024-01-15T09:30:00Z",
-            date: "2023-01-15",
-            uuid: "d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32",
-            base64: "SGVsbG8gd29ybGQh",
-            list: ["list", "list"],
-            set: ["set"],
-            map: {
-                1: "map",
-            },
-            bigint: "1000000",
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("testPut", async () => {
@@ -99,23 +83,7 @@ describe("HttpMethodsClient", () => {
         const response = await client.endpoints.httpMethods.testPut("id", {
             string: "string",
         });
-        expect(response).toEqual({
-            string: "string",
-            integer: 1,
-            long: 1000000,
-            double: 1.1,
-            bool: true,
-            datetime: "2024-01-15T09:30:00Z",
-            date: "2023-01-15",
-            uuid: "d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32",
-            base64: "SGVsbG8gd29ybGQh",
-            list: ["list", "list"],
-            set: ["set"],
-            map: {
-                1: "map",
-            },
-            bigint: "1000000",
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("testPatch", async () => {
@@ -178,23 +146,7 @@ describe("HttpMethodsClient", () => {
             },
             bigint: "1000000",
         });
-        expect(response).toEqual({
-            string: "string",
-            integer: 1,
-            long: 1000000,
-            double: 1.1,
-            bool: true,
-            datetime: "2024-01-15T09:30:00Z",
-            date: "2023-01-15",
-            uuid: "d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32",
-            base64: "SGVsbG8gd29ybGQh",
-            list: ["list", "list"],
-            set: ["set"],
-            map: {
-                1: "map",
-            },
-            bigint: "1000000",
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("testDelete", async () => {
@@ -212,6 +164,6 @@ describe("HttpMethodsClient", () => {
             .build();
 
         const response = await client.endpoints.httpMethods.testDelete("id");
-        expect(response).toEqual(true);
+        expect(response).toEqual(rawResponseBody);
     });
 });

--- a/seed/ts-sdk/exhaustive/consolidate-type-files/tests/wire/endpoints/object.test.ts
+++ b/seed/ts-sdk/exhaustive/consolidate-type-files/tests/wire/endpoints/object.test.ts
@@ -64,23 +64,7 @@ describe("ObjectClient", () => {
             },
             bigint: "1000000",
         });
-        expect(response).toEqual({
-            string: "string",
-            integer: 1,
-            long: 1000000,
-            double: 1.1,
-            bool: true,
-            datetime: "2024-01-15T09:30:00Z",
-            date: "2023-01-15",
-            uuid: "d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32",
-            base64: "SGVsbG8gd29ybGQh",
-            list: ["list", "list"],
-            set: ["set"],
-            map: {
-                1: "map",
-            },
-            bigint: "1000000",
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnWithRequiredField", async () => {
@@ -101,9 +85,7 @@ describe("ObjectClient", () => {
         const response = await client.endpoints.object.getAndReturnWithRequiredField({
             string: "string",
         });
-        expect(response).toEqual({
-            string: "string",
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnWithMapOfMap", async () => {
@@ -128,13 +110,7 @@ describe("ObjectClient", () => {
                 },
             },
         });
-        expect(response).toEqual({
-            map: {
-                map: {
-                    map: "map",
-                },
-            },
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnNestedWithOptionalField", async () => {
@@ -206,26 +182,7 @@ describe("ObjectClient", () => {
                 bigint: "1000000",
             },
         });
-        expect(response).toEqual({
-            string: "string",
-            NestedObject: {
-                string: "string",
-                integer: 1,
-                long: 1000000,
-                double: 1.1,
-                bool: true,
-                datetime: "2024-01-15T09:30:00Z",
-                date: "2023-01-15",
-                uuid: "d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32",
-                base64: "SGVsbG8gd29ybGQh",
-                list: ["list", "list"],
-                set: ["set"],
-                map: {
-                    1: "map",
-                },
-                bigint: "1000000",
-            },
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnNestedWithRequiredField", async () => {
@@ -297,26 +254,7 @@ describe("ObjectClient", () => {
                 bigint: "1000000",
             },
         });
-        expect(response).toEqual({
-            string: "string",
-            NestedObject: {
-                string: "string",
-                integer: 1,
-                long: 1000000,
-                double: 1.1,
-                bool: true,
-                datetime: "2024-01-15T09:30:00Z",
-                date: "2023-01-15",
-                uuid: "d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32",
-                base64: "SGVsbG8gd29ybGQh",
-                list: ["list", "list"],
-                set: ["set"],
-                map: {
-                    1: "map",
-                },
-                bigint: "1000000",
-            },
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnNestedWithRequiredFieldAsList", async () => {
@@ -430,26 +368,7 @@ describe("ObjectClient", () => {
                 },
             },
         ]);
-        expect(response).toEqual({
-            string: "string",
-            NestedObject: {
-                string: "string",
-                integer: 1,
-                long: 1000000,
-                double: 1.1,
-                bool: true,
-                datetime: "2024-01-15T09:30:00Z",
-                date: "2023-01-15",
-                uuid: "d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32",
-                base64: "SGVsbG8gd29ybGQh",
-                list: ["list", "list"],
-                set: ["set"],
-                map: {
-                    1: "map",
-                },
-                bigint: "1000000",
-            },
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnWithUnknownField", async () => {
@@ -472,11 +391,7 @@ describe("ObjectClient", () => {
                 $ref: "https://example.com/schema",
             },
         });
-        expect(response).toEqual({
-            unknown: {
-                $ref: "https://example.com/schema",
-            },
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnWithDocumentedUnknownType", async () => {
@@ -499,11 +414,7 @@ describe("ObjectClient", () => {
                 key: "value",
             },
         });
-        expect(response).toEqual({
-            documentedUnknownType: {
-                key: "value",
-            },
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnMapOfDocumentedUnknownType", async () => {
@@ -526,11 +437,7 @@ describe("ObjectClient", () => {
                 key: "value",
             },
         });
-        expect(response).toEqual({
-            string: {
-                key: "value",
-            },
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnWithDatetimeLikeString", async () => {
@@ -552,9 +459,6 @@ describe("ObjectClient", () => {
             datetimeLikeString: "2023-08-31T14:15:22Z",
             actualDatetime: "2023-08-31T14:15:22Z",
         });
-        expect(response).toEqual({
-            datetimeLikeString: "2023-08-31T14:15:22Z",
-            actualDatetime: "2023-08-31T14:15:22Z",
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 });

--- a/seed/ts-sdk/exhaustive/consolidate-type-files/tests/wire/endpoints/pagination.test.ts
+++ b/seed/ts-sdk/exhaustive/consolidate-type-files/tests/wire/endpoints/pagination.test.ts
@@ -18,17 +18,7 @@ describe("PaginationClient", () => {
             .jsonBody(rawResponseBody)
             .build();
 
-        const expected = {
-            items: [
-                {
-                    string: "string",
-                },
-                {
-                    string: "string",
-                },
-            ],
-            next: "next",
-        };
+        const expected = rawResponseBody;
         const page = await client.endpoints.pagination.listItems({
             cursor: "cursor",
             limit: 1,

--- a/seed/ts-sdk/exhaustive/consolidate-type-files/tests/wire/endpoints/params.test.ts
+++ b/seed/ts-sdk/exhaustive/consolidate-type-files/tests/wire/endpoints/params.test.ts
@@ -14,7 +14,7 @@ describe("ParamsClient", () => {
         server.mockEndpoint().get("/params/path/param").respondWith().statusCode(200).jsonBody(rawResponseBody).build();
 
         const response = await client.endpoints.params.getWithPath("param");
-        expect(response).toEqual("string");
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getWithInlinePath", async () => {
@@ -28,7 +28,7 @@ describe("ParamsClient", () => {
         const response = await client.endpoints.params.getWithInlinePath({
             param: "param",
         });
-        expect(response).toEqual("string");
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getWithQuery", async () => {
@@ -98,7 +98,7 @@ describe("ParamsClient", () => {
             .build();
 
         const response = await client.endpoints.params.modifyWithPath("param", "string");
-        expect(response).toEqual("string");
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("modifyWithInlinePath", async () => {
@@ -120,7 +120,7 @@ describe("ParamsClient", () => {
             param: "param",
             body: "string",
         });
-        expect(response).toEqual("string");
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getWithPathAndErrors (1)", async () => {
@@ -132,7 +132,7 @@ describe("ParamsClient", () => {
         server.mockEndpoint().get("/params/path/param").respondWith().statusCode(200).jsonBody(rawResponseBody).build();
 
         const response = await client.endpoints.params.getWithPathAndErrors("param");
-        expect(response).toEqual("string");
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getWithPathAndErrors (2)", async () => {

--- a/seed/ts-sdk/exhaustive/consolidate-type-files/tests/wire/endpoints/primitive.test.ts
+++ b/seed/ts-sdk/exhaustive/consolidate-type-files/tests/wire/endpoints/primitive.test.ts
@@ -20,7 +20,7 @@ describe("PrimitiveClient", () => {
             .build();
 
         const response = await client.endpoints.primitive.getAndReturnString("string");
-        expect(response).toEqual("string");
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnInt", async () => {
@@ -39,7 +39,7 @@ describe("PrimitiveClient", () => {
             .build();
 
         const response = await client.endpoints.primitive.getAndReturnInt(1);
-        expect(response).toEqual(1);
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnLong", async () => {
@@ -58,7 +58,7 @@ describe("PrimitiveClient", () => {
             .build();
 
         const response = await client.endpoints.primitive.getAndReturnLong(1000000);
-        expect(response).toEqual(1000000);
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnDouble", async () => {
@@ -77,7 +77,7 @@ describe("PrimitiveClient", () => {
             .build();
 
         const response = await client.endpoints.primitive.getAndReturnDouble(1.1);
-        expect(response).toEqual(1.1);
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnBool", async () => {
@@ -96,7 +96,7 @@ describe("PrimitiveClient", () => {
             .build();
 
         const response = await client.endpoints.primitive.getAndReturnBool(true);
-        expect(response).toEqual(true);
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnDatetime", async () => {
@@ -115,7 +115,7 @@ describe("PrimitiveClient", () => {
             .build();
 
         const response = await client.endpoints.primitive.getAndReturnDatetime("2024-01-15T09:30:00Z");
-        expect(response).toEqual("2024-01-15T09:30:00Z");
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnDate", async () => {
@@ -134,7 +134,7 @@ describe("PrimitiveClient", () => {
             .build();
 
         const response = await client.endpoints.primitive.getAndReturnDate("2023-01-15");
-        expect(response).toEqual("2023-01-15");
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnUUID", async () => {
@@ -153,7 +153,7 @@ describe("PrimitiveClient", () => {
             .build();
 
         const response = await client.endpoints.primitive.getAndReturnUuid("d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32");
-        expect(response).toEqual("d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32");
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnBase64", async () => {
@@ -172,6 +172,6 @@ describe("PrimitiveClient", () => {
             .build();
 
         const response = await client.endpoints.primitive.getAndReturnBase64("SGVsbG8gd29ybGQh");
-        expect(response).toEqual("SGVsbG8gd29ybGQh");
+        expect(response).toEqual(rawResponseBody);
     });
 });

--- a/seed/ts-sdk/exhaustive/consolidate-type-files/tests/wire/endpoints/put.test.ts
+++ b/seed/ts-sdk/exhaustive/consolidate-type-files/tests/wire/endpoints/put.test.ts
@@ -20,21 +20,6 @@ describe("PutClient", () => {
         const response = await client.endpoints.put.add({
             id: "id",
         });
-        expect(response).toEqual({
-            errors: [
-                {
-                    category: "API_ERROR",
-                    code: "INTERNAL_SERVER_ERROR",
-                    detail: "detail",
-                    field: "field",
-                },
-                {
-                    category: "API_ERROR",
-                    code: "INTERNAL_SERVER_ERROR",
-                    detail: "detail",
-                    field: "field",
-                },
-            ],
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 });

--- a/seed/ts-sdk/exhaustive/consolidate-type-files/tests/wire/endpoints/union.test.ts
+++ b/seed/ts-sdk/exhaustive/consolidate-type-files/tests/wire/endpoints/union.test.ts
@@ -24,10 +24,6 @@ describe("UnionClient", () => {
             name: "name",
             likesToWoof: true,
         });
-        expect(response).toEqual({
-            animal: "dog",
-            name: "name",
-            likesToWoof: true,
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 });

--- a/seed/ts-sdk/exhaustive/consolidate-type-files/tests/wire/endpoints/urls.test.ts
+++ b/seed/ts-sdk/exhaustive/consolidate-type-files/tests/wire/endpoints/urls.test.ts
@@ -13,7 +13,7 @@ describe("UrlsClient", () => {
         server.mockEndpoint().get("/urls/MixedCase").respondWith().statusCode(200).jsonBody(rawResponseBody).build();
 
         const response = await client.endpoints.urls.withMixedCase();
-        expect(response).toEqual("string");
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("noEndingSlash", async () => {
@@ -31,7 +31,7 @@ describe("UrlsClient", () => {
             .build();
 
         const response = await client.endpoints.urls.noEndingSlash();
-        expect(response).toEqual("string");
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("withEndingSlash", async () => {
@@ -49,7 +49,7 @@ describe("UrlsClient", () => {
             .build();
 
         const response = await client.endpoints.urls.withEndingSlash();
-        expect(response).toEqual("string");
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("withUnderscores", async () => {
@@ -67,6 +67,6 @@ describe("UrlsClient", () => {
             .build();
 
         const response = await client.endpoints.urls.withUnderscores();
-        expect(response).toEqual("string");
+        expect(response).toEqual(rawResponseBody);
     });
 });

--- a/seed/ts-sdk/exhaustive/consolidate-type-files/tests/wire/inlinedRequests.test.ts
+++ b/seed/ts-sdk/exhaustive/consolidate-type-files/tests/wire/inlinedRequests.test.ts
@@ -73,23 +73,7 @@ describe("InlinedRequestsClient", () => {
                 bigint: "1000000",
             },
         });
-        expect(response).toEqual({
-            string: "string",
-            integer: 1,
-            long: 1000000,
-            double: 1.1,
-            bool: true,
-            datetime: "2024-01-15T09:30:00Z",
-            date: "2023-01-15",
-            uuid: "d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32",
-            base64: "SGVsbG8gd29ybGQh",
-            list: ["list", "list"],
-            set: ["set"],
-            map: {
-                1: "map",
-            },
-            bigint: "1000000",
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("postWithObjectBodyandResponse (2)", async () => {

--- a/seed/ts-sdk/exhaustive/consolidate-type-files/tests/wire/noAuth.test.ts
+++ b/seed/ts-sdk/exhaustive/consolidate-type-files/tests/wire/noAuth.test.ts
@@ -23,7 +23,7 @@ describe("NoAuthClient", () => {
         const response = await client.noAuth.postWithNoAuth({
             key: "value",
         });
-        expect(response).toEqual(true);
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("postWithNoAuth (2)", async () => {

--- a/seed/ts-sdk/exhaustive/consolidate-type-files/tests/wire/noReqBody.test.ts
+++ b/seed/ts-sdk/exhaustive/consolidate-type-files/tests/wire/noReqBody.test.ts
@@ -27,23 +27,7 @@ describe("NoReqBodyClient", () => {
         server.mockEndpoint().get("/no-req-body").respondWith().statusCode(200).jsonBody(rawResponseBody).build();
 
         const response = await client.noReqBody.getWithNoRequestBody();
-        expect(response).toEqual({
-            string: "string",
-            integer: 1,
-            long: 1000000,
-            double: 1.1,
-            bool: true,
-            datetime: "2024-01-15T09:30:00Z",
-            date: "2023-01-15",
-            uuid: "d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32",
-            base64: "SGVsbG8gd29ybGQh",
-            list: ["list", "list"],
-            set: ["set"],
-            map: {
-                1: "map",
-            },
-            bigint: "1000000",
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("postWithNoRequestBody", async () => {
@@ -55,6 +39,6 @@ describe("NoReqBodyClient", () => {
         server.mockEndpoint().post("/no-req-body").respondWith().statusCode(200).jsonBody(rawResponseBody).build();
 
         const response = await client.noReqBody.postWithNoRequestBody();
-        expect(response).toEqual("string");
+        expect(response).toEqual(rawResponseBody);
     });
 });

--- a/seed/ts-sdk/exhaustive/export-all-requests-at-root/tests/wire/endpoints/container.test.ts
+++ b/seed/ts-sdk/exhaustive/export-all-requests-at-root/tests/wire/endpoints/container.test.ts
@@ -20,7 +20,7 @@ describe("ContainerClient", () => {
             .build();
 
         const response = await client.endpoints.container.getAndReturnListOfPrimitives(["string", "string"]);
-        expect(response).toEqual(["string", "string"]);
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnListOfObjects", async () => {
@@ -46,14 +46,7 @@ describe("ContainerClient", () => {
                 string: "string",
             },
         ]);
-        expect(response).toEqual([
-            {
-                string: "string",
-            },
-            {
-                string: "string",
-            },
-        ]);
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnSetOfPrimitives", async () => {
@@ -72,7 +65,7 @@ describe("ContainerClient", () => {
             .build();
 
         const response = await client.endpoints.container.getAndReturnSetOfPrimitives(["string"]);
-        expect(response).toEqual(["string"]);
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnSetOfObjects", async () => {
@@ -95,11 +88,7 @@ describe("ContainerClient", () => {
                 string: "string",
             },
         ]);
-        expect(response).toEqual([
-            {
-                string: "string",
-            },
-        ]);
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnMapPrimToPrim", async () => {
@@ -120,9 +109,7 @@ describe("ContainerClient", () => {
         const response = await client.endpoints.container.getAndReturnMapPrimToPrim({
             string: "string",
         });
-        expect(response).toEqual({
-            string: "string",
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnMapOfPrimToObject", async () => {
@@ -145,11 +132,7 @@ describe("ContainerClient", () => {
                 string: "string",
             },
         });
-        expect(response).toEqual({
-            string: {
-                string: "string",
-            },
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnMapOfPrimToUndiscriminatedUnion", async () => {
@@ -170,9 +153,7 @@ describe("ContainerClient", () => {
         const response = await client.endpoints.container.getAndReturnMapOfPrimToUndiscriminatedUnion({
             string: 1.1,
         });
-        expect(response).toEqual({
-            string: 1.1,
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnOptional", async () => {
@@ -193,8 +174,6 @@ describe("ContainerClient", () => {
         const response = await client.endpoints.container.getAndReturnOptional({
             string: "string",
         });
-        expect(response).toEqual({
-            string: "string",
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 });

--- a/seed/ts-sdk/exhaustive/export-all-requests-at-root/tests/wire/endpoints/enum.test.ts
+++ b/seed/ts-sdk/exhaustive/export-all-requests-at-root/tests/wire/endpoints/enum.test.ts
@@ -20,6 +20,6 @@ describe("EnumClient", () => {
             .build();
 
         const response = await client.endpoints.enum.getAndReturnEnum("SUNNY");
-        expect(response).toEqual("SUNNY");
+        expect(response).toEqual(rawResponseBody);
     });
 });

--- a/seed/ts-sdk/exhaustive/export-all-requests-at-root/tests/wire/endpoints/httpMethods.test.ts
+++ b/seed/ts-sdk/exhaustive/export-all-requests-at-root/tests/wire/endpoints/httpMethods.test.ts
@@ -13,7 +13,7 @@ describe("HttpMethodsClient", () => {
         server.mockEndpoint().get("/http-methods/id").respondWith().statusCode(200).jsonBody(rawResponseBody).build();
 
         const response = await client.endpoints.httpMethods.testGet("id");
-        expect(response).toEqual("string");
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("testPost", async () => {
@@ -48,23 +48,7 @@ describe("HttpMethodsClient", () => {
         const response = await client.endpoints.httpMethods.testPost({
             string: "string",
         });
-        expect(response).toEqual({
-            string: "string",
-            integer: 1,
-            long: 1000000,
-            double: 1.1,
-            bool: true,
-            datetime: "2024-01-15T09:30:00Z",
-            date: "2023-01-15",
-            uuid: "d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32",
-            base64: "SGVsbG8gd29ybGQh",
-            list: ["list", "list"],
-            set: ["set"],
-            map: {
-                1: "map",
-            },
-            bigint: "1000000",
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("testPut", async () => {
@@ -99,23 +83,7 @@ describe("HttpMethodsClient", () => {
         const response = await client.endpoints.httpMethods.testPut("id", {
             string: "string",
         });
-        expect(response).toEqual({
-            string: "string",
-            integer: 1,
-            long: 1000000,
-            double: 1.1,
-            bool: true,
-            datetime: "2024-01-15T09:30:00Z",
-            date: "2023-01-15",
-            uuid: "d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32",
-            base64: "SGVsbG8gd29ybGQh",
-            list: ["list", "list"],
-            set: ["set"],
-            map: {
-                1: "map",
-            },
-            bigint: "1000000",
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("testPatch", async () => {
@@ -178,23 +146,7 @@ describe("HttpMethodsClient", () => {
             },
             bigint: "1000000",
         });
-        expect(response).toEqual({
-            string: "string",
-            integer: 1,
-            long: 1000000,
-            double: 1.1,
-            bool: true,
-            datetime: "2024-01-15T09:30:00Z",
-            date: "2023-01-15",
-            uuid: "d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32",
-            base64: "SGVsbG8gd29ybGQh",
-            list: ["list", "list"],
-            set: ["set"],
-            map: {
-                1: "map",
-            },
-            bigint: "1000000",
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("testDelete", async () => {
@@ -212,6 +164,6 @@ describe("HttpMethodsClient", () => {
             .build();
 
         const response = await client.endpoints.httpMethods.testDelete("id");
-        expect(response).toEqual(true);
+        expect(response).toEqual(rawResponseBody);
     });
 });

--- a/seed/ts-sdk/exhaustive/export-all-requests-at-root/tests/wire/endpoints/object.test.ts
+++ b/seed/ts-sdk/exhaustive/export-all-requests-at-root/tests/wire/endpoints/object.test.ts
@@ -64,23 +64,7 @@ describe("ObjectClient", () => {
             },
             bigint: "1000000",
         });
-        expect(response).toEqual({
-            string: "string",
-            integer: 1,
-            long: 1000000,
-            double: 1.1,
-            bool: true,
-            datetime: "2024-01-15T09:30:00Z",
-            date: "2023-01-15",
-            uuid: "d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32",
-            base64: "SGVsbG8gd29ybGQh",
-            list: ["list", "list"],
-            set: ["set"],
-            map: {
-                1: "map",
-            },
-            bigint: "1000000",
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnWithRequiredField", async () => {
@@ -101,9 +85,7 @@ describe("ObjectClient", () => {
         const response = await client.endpoints.object.getAndReturnWithRequiredField({
             string: "string",
         });
-        expect(response).toEqual({
-            string: "string",
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnWithMapOfMap", async () => {
@@ -128,13 +110,7 @@ describe("ObjectClient", () => {
                 },
             },
         });
-        expect(response).toEqual({
-            map: {
-                map: {
-                    map: "map",
-                },
-            },
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnNestedWithOptionalField", async () => {
@@ -206,26 +182,7 @@ describe("ObjectClient", () => {
                 bigint: "1000000",
             },
         });
-        expect(response).toEqual({
-            string: "string",
-            NestedObject: {
-                string: "string",
-                integer: 1,
-                long: 1000000,
-                double: 1.1,
-                bool: true,
-                datetime: "2024-01-15T09:30:00Z",
-                date: "2023-01-15",
-                uuid: "d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32",
-                base64: "SGVsbG8gd29ybGQh",
-                list: ["list", "list"],
-                set: ["set"],
-                map: {
-                    1: "map",
-                },
-                bigint: "1000000",
-            },
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnNestedWithRequiredField", async () => {
@@ -297,26 +254,7 @@ describe("ObjectClient", () => {
                 bigint: "1000000",
             },
         });
-        expect(response).toEqual({
-            string: "string",
-            NestedObject: {
-                string: "string",
-                integer: 1,
-                long: 1000000,
-                double: 1.1,
-                bool: true,
-                datetime: "2024-01-15T09:30:00Z",
-                date: "2023-01-15",
-                uuid: "d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32",
-                base64: "SGVsbG8gd29ybGQh",
-                list: ["list", "list"],
-                set: ["set"],
-                map: {
-                    1: "map",
-                },
-                bigint: "1000000",
-            },
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnNestedWithRequiredFieldAsList", async () => {
@@ -430,26 +368,7 @@ describe("ObjectClient", () => {
                 },
             },
         ]);
-        expect(response).toEqual({
-            string: "string",
-            NestedObject: {
-                string: "string",
-                integer: 1,
-                long: 1000000,
-                double: 1.1,
-                bool: true,
-                datetime: "2024-01-15T09:30:00Z",
-                date: "2023-01-15",
-                uuid: "d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32",
-                base64: "SGVsbG8gd29ybGQh",
-                list: ["list", "list"],
-                set: ["set"],
-                map: {
-                    1: "map",
-                },
-                bigint: "1000000",
-            },
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnWithUnknownField", async () => {
@@ -472,11 +391,7 @@ describe("ObjectClient", () => {
                 $ref: "https://example.com/schema",
             },
         });
-        expect(response).toEqual({
-            unknown: {
-                $ref: "https://example.com/schema",
-            },
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnWithDocumentedUnknownType", async () => {
@@ -499,11 +414,7 @@ describe("ObjectClient", () => {
                 key: "value",
             },
         });
-        expect(response).toEqual({
-            documentedUnknownType: {
-                key: "value",
-            },
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnMapOfDocumentedUnknownType", async () => {
@@ -526,11 +437,7 @@ describe("ObjectClient", () => {
                 key: "value",
             },
         });
-        expect(response).toEqual({
-            string: {
-                key: "value",
-            },
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnWithDatetimeLikeString", async () => {
@@ -552,9 +459,6 @@ describe("ObjectClient", () => {
             datetimeLikeString: "2023-08-31T14:15:22Z",
             actualDatetime: "2023-08-31T14:15:22Z",
         });
-        expect(response).toEqual({
-            datetimeLikeString: "2023-08-31T14:15:22Z",
-            actualDatetime: "2023-08-31T14:15:22Z",
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 });

--- a/seed/ts-sdk/exhaustive/export-all-requests-at-root/tests/wire/endpoints/pagination.test.ts
+++ b/seed/ts-sdk/exhaustive/export-all-requests-at-root/tests/wire/endpoints/pagination.test.ts
@@ -18,17 +18,7 @@ describe("PaginationClient", () => {
             .jsonBody(rawResponseBody)
             .build();
 
-        const expected = {
-            items: [
-                {
-                    string: "string",
-                },
-                {
-                    string: "string",
-                },
-            ],
-            next: "next",
-        };
+        const expected = rawResponseBody;
         const page = await client.endpoints.pagination.listItems({
             cursor: "cursor",
             limit: 1,

--- a/seed/ts-sdk/exhaustive/export-all-requests-at-root/tests/wire/endpoints/params.test.ts
+++ b/seed/ts-sdk/exhaustive/export-all-requests-at-root/tests/wire/endpoints/params.test.ts
@@ -14,7 +14,7 @@ describe("ParamsClient", () => {
         server.mockEndpoint().get("/params/path/param").respondWith().statusCode(200).jsonBody(rawResponseBody).build();
 
         const response = await client.endpoints.params.getWithPath("param");
-        expect(response).toEqual("string");
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getWithInlinePath", async () => {
@@ -28,7 +28,7 @@ describe("ParamsClient", () => {
         const response = await client.endpoints.params.getWithInlinePath({
             param: "param",
         });
-        expect(response).toEqual("string");
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getWithQuery", async () => {
@@ -98,7 +98,7 @@ describe("ParamsClient", () => {
             .build();
 
         const response = await client.endpoints.params.modifyWithPath("param", "string");
-        expect(response).toEqual("string");
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("modifyWithInlinePath", async () => {
@@ -120,7 +120,7 @@ describe("ParamsClient", () => {
             param: "param",
             body: "string",
         });
-        expect(response).toEqual("string");
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getWithPathAndErrors (1)", async () => {
@@ -132,7 +132,7 @@ describe("ParamsClient", () => {
         server.mockEndpoint().get("/params/path/param").respondWith().statusCode(200).jsonBody(rawResponseBody).build();
 
         const response = await client.endpoints.params.getWithPathAndErrors("param");
-        expect(response).toEqual("string");
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getWithPathAndErrors (2)", async () => {

--- a/seed/ts-sdk/exhaustive/export-all-requests-at-root/tests/wire/endpoints/primitive.test.ts
+++ b/seed/ts-sdk/exhaustive/export-all-requests-at-root/tests/wire/endpoints/primitive.test.ts
@@ -20,7 +20,7 @@ describe("PrimitiveClient", () => {
             .build();
 
         const response = await client.endpoints.primitive.getAndReturnString("string");
-        expect(response).toEqual("string");
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnInt", async () => {
@@ -39,7 +39,7 @@ describe("PrimitiveClient", () => {
             .build();
 
         const response = await client.endpoints.primitive.getAndReturnInt(1);
-        expect(response).toEqual(1);
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnLong", async () => {
@@ -58,7 +58,7 @@ describe("PrimitiveClient", () => {
             .build();
 
         const response = await client.endpoints.primitive.getAndReturnLong(1000000);
-        expect(response).toEqual(1000000);
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnDouble", async () => {
@@ -77,7 +77,7 @@ describe("PrimitiveClient", () => {
             .build();
 
         const response = await client.endpoints.primitive.getAndReturnDouble(1.1);
-        expect(response).toEqual(1.1);
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnBool", async () => {
@@ -96,7 +96,7 @@ describe("PrimitiveClient", () => {
             .build();
 
         const response = await client.endpoints.primitive.getAndReturnBool(true);
-        expect(response).toEqual(true);
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnDatetime", async () => {
@@ -115,7 +115,7 @@ describe("PrimitiveClient", () => {
             .build();
 
         const response = await client.endpoints.primitive.getAndReturnDatetime("2024-01-15T09:30:00Z");
-        expect(response).toEqual("2024-01-15T09:30:00Z");
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnDate", async () => {
@@ -134,7 +134,7 @@ describe("PrimitiveClient", () => {
             .build();
 
         const response = await client.endpoints.primitive.getAndReturnDate("2023-01-15");
-        expect(response).toEqual("2023-01-15");
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnUUID", async () => {
@@ -153,7 +153,7 @@ describe("PrimitiveClient", () => {
             .build();
 
         const response = await client.endpoints.primitive.getAndReturnUuid("d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32");
-        expect(response).toEqual("d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32");
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnBase64", async () => {
@@ -172,6 +172,6 @@ describe("PrimitiveClient", () => {
             .build();
 
         const response = await client.endpoints.primitive.getAndReturnBase64("SGVsbG8gd29ybGQh");
-        expect(response).toEqual("SGVsbG8gd29ybGQh");
+        expect(response).toEqual(rawResponseBody);
     });
 });

--- a/seed/ts-sdk/exhaustive/export-all-requests-at-root/tests/wire/endpoints/put.test.ts
+++ b/seed/ts-sdk/exhaustive/export-all-requests-at-root/tests/wire/endpoints/put.test.ts
@@ -20,21 +20,6 @@ describe("PutClient", () => {
         const response = await client.endpoints.put.add({
             id: "id",
         });
-        expect(response).toEqual({
-            errors: [
-                {
-                    category: "API_ERROR",
-                    code: "INTERNAL_SERVER_ERROR",
-                    detail: "detail",
-                    field: "field",
-                },
-                {
-                    category: "API_ERROR",
-                    code: "INTERNAL_SERVER_ERROR",
-                    detail: "detail",
-                    field: "field",
-                },
-            ],
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 });

--- a/seed/ts-sdk/exhaustive/export-all-requests-at-root/tests/wire/endpoints/union.test.ts
+++ b/seed/ts-sdk/exhaustive/export-all-requests-at-root/tests/wire/endpoints/union.test.ts
@@ -24,10 +24,6 @@ describe("UnionClient", () => {
             name: "name",
             likesToWoof: true,
         });
-        expect(response).toEqual({
-            animal: "dog",
-            name: "name",
-            likesToWoof: true,
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 });

--- a/seed/ts-sdk/exhaustive/export-all-requests-at-root/tests/wire/endpoints/urls.test.ts
+++ b/seed/ts-sdk/exhaustive/export-all-requests-at-root/tests/wire/endpoints/urls.test.ts
@@ -13,7 +13,7 @@ describe("UrlsClient", () => {
         server.mockEndpoint().get("/urls/MixedCase").respondWith().statusCode(200).jsonBody(rawResponseBody).build();
 
         const response = await client.endpoints.urls.withMixedCase();
-        expect(response).toEqual("string");
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("noEndingSlash", async () => {
@@ -31,7 +31,7 @@ describe("UrlsClient", () => {
             .build();
 
         const response = await client.endpoints.urls.noEndingSlash();
-        expect(response).toEqual("string");
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("withEndingSlash", async () => {
@@ -49,7 +49,7 @@ describe("UrlsClient", () => {
             .build();
 
         const response = await client.endpoints.urls.withEndingSlash();
-        expect(response).toEqual("string");
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("withUnderscores", async () => {
@@ -67,6 +67,6 @@ describe("UrlsClient", () => {
             .build();
 
         const response = await client.endpoints.urls.withUnderscores();
-        expect(response).toEqual("string");
+        expect(response).toEqual(rawResponseBody);
     });
 });

--- a/seed/ts-sdk/exhaustive/export-all-requests-at-root/tests/wire/inlinedRequests.test.ts
+++ b/seed/ts-sdk/exhaustive/export-all-requests-at-root/tests/wire/inlinedRequests.test.ts
@@ -73,23 +73,7 @@ describe("InlinedRequestsClient", () => {
                 bigint: "1000000",
             },
         });
-        expect(response).toEqual({
-            string: "string",
-            integer: 1,
-            long: 1000000,
-            double: 1.1,
-            bool: true,
-            datetime: "2024-01-15T09:30:00Z",
-            date: "2023-01-15",
-            uuid: "d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32",
-            base64: "SGVsbG8gd29ybGQh",
-            list: ["list", "list"],
-            set: ["set"],
-            map: {
-                1: "map",
-            },
-            bigint: "1000000",
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("postWithObjectBodyandResponse (2)", async () => {

--- a/seed/ts-sdk/exhaustive/export-all-requests-at-root/tests/wire/noAuth.test.ts
+++ b/seed/ts-sdk/exhaustive/export-all-requests-at-root/tests/wire/noAuth.test.ts
@@ -23,7 +23,7 @@ describe("NoAuthClient", () => {
         const response = await client.noAuth.postWithNoAuth({
             key: "value",
         });
-        expect(response).toEqual(true);
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("postWithNoAuth (2)", async () => {

--- a/seed/ts-sdk/exhaustive/export-all-requests-at-root/tests/wire/noReqBody.test.ts
+++ b/seed/ts-sdk/exhaustive/export-all-requests-at-root/tests/wire/noReqBody.test.ts
@@ -27,23 +27,7 @@ describe("NoReqBodyClient", () => {
         server.mockEndpoint().get("/no-req-body").respondWith().statusCode(200).jsonBody(rawResponseBody).build();
 
         const response = await client.noReqBody.getWithNoRequestBody();
-        expect(response).toEqual({
-            string: "string",
-            integer: 1,
-            long: 1000000,
-            double: 1.1,
-            bool: true,
-            datetime: "2024-01-15T09:30:00Z",
-            date: "2023-01-15",
-            uuid: "d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32",
-            base64: "SGVsbG8gd29ybGQh",
-            list: ["list", "list"],
-            set: ["set"],
-            map: {
-                1: "map",
-            },
-            bigint: "1000000",
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("postWithNoRequestBody", async () => {
@@ -55,6 +39,6 @@ describe("NoReqBodyClient", () => {
         server.mockEndpoint().post("/no-req-body").respondWith().statusCode(200).jsonBody(rawResponseBody).build();
 
         const response = await client.noReqBody.postWithNoRequestBody();
-        expect(response).toEqual("string");
+        expect(response).toEqual(rawResponseBody);
     });
 });

--- a/seed/ts-sdk/exhaustive/multiple-exports/tests/wire/endpoints/container.test.ts
+++ b/seed/ts-sdk/exhaustive/multiple-exports/tests/wire/endpoints/container.test.ts
@@ -20,7 +20,7 @@ describe("ContainerClient", () => {
             .build();
 
         const response = await client.endpoints.container.getAndReturnListOfPrimitives(["string", "string"]);
-        expect(response).toEqual(["string", "string"]);
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnListOfObjects", async () => {
@@ -46,14 +46,7 @@ describe("ContainerClient", () => {
                 string: "string",
             },
         ]);
-        expect(response).toEqual([
-            {
-                string: "string",
-            },
-            {
-                string: "string",
-            },
-        ]);
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnSetOfPrimitives", async () => {
@@ -72,7 +65,7 @@ describe("ContainerClient", () => {
             .build();
 
         const response = await client.endpoints.container.getAndReturnSetOfPrimitives(["string"]);
-        expect(response).toEqual(["string"]);
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnSetOfObjects", async () => {
@@ -95,11 +88,7 @@ describe("ContainerClient", () => {
                 string: "string",
             },
         ]);
-        expect(response).toEqual([
-            {
-                string: "string",
-            },
-        ]);
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnMapPrimToPrim", async () => {
@@ -120,9 +109,7 @@ describe("ContainerClient", () => {
         const response = await client.endpoints.container.getAndReturnMapPrimToPrim({
             string: "string",
         });
-        expect(response).toEqual({
-            string: "string",
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnMapOfPrimToObject", async () => {
@@ -145,11 +132,7 @@ describe("ContainerClient", () => {
                 string: "string",
             },
         });
-        expect(response).toEqual({
-            string: {
-                string: "string",
-            },
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnMapOfPrimToUndiscriminatedUnion", async () => {
@@ -170,9 +153,7 @@ describe("ContainerClient", () => {
         const response = await client.endpoints.container.getAndReturnMapOfPrimToUndiscriminatedUnion({
             string: 1.1,
         });
-        expect(response).toEqual({
-            string: 1.1,
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnOptional", async () => {
@@ -193,8 +174,6 @@ describe("ContainerClient", () => {
         const response = await client.endpoints.container.getAndReturnOptional({
             string: "string",
         });
-        expect(response).toEqual({
-            string: "string",
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 });

--- a/seed/ts-sdk/exhaustive/multiple-exports/tests/wire/endpoints/enum.test.ts
+++ b/seed/ts-sdk/exhaustive/multiple-exports/tests/wire/endpoints/enum.test.ts
@@ -20,6 +20,6 @@ describe("EnumClient", () => {
             .build();
 
         const response = await client.endpoints.enum.getAndReturnEnum("SUNNY");
-        expect(response).toEqual("SUNNY");
+        expect(response).toEqual(rawResponseBody);
     });
 });

--- a/seed/ts-sdk/exhaustive/multiple-exports/tests/wire/endpoints/httpMethods.test.ts
+++ b/seed/ts-sdk/exhaustive/multiple-exports/tests/wire/endpoints/httpMethods.test.ts
@@ -13,7 +13,7 @@ describe("HttpMethodsClient", () => {
         server.mockEndpoint().get("/http-methods/id").respondWith().statusCode(200).jsonBody(rawResponseBody).build();
 
         const response = await client.endpoints.httpMethods.testGet("id");
-        expect(response).toEqual("string");
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("testPost", async () => {
@@ -48,23 +48,7 @@ describe("HttpMethodsClient", () => {
         const response = await client.endpoints.httpMethods.testPost({
             string: "string",
         });
-        expect(response).toEqual({
-            string: "string",
-            integer: 1,
-            long: 1000000,
-            double: 1.1,
-            bool: true,
-            datetime: "2024-01-15T09:30:00Z",
-            date: "2023-01-15",
-            uuid: "d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32",
-            base64: "SGVsbG8gd29ybGQh",
-            list: ["list", "list"],
-            set: ["set"],
-            map: {
-                1: "map",
-            },
-            bigint: "1000000",
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("testPut", async () => {
@@ -99,23 +83,7 @@ describe("HttpMethodsClient", () => {
         const response = await client.endpoints.httpMethods.testPut("id", {
             string: "string",
         });
-        expect(response).toEqual({
-            string: "string",
-            integer: 1,
-            long: 1000000,
-            double: 1.1,
-            bool: true,
-            datetime: "2024-01-15T09:30:00Z",
-            date: "2023-01-15",
-            uuid: "d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32",
-            base64: "SGVsbG8gd29ybGQh",
-            list: ["list", "list"],
-            set: ["set"],
-            map: {
-                1: "map",
-            },
-            bigint: "1000000",
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("testPatch", async () => {
@@ -178,23 +146,7 @@ describe("HttpMethodsClient", () => {
             },
             bigint: "1000000",
         });
-        expect(response).toEqual({
-            string: "string",
-            integer: 1,
-            long: 1000000,
-            double: 1.1,
-            bool: true,
-            datetime: "2024-01-15T09:30:00Z",
-            date: "2023-01-15",
-            uuid: "d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32",
-            base64: "SGVsbG8gd29ybGQh",
-            list: ["list", "list"],
-            set: ["set"],
-            map: {
-                1: "map",
-            },
-            bigint: "1000000",
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("testDelete", async () => {
@@ -212,6 +164,6 @@ describe("HttpMethodsClient", () => {
             .build();
 
         const response = await client.endpoints.httpMethods.testDelete("id");
-        expect(response).toEqual(true);
+        expect(response).toEqual(rawResponseBody);
     });
 });

--- a/seed/ts-sdk/exhaustive/multiple-exports/tests/wire/endpoints/object.test.ts
+++ b/seed/ts-sdk/exhaustive/multiple-exports/tests/wire/endpoints/object.test.ts
@@ -64,23 +64,7 @@ describe("ObjectClient", () => {
             },
             bigint: "1000000",
         });
-        expect(response).toEqual({
-            string: "string",
-            integer: 1,
-            long: 1000000,
-            double: 1.1,
-            bool: true,
-            datetime: "2024-01-15T09:30:00Z",
-            date: "2023-01-15",
-            uuid: "d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32",
-            base64: "SGVsbG8gd29ybGQh",
-            list: ["list", "list"],
-            set: ["set"],
-            map: {
-                1: "map",
-            },
-            bigint: "1000000",
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnWithRequiredField", async () => {
@@ -101,9 +85,7 @@ describe("ObjectClient", () => {
         const response = await client.endpoints.object.getAndReturnWithRequiredField({
             string: "string",
         });
-        expect(response).toEqual({
-            string: "string",
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnWithMapOfMap", async () => {
@@ -128,13 +110,7 @@ describe("ObjectClient", () => {
                 },
             },
         });
-        expect(response).toEqual({
-            map: {
-                map: {
-                    map: "map",
-                },
-            },
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnNestedWithOptionalField", async () => {
@@ -206,26 +182,7 @@ describe("ObjectClient", () => {
                 bigint: "1000000",
             },
         });
-        expect(response).toEqual({
-            string: "string",
-            NestedObject: {
-                string: "string",
-                integer: 1,
-                long: 1000000,
-                double: 1.1,
-                bool: true,
-                datetime: "2024-01-15T09:30:00Z",
-                date: "2023-01-15",
-                uuid: "d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32",
-                base64: "SGVsbG8gd29ybGQh",
-                list: ["list", "list"],
-                set: ["set"],
-                map: {
-                    1: "map",
-                },
-                bigint: "1000000",
-            },
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnNestedWithRequiredField", async () => {
@@ -297,26 +254,7 @@ describe("ObjectClient", () => {
                 bigint: "1000000",
             },
         });
-        expect(response).toEqual({
-            string: "string",
-            NestedObject: {
-                string: "string",
-                integer: 1,
-                long: 1000000,
-                double: 1.1,
-                bool: true,
-                datetime: "2024-01-15T09:30:00Z",
-                date: "2023-01-15",
-                uuid: "d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32",
-                base64: "SGVsbG8gd29ybGQh",
-                list: ["list", "list"],
-                set: ["set"],
-                map: {
-                    1: "map",
-                },
-                bigint: "1000000",
-            },
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnNestedWithRequiredFieldAsList", async () => {
@@ -430,26 +368,7 @@ describe("ObjectClient", () => {
                 },
             },
         ]);
-        expect(response).toEqual({
-            string: "string",
-            NestedObject: {
-                string: "string",
-                integer: 1,
-                long: 1000000,
-                double: 1.1,
-                bool: true,
-                datetime: "2024-01-15T09:30:00Z",
-                date: "2023-01-15",
-                uuid: "d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32",
-                base64: "SGVsbG8gd29ybGQh",
-                list: ["list", "list"],
-                set: ["set"],
-                map: {
-                    1: "map",
-                },
-                bigint: "1000000",
-            },
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnWithUnknownField", async () => {
@@ -472,11 +391,7 @@ describe("ObjectClient", () => {
                 $ref: "https://example.com/schema",
             },
         });
-        expect(response).toEqual({
-            unknown: {
-                $ref: "https://example.com/schema",
-            },
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnWithDocumentedUnknownType", async () => {
@@ -499,11 +414,7 @@ describe("ObjectClient", () => {
                 key: "value",
             },
         });
-        expect(response).toEqual({
-            documentedUnknownType: {
-                key: "value",
-            },
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnMapOfDocumentedUnknownType", async () => {
@@ -526,11 +437,7 @@ describe("ObjectClient", () => {
                 key: "value",
             },
         });
-        expect(response).toEqual({
-            string: {
-                key: "value",
-            },
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnWithDatetimeLikeString", async () => {
@@ -552,9 +459,6 @@ describe("ObjectClient", () => {
             datetimeLikeString: "2023-08-31T14:15:22Z",
             actualDatetime: "2023-08-31T14:15:22Z",
         });
-        expect(response).toEqual({
-            datetimeLikeString: "2023-08-31T14:15:22Z",
-            actualDatetime: "2023-08-31T14:15:22Z",
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 });

--- a/seed/ts-sdk/exhaustive/multiple-exports/tests/wire/endpoints/pagination.test.ts
+++ b/seed/ts-sdk/exhaustive/multiple-exports/tests/wire/endpoints/pagination.test.ts
@@ -18,17 +18,7 @@ describe("PaginationClient", () => {
             .jsonBody(rawResponseBody)
             .build();
 
-        const expected = {
-            items: [
-                {
-                    string: "string",
-                },
-                {
-                    string: "string",
-                },
-            ],
-            next: "next",
-        };
+        const expected = rawResponseBody;
         const page = await client.endpoints.pagination.listItems({
             cursor: "cursor",
             limit: 1,

--- a/seed/ts-sdk/exhaustive/multiple-exports/tests/wire/endpoints/params.test.ts
+++ b/seed/ts-sdk/exhaustive/multiple-exports/tests/wire/endpoints/params.test.ts
@@ -14,7 +14,7 @@ describe("ParamsClient", () => {
         server.mockEndpoint().get("/params/path/param").respondWith().statusCode(200).jsonBody(rawResponseBody).build();
 
         const response = await client.endpoints.params.getWithPath("param");
-        expect(response).toEqual("string");
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getWithInlinePath", async () => {
@@ -28,7 +28,7 @@ describe("ParamsClient", () => {
         const response = await client.endpoints.params.getWithInlinePath({
             param: "param",
         });
-        expect(response).toEqual("string");
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getWithQuery", async () => {
@@ -98,7 +98,7 @@ describe("ParamsClient", () => {
             .build();
 
         const response = await client.endpoints.params.modifyWithPath("param", "string");
-        expect(response).toEqual("string");
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("modifyWithInlinePath", async () => {
@@ -120,7 +120,7 @@ describe("ParamsClient", () => {
             param: "param",
             body: "string",
         });
-        expect(response).toEqual("string");
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getWithPathAndErrors (1)", async () => {
@@ -132,7 +132,7 @@ describe("ParamsClient", () => {
         server.mockEndpoint().get("/params/path/param").respondWith().statusCode(200).jsonBody(rawResponseBody).build();
 
         const response = await client.endpoints.params.getWithPathAndErrors("param");
-        expect(response).toEqual("string");
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getWithPathAndErrors (2)", async () => {

--- a/seed/ts-sdk/exhaustive/multiple-exports/tests/wire/endpoints/primitive.test.ts
+++ b/seed/ts-sdk/exhaustive/multiple-exports/tests/wire/endpoints/primitive.test.ts
@@ -20,7 +20,7 @@ describe("PrimitiveClient", () => {
             .build();
 
         const response = await client.endpoints.primitive.getAndReturnString("string");
-        expect(response).toEqual("string");
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnInt", async () => {
@@ -39,7 +39,7 @@ describe("PrimitiveClient", () => {
             .build();
 
         const response = await client.endpoints.primitive.getAndReturnInt(1);
-        expect(response).toEqual(1);
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnLong", async () => {
@@ -58,7 +58,7 @@ describe("PrimitiveClient", () => {
             .build();
 
         const response = await client.endpoints.primitive.getAndReturnLong(1000000);
-        expect(response).toEqual(1000000);
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnDouble", async () => {
@@ -77,7 +77,7 @@ describe("PrimitiveClient", () => {
             .build();
 
         const response = await client.endpoints.primitive.getAndReturnDouble(1.1);
-        expect(response).toEqual(1.1);
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnBool", async () => {
@@ -96,7 +96,7 @@ describe("PrimitiveClient", () => {
             .build();
 
         const response = await client.endpoints.primitive.getAndReturnBool(true);
-        expect(response).toEqual(true);
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnDatetime", async () => {
@@ -115,7 +115,7 @@ describe("PrimitiveClient", () => {
             .build();
 
         const response = await client.endpoints.primitive.getAndReturnDatetime("2024-01-15T09:30:00Z");
-        expect(response).toEqual("2024-01-15T09:30:00Z");
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnDate", async () => {
@@ -134,7 +134,7 @@ describe("PrimitiveClient", () => {
             .build();
 
         const response = await client.endpoints.primitive.getAndReturnDate("2023-01-15");
-        expect(response).toEqual("2023-01-15");
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnUUID", async () => {
@@ -153,7 +153,7 @@ describe("PrimitiveClient", () => {
             .build();
 
         const response = await client.endpoints.primitive.getAndReturnUuid("d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32");
-        expect(response).toEqual("d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32");
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnBase64", async () => {
@@ -172,6 +172,6 @@ describe("PrimitiveClient", () => {
             .build();
 
         const response = await client.endpoints.primitive.getAndReturnBase64("SGVsbG8gd29ybGQh");
-        expect(response).toEqual("SGVsbG8gd29ybGQh");
+        expect(response).toEqual(rawResponseBody);
     });
 });

--- a/seed/ts-sdk/exhaustive/multiple-exports/tests/wire/endpoints/put.test.ts
+++ b/seed/ts-sdk/exhaustive/multiple-exports/tests/wire/endpoints/put.test.ts
@@ -20,21 +20,6 @@ describe("PutClient", () => {
         const response = await client.endpoints.put.add({
             id: "id",
         });
-        expect(response).toEqual({
-            errors: [
-                {
-                    category: "API_ERROR",
-                    code: "INTERNAL_SERVER_ERROR",
-                    detail: "detail",
-                    field: "field",
-                },
-                {
-                    category: "API_ERROR",
-                    code: "INTERNAL_SERVER_ERROR",
-                    detail: "detail",
-                    field: "field",
-                },
-            ],
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 });

--- a/seed/ts-sdk/exhaustive/multiple-exports/tests/wire/endpoints/union.test.ts
+++ b/seed/ts-sdk/exhaustive/multiple-exports/tests/wire/endpoints/union.test.ts
@@ -24,10 +24,6 @@ describe("UnionClient", () => {
             name: "name",
             likesToWoof: true,
         });
-        expect(response).toEqual({
-            animal: "dog",
-            name: "name",
-            likesToWoof: true,
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 });

--- a/seed/ts-sdk/exhaustive/multiple-exports/tests/wire/endpoints/urls.test.ts
+++ b/seed/ts-sdk/exhaustive/multiple-exports/tests/wire/endpoints/urls.test.ts
@@ -13,7 +13,7 @@ describe("UrlsClient", () => {
         server.mockEndpoint().get("/urls/MixedCase").respondWith().statusCode(200).jsonBody(rawResponseBody).build();
 
         const response = await client.endpoints.urls.withMixedCase();
-        expect(response).toEqual("string");
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("noEndingSlash", async () => {
@@ -31,7 +31,7 @@ describe("UrlsClient", () => {
             .build();
 
         const response = await client.endpoints.urls.noEndingSlash();
-        expect(response).toEqual("string");
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("withEndingSlash", async () => {
@@ -49,7 +49,7 @@ describe("UrlsClient", () => {
             .build();
 
         const response = await client.endpoints.urls.withEndingSlash();
-        expect(response).toEqual("string");
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("withUnderscores", async () => {
@@ -67,6 +67,6 @@ describe("UrlsClient", () => {
             .build();
 
         const response = await client.endpoints.urls.withUnderscores();
-        expect(response).toEqual("string");
+        expect(response).toEqual(rawResponseBody);
     });
 });

--- a/seed/ts-sdk/exhaustive/multiple-exports/tests/wire/inlinedRequests.test.ts
+++ b/seed/ts-sdk/exhaustive/multiple-exports/tests/wire/inlinedRequests.test.ts
@@ -73,23 +73,7 @@ describe("InlinedRequestsClient", () => {
                 bigint: "1000000",
             },
         });
-        expect(response).toEqual({
-            string: "string",
-            integer: 1,
-            long: 1000000,
-            double: 1.1,
-            bool: true,
-            datetime: "2024-01-15T09:30:00Z",
-            date: "2023-01-15",
-            uuid: "d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32",
-            base64: "SGVsbG8gd29ybGQh",
-            list: ["list", "list"],
-            set: ["set"],
-            map: {
-                1: "map",
-            },
-            bigint: "1000000",
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("postWithObjectBodyandResponse (2)", async () => {

--- a/seed/ts-sdk/exhaustive/multiple-exports/tests/wire/noAuth.test.ts
+++ b/seed/ts-sdk/exhaustive/multiple-exports/tests/wire/noAuth.test.ts
@@ -23,7 +23,7 @@ describe("NoAuthClient", () => {
         const response = await client.noAuth.postWithNoAuth({
             key: "value",
         });
-        expect(response).toEqual(true);
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("postWithNoAuth (2)", async () => {

--- a/seed/ts-sdk/exhaustive/multiple-exports/tests/wire/noReqBody.test.ts
+++ b/seed/ts-sdk/exhaustive/multiple-exports/tests/wire/noReqBody.test.ts
@@ -27,23 +27,7 @@ describe("NoReqBodyClient", () => {
         server.mockEndpoint().get("/no-req-body").respondWith().statusCode(200).jsonBody(rawResponseBody).build();
 
         const response = await client.noReqBody.getWithNoRequestBody();
-        expect(response).toEqual({
-            string: "string",
-            integer: 1,
-            long: 1000000,
-            double: 1.1,
-            bool: true,
-            datetime: "2024-01-15T09:30:00Z",
-            date: "2023-01-15",
-            uuid: "d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32",
-            base64: "SGVsbG8gd29ybGQh",
-            list: ["list", "list"],
-            set: ["set"],
-            map: {
-                1: "map",
-            },
-            bigint: "1000000",
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("postWithNoRequestBody", async () => {
@@ -55,6 +39,6 @@ describe("NoReqBodyClient", () => {
         server.mockEndpoint().post("/no-req-body").respondWith().statusCode(200).jsonBody(rawResponseBody).build();
 
         const response = await client.noReqBody.postWithNoRequestBody();
-        expect(response).toEqual("string");
+        expect(response).toEqual(rawResponseBody);
     });
 });

--- a/seed/ts-sdk/exhaustive/never-throw-errors/tests/wire/endpoints/container.test.ts
+++ b/seed/ts-sdk/exhaustive/never-throw-errors/tests/wire/endpoints/container.test.ts
@@ -21,7 +21,7 @@ describe("ContainerClient", () => {
 
         const response = await client.endpoints.container.getAndReturnListOfPrimitives(["string", "string"]);
         expect(response).toEqual({
-            body: ["string", "string"],
+            body: rawResponseBody,
             ok: true,
             headers: expect.any(Object),
             rawResponse: expect.any(Object),
@@ -52,14 +52,7 @@ describe("ContainerClient", () => {
             },
         ]);
         expect(response).toEqual({
-            body: [
-                {
-                    string: "string",
-                },
-                {
-                    string: "string",
-                },
-            ],
+            body: rawResponseBody,
             ok: true,
             headers: expect.any(Object),
             rawResponse: expect.any(Object),
@@ -83,7 +76,7 @@ describe("ContainerClient", () => {
 
         const response = await client.endpoints.container.getAndReturnSetOfPrimitives(["string"]);
         expect(response).toEqual({
-            body: ["string"],
+            body: rawResponseBody,
             ok: true,
             headers: expect.any(Object),
             rawResponse: expect.any(Object),
@@ -111,11 +104,7 @@ describe("ContainerClient", () => {
             },
         ]);
         expect(response).toEqual({
-            body: [
-                {
-                    string: "string",
-                },
-            ],
+            body: rawResponseBody,
             ok: true,
             headers: expect.any(Object),
             rawResponse: expect.any(Object),
@@ -141,9 +130,7 @@ describe("ContainerClient", () => {
             string: "string",
         });
         expect(response).toEqual({
-            body: {
-                string: "string",
-            },
+            body: rawResponseBody,
             ok: true,
             headers: expect.any(Object),
             rawResponse: expect.any(Object),
@@ -171,11 +158,7 @@ describe("ContainerClient", () => {
             },
         });
         expect(response).toEqual({
-            body: {
-                string: {
-                    string: "string",
-                },
-            },
+            body: rawResponseBody,
             ok: true,
             headers: expect.any(Object),
             rawResponse: expect.any(Object),
@@ -201,9 +184,7 @@ describe("ContainerClient", () => {
             string: 1.1,
         });
         expect(response).toEqual({
-            body: {
-                string: 1.1,
-            },
+            body: rawResponseBody,
             ok: true,
             headers: expect.any(Object),
             rawResponse: expect.any(Object),
@@ -229,9 +210,7 @@ describe("ContainerClient", () => {
             string: "string",
         });
         expect(response).toEqual({
-            body: {
-                string: "string",
-            },
+            body: rawResponseBody,
             ok: true,
             headers: expect.any(Object),
             rawResponse: expect.any(Object),

--- a/seed/ts-sdk/exhaustive/never-throw-errors/tests/wire/endpoints/enum.test.ts
+++ b/seed/ts-sdk/exhaustive/never-throw-errors/tests/wire/endpoints/enum.test.ts
@@ -21,7 +21,7 @@ describe("EnumClient", () => {
 
         const response = await client.endpoints.enum.getAndReturnEnum("SUNNY");
         expect(response).toEqual({
-            body: "SUNNY",
+            body: rawResponseBody,
             ok: true,
             headers: expect.any(Object),
             rawResponse: expect.any(Object),

--- a/seed/ts-sdk/exhaustive/never-throw-errors/tests/wire/endpoints/httpMethods.test.ts
+++ b/seed/ts-sdk/exhaustive/never-throw-errors/tests/wire/endpoints/httpMethods.test.ts
@@ -14,7 +14,7 @@ describe("HttpMethodsClient", () => {
 
         const response = await client.endpoints.httpMethods.testGet("id");
         expect(response).toEqual({
-            body: "string",
+            body: rawResponseBody,
             ok: true,
             headers: expect.any(Object),
             rawResponse: expect.any(Object),
@@ -54,23 +54,7 @@ describe("HttpMethodsClient", () => {
             string: "string",
         });
         expect(response).toEqual({
-            body: {
-                string: "string",
-                integer: 1,
-                long: 1000000,
-                double: 1.1,
-                bool: true,
-                datetime: "2024-01-15T09:30:00Z",
-                date: "2023-01-15",
-                uuid: "d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32",
-                base64: "SGVsbG8gd29ybGQh",
-                list: ["list", "list"],
-                set: ["set"],
-                map: {
-                    1: "map",
-                },
-                bigint: "1000000",
-            },
+            body: rawResponseBody,
             ok: true,
             headers: expect.any(Object),
             rawResponse: expect.any(Object),
@@ -110,23 +94,7 @@ describe("HttpMethodsClient", () => {
             string: "string",
         });
         expect(response).toEqual({
-            body: {
-                string: "string",
-                integer: 1,
-                long: 1000000,
-                double: 1.1,
-                bool: true,
-                datetime: "2024-01-15T09:30:00Z",
-                date: "2023-01-15",
-                uuid: "d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32",
-                base64: "SGVsbG8gd29ybGQh",
-                list: ["list", "list"],
-                set: ["set"],
-                map: {
-                    1: "map",
-                },
-                bigint: "1000000",
-            },
+            body: rawResponseBody,
             ok: true,
             headers: expect.any(Object),
             rawResponse: expect.any(Object),
@@ -194,23 +162,7 @@ describe("HttpMethodsClient", () => {
             bigint: "1000000",
         });
         expect(response).toEqual({
-            body: {
-                string: "string",
-                integer: 1,
-                long: 1000000,
-                double: 1.1,
-                bool: true,
-                datetime: "2024-01-15T09:30:00Z",
-                date: "2023-01-15",
-                uuid: "d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32",
-                base64: "SGVsbG8gd29ybGQh",
-                list: ["list", "list"],
-                set: ["set"],
-                map: {
-                    1: "map",
-                },
-                bigint: "1000000",
-            },
+            body: rawResponseBody,
             ok: true,
             headers: expect.any(Object),
             rawResponse: expect.any(Object),
@@ -233,7 +185,7 @@ describe("HttpMethodsClient", () => {
 
         const response = await client.endpoints.httpMethods.testDelete("id");
         expect(response).toEqual({
-            body: true,
+            body: rawResponseBody,
             ok: true,
             headers: expect.any(Object),
             rawResponse: expect.any(Object),

--- a/seed/ts-sdk/exhaustive/never-throw-errors/tests/wire/endpoints/object.test.ts
+++ b/seed/ts-sdk/exhaustive/never-throw-errors/tests/wire/endpoints/object.test.ts
@@ -65,23 +65,7 @@ describe("ObjectClient", () => {
             bigint: "1000000",
         });
         expect(response).toEqual({
-            body: {
-                string: "string",
-                integer: 1,
-                long: 1000000,
-                double: 1.1,
-                bool: true,
-                datetime: "2024-01-15T09:30:00Z",
-                date: "2023-01-15",
-                uuid: "d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32",
-                base64: "SGVsbG8gd29ybGQh",
-                list: ["list", "list"],
-                set: ["set"],
-                map: {
-                    1: "map",
-                },
-                bigint: "1000000",
-            },
+            body: rawResponseBody,
             ok: true,
             headers: expect.any(Object),
             rawResponse: expect.any(Object),
@@ -107,9 +91,7 @@ describe("ObjectClient", () => {
             string: "string",
         });
         expect(response).toEqual({
-            body: {
-                string: "string",
-            },
+            body: rawResponseBody,
             ok: true,
             headers: expect.any(Object),
             rawResponse: expect.any(Object),
@@ -139,13 +121,7 @@ describe("ObjectClient", () => {
             },
         });
         expect(response).toEqual({
-            body: {
-                map: {
-                    map: {
-                        map: "map",
-                    },
-                },
-            },
+            body: rawResponseBody,
             ok: true,
             headers: expect.any(Object),
             rawResponse: expect.any(Object),
@@ -222,26 +198,7 @@ describe("ObjectClient", () => {
             },
         });
         expect(response).toEqual({
-            body: {
-                string: "string",
-                NestedObject: {
-                    string: "string",
-                    integer: 1,
-                    long: 1000000,
-                    double: 1.1,
-                    bool: true,
-                    datetime: "2024-01-15T09:30:00Z",
-                    date: "2023-01-15",
-                    uuid: "d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32",
-                    base64: "SGVsbG8gd29ybGQh",
-                    list: ["list", "list"],
-                    set: ["set"],
-                    map: {
-                        1: "map",
-                    },
-                    bigint: "1000000",
-                },
-            },
+            body: rawResponseBody,
             ok: true,
             headers: expect.any(Object),
             rawResponse: expect.any(Object),
@@ -318,26 +275,7 @@ describe("ObjectClient", () => {
             },
         });
         expect(response).toEqual({
-            body: {
-                string: "string",
-                NestedObject: {
-                    string: "string",
-                    integer: 1,
-                    long: 1000000,
-                    double: 1.1,
-                    bool: true,
-                    datetime: "2024-01-15T09:30:00Z",
-                    date: "2023-01-15",
-                    uuid: "d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32",
-                    base64: "SGVsbG8gd29ybGQh",
-                    list: ["list", "list"],
-                    set: ["set"],
-                    map: {
-                        1: "map",
-                    },
-                    bigint: "1000000",
-                },
-            },
+            body: rawResponseBody,
             ok: true,
             headers: expect.any(Object),
             rawResponse: expect.any(Object),
@@ -456,26 +394,7 @@ describe("ObjectClient", () => {
             },
         ]);
         expect(response).toEqual({
-            body: {
-                string: "string",
-                NestedObject: {
-                    string: "string",
-                    integer: 1,
-                    long: 1000000,
-                    double: 1.1,
-                    bool: true,
-                    datetime: "2024-01-15T09:30:00Z",
-                    date: "2023-01-15",
-                    uuid: "d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32",
-                    base64: "SGVsbG8gd29ybGQh",
-                    list: ["list", "list"],
-                    set: ["set"],
-                    map: {
-                        1: "map",
-                    },
-                    bigint: "1000000",
-                },
-            },
+            body: rawResponseBody,
             ok: true,
             headers: expect.any(Object),
             rawResponse: expect.any(Object),
@@ -503,11 +422,7 @@ describe("ObjectClient", () => {
             },
         });
         expect(response).toEqual({
-            body: {
-                unknown: {
-                    $ref: "https://example.com/schema",
-                },
-            },
+            body: rawResponseBody,
             ok: true,
             headers: expect.any(Object),
             rawResponse: expect.any(Object),
@@ -535,11 +450,7 @@ describe("ObjectClient", () => {
             },
         });
         expect(response).toEqual({
-            body: {
-                documentedUnknownType: {
-                    key: "value",
-                },
-            },
+            body: rawResponseBody,
             ok: true,
             headers: expect.any(Object),
             rawResponse: expect.any(Object),
@@ -567,11 +478,7 @@ describe("ObjectClient", () => {
             },
         });
         expect(response).toEqual({
-            body: {
-                string: {
-                    key: "value",
-                },
-            },
+            body: rawResponseBody,
             ok: true,
             headers: expect.any(Object),
             rawResponse: expect.any(Object),
@@ -598,10 +505,7 @@ describe("ObjectClient", () => {
             actualDatetime: "2023-08-31T14:15:22Z",
         });
         expect(response).toEqual({
-            body: {
-                datetimeLikeString: "2023-08-31T14:15:22Z",
-                actualDatetime: "2023-08-31T14:15:22Z",
-            },
+            body: rawResponseBody,
             ok: true,
             headers: expect.any(Object),
             rawResponse: expect.any(Object),

--- a/seed/ts-sdk/exhaustive/never-throw-errors/tests/wire/endpoints/pagination.test.ts
+++ b/seed/ts-sdk/exhaustive/never-throw-errors/tests/wire/endpoints/pagination.test.ts
@@ -19,17 +19,7 @@ describe("PaginationClient", () => {
             .build();
 
         const expected = {
-            body: {
-                items: [
-                    {
-                        string: "string",
-                    },
-                    {
-                        string: "string",
-                    },
-                ],
-                next: "next",
-            },
+            body: rawResponseBody,
             ok: true,
             headers: expect.any(Object),
             rawResponse: expect.any(Object),

--- a/seed/ts-sdk/exhaustive/never-throw-errors/tests/wire/endpoints/params.test.ts
+++ b/seed/ts-sdk/exhaustive/never-throw-errors/tests/wire/endpoints/params.test.ts
@@ -14,7 +14,7 @@ describe("ParamsClient", () => {
 
         const response = await client.endpoints.params.getWithPath("param");
         expect(response).toEqual({
-            body: "string",
+            body: rawResponseBody,
             ok: true,
             headers: expect.any(Object),
             rawResponse: expect.any(Object),
@@ -33,7 +33,7 @@ describe("ParamsClient", () => {
             param: "param",
         });
         expect(response).toEqual({
-            body: "string",
+            body: rawResponseBody,
             ok: true,
             headers: expect.any(Object),
             rawResponse: expect.any(Object),
@@ -128,7 +128,7 @@ describe("ParamsClient", () => {
 
         const response = await client.endpoints.params.modifyWithPath("param", "string");
         expect(response).toEqual({
-            body: "string",
+            body: rawResponseBody,
             ok: true,
             headers: expect.any(Object),
             rawResponse: expect.any(Object),
@@ -155,7 +155,7 @@ describe("ParamsClient", () => {
             body: "string",
         });
         expect(response).toEqual({
-            body: "string",
+            body: rawResponseBody,
             ok: true,
             headers: expect.any(Object),
             rawResponse: expect.any(Object),
@@ -172,7 +172,7 @@ describe("ParamsClient", () => {
 
         const response = await client.endpoints.params.getWithPathAndErrors("param");
         expect(response).toEqual({
-            body: "string",
+            body: rawResponseBody,
             ok: true,
             headers: expect.any(Object),
             rawResponse: expect.any(Object),

--- a/seed/ts-sdk/exhaustive/never-throw-errors/tests/wire/endpoints/primitive.test.ts
+++ b/seed/ts-sdk/exhaustive/never-throw-errors/tests/wire/endpoints/primitive.test.ts
@@ -21,7 +21,7 @@ describe("PrimitiveClient", () => {
 
         const response = await client.endpoints.primitive.getAndReturnString("string");
         expect(response).toEqual({
-            body: "string",
+            body: rawResponseBody,
             ok: true,
             headers: expect.any(Object),
             rawResponse: expect.any(Object),
@@ -45,7 +45,7 @@ describe("PrimitiveClient", () => {
 
         const response = await client.endpoints.primitive.getAndReturnInt(1);
         expect(response).toEqual({
-            body: 1,
+            body: rawResponseBody,
             ok: true,
             headers: expect.any(Object),
             rawResponse: expect.any(Object),
@@ -69,7 +69,7 @@ describe("PrimitiveClient", () => {
 
         const response = await client.endpoints.primitive.getAndReturnLong(1000000);
         expect(response).toEqual({
-            body: 1000000,
+            body: rawResponseBody,
             ok: true,
             headers: expect.any(Object),
             rawResponse: expect.any(Object),
@@ -93,7 +93,7 @@ describe("PrimitiveClient", () => {
 
         const response = await client.endpoints.primitive.getAndReturnDouble(1.1);
         expect(response).toEqual({
-            body: 1.1,
+            body: rawResponseBody,
             ok: true,
             headers: expect.any(Object),
             rawResponse: expect.any(Object),
@@ -117,7 +117,7 @@ describe("PrimitiveClient", () => {
 
         const response = await client.endpoints.primitive.getAndReturnBool(true);
         expect(response).toEqual({
-            body: true,
+            body: rawResponseBody,
             ok: true,
             headers: expect.any(Object),
             rawResponse: expect.any(Object),
@@ -141,7 +141,7 @@ describe("PrimitiveClient", () => {
 
         const response = await client.endpoints.primitive.getAndReturnDatetime("2024-01-15T09:30:00Z");
         expect(response).toEqual({
-            body: "2024-01-15T09:30:00Z",
+            body: rawResponseBody,
             ok: true,
             headers: expect.any(Object),
             rawResponse: expect.any(Object),
@@ -165,7 +165,7 @@ describe("PrimitiveClient", () => {
 
         const response = await client.endpoints.primitive.getAndReturnDate("2023-01-15");
         expect(response).toEqual({
-            body: "2023-01-15",
+            body: rawResponseBody,
             ok: true,
             headers: expect.any(Object),
             rawResponse: expect.any(Object),
@@ -189,7 +189,7 @@ describe("PrimitiveClient", () => {
 
         const response = await client.endpoints.primitive.getAndReturnUuid("d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32");
         expect(response).toEqual({
-            body: "d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32",
+            body: rawResponseBody,
             ok: true,
             headers: expect.any(Object),
             rawResponse: expect.any(Object),
@@ -213,7 +213,7 @@ describe("PrimitiveClient", () => {
 
         const response = await client.endpoints.primitive.getAndReturnBase64("SGVsbG8gd29ybGQh");
         expect(response).toEqual({
-            body: "SGVsbG8gd29ybGQh",
+            body: rawResponseBody,
             ok: true,
             headers: expect.any(Object),
             rawResponse: expect.any(Object),

--- a/seed/ts-sdk/exhaustive/never-throw-errors/tests/wire/endpoints/put.test.ts
+++ b/seed/ts-sdk/exhaustive/never-throw-errors/tests/wire/endpoints/put.test.ts
@@ -21,22 +21,7 @@ describe("PutClient", () => {
             id: "id",
         });
         expect(response).toEqual({
-            body: {
-                errors: [
-                    {
-                        category: "API_ERROR",
-                        code: "INTERNAL_SERVER_ERROR",
-                        detail: "detail",
-                        field: "field",
-                    },
-                    {
-                        category: "API_ERROR",
-                        code: "INTERNAL_SERVER_ERROR",
-                        detail: "detail",
-                        field: "field",
-                    },
-                ],
-            },
+            body: rawResponseBody,
             ok: true,
             headers: expect.any(Object),
             rawResponse: expect.any(Object),

--- a/seed/ts-sdk/exhaustive/never-throw-errors/tests/wire/endpoints/union.test.ts
+++ b/seed/ts-sdk/exhaustive/never-throw-errors/tests/wire/endpoints/union.test.ts
@@ -25,11 +25,7 @@ describe("UnionClient", () => {
             likesToWoof: true,
         });
         expect(response).toEqual({
-            body: {
-                animal: "dog",
-                name: "name",
-                likesToWoof: true,
-            },
+            body: rawResponseBody,
             ok: true,
             headers: expect.any(Object),
             rawResponse: expect.any(Object),

--- a/seed/ts-sdk/exhaustive/never-throw-errors/tests/wire/endpoints/urls.test.ts
+++ b/seed/ts-sdk/exhaustive/never-throw-errors/tests/wire/endpoints/urls.test.ts
@@ -14,7 +14,7 @@ describe("UrlsClient", () => {
 
         const response = await client.endpoints.urls.withMixedCase();
         expect(response).toEqual({
-            body: "string",
+            body: rawResponseBody,
             ok: true,
             headers: expect.any(Object),
             rawResponse: expect.any(Object),
@@ -37,7 +37,7 @@ describe("UrlsClient", () => {
 
         const response = await client.endpoints.urls.noEndingSlash();
         expect(response).toEqual({
-            body: "string",
+            body: rawResponseBody,
             ok: true,
             headers: expect.any(Object),
             rawResponse: expect.any(Object),
@@ -60,7 +60,7 @@ describe("UrlsClient", () => {
 
         const response = await client.endpoints.urls.withEndingSlash();
         expect(response).toEqual({
-            body: "string",
+            body: rawResponseBody,
             ok: true,
             headers: expect.any(Object),
             rawResponse: expect.any(Object),
@@ -83,7 +83,7 @@ describe("UrlsClient", () => {
 
         const response = await client.endpoints.urls.withUnderscores();
         expect(response).toEqual({
-            body: "string",
+            body: rawResponseBody,
             ok: true,
             headers: expect.any(Object),
             rawResponse: expect.any(Object),

--- a/seed/ts-sdk/exhaustive/never-throw-errors/tests/wire/inlinedRequests.test.ts
+++ b/seed/ts-sdk/exhaustive/never-throw-errors/tests/wire/inlinedRequests.test.ts
@@ -73,23 +73,7 @@ describe("InlinedRequestsClient", () => {
             },
         });
         expect(response).toEqual({
-            body: {
-                string: "string",
-                integer: 1,
-                long: 1000000,
-                double: 1.1,
-                bool: true,
-                datetime: "2024-01-15T09:30:00Z",
-                date: "2023-01-15",
-                uuid: "d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32",
-                base64: "SGVsbG8gd29ybGQh",
-                list: ["list", "list"],
-                set: ["set"],
-                map: {
-                    1: "map",
-                },
-                bigint: "1000000",
-            },
+            body: rawResponseBody,
             ok: true,
             headers: expect.any(Object),
             rawResponse: expect.any(Object),

--- a/seed/ts-sdk/exhaustive/never-throw-errors/tests/wire/noAuth.test.ts
+++ b/seed/ts-sdk/exhaustive/never-throw-errors/tests/wire/noAuth.test.ts
@@ -23,7 +23,7 @@ describe("NoAuthClient", () => {
             key: "value",
         });
         expect(response).toEqual({
-            body: true,
+            body: rawResponseBody,
             ok: true,
             headers: expect.any(Object),
             rawResponse: expect.any(Object),

--- a/seed/ts-sdk/exhaustive/never-throw-errors/tests/wire/noReqBody.test.ts
+++ b/seed/ts-sdk/exhaustive/never-throw-errors/tests/wire/noReqBody.test.ts
@@ -28,23 +28,7 @@ describe("NoReqBodyClient", () => {
 
         const response = await client.noReqBody.getWithNoRequestBody();
         expect(response).toEqual({
-            body: {
-                string: "string",
-                integer: 1,
-                long: 1000000,
-                double: 1.1,
-                bool: true,
-                datetime: "2024-01-15T09:30:00Z",
-                date: "2023-01-15",
-                uuid: "d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32",
-                base64: "SGVsbG8gd29ybGQh",
-                list: ["list", "list"],
-                set: ["set"],
-                map: {
-                    1: "map",
-                },
-                bigint: "1000000",
-            },
+            body: rawResponseBody,
             ok: true,
             headers: expect.any(Object),
             rawResponse: expect.any(Object),
@@ -61,7 +45,7 @@ describe("NoReqBodyClient", () => {
 
         const response = await client.noReqBody.postWithNoRequestBody();
         expect(response).toEqual({
-            body: "string",
+            body: rawResponseBody,
             ok: true,
             headers: expect.any(Object),
             rawResponse: expect.any(Object),

--- a/seed/ts-sdk/exhaustive/no-custom-config/tests/wire/endpoints/container.test.ts
+++ b/seed/ts-sdk/exhaustive/no-custom-config/tests/wire/endpoints/container.test.ts
@@ -20,7 +20,7 @@ describe("ContainerClient", () => {
             .build();
 
         const response = await client.endpoints.container.getAndReturnListOfPrimitives(["string", "string"]);
-        expect(response).toEqual(["string", "string"]);
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnListOfObjects", async () => {
@@ -46,14 +46,7 @@ describe("ContainerClient", () => {
                 string: "string",
             },
         ]);
-        expect(response).toEqual([
-            {
-                string: "string",
-            },
-            {
-                string: "string",
-            },
-        ]);
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnSetOfPrimitives", async () => {
@@ -72,7 +65,7 @@ describe("ContainerClient", () => {
             .build();
 
         const response = await client.endpoints.container.getAndReturnSetOfPrimitives(["string"]);
-        expect(response).toEqual(["string"]);
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnSetOfObjects", async () => {
@@ -95,11 +88,7 @@ describe("ContainerClient", () => {
                 string: "string",
             },
         ]);
-        expect(response).toEqual([
-            {
-                string: "string",
-            },
-        ]);
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnMapPrimToPrim", async () => {
@@ -120,9 +109,7 @@ describe("ContainerClient", () => {
         const response = await client.endpoints.container.getAndReturnMapPrimToPrim({
             string: "string",
         });
-        expect(response).toEqual({
-            string: "string",
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnMapOfPrimToObject", async () => {
@@ -145,11 +132,7 @@ describe("ContainerClient", () => {
                 string: "string",
             },
         });
-        expect(response).toEqual({
-            string: {
-                string: "string",
-            },
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnMapOfPrimToUndiscriminatedUnion", async () => {
@@ -170,9 +153,7 @@ describe("ContainerClient", () => {
         const response = await client.endpoints.container.getAndReturnMapOfPrimToUndiscriminatedUnion({
             string: 1.1,
         });
-        expect(response).toEqual({
-            string: 1.1,
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnOptional", async () => {
@@ -193,8 +174,6 @@ describe("ContainerClient", () => {
         const response = await client.endpoints.container.getAndReturnOptional({
             string: "string",
         });
-        expect(response).toEqual({
-            string: "string",
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 });

--- a/seed/ts-sdk/exhaustive/no-custom-config/tests/wire/endpoints/enum.test.ts
+++ b/seed/ts-sdk/exhaustive/no-custom-config/tests/wire/endpoints/enum.test.ts
@@ -20,6 +20,6 @@ describe("EnumClient", () => {
             .build();
 
         const response = await client.endpoints.enum.getAndReturnEnum("SUNNY");
-        expect(response).toEqual("SUNNY");
+        expect(response).toEqual(rawResponseBody);
     });
 });

--- a/seed/ts-sdk/exhaustive/no-custom-config/tests/wire/endpoints/httpMethods.test.ts
+++ b/seed/ts-sdk/exhaustive/no-custom-config/tests/wire/endpoints/httpMethods.test.ts
@@ -13,7 +13,7 @@ describe("HttpMethodsClient", () => {
         server.mockEndpoint().get("/http-methods/id").respondWith().statusCode(200).jsonBody(rawResponseBody).build();
 
         const response = await client.endpoints.httpMethods.testGet("id");
-        expect(response).toEqual("string");
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("testPost", async () => {
@@ -48,23 +48,7 @@ describe("HttpMethodsClient", () => {
         const response = await client.endpoints.httpMethods.testPost({
             string: "string",
         });
-        expect(response).toEqual({
-            string: "string",
-            integer: 1,
-            long: 1000000,
-            double: 1.1,
-            bool: true,
-            datetime: "2024-01-15T09:30:00Z",
-            date: "2023-01-15",
-            uuid: "d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32",
-            base64: "SGVsbG8gd29ybGQh",
-            list: ["list", "list"],
-            set: ["set"],
-            map: {
-                1: "map",
-            },
-            bigint: "1000000",
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("testPut", async () => {
@@ -99,23 +83,7 @@ describe("HttpMethodsClient", () => {
         const response = await client.endpoints.httpMethods.testPut("id", {
             string: "string",
         });
-        expect(response).toEqual({
-            string: "string",
-            integer: 1,
-            long: 1000000,
-            double: 1.1,
-            bool: true,
-            datetime: "2024-01-15T09:30:00Z",
-            date: "2023-01-15",
-            uuid: "d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32",
-            base64: "SGVsbG8gd29ybGQh",
-            list: ["list", "list"],
-            set: ["set"],
-            map: {
-                1: "map",
-            },
-            bigint: "1000000",
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("testPatch", async () => {
@@ -178,23 +146,7 @@ describe("HttpMethodsClient", () => {
             },
             bigint: "1000000",
         });
-        expect(response).toEqual({
-            string: "string",
-            integer: 1,
-            long: 1000000,
-            double: 1.1,
-            bool: true,
-            datetime: "2024-01-15T09:30:00Z",
-            date: "2023-01-15",
-            uuid: "d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32",
-            base64: "SGVsbG8gd29ybGQh",
-            list: ["list", "list"],
-            set: ["set"],
-            map: {
-                1: "map",
-            },
-            bigint: "1000000",
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("testDelete", async () => {
@@ -212,6 +164,6 @@ describe("HttpMethodsClient", () => {
             .build();
 
         const response = await client.endpoints.httpMethods.testDelete("id");
-        expect(response).toEqual(true);
+        expect(response).toEqual(rawResponseBody);
     });
 });

--- a/seed/ts-sdk/exhaustive/no-custom-config/tests/wire/endpoints/object.test.ts
+++ b/seed/ts-sdk/exhaustive/no-custom-config/tests/wire/endpoints/object.test.ts
@@ -64,23 +64,7 @@ describe("ObjectClient", () => {
             },
             bigint: "1000000",
         });
-        expect(response).toEqual({
-            string: "string",
-            integer: 1,
-            long: 1000000,
-            double: 1.1,
-            bool: true,
-            datetime: "2024-01-15T09:30:00Z",
-            date: "2023-01-15",
-            uuid: "d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32",
-            base64: "SGVsbG8gd29ybGQh",
-            list: ["list", "list"],
-            set: ["set"],
-            map: {
-                1: "map",
-            },
-            bigint: "1000000",
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnWithRequiredField", async () => {
@@ -101,9 +85,7 @@ describe("ObjectClient", () => {
         const response = await client.endpoints.object.getAndReturnWithRequiredField({
             string: "string",
         });
-        expect(response).toEqual({
-            string: "string",
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnWithMapOfMap", async () => {
@@ -128,13 +110,7 @@ describe("ObjectClient", () => {
                 },
             },
         });
-        expect(response).toEqual({
-            map: {
-                map: {
-                    map: "map",
-                },
-            },
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnNestedWithOptionalField", async () => {
@@ -206,26 +182,7 @@ describe("ObjectClient", () => {
                 bigint: "1000000",
             },
         });
-        expect(response).toEqual({
-            string: "string",
-            NestedObject: {
-                string: "string",
-                integer: 1,
-                long: 1000000,
-                double: 1.1,
-                bool: true,
-                datetime: "2024-01-15T09:30:00Z",
-                date: "2023-01-15",
-                uuid: "d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32",
-                base64: "SGVsbG8gd29ybGQh",
-                list: ["list", "list"],
-                set: ["set"],
-                map: {
-                    1: "map",
-                },
-                bigint: "1000000",
-            },
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnNestedWithRequiredField", async () => {
@@ -297,26 +254,7 @@ describe("ObjectClient", () => {
                 bigint: "1000000",
             },
         });
-        expect(response).toEqual({
-            string: "string",
-            NestedObject: {
-                string: "string",
-                integer: 1,
-                long: 1000000,
-                double: 1.1,
-                bool: true,
-                datetime: "2024-01-15T09:30:00Z",
-                date: "2023-01-15",
-                uuid: "d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32",
-                base64: "SGVsbG8gd29ybGQh",
-                list: ["list", "list"],
-                set: ["set"],
-                map: {
-                    1: "map",
-                },
-                bigint: "1000000",
-            },
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnNestedWithRequiredFieldAsList", async () => {
@@ -430,26 +368,7 @@ describe("ObjectClient", () => {
                 },
             },
         ]);
-        expect(response).toEqual({
-            string: "string",
-            NestedObject: {
-                string: "string",
-                integer: 1,
-                long: 1000000,
-                double: 1.1,
-                bool: true,
-                datetime: "2024-01-15T09:30:00Z",
-                date: "2023-01-15",
-                uuid: "d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32",
-                base64: "SGVsbG8gd29ybGQh",
-                list: ["list", "list"],
-                set: ["set"],
-                map: {
-                    1: "map",
-                },
-                bigint: "1000000",
-            },
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnWithUnknownField", async () => {
@@ -472,11 +391,7 @@ describe("ObjectClient", () => {
                 $ref: "https://example.com/schema",
             },
         });
-        expect(response).toEqual({
-            unknown: {
-                $ref: "https://example.com/schema",
-            },
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnWithDocumentedUnknownType", async () => {
@@ -499,11 +414,7 @@ describe("ObjectClient", () => {
                 key: "value",
             },
         });
-        expect(response).toEqual({
-            documentedUnknownType: {
-                key: "value",
-            },
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnMapOfDocumentedUnknownType", async () => {
@@ -526,11 +437,7 @@ describe("ObjectClient", () => {
                 key: "value",
             },
         });
-        expect(response).toEqual({
-            string: {
-                key: "value",
-            },
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnWithDatetimeLikeString", async () => {
@@ -552,9 +459,6 @@ describe("ObjectClient", () => {
             datetimeLikeString: "2023-08-31T14:15:22Z",
             actualDatetime: "2023-08-31T14:15:22Z",
         });
-        expect(response).toEqual({
-            datetimeLikeString: "2023-08-31T14:15:22Z",
-            actualDatetime: "2023-08-31T14:15:22Z",
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 });

--- a/seed/ts-sdk/exhaustive/no-custom-config/tests/wire/endpoints/pagination.test.ts
+++ b/seed/ts-sdk/exhaustive/no-custom-config/tests/wire/endpoints/pagination.test.ts
@@ -18,17 +18,7 @@ describe("PaginationClient", () => {
             .jsonBody(rawResponseBody)
             .build();
 
-        const expected = {
-            items: [
-                {
-                    string: "string",
-                },
-                {
-                    string: "string",
-                },
-            ],
-            next: "next",
-        };
+        const expected = rawResponseBody;
         const page = await client.endpoints.pagination.listItems({
             cursor: "cursor",
             limit: 1,

--- a/seed/ts-sdk/exhaustive/no-custom-config/tests/wire/endpoints/params.test.ts
+++ b/seed/ts-sdk/exhaustive/no-custom-config/tests/wire/endpoints/params.test.ts
@@ -14,7 +14,7 @@ describe("ParamsClient", () => {
         server.mockEndpoint().get("/params/path/param").respondWith().statusCode(200).jsonBody(rawResponseBody).build();
 
         const response = await client.endpoints.params.getWithPath("param");
-        expect(response).toEqual("string");
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getWithInlinePath", async () => {
@@ -28,7 +28,7 @@ describe("ParamsClient", () => {
         const response = await client.endpoints.params.getWithInlinePath({
             param: "param",
         });
-        expect(response).toEqual("string");
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getWithQuery", async () => {
@@ -98,7 +98,7 @@ describe("ParamsClient", () => {
             .build();
 
         const response = await client.endpoints.params.modifyWithPath("param", "string");
-        expect(response).toEqual("string");
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("modifyWithInlinePath", async () => {
@@ -120,7 +120,7 @@ describe("ParamsClient", () => {
             param: "param",
             body: "string",
         });
-        expect(response).toEqual("string");
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getWithPathAndErrors (1)", async () => {
@@ -132,7 +132,7 @@ describe("ParamsClient", () => {
         server.mockEndpoint().get("/params/path/param").respondWith().statusCode(200).jsonBody(rawResponseBody).build();
 
         const response = await client.endpoints.params.getWithPathAndErrors("param");
-        expect(response).toEqual("string");
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getWithPathAndErrors (2)", async () => {

--- a/seed/ts-sdk/exhaustive/no-custom-config/tests/wire/endpoints/primitive.test.ts
+++ b/seed/ts-sdk/exhaustive/no-custom-config/tests/wire/endpoints/primitive.test.ts
@@ -20,7 +20,7 @@ describe("PrimitiveClient", () => {
             .build();
 
         const response = await client.endpoints.primitive.getAndReturnString("string");
-        expect(response).toEqual("string");
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnInt", async () => {
@@ -39,7 +39,7 @@ describe("PrimitiveClient", () => {
             .build();
 
         const response = await client.endpoints.primitive.getAndReturnInt(1);
-        expect(response).toEqual(1);
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnLong", async () => {
@@ -58,7 +58,7 @@ describe("PrimitiveClient", () => {
             .build();
 
         const response = await client.endpoints.primitive.getAndReturnLong(1000000);
-        expect(response).toEqual(1000000);
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnDouble", async () => {
@@ -77,7 +77,7 @@ describe("PrimitiveClient", () => {
             .build();
 
         const response = await client.endpoints.primitive.getAndReturnDouble(1.1);
-        expect(response).toEqual(1.1);
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnBool", async () => {
@@ -96,7 +96,7 @@ describe("PrimitiveClient", () => {
             .build();
 
         const response = await client.endpoints.primitive.getAndReturnBool(true);
-        expect(response).toEqual(true);
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnDatetime", async () => {
@@ -115,7 +115,7 @@ describe("PrimitiveClient", () => {
             .build();
 
         const response = await client.endpoints.primitive.getAndReturnDatetime("2024-01-15T09:30:00Z");
-        expect(response).toEqual("2024-01-15T09:30:00Z");
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnDate", async () => {
@@ -134,7 +134,7 @@ describe("PrimitiveClient", () => {
             .build();
 
         const response = await client.endpoints.primitive.getAndReturnDate("2023-01-15");
-        expect(response).toEqual("2023-01-15");
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnUUID", async () => {
@@ -153,7 +153,7 @@ describe("PrimitiveClient", () => {
             .build();
 
         const response = await client.endpoints.primitive.getAndReturnUuid("d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32");
-        expect(response).toEqual("d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32");
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnBase64", async () => {
@@ -172,6 +172,6 @@ describe("PrimitiveClient", () => {
             .build();
 
         const response = await client.endpoints.primitive.getAndReturnBase64("SGVsbG8gd29ybGQh");
-        expect(response).toEqual("SGVsbG8gd29ybGQh");
+        expect(response).toEqual(rawResponseBody);
     });
 });

--- a/seed/ts-sdk/exhaustive/no-custom-config/tests/wire/endpoints/put.test.ts
+++ b/seed/ts-sdk/exhaustive/no-custom-config/tests/wire/endpoints/put.test.ts
@@ -20,21 +20,6 @@ describe("PutClient", () => {
         const response = await client.endpoints.put.add({
             id: "id",
         });
-        expect(response).toEqual({
-            errors: [
-                {
-                    category: "API_ERROR",
-                    code: "INTERNAL_SERVER_ERROR",
-                    detail: "detail",
-                    field: "field",
-                },
-                {
-                    category: "API_ERROR",
-                    code: "INTERNAL_SERVER_ERROR",
-                    detail: "detail",
-                    field: "field",
-                },
-            ],
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 });

--- a/seed/ts-sdk/exhaustive/no-custom-config/tests/wire/endpoints/union.test.ts
+++ b/seed/ts-sdk/exhaustive/no-custom-config/tests/wire/endpoints/union.test.ts
@@ -24,10 +24,6 @@ describe("UnionClient", () => {
             name: "name",
             likesToWoof: true,
         });
-        expect(response).toEqual({
-            animal: "dog",
-            name: "name",
-            likesToWoof: true,
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 });

--- a/seed/ts-sdk/exhaustive/no-custom-config/tests/wire/endpoints/urls.test.ts
+++ b/seed/ts-sdk/exhaustive/no-custom-config/tests/wire/endpoints/urls.test.ts
@@ -13,7 +13,7 @@ describe("UrlsClient", () => {
         server.mockEndpoint().get("/urls/MixedCase").respondWith().statusCode(200).jsonBody(rawResponseBody).build();
 
         const response = await client.endpoints.urls.withMixedCase();
-        expect(response).toEqual("string");
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("noEndingSlash", async () => {
@@ -31,7 +31,7 @@ describe("UrlsClient", () => {
             .build();
 
         const response = await client.endpoints.urls.noEndingSlash();
-        expect(response).toEqual("string");
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("withEndingSlash", async () => {
@@ -49,7 +49,7 @@ describe("UrlsClient", () => {
             .build();
 
         const response = await client.endpoints.urls.withEndingSlash();
-        expect(response).toEqual("string");
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("withUnderscores", async () => {
@@ -67,6 +67,6 @@ describe("UrlsClient", () => {
             .build();
 
         const response = await client.endpoints.urls.withUnderscores();
-        expect(response).toEqual("string");
+        expect(response).toEqual(rawResponseBody);
     });
 });

--- a/seed/ts-sdk/exhaustive/no-custom-config/tests/wire/inlinedRequests.test.ts
+++ b/seed/ts-sdk/exhaustive/no-custom-config/tests/wire/inlinedRequests.test.ts
@@ -73,23 +73,7 @@ describe("InlinedRequestsClient", () => {
                 bigint: "1000000",
             },
         });
-        expect(response).toEqual({
-            string: "string",
-            integer: 1,
-            long: 1000000,
-            double: 1.1,
-            bool: true,
-            datetime: "2024-01-15T09:30:00Z",
-            date: "2023-01-15",
-            uuid: "d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32",
-            base64: "SGVsbG8gd29ybGQh",
-            list: ["list", "list"],
-            set: ["set"],
-            map: {
-                1: "map",
-            },
-            bigint: "1000000",
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("postWithObjectBodyandResponse (2)", async () => {

--- a/seed/ts-sdk/exhaustive/no-custom-config/tests/wire/noAuth.test.ts
+++ b/seed/ts-sdk/exhaustive/no-custom-config/tests/wire/noAuth.test.ts
@@ -23,7 +23,7 @@ describe("NoAuthClient", () => {
         const response = await client.noAuth.postWithNoAuth({
             key: "value",
         });
-        expect(response).toEqual(true);
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("postWithNoAuth (2)", async () => {

--- a/seed/ts-sdk/exhaustive/no-custom-config/tests/wire/noReqBody.test.ts
+++ b/seed/ts-sdk/exhaustive/no-custom-config/tests/wire/noReqBody.test.ts
@@ -27,23 +27,7 @@ describe("NoReqBodyClient", () => {
         server.mockEndpoint().get("/no-req-body").respondWith().statusCode(200).jsonBody(rawResponseBody).build();
 
         const response = await client.noReqBody.getWithNoRequestBody();
-        expect(response).toEqual({
-            string: "string",
-            integer: 1,
-            long: 1000000,
-            double: 1.1,
-            bool: true,
-            datetime: "2024-01-15T09:30:00Z",
-            date: "2023-01-15",
-            uuid: "d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32",
-            base64: "SGVsbG8gd29ybGQh",
-            list: ["list", "list"],
-            set: ["set"],
-            map: {
-                1: "map",
-            },
-            bigint: "1000000",
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("postWithNoRequestBody", async () => {
@@ -55,6 +39,6 @@ describe("NoReqBodyClient", () => {
         server.mockEndpoint().post("/no-req-body").respondWith().statusCode(200).jsonBody(rawResponseBody).build();
 
         const response = await client.noReqBody.postWithNoRequestBody();
-        expect(response).toEqual("string");
+        expect(response).toEqual(rawResponseBody);
     });
 });

--- a/seed/ts-sdk/exhaustive/node-fetch/tests/wire/endpoints/container.test.ts
+++ b/seed/ts-sdk/exhaustive/node-fetch/tests/wire/endpoints/container.test.ts
@@ -20,7 +20,7 @@ describe("ContainerClient", () => {
             .build();
 
         const response = await client.endpoints.container.getAndReturnListOfPrimitives(["string", "string"]);
-        expect(response).toEqual(["string", "string"]);
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnListOfObjects", async () => {
@@ -46,14 +46,7 @@ describe("ContainerClient", () => {
                 string: "string",
             },
         ]);
-        expect(response).toEqual([
-            {
-                string: "string",
-            },
-            {
-                string: "string",
-            },
-        ]);
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnSetOfPrimitives", async () => {
@@ -72,7 +65,7 @@ describe("ContainerClient", () => {
             .build();
 
         const response = await client.endpoints.container.getAndReturnSetOfPrimitives(["string"]);
-        expect(response).toEqual(["string"]);
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnSetOfObjects", async () => {
@@ -95,11 +88,7 @@ describe("ContainerClient", () => {
                 string: "string",
             },
         ]);
-        expect(response).toEqual([
-            {
-                string: "string",
-            },
-        ]);
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnMapPrimToPrim", async () => {
@@ -120,9 +109,7 @@ describe("ContainerClient", () => {
         const response = await client.endpoints.container.getAndReturnMapPrimToPrim({
             string: "string",
         });
-        expect(response).toEqual({
-            string: "string",
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnMapOfPrimToObject", async () => {
@@ -145,11 +132,7 @@ describe("ContainerClient", () => {
                 string: "string",
             },
         });
-        expect(response).toEqual({
-            string: {
-                string: "string",
-            },
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnMapOfPrimToUndiscriminatedUnion", async () => {
@@ -170,9 +153,7 @@ describe("ContainerClient", () => {
         const response = await client.endpoints.container.getAndReturnMapOfPrimToUndiscriminatedUnion({
             string: 1.1,
         });
-        expect(response).toEqual({
-            string: 1.1,
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnOptional", async () => {
@@ -193,8 +174,6 @@ describe("ContainerClient", () => {
         const response = await client.endpoints.container.getAndReturnOptional({
             string: "string",
         });
-        expect(response).toEqual({
-            string: "string",
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 });

--- a/seed/ts-sdk/exhaustive/node-fetch/tests/wire/endpoints/enum.test.ts
+++ b/seed/ts-sdk/exhaustive/node-fetch/tests/wire/endpoints/enum.test.ts
@@ -20,6 +20,6 @@ describe("EnumClient", () => {
             .build();
 
         const response = await client.endpoints.enum.getAndReturnEnum("SUNNY");
-        expect(response).toEqual("SUNNY");
+        expect(response).toEqual(rawResponseBody);
     });
 });

--- a/seed/ts-sdk/exhaustive/node-fetch/tests/wire/endpoints/httpMethods.test.ts
+++ b/seed/ts-sdk/exhaustive/node-fetch/tests/wire/endpoints/httpMethods.test.ts
@@ -13,7 +13,7 @@ describe("HttpMethodsClient", () => {
         server.mockEndpoint().get("/http-methods/id").respondWith().statusCode(200).jsonBody(rawResponseBody).build();
 
         const response = await client.endpoints.httpMethods.testGet("id");
-        expect(response).toEqual("string");
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("testPost", async () => {
@@ -48,23 +48,7 @@ describe("HttpMethodsClient", () => {
         const response = await client.endpoints.httpMethods.testPost({
             string: "string",
         });
-        expect(response).toEqual({
-            string: "string",
-            integer: 1,
-            long: 1000000,
-            double: 1.1,
-            bool: true,
-            datetime: "2024-01-15T09:30:00Z",
-            date: "2023-01-15",
-            uuid: "d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32",
-            base64: "SGVsbG8gd29ybGQh",
-            list: ["list", "list"],
-            set: ["set"],
-            map: {
-                1: "map",
-            },
-            bigint: "1000000",
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("testPut", async () => {
@@ -99,23 +83,7 @@ describe("HttpMethodsClient", () => {
         const response = await client.endpoints.httpMethods.testPut("id", {
             string: "string",
         });
-        expect(response).toEqual({
-            string: "string",
-            integer: 1,
-            long: 1000000,
-            double: 1.1,
-            bool: true,
-            datetime: "2024-01-15T09:30:00Z",
-            date: "2023-01-15",
-            uuid: "d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32",
-            base64: "SGVsbG8gd29ybGQh",
-            list: ["list", "list"],
-            set: ["set"],
-            map: {
-                1: "map",
-            },
-            bigint: "1000000",
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("testPatch", async () => {
@@ -178,23 +146,7 @@ describe("HttpMethodsClient", () => {
             },
             bigint: "1000000",
         });
-        expect(response).toEqual({
-            string: "string",
-            integer: 1,
-            long: 1000000,
-            double: 1.1,
-            bool: true,
-            datetime: "2024-01-15T09:30:00Z",
-            date: "2023-01-15",
-            uuid: "d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32",
-            base64: "SGVsbG8gd29ybGQh",
-            list: ["list", "list"],
-            set: ["set"],
-            map: {
-                1: "map",
-            },
-            bigint: "1000000",
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("testDelete", async () => {
@@ -212,6 +164,6 @@ describe("HttpMethodsClient", () => {
             .build();
 
         const response = await client.endpoints.httpMethods.testDelete("id");
-        expect(response).toEqual(true);
+        expect(response).toEqual(rawResponseBody);
     });
 });

--- a/seed/ts-sdk/exhaustive/node-fetch/tests/wire/endpoints/object.test.ts
+++ b/seed/ts-sdk/exhaustive/node-fetch/tests/wire/endpoints/object.test.ts
@@ -64,23 +64,7 @@ describe("ObjectClient", () => {
             },
             bigint: "1000000",
         });
-        expect(response).toEqual({
-            string: "string",
-            integer: 1,
-            long: 1000000,
-            double: 1.1,
-            bool: true,
-            datetime: "2024-01-15T09:30:00Z",
-            date: "2023-01-15",
-            uuid: "d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32",
-            base64: "SGVsbG8gd29ybGQh",
-            list: ["list", "list"],
-            set: ["set"],
-            map: {
-                1: "map",
-            },
-            bigint: "1000000",
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnWithRequiredField", async () => {
@@ -101,9 +85,7 @@ describe("ObjectClient", () => {
         const response = await client.endpoints.object.getAndReturnWithRequiredField({
             string: "string",
         });
-        expect(response).toEqual({
-            string: "string",
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnWithMapOfMap", async () => {
@@ -128,13 +110,7 @@ describe("ObjectClient", () => {
                 },
             },
         });
-        expect(response).toEqual({
-            map: {
-                map: {
-                    map: "map",
-                },
-            },
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnNestedWithOptionalField", async () => {
@@ -206,26 +182,7 @@ describe("ObjectClient", () => {
                 bigint: "1000000",
             },
         });
-        expect(response).toEqual({
-            string: "string",
-            NestedObject: {
-                string: "string",
-                integer: 1,
-                long: 1000000,
-                double: 1.1,
-                bool: true,
-                datetime: "2024-01-15T09:30:00Z",
-                date: "2023-01-15",
-                uuid: "d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32",
-                base64: "SGVsbG8gd29ybGQh",
-                list: ["list", "list"],
-                set: ["set"],
-                map: {
-                    1: "map",
-                },
-                bigint: "1000000",
-            },
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnNestedWithRequiredField", async () => {
@@ -297,26 +254,7 @@ describe("ObjectClient", () => {
                 bigint: "1000000",
             },
         });
-        expect(response).toEqual({
-            string: "string",
-            NestedObject: {
-                string: "string",
-                integer: 1,
-                long: 1000000,
-                double: 1.1,
-                bool: true,
-                datetime: "2024-01-15T09:30:00Z",
-                date: "2023-01-15",
-                uuid: "d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32",
-                base64: "SGVsbG8gd29ybGQh",
-                list: ["list", "list"],
-                set: ["set"],
-                map: {
-                    1: "map",
-                },
-                bigint: "1000000",
-            },
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnNestedWithRequiredFieldAsList", async () => {
@@ -430,26 +368,7 @@ describe("ObjectClient", () => {
                 },
             },
         ]);
-        expect(response).toEqual({
-            string: "string",
-            NestedObject: {
-                string: "string",
-                integer: 1,
-                long: 1000000,
-                double: 1.1,
-                bool: true,
-                datetime: "2024-01-15T09:30:00Z",
-                date: "2023-01-15",
-                uuid: "d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32",
-                base64: "SGVsbG8gd29ybGQh",
-                list: ["list", "list"],
-                set: ["set"],
-                map: {
-                    1: "map",
-                },
-                bigint: "1000000",
-            },
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnWithUnknownField", async () => {
@@ -472,11 +391,7 @@ describe("ObjectClient", () => {
                 $ref: "https://example.com/schema",
             },
         });
-        expect(response).toEqual({
-            unknown: {
-                $ref: "https://example.com/schema",
-            },
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnWithDocumentedUnknownType", async () => {
@@ -499,11 +414,7 @@ describe("ObjectClient", () => {
                 key: "value",
             },
         });
-        expect(response).toEqual({
-            documentedUnknownType: {
-                key: "value",
-            },
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnMapOfDocumentedUnknownType", async () => {
@@ -526,11 +437,7 @@ describe("ObjectClient", () => {
                 key: "value",
             },
         });
-        expect(response).toEqual({
-            string: {
-                key: "value",
-            },
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnWithDatetimeLikeString", async () => {
@@ -552,9 +459,6 @@ describe("ObjectClient", () => {
             datetimeLikeString: "2023-08-31T14:15:22Z",
             actualDatetime: "2023-08-31T14:15:22Z",
         });
-        expect(response).toEqual({
-            datetimeLikeString: "2023-08-31T14:15:22Z",
-            actualDatetime: "2023-08-31T14:15:22Z",
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 });

--- a/seed/ts-sdk/exhaustive/node-fetch/tests/wire/endpoints/pagination.test.ts
+++ b/seed/ts-sdk/exhaustive/node-fetch/tests/wire/endpoints/pagination.test.ts
@@ -18,17 +18,7 @@ describe("PaginationClient", () => {
             .jsonBody(rawResponseBody)
             .build();
 
-        const expected = {
-            items: [
-                {
-                    string: "string",
-                },
-                {
-                    string: "string",
-                },
-            ],
-            next: "next",
-        };
+        const expected = rawResponseBody;
         const page = await client.endpoints.pagination.listItems({
             cursor: "cursor",
             limit: 1,

--- a/seed/ts-sdk/exhaustive/node-fetch/tests/wire/endpoints/params.test.ts
+++ b/seed/ts-sdk/exhaustive/node-fetch/tests/wire/endpoints/params.test.ts
@@ -14,7 +14,7 @@ describe("ParamsClient", () => {
         server.mockEndpoint().get("/params/path/param").respondWith().statusCode(200).jsonBody(rawResponseBody).build();
 
         const response = await client.endpoints.params.getWithPath("param");
-        expect(response).toEqual("string");
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getWithInlinePath", async () => {
@@ -28,7 +28,7 @@ describe("ParamsClient", () => {
         const response = await client.endpoints.params.getWithInlinePath({
             param: "param",
         });
-        expect(response).toEqual("string");
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getWithQuery", async () => {
@@ -98,7 +98,7 @@ describe("ParamsClient", () => {
             .build();
 
         const response = await client.endpoints.params.modifyWithPath("param", "string");
-        expect(response).toEqual("string");
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("modifyWithInlinePath", async () => {
@@ -120,7 +120,7 @@ describe("ParamsClient", () => {
             param: "param",
             body: "string",
         });
-        expect(response).toEqual("string");
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getWithPathAndErrors (1)", async () => {
@@ -132,7 +132,7 @@ describe("ParamsClient", () => {
         server.mockEndpoint().get("/params/path/param").respondWith().statusCode(200).jsonBody(rawResponseBody).build();
 
         const response = await client.endpoints.params.getWithPathAndErrors("param");
-        expect(response).toEqual("string");
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getWithPathAndErrors (2)", async () => {

--- a/seed/ts-sdk/exhaustive/node-fetch/tests/wire/endpoints/primitive.test.ts
+++ b/seed/ts-sdk/exhaustive/node-fetch/tests/wire/endpoints/primitive.test.ts
@@ -20,7 +20,7 @@ describe("PrimitiveClient", () => {
             .build();
 
         const response = await client.endpoints.primitive.getAndReturnString("string");
-        expect(response).toEqual("string");
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnInt", async () => {
@@ -39,7 +39,7 @@ describe("PrimitiveClient", () => {
             .build();
 
         const response = await client.endpoints.primitive.getAndReturnInt(1);
-        expect(response).toEqual(1);
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnLong", async () => {
@@ -58,7 +58,7 @@ describe("PrimitiveClient", () => {
             .build();
 
         const response = await client.endpoints.primitive.getAndReturnLong(1000000);
-        expect(response).toEqual(1000000);
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnDouble", async () => {
@@ -77,7 +77,7 @@ describe("PrimitiveClient", () => {
             .build();
 
         const response = await client.endpoints.primitive.getAndReturnDouble(1.1);
-        expect(response).toEqual(1.1);
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnBool", async () => {
@@ -96,7 +96,7 @@ describe("PrimitiveClient", () => {
             .build();
 
         const response = await client.endpoints.primitive.getAndReturnBool(true);
-        expect(response).toEqual(true);
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnDatetime", async () => {
@@ -115,7 +115,7 @@ describe("PrimitiveClient", () => {
             .build();
 
         const response = await client.endpoints.primitive.getAndReturnDatetime("2024-01-15T09:30:00Z");
-        expect(response).toEqual("2024-01-15T09:30:00Z");
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnDate", async () => {
@@ -134,7 +134,7 @@ describe("PrimitiveClient", () => {
             .build();
 
         const response = await client.endpoints.primitive.getAndReturnDate("2023-01-15");
-        expect(response).toEqual("2023-01-15");
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnUUID", async () => {
@@ -153,7 +153,7 @@ describe("PrimitiveClient", () => {
             .build();
 
         const response = await client.endpoints.primitive.getAndReturnUuid("d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32");
-        expect(response).toEqual("d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32");
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnBase64", async () => {
@@ -172,6 +172,6 @@ describe("PrimitiveClient", () => {
             .build();
 
         const response = await client.endpoints.primitive.getAndReturnBase64("SGVsbG8gd29ybGQh");
-        expect(response).toEqual("SGVsbG8gd29ybGQh");
+        expect(response).toEqual(rawResponseBody);
     });
 });

--- a/seed/ts-sdk/exhaustive/node-fetch/tests/wire/endpoints/put.test.ts
+++ b/seed/ts-sdk/exhaustive/node-fetch/tests/wire/endpoints/put.test.ts
@@ -20,21 +20,6 @@ describe("PutClient", () => {
         const response = await client.endpoints.put.add({
             id: "id",
         });
-        expect(response).toEqual({
-            errors: [
-                {
-                    category: "API_ERROR",
-                    code: "INTERNAL_SERVER_ERROR",
-                    detail: "detail",
-                    field: "field",
-                },
-                {
-                    category: "API_ERROR",
-                    code: "INTERNAL_SERVER_ERROR",
-                    detail: "detail",
-                    field: "field",
-                },
-            ],
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 });

--- a/seed/ts-sdk/exhaustive/node-fetch/tests/wire/endpoints/union.test.ts
+++ b/seed/ts-sdk/exhaustive/node-fetch/tests/wire/endpoints/union.test.ts
@@ -24,10 +24,6 @@ describe("UnionClient", () => {
             name: "name",
             likesToWoof: true,
         });
-        expect(response).toEqual({
-            animal: "dog",
-            name: "name",
-            likesToWoof: true,
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 });

--- a/seed/ts-sdk/exhaustive/node-fetch/tests/wire/endpoints/urls.test.ts
+++ b/seed/ts-sdk/exhaustive/node-fetch/tests/wire/endpoints/urls.test.ts
@@ -13,7 +13,7 @@ describe("UrlsClient", () => {
         server.mockEndpoint().get("/urls/MixedCase").respondWith().statusCode(200).jsonBody(rawResponseBody).build();
 
         const response = await client.endpoints.urls.withMixedCase();
-        expect(response).toEqual("string");
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("noEndingSlash", async () => {
@@ -31,7 +31,7 @@ describe("UrlsClient", () => {
             .build();
 
         const response = await client.endpoints.urls.noEndingSlash();
-        expect(response).toEqual("string");
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("withEndingSlash", async () => {
@@ -49,7 +49,7 @@ describe("UrlsClient", () => {
             .build();
 
         const response = await client.endpoints.urls.withEndingSlash();
-        expect(response).toEqual("string");
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("withUnderscores", async () => {
@@ -67,6 +67,6 @@ describe("UrlsClient", () => {
             .build();
 
         const response = await client.endpoints.urls.withUnderscores();
-        expect(response).toEqual("string");
+        expect(response).toEqual(rawResponseBody);
     });
 });

--- a/seed/ts-sdk/exhaustive/node-fetch/tests/wire/inlinedRequests.test.ts
+++ b/seed/ts-sdk/exhaustive/node-fetch/tests/wire/inlinedRequests.test.ts
@@ -73,23 +73,7 @@ describe("InlinedRequestsClient", () => {
                 bigint: "1000000",
             },
         });
-        expect(response).toEqual({
-            string: "string",
-            integer: 1,
-            long: 1000000,
-            double: 1.1,
-            bool: true,
-            datetime: "2024-01-15T09:30:00Z",
-            date: "2023-01-15",
-            uuid: "d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32",
-            base64: "SGVsbG8gd29ybGQh",
-            list: ["list", "list"],
-            set: ["set"],
-            map: {
-                1: "map",
-            },
-            bigint: "1000000",
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("postWithObjectBodyandResponse (2)", async () => {

--- a/seed/ts-sdk/exhaustive/node-fetch/tests/wire/noAuth.test.ts
+++ b/seed/ts-sdk/exhaustive/node-fetch/tests/wire/noAuth.test.ts
@@ -23,7 +23,7 @@ describe("NoAuthClient", () => {
         const response = await client.noAuth.postWithNoAuth({
             key: "value",
         });
-        expect(response).toEqual(true);
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("postWithNoAuth (2)", async () => {

--- a/seed/ts-sdk/exhaustive/node-fetch/tests/wire/noReqBody.test.ts
+++ b/seed/ts-sdk/exhaustive/node-fetch/tests/wire/noReqBody.test.ts
@@ -27,23 +27,7 @@ describe("NoReqBodyClient", () => {
         server.mockEndpoint().get("/no-req-body").respondWith().statusCode(200).jsonBody(rawResponseBody).build();
 
         const response = await client.noReqBody.getWithNoRequestBody();
-        expect(response).toEqual({
-            string: "string",
-            integer: 1,
-            long: 1000000,
-            double: 1.1,
-            bool: true,
-            datetime: "2024-01-15T09:30:00Z",
-            date: "2023-01-15",
-            uuid: "d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32",
-            base64: "SGVsbG8gd29ybGQh",
-            list: ["list", "list"],
-            set: ["set"],
-            map: {
-                1: "map",
-            },
-            bigint: "1000000",
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("postWithNoRequestBody", async () => {
@@ -55,6 +39,6 @@ describe("NoReqBodyClient", () => {
         server.mockEndpoint().post("/no-req-body").respondWith().statusCode(200).jsonBody(rawResponseBody).build();
 
         const response = await client.noReqBody.postWithNoRequestBody();
-        expect(response).toEqual("string");
+        expect(response).toEqual(rawResponseBody);
     });
 });

--- a/seed/ts-sdk/exhaustive/package-path/src/test-packagePath/tests/wire/endpoints/container.test.ts
+++ b/seed/ts-sdk/exhaustive/package-path/src/test-packagePath/tests/wire/endpoints/container.test.ts
@@ -20,7 +20,7 @@ describe("ContainerClient", () => {
             .build();
 
         const response = await client.endpoints.container.getAndReturnListOfPrimitives(["string", "string"]);
-        expect(response).toEqual(["string", "string"]);
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnListOfObjects", async () => {
@@ -46,14 +46,7 @@ describe("ContainerClient", () => {
                 string: "string",
             },
         ]);
-        expect(response).toEqual([
-            {
-                string: "string",
-            },
-            {
-                string: "string",
-            },
-        ]);
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnSetOfPrimitives", async () => {
@@ -72,7 +65,7 @@ describe("ContainerClient", () => {
             .build();
 
         const response = await client.endpoints.container.getAndReturnSetOfPrimitives(["string"]);
-        expect(response).toEqual(["string"]);
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnSetOfObjects", async () => {
@@ -95,11 +88,7 @@ describe("ContainerClient", () => {
                 string: "string",
             },
         ]);
-        expect(response).toEqual([
-            {
-                string: "string",
-            },
-        ]);
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnMapPrimToPrim", async () => {
@@ -120,9 +109,7 @@ describe("ContainerClient", () => {
         const response = await client.endpoints.container.getAndReturnMapPrimToPrim({
             string: "string",
         });
-        expect(response).toEqual({
-            string: "string",
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnMapOfPrimToObject", async () => {
@@ -145,11 +132,7 @@ describe("ContainerClient", () => {
                 string: "string",
             },
         });
-        expect(response).toEqual({
-            string: {
-                string: "string",
-            },
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnMapOfPrimToUndiscriminatedUnion", async () => {
@@ -170,9 +153,7 @@ describe("ContainerClient", () => {
         const response = await client.endpoints.container.getAndReturnMapOfPrimToUndiscriminatedUnion({
             string: 1.1,
         });
-        expect(response).toEqual({
-            string: 1.1,
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnOptional", async () => {
@@ -193,8 +174,6 @@ describe("ContainerClient", () => {
         const response = await client.endpoints.container.getAndReturnOptional({
             string: "string",
         });
-        expect(response).toEqual({
-            string: "string",
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 });

--- a/seed/ts-sdk/exhaustive/package-path/src/test-packagePath/tests/wire/endpoints/enum.test.ts
+++ b/seed/ts-sdk/exhaustive/package-path/src/test-packagePath/tests/wire/endpoints/enum.test.ts
@@ -20,6 +20,6 @@ describe("EnumClient", () => {
             .build();
 
         const response = await client.endpoints.enum.getAndReturnEnum("SUNNY");
-        expect(response).toEqual("SUNNY");
+        expect(response).toEqual(rawResponseBody);
     });
 });

--- a/seed/ts-sdk/exhaustive/package-path/src/test-packagePath/tests/wire/endpoints/httpMethods.test.ts
+++ b/seed/ts-sdk/exhaustive/package-path/src/test-packagePath/tests/wire/endpoints/httpMethods.test.ts
@@ -13,7 +13,7 @@ describe("HttpMethodsClient", () => {
         server.mockEndpoint().get("/http-methods/id").respondWith().statusCode(200).jsonBody(rawResponseBody).build();
 
         const response = await client.endpoints.httpMethods.testGet("id");
-        expect(response).toEqual("string");
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("testPost", async () => {
@@ -48,23 +48,7 @@ describe("HttpMethodsClient", () => {
         const response = await client.endpoints.httpMethods.testPost({
             string: "string",
         });
-        expect(response).toEqual({
-            string: "string",
-            integer: 1,
-            long: 1000000,
-            double: 1.1,
-            bool: true,
-            datetime: "2024-01-15T09:30:00Z",
-            date: "2023-01-15",
-            uuid: "d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32",
-            base64: "SGVsbG8gd29ybGQh",
-            list: ["list", "list"],
-            set: ["set"],
-            map: {
-                1: "map",
-            },
-            bigint: "1000000",
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("testPut", async () => {
@@ -99,23 +83,7 @@ describe("HttpMethodsClient", () => {
         const response = await client.endpoints.httpMethods.testPut("id", {
             string: "string",
         });
-        expect(response).toEqual({
-            string: "string",
-            integer: 1,
-            long: 1000000,
-            double: 1.1,
-            bool: true,
-            datetime: "2024-01-15T09:30:00Z",
-            date: "2023-01-15",
-            uuid: "d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32",
-            base64: "SGVsbG8gd29ybGQh",
-            list: ["list", "list"],
-            set: ["set"],
-            map: {
-                1: "map",
-            },
-            bigint: "1000000",
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("testPatch", async () => {
@@ -178,23 +146,7 @@ describe("HttpMethodsClient", () => {
             },
             bigint: "1000000",
         });
-        expect(response).toEqual({
-            string: "string",
-            integer: 1,
-            long: 1000000,
-            double: 1.1,
-            bool: true,
-            datetime: "2024-01-15T09:30:00Z",
-            date: "2023-01-15",
-            uuid: "d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32",
-            base64: "SGVsbG8gd29ybGQh",
-            list: ["list", "list"],
-            set: ["set"],
-            map: {
-                1: "map",
-            },
-            bigint: "1000000",
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("testDelete", async () => {
@@ -212,6 +164,6 @@ describe("HttpMethodsClient", () => {
             .build();
 
         const response = await client.endpoints.httpMethods.testDelete("id");
-        expect(response).toEqual(true);
+        expect(response).toEqual(rawResponseBody);
     });
 });

--- a/seed/ts-sdk/exhaustive/package-path/src/test-packagePath/tests/wire/endpoints/object.test.ts
+++ b/seed/ts-sdk/exhaustive/package-path/src/test-packagePath/tests/wire/endpoints/object.test.ts
@@ -64,23 +64,7 @@ describe("ObjectClient", () => {
             },
             bigint: "1000000",
         });
-        expect(response).toEqual({
-            string: "string",
-            integer: 1,
-            long: 1000000,
-            double: 1.1,
-            bool: true,
-            datetime: "2024-01-15T09:30:00Z",
-            date: "2023-01-15",
-            uuid: "d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32",
-            base64: "SGVsbG8gd29ybGQh",
-            list: ["list", "list"],
-            set: ["set"],
-            map: {
-                1: "map",
-            },
-            bigint: "1000000",
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnWithRequiredField", async () => {
@@ -101,9 +85,7 @@ describe("ObjectClient", () => {
         const response = await client.endpoints.object.getAndReturnWithRequiredField({
             string: "string",
         });
-        expect(response).toEqual({
-            string: "string",
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnWithMapOfMap", async () => {
@@ -128,13 +110,7 @@ describe("ObjectClient", () => {
                 },
             },
         });
-        expect(response).toEqual({
-            map: {
-                map: {
-                    map: "map",
-                },
-            },
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnNestedWithOptionalField", async () => {
@@ -206,26 +182,7 @@ describe("ObjectClient", () => {
                 bigint: "1000000",
             },
         });
-        expect(response).toEqual({
-            string: "string",
-            NestedObject: {
-                string: "string",
-                integer: 1,
-                long: 1000000,
-                double: 1.1,
-                bool: true,
-                datetime: "2024-01-15T09:30:00Z",
-                date: "2023-01-15",
-                uuid: "d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32",
-                base64: "SGVsbG8gd29ybGQh",
-                list: ["list", "list"],
-                set: ["set"],
-                map: {
-                    1: "map",
-                },
-                bigint: "1000000",
-            },
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnNestedWithRequiredField", async () => {
@@ -297,26 +254,7 @@ describe("ObjectClient", () => {
                 bigint: "1000000",
             },
         });
-        expect(response).toEqual({
-            string: "string",
-            NestedObject: {
-                string: "string",
-                integer: 1,
-                long: 1000000,
-                double: 1.1,
-                bool: true,
-                datetime: "2024-01-15T09:30:00Z",
-                date: "2023-01-15",
-                uuid: "d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32",
-                base64: "SGVsbG8gd29ybGQh",
-                list: ["list", "list"],
-                set: ["set"],
-                map: {
-                    1: "map",
-                },
-                bigint: "1000000",
-            },
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnNestedWithRequiredFieldAsList", async () => {
@@ -430,26 +368,7 @@ describe("ObjectClient", () => {
                 },
             },
         ]);
-        expect(response).toEqual({
-            string: "string",
-            NestedObject: {
-                string: "string",
-                integer: 1,
-                long: 1000000,
-                double: 1.1,
-                bool: true,
-                datetime: "2024-01-15T09:30:00Z",
-                date: "2023-01-15",
-                uuid: "d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32",
-                base64: "SGVsbG8gd29ybGQh",
-                list: ["list", "list"],
-                set: ["set"],
-                map: {
-                    1: "map",
-                },
-                bigint: "1000000",
-            },
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnWithUnknownField", async () => {
@@ -472,11 +391,7 @@ describe("ObjectClient", () => {
                 $ref: "https://example.com/schema",
             },
         });
-        expect(response).toEqual({
-            unknown: {
-                $ref: "https://example.com/schema",
-            },
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnWithDocumentedUnknownType", async () => {
@@ -499,11 +414,7 @@ describe("ObjectClient", () => {
                 key: "value",
             },
         });
-        expect(response).toEqual({
-            documentedUnknownType: {
-                key: "value",
-            },
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnMapOfDocumentedUnknownType", async () => {
@@ -526,11 +437,7 @@ describe("ObjectClient", () => {
                 key: "value",
             },
         });
-        expect(response).toEqual({
-            string: {
-                key: "value",
-            },
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnWithDatetimeLikeString", async () => {
@@ -552,9 +459,6 @@ describe("ObjectClient", () => {
             datetimeLikeString: "2023-08-31T14:15:22Z",
             actualDatetime: "2023-08-31T14:15:22Z",
         });
-        expect(response).toEqual({
-            datetimeLikeString: "2023-08-31T14:15:22Z",
-            actualDatetime: "2023-08-31T14:15:22Z",
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 });

--- a/seed/ts-sdk/exhaustive/package-path/src/test-packagePath/tests/wire/endpoints/pagination.test.ts
+++ b/seed/ts-sdk/exhaustive/package-path/src/test-packagePath/tests/wire/endpoints/pagination.test.ts
@@ -18,17 +18,7 @@ describe("PaginationClient", () => {
             .jsonBody(rawResponseBody)
             .build();
 
-        const expected = {
-            items: [
-                {
-                    string: "string",
-                },
-                {
-                    string: "string",
-                },
-            ],
-            next: "next",
-        };
+        const expected = rawResponseBody;
         const page = await client.endpoints.pagination.listItems({
             cursor: "cursor",
             limit: 1,

--- a/seed/ts-sdk/exhaustive/package-path/src/test-packagePath/tests/wire/endpoints/params.test.ts
+++ b/seed/ts-sdk/exhaustive/package-path/src/test-packagePath/tests/wire/endpoints/params.test.ts
@@ -14,7 +14,7 @@ describe("ParamsClient", () => {
         server.mockEndpoint().get("/params/path/param").respondWith().statusCode(200).jsonBody(rawResponseBody).build();
 
         const response = await client.endpoints.params.getWithPath("param");
-        expect(response).toEqual("string");
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getWithInlinePath", async () => {
@@ -28,7 +28,7 @@ describe("ParamsClient", () => {
         const response = await client.endpoints.params.getWithInlinePath({
             param: "param",
         });
-        expect(response).toEqual("string");
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getWithQuery", async () => {
@@ -98,7 +98,7 @@ describe("ParamsClient", () => {
             .build();
 
         const response = await client.endpoints.params.modifyWithPath("param", "string");
-        expect(response).toEqual("string");
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("modifyWithInlinePath", async () => {
@@ -120,7 +120,7 @@ describe("ParamsClient", () => {
             param: "param",
             body: "string",
         });
-        expect(response).toEqual("string");
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getWithPathAndErrors (1)", async () => {
@@ -132,7 +132,7 @@ describe("ParamsClient", () => {
         server.mockEndpoint().get("/params/path/param").respondWith().statusCode(200).jsonBody(rawResponseBody).build();
 
         const response = await client.endpoints.params.getWithPathAndErrors("param");
-        expect(response).toEqual("string");
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getWithPathAndErrors (2)", async () => {

--- a/seed/ts-sdk/exhaustive/package-path/src/test-packagePath/tests/wire/endpoints/primitive.test.ts
+++ b/seed/ts-sdk/exhaustive/package-path/src/test-packagePath/tests/wire/endpoints/primitive.test.ts
@@ -20,7 +20,7 @@ describe("PrimitiveClient", () => {
             .build();
 
         const response = await client.endpoints.primitive.getAndReturnString("string");
-        expect(response).toEqual("string");
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnInt", async () => {
@@ -39,7 +39,7 @@ describe("PrimitiveClient", () => {
             .build();
 
         const response = await client.endpoints.primitive.getAndReturnInt(1);
-        expect(response).toEqual(1);
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnLong", async () => {
@@ -58,7 +58,7 @@ describe("PrimitiveClient", () => {
             .build();
 
         const response = await client.endpoints.primitive.getAndReturnLong(1000000);
-        expect(response).toEqual(1000000);
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnDouble", async () => {
@@ -77,7 +77,7 @@ describe("PrimitiveClient", () => {
             .build();
 
         const response = await client.endpoints.primitive.getAndReturnDouble(1.1);
-        expect(response).toEqual(1.1);
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnBool", async () => {
@@ -96,7 +96,7 @@ describe("PrimitiveClient", () => {
             .build();
 
         const response = await client.endpoints.primitive.getAndReturnBool(true);
-        expect(response).toEqual(true);
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnDatetime", async () => {
@@ -115,7 +115,7 @@ describe("PrimitiveClient", () => {
             .build();
 
         const response = await client.endpoints.primitive.getAndReturnDatetime("2024-01-15T09:30:00Z");
-        expect(response).toEqual("2024-01-15T09:30:00Z");
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnDate", async () => {
@@ -134,7 +134,7 @@ describe("PrimitiveClient", () => {
             .build();
 
         const response = await client.endpoints.primitive.getAndReturnDate("2023-01-15");
-        expect(response).toEqual("2023-01-15");
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnUUID", async () => {
@@ -153,7 +153,7 @@ describe("PrimitiveClient", () => {
             .build();
 
         const response = await client.endpoints.primitive.getAndReturnUuid("d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32");
-        expect(response).toEqual("d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32");
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnBase64", async () => {
@@ -172,6 +172,6 @@ describe("PrimitiveClient", () => {
             .build();
 
         const response = await client.endpoints.primitive.getAndReturnBase64("SGVsbG8gd29ybGQh");
-        expect(response).toEqual("SGVsbG8gd29ybGQh");
+        expect(response).toEqual(rawResponseBody);
     });
 });

--- a/seed/ts-sdk/exhaustive/package-path/src/test-packagePath/tests/wire/endpoints/put.test.ts
+++ b/seed/ts-sdk/exhaustive/package-path/src/test-packagePath/tests/wire/endpoints/put.test.ts
@@ -20,21 +20,6 @@ describe("PutClient", () => {
         const response = await client.endpoints.put.add({
             id: "id",
         });
-        expect(response).toEqual({
-            errors: [
-                {
-                    category: "API_ERROR",
-                    code: "INTERNAL_SERVER_ERROR",
-                    detail: "detail",
-                    field: "field",
-                },
-                {
-                    category: "API_ERROR",
-                    code: "INTERNAL_SERVER_ERROR",
-                    detail: "detail",
-                    field: "field",
-                },
-            ],
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 });

--- a/seed/ts-sdk/exhaustive/package-path/src/test-packagePath/tests/wire/endpoints/union.test.ts
+++ b/seed/ts-sdk/exhaustive/package-path/src/test-packagePath/tests/wire/endpoints/union.test.ts
@@ -24,10 +24,6 @@ describe("UnionClient", () => {
             name: "name",
             likesToWoof: true,
         });
-        expect(response).toEqual({
-            animal: "dog",
-            name: "name",
-            likesToWoof: true,
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 });

--- a/seed/ts-sdk/exhaustive/package-path/src/test-packagePath/tests/wire/endpoints/urls.test.ts
+++ b/seed/ts-sdk/exhaustive/package-path/src/test-packagePath/tests/wire/endpoints/urls.test.ts
@@ -13,7 +13,7 @@ describe("UrlsClient", () => {
         server.mockEndpoint().get("/urls/MixedCase").respondWith().statusCode(200).jsonBody(rawResponseBody).build();
 
         const response = await client.endpoints.urls.withMixedCase();
-        expect(response).toEqual("string");
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("noEndingSlash", async () => {
@@ -31,7 +31,7 @@ describe("UrlsClient", () => {
             .build();
 
         const response = await client.endpoints.urls.noEndingSlash();
-        expect(response).toEqual("string");
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("withEndingSlash", async () => {
@@ -49,7 +49,7 @@ describe("UrlsClient", () => {
             .build();
 
         const response = await client.endpoints.urls.withEndingSlash();
-        expect(response).toEqual("string");
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("withUnderscores", async () => {
@@ -67,6 +67,6 @@ describe("UrlsClient", () => {
             .build();
 
         const response = await client.endpoints.urls.withUnderscores();
-        expect(response).toEqual("string");
+        expect(response).toEqual(rawResponseBody);
     });
 });

--- a/seed/ts-sdk/exhaustive/package-path/src/test-packagePath/tests/wire/inlinedRequests.test.ts
+++ b/seed/ts-sdk/exhaustive/package-path/src/test-packagePath/tests/wire/inlinedRequests.test.ts
@@ -73,23 +73,7 @@ describe("InlinedRequestsClient", () => {
                 bigint: "1000000",
             },
         });
-        expect(response).toEqual({
-            string: "string",
-            integer: 1,
-            long: 1000000,
-            double: 1.1,
-            bool: true,
-            datetime: "2024-01-15T09:30:00Z",
-            date: "2023-01-15",
-            uuid: "d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32",
-            base64: "SGVsbG8gd29ybGQh",
-            list: ["list", "list"],
-            set: ["set"],
-            map: {
-                1: "map",
-            },
-            bigint: "1000000",
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("postWithObjectBodyandResponse (2)", async () => {

--- a/seed/ts-sdk/exhaustive/package-path/src/test-packagePath/tests/wire/noAuth.test.ts
+++ b/seed/ts-sdk/exhaustive/package-path/src/test-packagePath/tests/wire/noAuth.test.ts
@@ -23,7 +23,7 @@ describe("NoAuthClient", () => {
         const response = await client.noAuth.postWithNoAuth({
             key: "value",
         });
-        expect(response).toEqual(true);
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("postWithNoAuth (2)", async () => {

--- a/seed/ts-sdk/exhaustive/package-path/src/test-packagePath/tests/wire/noReqBody.test.ts
+++ b/seed/ts-sdk/exhaustive/package-path/src/test-packagePath/tests/wire/noReqBody.test.ts
@@ -27,23 +27,7 @@ describe("NoReqBodyClient", () => {
         server.mockEndpoint().get("/no-req-body").respondWith().statusCode(200).jsonBody(rawResponseBody).build();
 
         const response = await client.noReqBody.getWithNoRequestBody();
-        expect(response).toEqual({
-            string: "string",
-            integer: 1,
-            long: 1000000,
-            double: 1.1,
-            bool: true,
-            datetime: "2024-01-15T09:30:00Z",
-            date: "2023-01-15",
-            uuid: "d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32",
-            base64: "SGVsbG8gd29ybGQh",
-            list: ["list", "list"],
-            set: ["set"],
-            map: {
-                1: "map",
-            },
-            bigint: "1000000",
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("postWithNoRequestBody", async () => {
@@ -55,6 +39,6 @@ describe("NoReqBodyClient", () => {
         server.mockEndpoint().post("/no-req-body").respondWith().statusCode(200).jsonBody(rawResponseBody).build();
 
         const response = await client.noReqBody.postWithNoRequestBody();
-        expect(response).toEqual("string");
+        expect(response).toEqual(rawResponseBody);
     });
 });

--- a/seed/ts-sdk/exhaustive/parameter-naming-camel-case/tests/wire/endpoints/container.test.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-camel-case/tests/wire/endpoints/container.test.ts
@@ -20,7 +20,7 @@ describe("ContainerClient", () => {
             .build();
 
         const response = await client.endpoints.container.getAndReturnListOfPrimitives(["string", "string"]);
-        expect(response).toEqual(["string", "string"]);
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnListOfObjects", async () => {
@@ -46,14 +46,7 @@ describe("ContainerClient", () => {
                 string: "string",
             },
         ]);
-        expect(response).toEqual([
-            {
-                string: "string",
-            },
-            {
-                string: "string",
-            },
-        ]);
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnSetOfPrimitives", async () => {
@@ -72,7 +65,7 @@ describe("ContainerClient", () => {
             .build();
 
         const response = await client.endpoints.container.getAndReturnSetOfPrimitives(["string"]);
-        expect(response).toEqual(["string"]);
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnSetOfObjects", async () => {
@@ -95,11 +88,7 @@ describe("ContainerClient", () => {
                 string: "string",
             },
         ]);
-        expect(response).toEqual([
-            {
-                string: "string",
-            },
-        ]);
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnMapPrimToPrim", async () => {
@@ -120,9 +109,7 @@ describe("ContainerClient", () => {
         const response = await client.endpoints.container.getAndReturnMapPrimToPrim({
             string: "string",
         });
-        expect(response).toEqual({
-            string: "string",
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnMapOfPrimToObject", async () => {
@@ -145,11 +132,7 @@ describe("ContainerClient", () => {
                 string: "string",
             },
         });
-        expect(response).toEqual({
-            string: {
-                string: "string",
-            },
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnMapOfPrimToUndiscriminatedUnion", async () => {
@@ -170,9 +153,7 @@ describe("ContainerClient", () => {
         const response = await client.endpoints.container.getAndReturnMapOfPrimToUndiscriminatedUnion({
             string: 1.1,
         });
-        expect(response).toEqual({
-            string: 1.1,
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnOptional", async () => {
@@ -193,8 +174,6 @@ describe("ContainerClient", () => {
         const response = await client.endpoints.container.getAndReturnOptional({
             string: "string",
         });
-        expect(response).toEqual({
-            string: "string",
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 });

--- a/seed/ts-sdk/exhaustive/parameter-naming-camel-case/tests/wire/endpoints/enum.test.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-camel-case/tests/wire/endpoints/enum.test.ts
@@ -20,6 +20,6 @@ describe("EnumClient", () => {
             .build();
 
         const response = await client.endpoints.enum.getAndReturnEnum("SUNNY");
-        expect(response).toEqual("SUNNY");
+        expect(response).toEqual(rawResponseBody);
     });
 });

--- a/seed/ts-sdk/exhaustive/parameter-naming-camel-case/tests/wire/endpoints/httpMethods.test.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-camel-case/tests/wire/endpoints/httpMethods.test.ts
@@ -13,7 +13,7 @@ describe("HttpMethodsClient", () => {
         server.mockEndpoint().get("/http-methods/id").respondWith().statusCode(200).jsonBody(rawResponseBody).build();
 
         const response = await client.endpoints.httpMethods.testGet("id");
-        expect(response).toEqual("string");
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("testPost", async () => {
@@ -48,23 +48,7 @@ describe("HttpMethodsClient", () => {
         const response = await client.endpoints.httpMethods.testPost({
             string: "string",
         });
-        expect(response).toEqual({
-            string: "string",
-            integer: 1,
-            long: 1000000,
-            double: 1.1,
-            bool: true,
-            datetime: "2024-01-15T09:30:00Z",
-            date: "2023-01-15",
-            uuid: "d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32",
-            base64: "SGVsbG8gd29ybGQh",
-            list: ["list", "list"],
-            set: ["set"],
-            map: {
-                1: "map",
-            },
-            bigint: "1000000",
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("testPut", async () => {
@@ -99,23 +83,7 @@ describe("HttpMethodsClient", () => {
         const response = await client.endpoints.httpMethods.testPut("id", {
             string: "string",
         });
-        expect(response).toEqual({
-            string: "string",
-            integer: 1,
-            long: 1000000,
-            double: 1.1,
-            bool: true,
-            datetime: "2024-01-15T09:30:00Z",
-            date: "2023-01-15",
-            uuid: "d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32",
-            base64: "SGVsbG8gd29ybGQh",
-            list: ["list", "list"],
-            set: ["set"],
-            map: {
-                1: "map",
-            },
-            bigint: "1000000",
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("testPatch", async () => {
@@ -178,23 +146,7 @@ describe("HttpMethodsClient", () => {
             },
             bigint: "1000000",
         });
-        expect(response).toEqual({
-            string: "string",
-            integer: 1,
-            long: 1000000,
-            double: 1.1,
-            bool: true,
-            datetime: "2024-01-15T09:30:00Z",
-            date: "2023-01-15",
-            uuid: "d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32",
-            base64: "SGVsbG8gd29ybGQh",
-            list: ["list", "list"],
-            set: ["set"],
-            map: {
-                1: "map",
-            },
-            bigint: "1000000",
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("testDelete", async () => {
@@ -212,6 +164,6 @@ describe("HttpMethodsClient", () => {
             .build();
 
         const response = await client.endpoints.httpMethods.testDelete("id");
-        expect(response).toEqual(true);
+        expect(response).toEqual(rawResponseBody);
     });
 });

--- a/seed/ts-sdk/exhaustive/parameter-naming-camel-case/tests/wire/endpoints/object.test.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-camel-case/tests/wire/endpoints/object.test.ts
@@ -64,23 +64,7 @@ describe("ObjectClient", () => {
             },
             bigint: "1000000",
         });
-        expect(response).toEqual({
-            string: "string",
-            integer: 1,
-            long: 1000000,
-            double: 1.1,
-            bool: true,
-            datetime: "2024-01-15T09:30:00Z",
-            date: "2023-01-15",
-            uuid: "d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32",
-            base64: "SGVsbG8gd29ybGQh",
-            list: ["list", "list"],
-            set: ["set"],
-            map: {
-                1: "map",
-            },
-            bigint: "1000000",
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnWithRequiredField", async () => {
@@ -101,9 +85,7 @@ describe("ObjectClient", () => {
         const response = await client.endpoints.object.getAndReturnWithRequiredField({
             string: "string",
         });
-        expect(response).toEqual({
-            string: "string",
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnWithMapOfMap", async () => {
@@ -128,13 +110,7 @@ describe("ObjectClient", () => {
                 },
             },
         });
-        expect(response).toEqual({
-            map: {
-                map: {
-                    map: "map",
-                },
-            },
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnNestedWithOptionalField", async () => {
@@ -206,26 +182,7 @@ describe("ObjectClient", () => {
                 bigint: "1000000",
             },
         });
-        expect(response).toEqual({
-            string: "string",
-            NestedObject: {
-                string: "string",
-                integer: 1,
-                long: 1000000,
-                double: 1.1,
-                bool: true,
-                datetime: "2024-01-15T09:30:00Z",
-                date: "2023-01-15",
-                uuid: "d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32",
-                base64: "SGVsbG8gd29ybGQh",
-                list: ["list", "list"],
-                set: ["set"],
-                map: {
-                    1: "map",
-                },
-                bigint: "1000000",
-            },
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnNestedWithRequiredField", async () => {
@@ -297,26 +254,7 @@ describe("ObjectClient", () => {
                 bigint: "1000000",
             },
         });
-        expect(response).toEqual({
-            string: "string",
-            NestedObject: {
-                string: "string",
-                integer: 1,
-                long: 1000000,
-                double: 1.1,
-                bool: true,
-                datetime: "2024-01-15T09:30:00Z",
-                date: "2023-01-15",
-                uuid: "d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32",
-                base64: "SGVsbG8gd29ybGQh",
-                list: ["list", "list"],
-                set: ["set"],
-                map: {
-                    1: "map",
-                },
-                bigint: "1000000",
-            },
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnNestedWithRequiredFieldAsList", async () => {
@@ -430,26 +368,7 @@ describe("ObjectClient", () => {
                 },
             },
         ]);
-        expect(response).toEqual({
-            string: "string",
-            NestedObject: {
-                string: "string",
-                integer: 1,
-                long: 1000000,
-                double: 1.1,
-                bool: true,
-                datetime: "2024-01-15T09:30:00Z",
-                date: "2023-01-15",
-                uuid: "d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32",
-                base64: "SGVsbG8gd29ybGQh",
-                list: ["list", "list"],
-                set: ["set"],
-                map: {
-                    1: "map",
-                },
-                bigint: "1000000",
-            },
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnWithUnknownField", async () => {
@@ -472,11 +391,7 @@ describe("ObjectClient", () => {
                 $ref: "https://example.com/schema",
             },
         });
-        expect(response).toEqual({
-            unknown: {
-                $ref: "https://example.com/schema",
-            },
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnWithDocumentedUnknownType", async () => {
@@ -499,11 +414,7 @@ describe("ObjectClient", () => {
                 key: "value",
             },
         });
-        expect(response).toEqual({
-            documentedUnknownType: {
-                key: "value",
-            },
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnMapOfDocumentedUnknownType", async () => {
@@ -526,11 +437,7 @@ describe("ObjectClient", () => {
                 key: "value",
             },
         });
-        expect(response).toEqual({
-            string: {
-                key: "value",
-            },
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnWithDatetimeLikeString", async () => {
@@ -552,9 +459,6 @@ describe("ObjectClient", () => {
             datetimeLikeString: "2023-08-31T14:15:22Z",
             actualDatetime: "2023-08-31T14:15:22Z",
         });
-        expect(response).toEqual({
-            datetimeLikeString: "2023-08-31T14:15:22Z",
-            actualDatetime: "2023-08-31T14:15:22Z",
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 });

--- a/seed/ts-sdk/exhaustive/parameter-naming-camel-case/tests/wire/endpoints/pagination.test.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-camel-case/tests/wire/endpoints/pagination.test.ts
@@ -18,17 +18,7 @@ describe("PaginationClient", () => {
             .jsonBody(rawResponseBody)
             .build();
 
-        const expected = {
-            items: [
-                {
-                    string: "string",
-                },
-                {
-                    string: "string",
-                },
-            ],
-            next: "next",
-        };
+        const expected = rawResponseBody;
         const page = await client.endpoints.pagination.listItems({
             cursor: "cursor",
             limit: 1,

--- a/seed/ts-sdk/exhaustive/parameter-naming-camel-case/tests/wire/endpoints/params.test.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-camel-case/tests/wire/endpoints/params.test.ts
@@ -14,7 +14,7 @@ describe("ParamsClient", () => {
         server.mockEndpoint().get("/params/path/param").respondWith().statusCode(200).jsonBody(rawResponseBody).build();
 
         const response = await client.endpoints.params.getWithPath("param");
-        expect(response).toEqual("string");
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getWithInlinePath", async () => {
@@ -28,7 +28,7 @@ describe("ParamsClient", () => {
         const response = await client.endpoints.params.getWithInlinePath({
             param: "param",
         });
-        expect(response).toEqual("string");
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getWithQuery", async () => {
@@ -98,7 +98,7 @@ describe("ParamsClient", () => {
             .build();
 
         const response = await client.endpoints.params.modifyWithPath("param", "string");
-        expect(response).toEqual("string");
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("modifyWithInlinePath", async () => {
@@ -120,7 +120,7 @@ describe("ParamsClient", () => {
             param: "param",
             body: "string",
         });
-        expect(response).toEqual("string");
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getWithPathAndErrors (1)", async () => {
@@ -132,7 +132,7 @@ describe("ParamsClient", () => {
         server.mockEndpoint().get("/params/path/param").respondWith().statusCode(200).jsonBody(rawResponseBody).build();
 
         const response = await client.endpoints.params.getWithPathAndErrors("param");
-        expect(response).toEqual("string");
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getWithPathAndErrors (2)", async () => {

--- a/seed/ts-sdk/exhaustive/parameter-naming-camel-case/tests/wire/endpoints/primitive.test.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-camel-case/tests/wire/endpoints/primitive.test.ts
@@ -20,7 +20,7 @@ describe("PrimitiveClient", () => {
             .build();
 
         const response = await client.endpoints.primitive.getAndReturnString("string");
-        expect(response).toEqual("string");
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnInt", async () => {
@@ -39,7 +39,7 @@ describe("PrimitiveClient", () => {
             .build();
 
         const response = await client.endpoints.primitive.getAndReturnInt(1);
-        expect(response).toEqual(1);
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnLong", async () => {
@@ -58,7 +58,7 @@ describe("PrimitiveClient", () => {
             .build();
 
         const response = await client.endpoints.primitive.getAndReturnLong(1000000);
-        expect(response).toEqual(1000000);
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnDouble", async () => {
@@ -77,7 +77,7 @@ describe("PrimitiveClient", () => {
             .build();
 
         const response = await client.endpoints.primitive.getAndReturnDouble(1.1);
-        expect(response).toEqual(1.1);
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnBool", async () => {
@@ -96,7 +96,7 @@ describe("PrimitiveClient", () => {
             .build();
 
         const response = await client.endpoints.primitive.getAndReturnBool(true);
-        expect(response).toEqual(true);
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnDatetime", async () => {
@@ -115,7 +115,7 @@ describe("PrimitiveClient", () => {
             .build();
 
         const response = await client.endpoints.primitive.getAndReturnDatetime("2024-01-15T09:30:00Z");
-        expect(response).toEqual("2024-01-15T09:30:00Z");
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnDate", async () => {
@@ -134,7 +134,7 @@ describe("PrimitiveClient", () => {
             .build();
 
         const response = await client.endpoints.primitive.getAndReturnDate("2023-01-15");
-        expect(response).toEqual("2023-01-15");
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnUUID", async () => {
@@ -153,7 +153,7 @@ describe("PrimitiveClient", () => {
             .build();
 
         const response = await client.endpoints.primitive.getAndReturnUuid("d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32");
-        expect(response).toEqual("d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32");
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnBase64", async () => {
@@ -172,6 +172,6 @@ describe("PrimitiveClient", () => {
             .build();
 
         const response = await client.endpoints.primitive.getAndReturnBase64("SGVsbG8gd29ybGQh");
-        expect(response).toEqual("SGVsbG8gd29ybGQh");
+        expect(response).toEqual(rawResponseBody);
     });
 });

--- a/seed/ts-sdk/exhaustive/parameter-naming-camel-case/tests/wire/endpoints/put.test.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-camel-case/tests/wire/endpoints/put.test.ts
@@ -20,21 +20,6 @@ describe("PutClient", () => {
         const response = await client.endpoints.put.add({
             id: "id",
         });
-        expect(response).toEqual({
-            errors: [
-                {
-                    category: "API_ERROR",
-                    code: "INTERNAL_SERVER_ERROR",
-                    detail: "detail",
-                    field: "field",
-                },
-                {
-                    category: "API_ERROR",
-                    code: "INTERNAL_SERVER_ERROR",
-                    detail: "detail",
-                    field: "field",
-                },
-            ],
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 });

--- a/seed/ts-sdk/exhaustive/parameter-naming-camel-case/tests/wire/endpoints/union.test.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-camel-case/tests/wire/endpoints/union.test.ts
@@ -24,10 +24,6 @@ describe("UnionClient", () => {
             name: "name",
             likesToWoof: true,
         });
-        expect(response).toEqual({
-            animal: "dog",
-            name: "name",
-            likesToWoof: true,
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 });

--- a/seed/ts-sdk/exhaustive/parameter-naming-camel-case/tests/wire/endpoints/urls.test.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-camel-case/tests/wire/endpoints/urls.test.ts
@@ -13,7 +13,7 @@ describe("UrlsClient", () => {
         server.mockEndpoint().get("/urls/MixedCase").respondWith().statusCode(200).jsonBody(rawResponseBody).build();
 
         const response = await client.endpoints.urls.withMixedCase();
-        expect(response).toEqual("string");
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("noEndingSlash", async () => {
@@ -31,7 +31,7 @@ describe("UrlsClient", () => {
             .build();
 
         const response = await client.endpoints.urls.noEndingSlash();
-        expect(response).toEqual("string");
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("withEndingSlash", async () => {
@@ -49,7 +49,7 @@ describe("UrlsClient", () => {
             .build();
 
         const response = await client.endpoints.urls.withEndingSlash();
-        expect(response).toEqual("string");
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("withUnderscores", async () => {
@@ -67,6 +67,6 @@ describe("UrlsClient", () => {
             .build();
 
         const response = await client.endpoints.urls.withUnderscores();
-        expect(response).toEqual("string");
+        expect(response).toEqual(rawResponseBody);
     });
 });

--- a/seed/ts-sdk/exhaustive/parameter-naming-camel-case/tests/wire/inlinedRequests.test.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-camel-case/tests/wire/inlinedRequests.test.ts
@@ -73,23 +73,7 @@ describe("InlinedRequestsClient", () => {
                 bigint: "1000000",
             },
         });
-        expect(response).toEqual({
-            string: "string",
-            integer: 1,
-            long: 1000000,
-            double: 1.1,
-            bool: true,
-            datetime: "2024-01-15T09:30:00Z",
-            date: "2023-01-15",
-            uuid: "d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32",
-            base64: "SGVsbG8gd29ybGQh",
-            list: ["list", "list"],
-            set: ["set"],
-            map: {
-                1: "map",
-            },
-            bigint: "1000000",
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("postWithObjectBodyandResponse (2)", async () => {

--- a/seed/ts-sdk/exhaustive/parameter-naming-camel-case/tests/wire/noAuth.test.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-camel-case/tests/wire/noAuth.test.ts
@@ -23,7 +23,7 @@ describe("NoAuthClient", () => {
         const response = await client.noAuth.postWithNoAuth({
             key: "value",
         });
-        expect(response).toEqual(true);
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("postWithNoAuth (2)", async () => {

--- a/seed/ts-sdk/exhaustive/parameter-naming-camel-case/tests/wire/noReqBody.test.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-camel-case/tests/wire/noReqBody.test.ts
@@ -27,23 +27,7 @@ describe("NoReqBodyClient", () => {
         server.mockEndpoint().get("/no-req-body").respondWith().statusCode(200).jsonBody(rawResponseBody).build();
 
         const response = await client.noReqBody.getWithNoRequestBody();
-        expect(response).toEqual({
-            string: "string",
-            integer: 1,
-            long: 1000000,
-            double: 1.1,
-            bool: true,
-            datetime: "2024-01-15T09:30:00Z",
-            date: "2023-01-15",
-            uuid: "d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32",
-            base64: "SGVsbG8gd29ybGQh",
-            list: ["list", "list"],
-            set: ["set"],
-            map: {
-                1: "map",
-            },
-            bigint: "1000000",
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("postWithNoRequestBody", async () => {
@@ -55,6 +39,6 @@ describe("NoReqBodyClient", () => {
         server.mockEndpoint().post("/no-req-body").respondWith().statusCode(200).jsonBody(rawResponseBody).build();
 
         const response = await client.noReqBody.postWithNoRequestBody();
-        expect(response).toEqual("string");
+        expect(response).toEqual(rawResponseBody);
     });
 });

--- a/seed/ts-sdk/exhaustive/parameter-naming-original-name/tests/wire/endpoints/container.test.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-original-name/tests/wire/endpoints/container.test.ts
@@ -20,7 +20,7 @@ describe("ContainerClient", () => {
             .build();
 
         const response = await client.endpoints.container.getAndReturnListOfPrimitives(["string", "string"]);
-        expect(response).toEqual(["string", "string"]);
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnListOfObjects", async () => {
@@ -46,14 +46,7 @@ describe("ContainerClient", () => {
                 string: "string",
             },
         ]);
-        expect(response).toEqual([
-            {
-                string: "string",
-            },
-            {
-                string: "string",
-            },
-        ]);
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnSetOfPrimitives", async () => {
@@ -72,7 +65,7 @@ describe("ContainerClient", () => {
             .build();
 
         const response = await client.endpoints.container.getAndReturnSetOfPrimitives(["string"]);
-        expect(response).toEqual(["string"]);
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnSetOfObjects", async () => {
@@ -95,11 +88,7 @@ describe("ContainerClient", () => {
                 string: "string",
             },
         ]);
-        expect(response).toEqual([
-            {
-                string: "string",
-            },
-        ]);
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnMapPrimToPrim", async () => {
@@ -120,9 +109,7 @@ describe("ContainerClient", () => {
         const response = await client.endpoints.container.getAndReturnMapPrimToPrim({
             string: "string",
         });
-        expect(response).toEqual({
-            string: "string",
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnMapOfPrimToObject", async () => {
@@ -145,11 +132,7 @@ describe("ContainerClient", () => {
                 string: "string",
             },
         });
-        expect(response).toEqual({
-            string: {
-                string: "string",
-            },
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnMapOfPrimToUndiscriminatedUnion", async () => {
@@ -170,9 +153,7 @@ describe("ContainerClient", () => {
         const response = await client.endpoints.container.getAndReturnMapOfPrimToUndiscriminatedUnion({
             string: 1.1,
         });
-        expect(response).toEqual({
-            string: 1.1,
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnOptional", async () => {
@@ -193,8 +174,6 @@ describe("ContainerClient", () => {
         const response = await client.endpoints.container.getAndReturnOptional({
             string: "string",
         });
-        expect(response).toEqual({
-            string: "string",
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 });

--- a/seed/ts-sdk/exhaustive/parameter-naming-original-name/tests/wire/endpoints/enum.test.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-original-name/tests/wire/endpoints/enum.test.ts
@@ -20,6 +20,6 @@ describe("EnumClient", () => {
             .build();
 
         const response = await client.endpoints.enum.getAndReturnEnum("SUNNY");
-        expect(response).toEqual("SUNNY");
+        expect(response).toEqual(rawResponseBody);
     });
 });

--- a/seed/ts-sdk/exhaustive/parameter-naming-original-name/tests/wire/endpoints/httpMethods.test.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-original-name/tests/wire/endpoints/httpMethods.test.ts
@@ -13,7 +13,7 @@ describe("HttpMethodsClient", () => {
         server.mockEndpoint().get("/http-methods/id").respondWith().statusCode(200).jsonBody(rawResponseBody).build();
 
         const response = await client.endpoints.httpMethods.testGet("id");
-        expect(response).toEqual("string");
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("testPost", async () => {
@@ -48,23 +48,7 @@ describe("HttpMethodsClient", () => {
         const response = await client.endpoints.httpMethods.testPost({
             string: "string",
         });
-        expect(response).toEqual({
-            string: "string",
-            integer: 1,
-            long: 1000000,
-            double: 1.1,
-            bool: true,
-            datetime: "2024-01-15T09:30:00Z",
-            date: "2023-01-15",
-            uuid: "d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32",
-            base64: "SGVsbG8gd29ybGQh",
-            list: ["list", "list"],
-            set: ["set"],
-            map: {
-                1: "map",
-            },
-            bigint: "1000000",
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("testPut", async () => {
@@ -99,23 +83,7 @@ describe("HttpMethodsClient", () => {
         const response = await client.endpoints.httpMethods.testPut("id", {
             string: "string",
         });
-        expect(response).toEqual({
-            string: "string",
-            integer: 1,
-            long: 1000000,
-            double: 1.1,
-            bool: true,
-            datetime: "2024-01-15T09:30:00Z",
-            date: "2023-01-15",
-            uuid: "d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32",
-            base64: "SGVsbG8gd29ybGQh",
-            list: ["list", "list"],
-            set: ["set"],
-            map: {
-                1: "map",
-            },
-            bigint: "1000000",
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("testPatch", async () => {
@@ -178,23 +146,7 @@ describe("HttpMethodsClient", () => {
             },
             bigint: "1000000",
         });
-        expect(response).toEqual({
-            string: "string",
-            integer: 1,
-            long: 1000000,
-            double: 1.1,
-            bool: true,
-            datetime: "2024-01-15T09:30:00Z",
-            date: "2023-01-15",
-            uuid: "d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32",
-            base64: "SGVsbG8gd29ybGQh",
-            list: ["list", "list"],
-            set: ["set"],
-            map: {
-                1: "map",
-            },
-            bigint: "1000000",
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("testDelete", async () => {
@@ -212,6 +164,6 @@ describe("HttpMethodsClient", () => {
             .build();
 
         const response = await client.endpoints.httpMethods.testDelete("id");
-        expect(response).toEqual(true);
+        expect(response).toEqual(rawResponseBody);
     });
 });

--- a/seed/ts-sdk/exhaustive/parameter-naming-original-name/tests/wire/endpoints/object.test.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-original-name/tests/wire/endpoints/object.test.ts
@@ -64,23 +64,7 @@ describe("ObjectClient", () => {
             },
             bigint: "1000000",
         });
-        expect(response).toEqual({
-            string: "string",
-            integer: 1,
-            long: 1000000,
-            double: 1.1,
-            bool: true,
-            datetime: "2024-01-15T09:30:00Z",
-            date: "2023-01-15",
-            uuid: "d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32",
-            base64: "SGVsbG8gd29ybGQh",
-            list: ["list", "list"],
-            set: ["set"],
-            map: {
-                1: "map",
-            },
-            bigint: "1000000",
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnWithRequiredField", async () => {
@@ -101,9 +85,7 @@ describe("ObjectClient", () => {
         const response = await client.endpoints.object.getAndReturnWithRequiredField({
             string: "string",
         });
-        expect(response).toEqual({
-            string: "string",
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnWithMapOfMap", async () => {
@@ -128,13 +110,7 @@ describe("ObjectClient", () => {
                 },
             },
         });
-        expect(response).toEqual({
-            map: {
-                map: {
-                    map: "map",
-                },
-            },
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnNestedWithOptionalField", async () => {
@@ -206,26 +182,7 @@ describe("ObjectClient", () => {
                 bigint: "1000000",
             },
         });
-        expect(response).toEqual({
-            string: "string",
-            NestedObject: {
-                string: "string",
-                integer: 1,
-                long: 1000000,
-                double: 1.1,
-                bool: true,
-                datetime: "2024-01-15T09:30:00Z",
-                date: "2023-01-15",
-                uuid: "d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32",
-                base64: "SGVsbG8gd29ybGQh",
-                list: ["list", "list"],
-                set: ["set"],
-                map: {
-                    1: "map",
-                },
-                bigint: "1000000",
-            },
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnNestedWithRequiredField", async () => {
@@ -297,26 +254,7 @@ describe("ObjectClient", () => {
                 bigint: "1000000",
             },
         });
-        expect(response).toEqual({
-            string: "string",
-            NestedObject: {
-                string: "string",
-                integer: 1,
-                long: 1000000,
-                double: 1.1,
-                bool: true,
-                datetime: "2024-01-15T09:30:00Z",
-                date: "2023-01-15",
-                uuid: "d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32",
-                base64: "SGVsbG8gd29ybGQh",
-                list: ["list", "list"],
-                set: ["set"],
-                map: {
-                    1: "map",
-                },
-                bigint: "1000000",
-            },
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnNestedWithRequiredFieldAsList", async () => {
@@ -430,26 +368,7 @@ describe("ObjectClient", () => {
                 },
             },
         ]);
-        expect(response).toEqual({
-            string: "string",
-            NestedObject: {
-                string: "string",
-                integer: 1,
-                long: 1000000,
-                double: 1.1,
-                bool: true,
-                datetime: "2024-01-15T09:30:00Z",
-                date: "2023-01-15",
-                uuid: "d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32",
-                base64: "SGVsbG8gd29ybGQh",
-                list: ["list", "list"],
-                set: ["set"],
-                map: {
-                    1: "map",
-                },
-                bigint: "1000000",
-            },
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnWithUnknownField", async () => {
@@ -472,11 +391,7 @@ describe("ObjectClient", () => {
                 $ref: "https://example.com/schema",
             },
         });
-        expect(response).toEqual({
-            unknown: {
-                $ref: "https://example.com/schema",
-            },
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnWithDocumentedUnknownType", async () => {
@@ -499,11 +414,7 @@ describe("ObjectClient", () => {
                 key: "value",
             },
         });
-        expect(response).toEqual({
-            documentedUnknownType: {
-                key: "value",
-            },
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnMapOfDocumentedUnknownType", async () => {
@@ -526,11 +437,7 @@ describe("ObjectClient", () => {
                 key: "value",
             },
         });
-        expect(response).toEqual({
-            string: {
-                key: "value",
-            },
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnWithDatetimeLikeString", async () => {
@@ -552,9 +459,6 @@ describe("ObjectClient", () => {
             datetimeLikeString: "2023-08-31T14:15:22Z",
             actualDatetime: "2023-08-31T14:15:22Z",
         });
-        expect(response).toEqual({
-            datetimeLikeString: "2023-08-31T14:15:22Z",
-            actualDatetime: "2023-08-31T14:15:22Z",
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 });

--- a/seed/ts-sdk/exhaustive/parameter-naming-original-name/tests/wire/endpoints/pagination.test.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-original-name/tests/wire/endpoints/pagination.test.ts
@@ -18,17 +18,7 @@ describe("PaginationClient", () => {
             .jsonBody(rawResponseBody)
             .build();
 
-        const expected = {
-            items: [
-                {
-                    string: "string",
-                },
-                {
-                    string: "string",
-                },
-            ],
-            next: "next",
-        };
+        const expected = rawResponseBody;
         const page = await client.endpoints.pagination.listItems({
             cursor: "cursor",
             limit: 1,

--- a/seed/ts-sdk/exhaustive/parameter-naming-original-name/tests/wire/endpoints/params.test.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-original-name/tests/wire/endpoints/params.test.ts
@@ -14,7 +14,7 @@ describe("ParamsClient", () => {
         server.mockEndpoint().get("/params/path/param").respondWith().statusCode(200).jsonBody(rawResponseBody).build();
 
         const response = await client.endpoints.params.getWithPath("param");
-        expect(response).toEqual("string");
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getWithInlinePath", async () => {
@@ -28,7 +28,7 @@ describe("ParamsClient", () => {
         const response = await client.endpoints.params.getWithInlinePath({
             param: "param",
         });
-        expect(response).toEqual("string");
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getWithQuery", async () => {
@@ -98,7 +98,7 @@ describe("ParamsClient", () => {
             .build();
 
         const response = await client.endpoints.params.modifyWithPath("param", "string");
-        expect(response).toEqual("string");
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("modifyWithInlinePath", async () => {
@@ -120,7 +120,7 @@ describe("ParamsClient", () => {
             param: "param",
             body: "string",
         });
-        expect(response).toEqual("string");
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getWithPathAndErrors (1)", async () => {
@@ -132,7 +132,7 @@ describe("ParamsClient", () => {
         server.mockEndpoint().get("/params/path/param").respondWith().statusCode(200).jsonBody(rawResponseBody).build();
 
         const response = await client.endpoints.params.getWithPathAndErrors("param");
-        expect(response).toEqual("string");
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getWithPathAndErrors (2)", async () => {

--- a/seed/ts-sdk/exhaustive/parameter-naming-original-name/tests/wire/endpoints/primitive.test.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-original-name/tests/wire/endpoints/primitive.test.ts
@@ -20,7 +20,7 @@ describe("PrimitiveClient", () => {
             .build();
 
         const response = await client.endpoints.primitive.getAndReturnString("string");
-        expect(response).toEqual("string");
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnInt", async () => {
@@ -39,7 +39,7 @@ describe("PrimitiveClient", () => {
             .build();
 
         const response = await client.endpoints.primitive.getAndReturnInt(1);
-        expect(response).toEqual(1);
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnLong", async () => {
@@ -58,7 +58,7 @@ describe("PrimitiveClient", () => {
             .build();
 
         const response = await client.endpoints.primitive.getAndReturnLong(1000000);
-        expect(response).toEqual(1000000);
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnDouble", async () => {
@@ -77,7 +77,7 @@ describe("PrimitiveClient", () => {
             .build();
 
         const response = await client.endpoints.primitive.getAndReturnDouble(1.1);
-        expect(response).toEqual(1.1);
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnBool", async () => {
@@ -96,7 +96,7 @@ describe("PrimitiveClient", () => {
             .build();
 
         const response = await client.endpoints.primitive.getAndReturnBool(true);
-        expect(response).toEqual(true);
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnDatetime", async () => {
@@ -115,7 +115,7 @@ describe("PrimitiveClient", () => {
             .build();
 
         const response = await client.endpoints.primitive.getAndReturnDatetime("2024-01-15T09:30:00Z");
-        expect(response).toEqual("2024-01-15T09:30:00Z");
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnDate", async () => {
@@ -134,7 +134,7 @@ describe("PrimitiveClient", () => {
             .build();
 
         const response = await client.endpoints.primitive.getAndReturnDate("2023-01-15");
-        expect(response).toEqual("2023-01-15");
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnUUID", async () => {
@@ -153,7 +153,7 @@ describe("PrimitiveClient", () => {
             .build();
 
         const response = await client.endpoints.primitive.getAndReturnUuid("d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32");
-        expect(response).toEqual("d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32");
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnBase64", async () => {
@@ -172,6 +172,6 @@ describe("PrimitiveClient", () => {
             .build();
 
         const response = await client.endpoints.primitive.getAndReturnBase64("SGVsbG8gd29ybGQh");
-        expect(response).toEqual("SGVsbG8gd29ybGQh");
+        expect(response).toEqual(rawResponseBody);
     });
 });

--- a/seed/ts-sdk/exhaustive/parameter-naming-original-name/tests/wire/endpoints/put.test.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-original-name/tests/wire/endpoints/put.test.ts
@@ -20,21 +20,6 @@ describe("PutClient", () => {
         const response = await client.endpoints.put.add({
             id: "id",
         });
-        expect(response).toEqual({
-            errors: [
-                {
-                    category: "API_ERROR",
-                    code: "INTERNAL_SERVER_ERROR",
-                    detail: "detail",
-                    field: "field",
-                },
-                {
-                    category: "API_ERROR",
-                    code: "INTERNAL_SERVER_ERROR",
-                    detail: "detail",
-                    field: "field",
-                },
-            ],
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 });

--- a/seed/ts-sdk/exhaustive/parameter-naming-original-name/tests/wire/endpoints/union.test.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-original-name/tests/wire/endpoints/union.test.ts
@@ -24,10 +24,6 @@ describe("UnionClient", () => {
             name: "name",
             likesToWoof: true,
         });
-        expect(response).toEqual({
-            animal: "dog",
-            name: "name",
-            likesToWoof: true,
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 });

--- a/seed/ts-sdk/exhaustive/parameter-naming-original-name/tests/wire/endpoints/urls.test.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-original-name/tests/wire/endpoints/urls.test.ts
@@ -13,7 +13,7 @@ describe("UrlsClient", () => {
         server.mockEndpoint().get("/urls/MixedCase").respondWith().statusCode(200).jsonBody(rawResponseBody).build();
 
         const response = await client.endpoints.urls.withMixedCase();
-        expect(response).toEqual("string");
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("noEndingSlash", async () => {
@@ -31,7 +31,7 @@ describe("UrlsClient", () => {
             .build();
 
         const response = await client.endpoints.urls.noEndingSlash();
-        expect(response).toEqual("string");
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("withEndingSlash", async () => {
@@ -49,7 +49,7 @@ describe("UrlsClient", () => {
             .build();
 
         const response = await client.endpoints.urls.withEndingSlash();
-        expect(response).toEqual("string");
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("withUnderscores", async () => {
@@ -67,6 +67,6 @@ describe("UrlsClient", () => {
             .build();
 
         const response = await client.endpoints.urls.withUnderscores();
-        expect(response).toEqual("string");
+        expect(response).toEqual(rawResponseBody);
     });
 });

--- a/seed/ts-sdk/exhaustive/parameter-naming-original-name/tests/wire/inlinedRequests.test.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-original-name/tests/wire/inlinedRequests.test.ts
@@ -73,23 +73,7 @@ describe("InlinedRequestsClient", () => {
                 bigint: "1000000",
             },
         });
-        expect(response).toEqual({
-            string: "string",
-            integer: 1,
-            long: 1000000,
-            double: 1.1,
-            bool: true,
-            datetime: "2024-01-15T09:30:00Z",
-            date: "2023-01-15",
-            uuid: "d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32",
-            base64: "SGVsbG8gd29ybGQh",
-            list: ["list", "list"],
-            set: ["set"],
-            map: {
-                1: "map",
-            },
-            bigint: "1000000",
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("postWithObjectBodyandResponse (2)", async () => {

--- a/seed/ts-sdk/exhaustive/parameter-naming-original-name/tests/wire/noAuth.test.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-original-name/tests/wire/noAuth.test.ts
@@ -23,7 +23,7 @@ describe("NoAuthClient", () => {
         const response = await client.noAuth.postWithNoAuth({
             key: "value",
         });
-        expect(response).toEqual(true);
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("postWithNoAuth (2)", async () => {

--- a/seed/ts-sdk/exhaustive/parameter-naming-original-name/tests/wire/noReqBody.test.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-original-name/tests/wire/noReqBody.test.ts
@@ -27,23 +27,7 @@ describe("NoReqBodyClient", () => {
         server.mockEndpoint().get("/no-req-body").respondWith().statusCode(200).jsonBody(rawResponseBody).build();
 
         const response = await client.noReqBody.getWithNoRequestBody();
-        expect(response).toEqual({
-            string: "string",
-            integer: 1,
-            long: 1000000,
-            double: 1.1,
-            bool: true,
-            datetime: "2024-01-15T09:30:00Z",
-            date: "2023-01-15",
-            uuid: "d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32",
-            base64: "SGVsbG8gd29ybGQh",
-            list: ["list", "list"],
-            set: ["set"],
-            map: {
-                1: "map",
-            },
-            bigint: "1000000",
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("postWithNoRequestBody", async () => {
@@ -55,6 +39,6 @@ describe("NoReqBodyClient", () => {
         server.mockEndpoint().post("/no-req-body").respondWith().statusCode(200).jsonBody(rawResponseBody).build();
 
         const response = await client.noReqBody.postWithNoRequestBody();
-        expect(response).toEqual("string");
+        expect(response).toEqual(rawResponseBody);
     });
 });

--- a/seed/ts-sdk/exhaustive/parameter-naming-snake-case/tests/wire/endpoints/container.test.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-snake-case/tests/wire/endpoints/container.test.ts
@@ -20,7 +20,7 @@ describe("ContainerClient", () => {
             .build();
 
         const response = await client.endpoints.container.getAndReturnListOfPrimitives(["string", "string"]);
-        expect(response).toEqual(["string", "string"]);
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnListOfObjects", async () => {
@@ -46,14 +46,7 @@ describe("ContainerClient", () => {
                 string: "string",
             },
         ]);
-        expect(response).toEqual([
-            {
-                string: "string",
-            },
-            {
-                string: "string",
-            },
-        ]);
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnSetOfPrimitives", async () => {
@@ -72,7 +65,7 @@ describe("ContainerClient", () => {
             .build();
 
         const response = await client.endpoints.container.getAndReturnSetOfPrimitives(["string"]);
-        expect(response).toEqual(["string"]);
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnSetOfObjects", async () => {
@@ -95,11 +88,7 @@ describe("ContainerClient", () => {
                 string: "string",
             },
         ]);
-        expect(response).toEqual([
-            {
-                string: "string",
-            },
-        ]);
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnMapPrimToPrim", async () => {
@@ -120,9 +109,7 @@ describe("ContainerClient", () => {
         const response = await client.endpoints.container.getAndReturnMapPrimToPrim({
             string: "string",
         });
-        expect(response).toEqual({
-            string: "string",
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnMapOfPrimToObject", async () => {
@@ -145,11 +132,7 @@ describe("ContainerClient", () => {
                 string: "string",
             },
         });
-        expect(response).toEqual({
-            string: {
-                string: "string",
-            },
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnMapOfPrimToUndiscriminatedUnion", async () => {
@@ -170,9 +153,7 @@ describe("ContainerClient", () => {
         const response = await client.endpoints.container.getAndReturnMapOfPrimToUndiscriminatedUnion({
             string: 1.1,
         });
-        expect(response).toEqual({
-            string: 1.1,
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnOptional", async () => {
@@ -193,8 +174,6 @@ describe("ContainerClient", () => {
         const response = await client.endpoints.container.getAndReturnOptional({
             string: "string",
         });
-        expect(response).toEqual({
-            string: "string",
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 });

--- a/seed/ts-sdk/exhaustive/parameter-naming-snake-case/tests/wire/endpoints/enum.test.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-snake-case/tests/wire/endpoints/enum.test.ts
@@ -20,6 +20,6 @@ describe("EnumClient", () => {
             .build();
 
         const response = await client.endpoints.enum.getAndReturnEnum("SUNNY");
-        expect(response).toEqual("SUNNY");
+        expect(response).toEqual(rawResponseBody);
     });
 });

--- a/seed/ts-sdk/exhaustive/parameter-naming-snake-case/tests/wire/endpoints/httpMethods.test.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-snake-case/tests/wire/endpoints/httpMethods.test.ts
@@ -13,7 +13,7 @@ describe("HttpMethodsClient", () => {
         server.mockEndpoint().get("/http-methods/id").respondWith().statusCode(200).jsonBody(rawResponseBody).build();
 
         const response = await client.endpoints.httpMethods.testGet("id");
-        expect(response).toEqual("string");
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("testPost", async () => {
@@ -48,23 +48,7 @@ describe("HttpMethodsClient", () => {
         const response = await client.endpoints.httpMethods.testPost({
             string: "string",
         });
-        expect(response).toEqual({
-            string: "string",
-            integer: 1,
-            long: 1000000,
-            double: 1.1,
-            bool: true,
-            datetime: "2024-01-15T09:30:00Z",
-            date: "2023-01-15",
-            uuid: "d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32",
-            base64: "SGVsbG8gd29ybGQh",
-            list: ["list", "list"],
-            set: ["set"],
-            map: {
-                1: "map",
-            },
-            bigint: "1000000",
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("testPut", async () => {
@@ -99,23 +83,7 @@ describe("HttpMethodsClient", () => {
         const response = await client.endpoints.httpMethods.testPut("id", {
             string: "string",
         });
-        expect(response).toEqual({
-            string: "string",
-            integer: 1,
-            long: 1000000,
-            double: 1.1,
-            bool: true,
-            datetime: "2024-01-15T09:30:00Z",
-            date: "2023-01-15",
-            uuid: "d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32",
-            base64: "SGVsbG8gd29ybGQh",
-            list: ["list", "list"],
-            set: ["set"],
-            map: {
-                1: "map",
-            },
-            bigint: "1000000",
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("testPatch", async () => {
@@ -178,23 +146,7 @@ describe("HttpMethodsClient", () => {
             },
             bigint: "1000000",
         });
-        expect(response).toEqual({
-            string: "string",
-            integer: 1,
-            long: 1000000,
-            double: 1.1,
-            bool: true,
-            datetime: "2024-01-15T09:30:00Z",
-            date: "2023-01-15",
-            uuid: "d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32",
-            base64: "SGVsbG8gd29ybGQh",
-            list: ["list", "list"],
-            set: ["set"],
-            map: {
-                1: "map",
-            },
-            bigint: "1000000",
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("testDelete", async () => {
@@ -212,6 +164,6 @@ describe("HttpMethodsClient", () => {
             .build();
 
         const response = await client.endpoints.httpMethods.testDelete("id");
-        expect(response).toEqual(true);
+        expect(response).toEqual(rawResponseBody);
     });
 });

--- a/seed/ts-sdk/exhaustive/parameter-naming-snake-case/tests/wire/endpoints/object.test.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-snake-case/tests/wire/endpoints/object.test.ts
@@ -64,23 +64,7 @@ describe("ObjectClient", () => {
             },
             bigint: "1000000",
         });
-        expect(response).toEqual({
-            string: "string",
-            integer: 1,
-            long: 1000000,
-            double: 1.1,
-            bool: true,
-            datetime: "2024-01-15T09:30:00Z",
-            date: "2023-01-15",
-            uuid: "d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32",
-            base64: "SGVsbG8gd29ybGQh",
-            list: ["list", "list"],
-            set: ["set"],
-            map: {
-                1: "map",
-            },
-            bigint: "1000000",
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnWithRequiredField", async () => {
@@ -101,9 +85,7 @@ describe("ObjectClient", () => {
         const response = await client.endpoints.object.getAndReturnWithRequiredField({
             string: "string",
         });
-        expect(response).toEqual({
-            string: "string",
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnWithMapOfMap", async () => {
@@ -128,13 +110,7 @@ describe("ObjectClient", () => {
                 },
             },
         });
-        expect(response).toEqual({
-            map: {
-                map: {
-                    map: "map",
-                },
-            },
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnNestedWithOptionalField", async () => {
@@ -206,26 +182,7 @@ describe("ObjectClient", () => {
                 bigint: "1000000",
             },
         });
-        expect(response).toEqual({
-            string: "string",
-            NestedObject: {
-                string: "string",
-                integer: 1,
-                long: 1000000,
-                double: 1.1,
-                bool: true,
-                datetime: "2024-01-15T09:30:00Z",
-                date: "2023-01-15",
-                uuid: "d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32",
-                base64: "SGVsbG8gd29ybGQh",
-                list: ["list", "list"],
-                set: ["set"],
-                map: {
-                    1: "map",
-                },
-                bigint: "1000000",
-            },
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnNestedWithRequiredField", async () => {
@@ -297,26 +254,7 @@ describe("ObjectClient", () => {
                 bigint: "1000000",
             },
         });
-        expect(response).toEqual({
-            string: "string",
-            NestedObject: {
-                string: "string",
-                integer: 1,
-                long: 1000000,
-                double: 1.1,
-                bool: true,
-                datetime: "2024-01-15T09:30:00Z",
-                date: "2023-01-15",
-                uuid: "d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32",
-                base64: "SGVsbG8gd29ybGQh",
-                list: ["list", "list"],
-                set: ["set"],
-                map: {
-                    1: "map",
-                },
-                bigint: "1000000",
-            },
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnNestedWithRequiredFieldAsList", async () => {
@@ -430,26 +368,7 @@ describe("ObjectClient", () => {
                 },
             },
         ]);
-        expect(response).toEqual({
-            string: "string",
-            NestedObject: {
-                string: "string",
-                integer: 1,
-                long: 1000000,
-                double: 1.1,
-                bool: true,
-                datetime: "2024-01-15T09:30:00Z",
-                date: "2023-01-15",
-                uuid: "d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32",
-                base64: "SGVsbG8gd29ybGQh",
-                list: ["list", "list"],
-                set: ["set"],
-                map: {
-                    1: "map",
-                },
-                bigint: "1000000",
-            },
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnWithUnknownField", async () => {
@@ -472,11 +391,7 @@ describe("ObjectClient", () => {
                 $ref: "https://example.com/schema",
             },
         });
-        expect(response).toEqual({
-            unknown: {
-                $ref: "https://example.com/schema",
-            },
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnWithDocumentedUnknownType", async () => {
@@ -499,11 +414,7 @@ describe("ObjectClient", () => {
                 key: "value",
             },
         });
-        expect(response).toEqual({
-            documentedUnknownType: {
-                key: "value",
-            },
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnMapOfDocumentedUnknownType", async () => {
@@ -526,11 +437,7 @@ describe("ObjectClient", () => {
                 key: "value",
             },
         });
-        expect(response).toEqual({
-            string: {
-                key: "value",
-            },
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnWithDatetimeLikeString", async () => {
@@ -552,9 +459,6 @@ describe("ObjectClient", () => {
             datetimeLikeString: "2023-08-31T14:15:22Z",
             actualDatetime: "2023-08-31T14:15:22Z",
         });
-        expect(response).toEqual({
-            datetimeLikeString: "2023-08-31T14:15:22Z",
-            actualDatetime: "2023-08-31T14:15:22Z",
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 });

--- a/seed/ts-sdk/exhaustive/parameter-naming-snake-case/tests/wire/endpoints/pagination.test.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-snake-case/tests/wire/endpoints/pagination.test.ts
@@ -18,17 +18,7 @@ describe("PaginationClient", () => {
             .jsonBody(rawResponseBody)
             .build();
 
-        const expected = {
-            items: [
-                {
-                    string: "string",
-                },
-                {
-                    string: "string",
-                },
-            ],
-            next: "next",
-        };
+        const expected = rawResponseBody;
         const page = await client.endpoints.pagination.listItems({
             cursor: "cursor",
             limit: 1,

--- a/seed/ts-sdk/exhaustive/parameter-naming-snake-case/tests/wire/endpoints/params.test.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-snake-case/tests/wire/endpoints/params.test.ts
@@ -14,7 +14,7 @@ describe("ParamsClient", () => {
         server.mockEndpoint().get("/params/path/param").respondWith().statusCode(200).jsonBody(rawResponseBody).build();
 
         const response = await client.endpoints.params.getWithPath("param");
-        expect(response).toEqual("string");
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getWithInlinePath", async () => {
@@ -28,7 +28,7 @@ describe("ParamsClient", () => {
         const response = await client.endpoints.params.getWithInlinePath({
             param: "param",
         });
-        expect(response).toEqual("string");
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getWithQuery", async () => {
@@ -98,7 +98,7 @@ describe("ParamsClient", () => {
             .build();
 
         const response = await client.endpoints.params.modifyWithPath("param", "string");
-        expect(response).toEqual("string");
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("modifyWithInlinePath", async () => {
@@ -120,7 +120,7 @@ describe("ParamsClient", () => {
             param: "param",
             body: "string",
         });
-        expect(response).toEqual("string");
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getWithPathAndErrors (1)", async () => {
@@ -132,7 +132,7 @@ describe("ParamsClient", () => {
         server.mockEndpoint().get("/params/path/param").respondWith().statusCode(200).jsonBody(rawResponseBody).build();
 
         const response = await client.endpoints.params.getWithPathAndErrors("param");
-        expect(response).toEqual("string");
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getWithPathAndErrors (2)", async () => {

--- a/seed/ts-sdk/exhaustive/parameter-naming-snake-case/tests/wire/endpoints/primitive.test.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-snake-case/tests/wire/endpoints/primitive.test.ts
@@ -20,7 +20,7 @@ describe("PrimitiveClient", () => {
             .build();
 
         const response = await client.endpoints.primitive.getAndReturnString("string");
-        expect(response).toEqual("string");
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnInt", async () => {
@@ -39,7 +39,7 @@ describe("PrimitiveClient", () => {
             .build();
 
         const response = await client.endpoints.primitive.getAndReturnInt(1);
-        expect(response).toEqual(1);
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnLong", async () => {
@@ -58,7 +58,7 @@ describe("PrimitiveClient", () => {
             .build();
 
         const response = await client.endpoints.primitive.getAndReturnLong(1000000);
-        expect(response).toEqual(1000000);
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnDouble", async () => {
@@ -77,7 +77,7 @@ describe("PrimitiveClient", () => {
             .build();
 
         const response = await client.endpoints.primitive.getAndReturnDouble(1.1);
-        expect(response).toEqual(1.1);
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnBool", async () => {
@@ -96,7 +96,7 @@ describe("PrimitiveClient", () => {
             .build();
 
         const response = await client.endpoints.primitive.getAndReturnBool(true);
-        expect(response).toEqual(true);
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnDatetime", async () => {
@@ -115,7 +115,7 @@ describe("PrimitiveClient", () => {
             .build();
 
         const response = await client.endpoints.primitive.getAndReturnDatetime("2024-01-15T09:30:00Z");
-        expect(response).toEqual("2024-01-15T09:30:00Z");
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnDate", async () => {
@@ -134,7 +134,7 @@ describe("PrimitiveClient", () => {
             .build();
 
         const response = await client.endpoints.primitive.getAndReturnDate("2023-01-15");
-        expect(response).toEqual("2023-01-15");
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnUUID", async () => {
@@ -153,7 +153,7 @@ describe("PrimitiveClient", () => {
             .build();
 
         const response = await client.endpoints.primitive.getAndReturnUuid("d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32");
-        expect(response).toEqual("d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32");
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnBase64", async () => {
@@ -172,6 +172,6 @@ describe("PrimitiveClient", () => {
             .build();
 
         const response = await client.endpoints.primitive.getAndReturnBase64("SGVsbG8gd29ybGQh");
-        expect(response).toEqual("SGVsbG8gd29ybGQh");
+        expect(response).toEqual(rawResponseBody);
     });
 });

--- a/seed/ts-sdk/exhaustive/parameter-naming-snake-case/tests/wire/endpoints/put.test.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-snake-case/tests/wire/endpoints/put.test.ts
@@ -20,21 +20,6 @@ describe("PutClient", () => {
         const response = await client.endpoints.put.add({
             id: "id",
         });
-        expect(response).toEqual({
-            errors: [
-                {
-                    category: "API_ERROR",
-                    code: "INTERNAL_SERVER_ERROR",
-                    detail: "detail",
-                    field: "field",
-                },
-                {
-                    category: "API_ERROR",
-                    code: "INTERNAL_SERVER_ERROR",
-                    detail: "detail",
-                    field: "field",
-                },
-            ],
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 });

--- a/seed/ts-sdk/exhaustive/parameter-naming-snake-case/tests/wire/endpoints/union.test.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-snake-case/tests/wire/endpoints/union.test.ts
@@ -24,10 +24,6 @@ describe("UnionClient", () => {
             name: "name",
             likesToWoof: true,
         });
-        expect(response).toEqual({
-            animal: "dog",
-            name: "name",
-            likesToWoof: true,
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 });

--- a/seed/ts-sdk/exhaustive/parameter-naming-snake-case/tests/wire/endpoints/urls.test.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-snake-case/tests/wire/endpoints/urls.test.ts
@@ -13,7 +13,7 @@ describe("UrlsClient", () => {
         server.mockEndpoint().get("/urls/MixedCase").respondWith().statusCode(200).jsonBody(rawResponseBody).build();
 
         const response = await client.endpoints.urls.withMixedCase();
-        expect(response).toEqual("string");
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("noEndingSlash", async () => {
@@ -31,7 +31,7 @@ describe("UrlsClient", () => {
             .build();
 
         const response = await client.endpoints.urls.noEndingSlash();
-        expect(response).toEqual("string");
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("withEndingSlash", async () => {
@@ -49,7 +49,7 @@ describe("UrlsClient", () => {
             .build();
 
         const response = await client.endpoints.urls.withEndingSlash();
-        expect(response).toEqual("string");
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("withUnderscores", async () => {
@@ -67,6 +67,6 @@ describe("UrlsClient", () => {
             .build();
 
         const response = await client.endpoints.urls.withUnderscores();
-        expect(response).toEqual("string");
+        expect(response).toEqual(rawResponseBody);
     });
 });

--- a/seed/ts-sdk/exhaustive/parameter-naming-snake-case/tests/wire/inlinedRequests.test.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-snake-case/tests/wire/inlinedRequests.test.ts
@@ -73,23 +73,7 @@ describe("InlinedRequestsClient", () => {
                 bigint: "1000000",
             },
         });
-        expect(response).toEqual({
-            string: "string",
-            integer: 1,
-            long: 1000000,
-            double: 1.1,
-            bool: true,
-            datetime: "2024-01-15T09:30:00Z",
-            date: "2023-01-15",
-            uuid: "d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32",
-            base64: "SGVsbG8gd29ybGQh",
-            list: ["list", "list"],
-            set: ["set"],
-            map: {
-                1: "map",
-            },
-            bigint: "1000000",
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("postWithObjectBodyandResponse (2)", async () => {

--- a/seed/ts-sdk/exhaustive/parameter-naming-snake-case/tests/wire/noAuth.test.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-snake-case/tests/wire/noAuth.test.ts
@@ -23,7 +23,7 @@ describe("NoAuthClient", () => {
         const response = await client.noAuth.postWithNoAuth({
             key: "value",
         });
-        expect(response).toEqual(true);
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("postWithNoAuth (2)", async () => {

--- a/seed/ts-sdk/exhaustive/parameter-naming-snake-case/tests/wire/noReqBody.test.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-snake-case/tests/wire/noReqBody.test.ts
@@ -27,23 +27,7 @@ describe("NoReqBodyClient", () => {
         server.mockEndpoint().get("/no-req-body").respondWith().statusCode(200).jsonBody(rawResponseBody).build();
 
         const response = await client.noReqBody.getWithNoRequestBody();
-        expect(response).toEqual({
-            string: "string",
-            integer: 1,
-            long: 1000000,
-            double: 1.1,
-            bool: true,
-            datetime: "2024-01-15T09:30:00Z",
-            date: "2023-01-15",
-            uuid: "d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32",
-            base64: "SGVsbG8gd29ybGQh",
-            list: ["list", "list"],
-            set: ["set"],
-            map: {
-                1: "map",
-            },
-            bigint: "1000000",
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("postWithNoRequestBody", async () => {
@@ -55,6 +39,6 @@ describe("NoReqBodyClient", () => {
         server.mockEndpoint().post("/no-req-body").respondWith().statusCode(200).jsonBody(rawResponseBody).build();
 
         const response = await client.noReqBody.postWithNoRequestBody();
-        expect(response).toEqual("string");
+        expect(response).toEqual(rawResponseBody);
     });
 });

--- a/seed/ts-sdk/exhaustive/parameter-naming-wire-value/tests/wire/endpoints/container.test.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-wire-value/tests/wire/endpoints/container.test.ts
@@ -20,7 +20,7 @@ describe("ContainerClient", () => {
             .build();
 
         const response = await client.endpoints.container.getAndReturnListOfPrimitives(["string", "string"]);
-        expect(response).toEqual(["string", "string"]);
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnListOfObjects", async () => {
@@ -46,14 +46,7 @@ describe("ContainerClient", () => {
                 string: "string",
             },
         ]);
-        expect(response).toEqual([
-            {
-                string: "string",
-            },
-            {
-                string: "string",
-            },
-        ]);
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnSetOfPrimitives", async () => {
@@ -72,7 +65,7 @@ describe("ContainerClient", () => {
             .build();
 
         const response = await client.endpoints.container.getAndReturnSetOfPrimitives(["string"]);
-        expect(response).toEqual(["string"]);
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnSetOfObjects", async () => {
@@ -95,11 +88,7 @@ describe("ContainerClient", () => {
                 string: "string",
             },
         ]);
-        expect(response).toEqual([
-            {
-                string: "string",
-            },
-        ]);
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnMapPrimToPrim", async () => {
@@ -120,9 +109,7 @@ describe("ContainerClient", () => {
         const response = await client.endpoints.container.getAndReturnMapPrimToPrim({
             string: "string",
         });
-        expect(response).toEqual({
-            string: "string",
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnMapOfPrimToObject", async () => {
@@ -145,11 +132,7 @@ describe("ContainerClient", () => {
                 string: "string",
             },
         });
-        expect(response).toEqual({
-            string: {
-                string: "string",
-            },
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnMapOfPrimToUndiscriminatedUnion", async () => {
@@ -170,9 +153,7 @@ describe("ContainerClient", () => {
         const response = await client.endpoints.container.getAndReturnMapOfPrimToUndiscriminatedUnion({
             string: 1.1,
         });
-        expect(response).toEqual({
-            string: 1.1,
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnOptional", async () => {
@@ -193,8 +174,6 @@ describe("ContainerClient", () => {
         const response = await client.endpoints.container.getAndReturnOptional({
             string: "string",
         });
-        expect(response).toEqual({
-            string: "string",
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 });

--- a/seed/ts-sdk/exhaustive/parameter-naming-wire-value/tests/wire/endpoints/enum.test.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-wire-value/tests/wire/endpoints/enum.test.ts
@@ -20,6 +20,6 @@ describe("EnumClient", () => {
             .build();
 
         const response = await client.endpoints.enum.getAndReturnEnum("SUNNY");
-        expect(response).toEqual("SUNNY");
+        expect(response).toEqual(rawResponseBody);
     });
 });

--- a/seed/ts-sdk/exhaustive/parameter-naming-wire-value/tests/wire/endpoints/httpMethods.test.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-wire-value/tests/wire/endpoints/httpMethods.test.ts
@@ -13,7 +13,7 @@ describe("HttpMethodsClient", () => {
         server.mockEndpoint().get("/http-methods/id").respondWith().statusCode(200).jsonBody(rawResponseBody).build();
 
         const response = await client.endpoints.httpMethods.testGet("id");
-        expect(response).toEqual("string");
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("testPost", async () => {
@@ -48,23 +48,7 @@ describe("HttpMethodsClient", () => {
         const response = await client.endpoints.httpMethods.testPost({
             string: "string",
         });
-        expect(response).toEqual({
-            string: "string",
-            integer: 1,
-            long: 1000000,
-            double: 1.1,
-            bool: true,
-            datetime: "2024-01-15T09:30:00Z",
-            date: "2023-01-15",
-            uuid: "d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32",
-            base64: "SGVsbG8gd29ybGQh",
-            list: ["list", "list"],
-            set: ["set"],
-            map: {
-                1: "map",
-            },
-            bigint: "1000000",
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("testPut", async () => {
@@ -99,23 +83,7 @@ describe("HttpMethodsClient", () => {
         const response = await client.endpoints.httpMethods.testPut("id", {
             string: "string",
         });
-        expect(response).toEqual({
-            string: "string",
-            integer: 1,
-            long: 1000000,
-            double: 1.1,
-            bool: true,
-            datetime: "2024-01-15T09:30:00Z",
-            date: "2023-01-15",
-            uuid: "d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32",
-            base64: "SGVsbG8gd29ybGQh",
-            list: ["list", "list"],
-            set: ["set"],
-            map: {
-                1: "map",
-            },
-            bigint: "1000000",
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("testPatch", async () => {
@@ -178,23 +146,7 @@ describe("HttpMethodsClient", () => {
             },
             bigint: "1000000",
         });
-        expect(response).toEqual({
-            string: "string",
-            integer: 1,
-            long: 1000000,
-            double: 1.1,
-            bool: true,
-            datetime: "2024-01-15T09:30:00Z",
-            date: "2023-01-15",
-            uuid: "d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32",
-            base64: "SGVsbG8gd29ybGQh",
-            list: ["list", "list"],
-            set: ["set"],
-            map: {
-                1: "map",
-            },
-            bigint: "1000000",
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("testDelete", async () => {
@@ -212,6 +164,6 @@ describe("HttpMethodsClient", () => {
             .build();
 
         const response = await client.endpoints.httpMethods.testDelete("id");
-        expect(response).toEqual(true);
+        expect(response).toEqual(rawResponseBody);
     });
 });

--- a/seed/ts-sdk/exhaustive/parameter-naming-wire-value/tests/wire/endpoints/object.test.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-wire-value/tests/wire/endpoints/object.test.ts
@@ -64,23 +64,7 @@ describe("ObjectClient", () => {
             },
             bigint: "1000000",
         });
-        expect(response).toEqual({
-            string: "string",
-            integer: 1,
-            long: 1000000,
-            double: 1.1,
-            bool: true,
-            datetime: "2024-01-15T09:30:00Z",
-            date: "2023-01-15",
-            uuid: "d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32",
-            base64: "SGVsbG8gd29ybGQh",
-            list: ["list", "list"],
-            set: ["set"],
-            map: {
-                1: "map",
-            },
-            bigint: "1000000",
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnWithRequiredField", async () => {
@@ -101,9 +85,7 @@ describe("ObjectClient", () => {
         const response = await client.endpoints.object.getAndReturnWithRequiredField({
             string: "string",
         });
-        expect(response).toEqual({
-            string: "string",
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnWithMapOfMap", async () => {
@@ -128,13 +110,7 @@ describe("ObjectClient", () => {
                 },
             },
         });
-        expect(response).toEqual({
-            map: {
-                map: {
-                    map: "map",
-                },
-            },
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnNestedWithOptionalField", async () => {
@@ -206,26 +182,7 @@ describe("ObjectClient", () => {
                 bigint: "1000000",
             },
         });
-        expect(response).toEqual({
-            string: "string",
-            NestedObject: {
-                string: "string",
-                integer: 1,
-                long: 1000000,
-                double: 1.1,
-                bool: true,
-                datetime: "2024-01-15T09:30:00Z",
-                date: "2023-01-15",
-                uuid: "d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32",
-                base64: "SGVsbG8gd29ybGQh",
-                list: ["list", "list"],
-                set: ["set"],
-                map: {
-                    1: "map",
-                },
-                bigint: "1000000",
-            },
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnNestedWithRequiredField", async () => {
@@ -297,26 +254,7 @@ describe("ObjectClient", () => {
                 bigint: "1000000",
             },
         });
-        expect(response).toEqual({
-            string: "string",
-            NestedObject: {
-                string: "string",
-                integer: 1,
-                long: 1000000,
-                double: 1.1,
-                bool: true,
-                datetime: "2024-01-15T09:30:00Z",
-                date: "2023-01-15",
-                uuid: "d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32",
-                base64: "SGVsbG8gd29ybGQh",
-                list: ["list", "list"],
-                set: ["set"],
-                map: {
-                    1: "map",
-                },
-                bigint: "1000000",
-            },
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnNestedWithRequiredFieldAsList", async () => {
@@ -430,26 +368,7 @@ describe("ObjectClient", () => {
                 },
             },
         ]);
-        expect(response).toEqual({
-            string: "string",
-            NestedObject: {
-                string: "string",
-                integer: 1,
-                long: 1000000,
-                double: 1.1,
-                bool: true,
-                datetime: "2024-01-15T09:30:00Z",
-                date: "2023-01-15",
-                uuid: "d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32",
-                base64: "SGVsbG8gd29ybGQh",
-                list: ["list", "list"],
-                set: ["set"],
-                map: {
-                    1: "map",
-                },
-                bigint: "1000000",
-            },
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnWithUnknownField", async () => {
@@ -472,11 +391,7 @@ describe("ObjectClient", () => {
                 $ref: "https://example.com/schema",
             },
         });
-        expect(response).toEqual({
-            unknown: {
-                $ref: "https://example.com/schema",
-            },
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnWithDocumentedUnknownType", async () => {
@@ -499,11 +414,7 @@ describe("ObjectClient", () => {
                 key: "value",
             },
         });
-        expect(response).toEqual({
-            documentedUnknownType: {
-                key: "value",
-            },
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnMapOfDocumentedUnknownType", async () => {
@@ -526,11 +437,7 @@ describe("ObjectClient", () => {
                 key: "value",
             },
         });
-        expect(response).toEqual({
-            string: {
-                key: "value",
-            },
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnWithDatetimeLikeString", async () => {
@@ -552,9 +459,6 @@ describe("ObjectClient", () => {
             datetimeLikeString: "2023-08-31T14:15:22Z",
             actualDatetime: "2023-08-31T14:15:22Z",
         });
-        expect(response).toEqual({
-            datetimeLikeString: "2023-08-31T14:15:22Z",
-            actualDatetime: "2023-08-31T14:15:22Z",
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 });

--- a/seed/ts-sdk/exhaustive/parameter-naming-wire-value/tests/wire/endpoints/pagination.test.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-wire-value/tests/wire/endpoints/pagination.test.ts
@@ -18,17 +18,7 @@ describe("PaginationClient", () => {
             .jsonBody(rawResponseBody)
             .build();
 
-        const expected = {
-            items: [
-                {
-                    string: "string",
-                },
-                {
-                    string: "string",
-                },
-            ],
-            next: "next",
-        };
+        const expected = rawResponseBody;
         const page = await client.endpoints.pagination.listItems({
             cursor: "cursor",
             limit: 1,

--- a/seed/ts-sdk/exhaustive/parameter-naming-wire-value/tests/wire/endpoints/params.test.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-wire-value/tests/wire/endpoints/params.test.ts
@@ -14,7 +14,7 @@ describe("ParamsClient", () => {
         server.mockEndpoint().get("/params/path/param").respondWith().statusCode(200).jsonBody(rawResponseBody).build();
 
         const response = await client.endpoints.params.getWithPath("param");
-        expect(response).toEqual("string");
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getWithInlinePath", async () => {
@@ -28,7 +28,7 @@ describe("ParamsClient", () => {
         const response = await client.endpoints.params.getWithInlinePath({
             param: "param",
         });
-        expect(response).toEqual("string");
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getWithQuery", async () => {
@@ -98,7 +98,7 @@ describe("ParamsClient", () => {
             .build();
 
         const response = await client.endpoints.params.modifyWithPath("param", "string");
-        expect(response).toEqual("string");
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("modifyWithInlinePath", async () => {
@@ -120,7 +120,7 @@ describe("ParamsClient", () => {
             param: "param",
             body: "string",
         });
-        expect(response).toEqual("string");
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getWithPathAndErrors (1)", async () => {
@@ -132,7 +132,7 @@ describe("ParamsClient", () => {
         server.mockEndpoint().get("/params/path/param").respondWith().statusCode(200).jsonBody(rawResponseBody).build();
 
         const response = await client.endpoints.params.getWithPathAndErrors("param");
-        expect(response).toEqual("string");
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getWithPathAndErrors (2)", async () => {

--- a/seed/ts-sdk/exhaustive/parameter-naming-wire-value/tests/wire/endpoints/primitive.test.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-wire-value/tests/wire/endpoints/primitive.test.ts
@@ -20,7 +20,7 @@ describe("PrimitiveClient", () => {
             .build();
 
         const response = await client.endpoints.primitive.getAndReturnString("string");
-        expect(response).toEqual("string");
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnInt", async () => {
@@ -39,7 +39,7 @@ describe("PrimitiveClient", () => {
             .build();
 
         const response = await client.endpoints.primitive.getAndReturnInt(1);
-        expect(response).toEqual(1);
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnLong", async () => {
@@ -58,7 +58,7 @@ describe("PrimitiveClient", () => {
             .build();
 
         const response = await client.endpoints.primitive.getAndReturnLong(1000000);
-        expect(response).toEqual(1000000);
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnDouble", async () => {
@@ -77,7 +77,7 @@ describe("PrimitiveClient", () => {
             .build();
 
         const response = await client.endpoints.primitive.getAndReturnDouble(1.1);
-        expect(response).toEqual(1.1);
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnBool", async () => {
@@ -96,7 +96,7 @@ describe("PrimitiveClient", () => {
             .build();
 
         const response = await client.endpoints.primitive.getAndReturnBool(true);
-        expect(response).toEqual(true);
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnDatetime", async () => {
@@ -115,7 +115,7 @@ describe("PrimitiveClient", () => {
             .build();
 
         const response = await client.endpoints.primitive.getAndReturnDatetime("2024-01-15T09:30:00Z");
-        expect(response).toEqual("2024-01-15T09:30:00Z");
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnDate", async () => {
@@ -134,7 +134,7 @@ describe("PrimitiveClient", () => {
             .build();
 
         const response = await client.endpoints.primitive.getAndReturnDate("2023-01-15");
-        expect(response).toEqual("2023-01-15");
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnUUID", async () => {
@@ -153,7 +153,7 @@ describe("PrimitiveClient", () => {
             .build();
 
         const response = await client.endpoints.primitive.getAndReturnUuid("d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32");
-        expect(response).toEqual("d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32");
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnBase64", async () => {
@@ -172,6 +172,6 @@ describe("PrimitiveClient", () => {
             .build();
 
         const response = await client.endpoints.primitive.getAndReturnBase64("SGVsbG8gd29ybGQh");
-        expect(response).toEqual("SGVsbG8gd29ybGQh");
+        expect(response).toEqual(rawResponseBody);
     });
 });

--- a/seed/ts-sdk/exhaustive/parameter-naming-wire-value/tests/wire/endpoints/put.test.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-wire-value/tests/wire/endpoints/put.test.ts
@@ -20,21 +20,6 @@ describe("PutClient", () => {
         const response = await client.endpoints.put.add({
             id: "id",
         });
-        expect(response).toEqual({
-            errors: [
-                {
-                    category: "API_ERROR",
-                    code: "INTERNAL_SERVER_ERROR",
-                    detail: "detail",
-                    field: "field",
-                },
-                {
-                    category: "API_ERROR",
-                    code: "INTERNAL_SERVER_ERROR",
-                    detail: "detail",
-                    field: "field",
-                },
-            ],
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 });

--- a/seed/ts-sdk/exhaustive/parameter-naming-wire-value/tests/wire/endpoints/union.test.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-wire-value/tests/wire/endpoints/union.test.ts
@@ -24,10 +24,6 @@ describe("UnionClient", () => {
             name: "name",
             likesToWoof: true,
         });
-        expect(response).toEqual({
-            animal: "dog",
-            name: "name",
-            likesToWoof: true,
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 });

--- a/seed/ts-sdk/exhaustive/parameter-naming-wire-value/tests/wire/endpoints/urls.test.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-wire-value/tests/wire/endpoints/urls.test.ts
@@ -13,7 +13,7 @@ describe("UrlsClient", () => {
         server.mockEndpoint().get("/urls/MixedCase").respondWith().statusCode(200).jsonBody(rawResponseBody).build();
 
         const response = await client.endpoints.urls.withMixedCase();
-        expect(response).toEqual("string");
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("noEndingSlash", async () => {
@@ -31,7 +31,7 @@ describe("UrlsClient", () => {
             .build();
 
         const response = await client.endpoints.urls.noEndingSlash();
-        expect(response).toEqual("string");
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("withEndingSlash", async () => {
@@ -49,7 +49,7 @@ describe("UrlsClient", () => {
             .build();
 
         const response = await client.endpoints.urls.withEndingSlash();
-        expect(response).toEqual("string");
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("withUnderscores", async () => {
@@ -67,6 +67,6 @@ describe("UrlsClient", () => {
             .build();
 
         const response = await client.endpoints.urls.withUnderscores();
-        expect(response).toEqual("string");
+        expect(response).toEqual(rawResponseBody);
     });
 });

--- a/seed/ts-sdk/exhaustive/parameter-naming-wire-value/tests/wire/inlinedRequests.test.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-wire-value/tests/wire/inlinedRequests.test.ts
@@ -73,23 +73,7 @@ describe("InlinedRequestsClient", () => {
                 bigint: "1000000",
             },
         });
-        expect(response).toEqual({
-            string: "string",
-            integer: 1,
-            long: 1000000,
-            double: 1.1,
-            bool: true,
-            datetime: "2024-01-15T09:30:00Z",
-            date: "2023-01-15",
-            uuid: "d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32",
-            base64: "SGVsbG8gd29ybGQh",
-            list: ["list", "list"],
-            set: ["set"],
-            map: {
-                1: "map",
-            },
-            bigint: "1000000",
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("postWithObjectBodyandResponse (2)", async () => {

--- a/seed/ts-sdk/exhaustive/parameter-naming-wire-value/tests/wire/noAuth.test.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-wire-value/tests/wire/noAuth.test.ts
@@ -23,7 +23,7 @@ describe("NoAuthClient", () => {
         const response = await client.noAuth.postWithNoAuth({
             key: "value",
         });
-        expect(response).toEqual(true);
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("postWithNoAuth (2)", async () => {

--- a/seed/ts-sdk/exhaustive/parameter-naming-wire-value/tests/wire/noReqBody.test.ts
+++ b/seed/ts-sdk/exhaustive/parameter-naming-wire-value/tests/wire/noReqBody.test.ts
@@ -27,23 +27,7 @@ describe("NoReqBodyClient", () => {
         server.mockEndpoint().get("/no-req-body").respondWith().statusCode(200).jsonBody(rawResponseBody).build();
 
         const response = await client.noReqBody.getWithNoRequestBody();
-        expect(response).toEqual({
-            string: "string",
-            integer: 1,
-            long: 1000000,
-            double: 1.1,
-            bool: true,
-            datetime: "2024-01-15T09:30:00Z",
-            date: "2023-01-15",
-            uuid: "d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32",
-            base64: "SGVsbG8gd29ybGQh",
-            list: ["list", "list"],
-            set: ["set"],
-            map: {
-                1: "map",
-            },
-            bigint: "1000000",
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("postWithNoRequestBody", async () => {
@@ -55,6 +39,6 @@ describe("NoReqBodyClient", () => {
         server.mockEndpoint().post("/no-req-body").respondWith().statusCode(200).jsonBody(rawResponseBody).build();
 
         const response = await client.noReqBody.postWithNoRequestBody();
-        expect(response).toEqual("string");
+        expect(response).toEqual(rawResponseBody);
     });
 });

--- a/seed/ts-sdk/exhaustive/retain-original-casing/tests/wire/endpoints/container.test.ts
+++ b/seed/ts-sdk/exhaustive/retain-original-casing/tests/wire/endpoints/container.test.ts
@@ -20,7 +20,7 @@ describe("ContainerClient", () => {
             .build();
 
         const response = await client.endpoints.container.getAndReturnListOfPrimitives(["string", "string"]);
-        expect(response).toEqual(["string", "string"]);
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnListOfObjects", async () => {
@@ -46,14 +46,7 @@ describe("ContainerClient", () => {
                 string: "string",
             },
         ]);
-        expect(response).toEqual([
-            {
-                string: "string",
-            },
-            {
-                string: "string",
-            },
-        ]);
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnSetOfPrimitives", async () => {
@@ -72,7 +65,7 @@ describe("ContainerClient", () => {
             .build();
 
         const response = await client.endpoints.container.getAndReturnSetOfPrimitives(["string"]);
-        expect(response).toEqual(["string"]);
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnSetOfObjects", async () => {
@@ -95,11 +88,7 @@ describe("ContainerClient", () => {
                 string: "string",
             },
         ]);
-        expect(response).toEqual([
-            {
-                string: "string",
-            },
-        ]);
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnMapPrimToPrim", async () => {
@@ -120,9 +109,7 @@ describe("ContainerClient", () => {
         const response = await client.endpoints.container.getAndReturnMapPrimToPrim({
             string: "string",
         });
-        expect(response).toEqual({
-            string: "string",
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnMapOfPrimToObject", async () => {
@@ -145,11 +132,7 @@ describe("ContainerClient", () => {
                 string: "string",
             },
         });
-        expect(response).toEqual({
-            string: {
-                string: "string",
-            },
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnMapOfPrimToUndiscriminatedUnion", async () => {
@@ -170,9 +153,7 @@ describe("ContainerClient", () => {
         const response = await client.endpoints.container.getAndReturnMapOfPrimToUndiscriminatedUnion({
             string: 1.1,
         });
-        expect(response).toEqual({
-            string: 1.1,
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnOptional", async () => {
@@ -193,8 +174,6 @@ describe("ContainerClient", () => {
         const response = await client.endpoints.container.getAndReturnOptional({
             string: "string",
         });
-        expect(response).toEqual({
-            string: "string",
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 });

--- a/seed/ts-sdk/exhaustive/retain-original-casing/tests/wire/endpoints/enum.test.ts
+++ b/seed/ts-sdk/exhaustive/retain-original-casing/tests/wire/endpoints/enum.test.ts
@@ -20,6 +20,6 @@ describe("EnumClient", () => {
             .build();
 
         const response = await client.endpoints.enum.getAndReturnEnum("SUNNY");
-        expect(response).toEqual("SUNNY");
+        expect(response).toEqual(rawResponseBody);
     });
 });

--- a/seed/ts-sdk/exhaustive/retain-original-casing/tests/wire/endpoints/httpMethods.test.ts
+++ b/seed/ts-sdk/exhaustive/retain-original-casing/tests/wire/endpoints/httpMethods.test.ts
@@ -13,7 +13,7 @@ describe("HttpMethodsClient", () => {
         server.mockEndpoint().get("/http-methods/id").respondWith().statusCode(200).jsonBody(rawResponseBody).build();
 
         const response = await client.endpoints.httpMethods.testGet("id");
-        expect(response).toEqual("string");
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("testPost", async () => {
@@ -48,23 +48,7 @@ describe("HttpMethodsClient", () => {
         const response = await client.endpoints.httpMethods.testPost({
             string: "string",
         });
-        expect(response).toEqual({
-            string: "string",
-            integer: 1,
-            long: 1000000,
-            double: 1.1,
-            bool: true,
-            datetime: "2024-01-15T09:30:00Z",
-            date: "2023-01-15",
-            uuid: "d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32",
-            base64: "SGVsbG8gd29ybGQh",
-            list: ["list", "list"],
-            set: ["set"],
-            map: {
-                1: "map",
-            },
-            bigint: "1000000",
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("testPut", async () => {
@@ -99,23 +83,7 @@ describe("HttpMethodsClient", () => {
         const response = await client.endpoints.httpMethods.testPut("id", {
             string: "string",
         });
-        expect(response).toEqual({
-            string: "string",
-            integer: 1,
-            long: 1000000,
-            double: 1.1,
-            bool: true,
-            datetime: "2024-01-15T09:30:00Z",
-            date: "2023-01-15",
-            uuid: "d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32",
-            base64: "SGVsbG8gd29ybGQh",
-            list: ["list", "list"],
-            set: ["set"],
-            map: {
-                1: "map",
-            },
-            bigint: "1000000",
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("testPatch", async () => {
@@ -178,23 +146,7 @@ describe("HttpMethodsClient", () => {
             },
             bigint: "1000000",
         });
-        expect(response).toEqual({
-            string: "string",
-            integer: 1,
-            long: 1000000,
-            double: 1.1,
-            bool: true,
-            datetime: "2024-01-15T09:30:00Z",
-            date: "2023-01-15",
-            uuid: "d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32",
-            base64: "SGVsbG8gd29ybGQh",
-            list: ["list", "list"],
-            set: ["set"],
-            map: {
-                1: "map",
-            },
-            bigint: "1000000",
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("testDelete", async () => {
@@ -212,6 +164,6 @@ describe("HttpMethodsClient", () => {
             .build();
 
         const response = await client.endpoints.httpMethods.testDelete("id");
-        expect(response).toEqual(true);
+        expect(response).toEqual(rawResponseBody);
     });
 });

--- a/seed/ts-sdk/exhaustive/retain-original-casing/tests/wire/endpoints/object.test.ts
+++ b/seed/ts-sdk/exhaustive/retain-original-casing/tests/wire/endpoints/object.test.ts
@@ -64,23 +64,7 @@ describe("ObjectClient", () => {
             },
             bigint: "1000000",
         });
-        expect(response).toEqual({
-            string: "string",
-            integer: 1,
-            long: 1000000,
-            double: 1.1,
-            bool: true,
-            datetime: "2024-01-15T09:30:00Z",
-            date: "2023-01-15",
-            uuid: "d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32",
-            base64: "SGVsbG8gd29ybGQh",
-            list: ["list", "list"],
-            set: ["set"],
-            map: {
-                1: "map",
-            },
-            bigint: "1000000",
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnWithRequiredField", async () => {
@@ -101,9 +85,7 @@ describe("ObjectClient", () => {
         const response = await client.endpoints.object.getAndReturnWithRequiredField({
             string: "string",
         });
-        expect(response).toEqual({
-            string: "string",
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnWithMapOfMap", async () => {
@@ -128,13 +110,7 @@ describe("ObjectClient", () => {
                 },
             },
         });
-        expect(response).toEqual({
-            map: {
-                map: {
-                    map: "map",
-                },
-            },
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnNestedWithOptionalField", async () => {
@@ -206,26 +182,7 @@ describe("ObjectClient", () => {
                 bigint: "1000000",
             },
         });
-        expect(response).toEqual({
-            string: "string",
-            NestedObject: {
-                string: "string",
-                integer: 1,
-                long: 1000000,
-                double: 1.1,
-                bool: true,
-                datetime: "2024-01-15T09:30:00Z",
-                date: "2023-01-15",
-                uuid: "d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32",
-                base64: "SGVsbG8gd29ybGQh",
-                list: ["list", "list"],
-                set: ["set"],
-                map: {
-                    1: "map",
-                },
-                bigint: "1000000",
-            },
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnNestedWithRequiredField", async () => {
@@ -297,26 +254,7 @@ describe("ObjectClient", () => {
                 bigint: "1000000",
             },
         });
-        expect(response).toEqual({
-            string: "string",
-            NestedObject: {
-                string: "string",
-                integer: 1,
-                long: 1000000,
-                double: 1.1,
-                bool: true,
-                datetime: "2024-01-15T09:30:00Z",
-                date: "2023-01-15",
-                uuid: "d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32",
-                base64: "SGVsbG8gd29ybGQh",
-                list: ["list", "list"],
-                set: ["set"],
-                map: {
-                    1: "map",
-                },
-                bigint: "1000000",
-            },
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnNestedWithRequiredFieldAsList", async () => {
@@ -430,26 +368,7 @@ describe("ObjectClient", () => {
                 },
             },
         ]);
-        expect(response).toEqual({
-            string: "string",
-            NestedObject: {
-                string: "string",
-                integer: 1,
-                long: 1000000,
-                double: 1.1,
-                bool: true,
-                datetime: "2024-01-15T09:30:00Z",
-                date: "2023-01-15",
-                uuid: "d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32",
-                base64: "SGVsbG8gd29ybGQh",
-                list: ["list", "list"],
-                set: ["set"],
-                map: {
-                    1: "map",
-                },
-                bigint: "1000000",
-            },
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnWithUnknownField", async () => {
@@ -472,11 +391,7 @@ describe("ObjectClient", () => {
                 $ref: "https://example.com/schema",
             },
         });
-        expect(response).toEqual({
-            unknown: {
-                $ref: "https://example.com/schema",
-            },
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnWithDocumentedUnknownType", async () => {
@@ -499,11 +414,7 @@ describe("ObjectClient", () => {
                 key: "value",
             },
         });
-        expect(response).toEqual({
-            documentedUnknownType: {
-                key: "value",
-            },
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnMapOfDocumentedUnknownType", async () => {
@@ -526,11 +437,7 @@ describe("ObjectClient", () => {
                 key: "value",
             },
         });
-        expect(response).toEqual({
-            string: {
-                key: "value",
-            },
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnWithDatetimeLikeString", async () => {
@@ -552,9 +459,6 @@ describe("ObjectClient", () => {
             datetimeLikeString: "2023-08-31T14:15:22Z",
             actualDatetime: "2023-08-31T14:15:22Z",
         });
-        expect(response).toEqual({
-            datetimeLikeString: "2023-08-31T14:15:22Z",
-            actualDatetime: "2023-08-31T14:15:22Z",
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 });

--- a/seed/ts-sdk/exhaustive/retain-original-casing/tests/wire/endpoints/pagination.test.ts
+++ b/seed/ts-sdk/exhaustive/retain-original-casing/tests/wire/endpoints/pagination.test.ts
@@ -18,17 +18,7 @@ describe("PaginationClient", () => {
             .jsonBody(rawResponseBody)
             .build();
 
-        const expected = {
-            items: [
-                {
-                    string: "string",
-                },
-                {
-                    string: "string",
-                },
-            ],
-            next: "next",
-        };
+        const expected = rawResponseBody;
         const page = await client.endpoints.pagination.listItems({
             cursor: "cursor",
             limit: 1,

--- a/seed/ts-sdk/exhaustive/retain-original-casing/tests/wire/endpoints/params.test.ts
+++ b/seed/ts-sdk/exhaustive/retain-original-casing/tests/wire/endpoints/params.test.ts
@@ -14,7 +14,7 @@ describe("ParamsClient", () => {
         server.mockEndpoint().get("/params/path/param").respondWith().statusCode(200).jsonBody(rawResponseBody).build();
 
         const response = await client.endpoints.params.getWithPath("param");
-        expect(response).toEqual("string");
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getWithInlinePath", async () => {
@@ -28,7 +28,7 @@ describe("ParamsClient", () => {
         const response = await client.endpoints.params.getWithInlinePath({
             param: "param",
         });
-        expect(response).toEqual("string");
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getWithQuery", async () => {
@@ -98,7 +98,7 @@ describe("ParamsClient", () => {
             .build();
 
         const response = await client.endpoints.params.modifyWithPath("param", "string");
-        expect(response).toEqual("string");
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("modifyWithInlinePath", async () => {
@@ -120,7 +120,7 @@ describe("ParamsClient", () => {
             param: "param",
             body: "string",
         });
-        expect(response).toEqual("string");
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getWithPathAndErrors (1)", async () => {
@@ -132,7 +132,7 @@ describe("ParamsClient", () => {
         server.mockEndpoint().get("/params/path/param").respondWith().statusCode(200).jsonBody(rawResponseBody).build();
 
         const response = await client.endpoints.params.getWithPathAndErrors("param");
-        expect(response).toEqual("string");
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getWithPathAndErrors (2)", async () => {

--- a/seed/ts-sdk/exhaustive/retain-original-casing/tests/wire/endpoints/primitive.test.ts
+++ b/seed/ts-sdk/exhaustive/retain-original-casing/tests/wire/endpoints/primitive.test.ts
@@ -20,7 +20,7 @@ describe("PrimitiveClient", () => {
             .build();
 
         const response = await client.endpoints.primitive.getAndReturnString("string");
-        expect(response).toEqual("string");
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnInt", async () => {
@@ -39,7 +39,7 @@ describe("PrimitiveClient", () => {
             .build();
 
         const response = await client.endpoints.primitive.getAndReturnInt(1);
-        expect(response).toEqual(1);
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnLong", async () => {
@@ -58,7 +58,7 @@ describe("PrimitiveClient", () => {
             .build();
 
         const response = await client.endpoints.primitive.getAndReturnLong(1000000);
-        expect(response).toEqual(1000000);
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnDouble", async () => {
@@ -77,7 +77,7 @@ describe("PrimitiveClient", () => {
             .build();
 
         const response = await client.endpoints.primitive.getAndReturnDouble(1.1);
-        expect(response).toEqual(1.1);
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnBool", async () => {
@@ -96,7 +96,7 @@ describe("PrimitiveClient", () => {
             .build();
 
         const response = await client.endpoints.primitive.getAndReturnBool(true);
-        expect(response).toEqual(true);
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnDatetime", async () => {
@@ -115,7 +115,7 @@ describe("PrimitiveClient", () => {
             .build();
 
         const response = await client.endpoints.primitive.getAndReturnDatetime("2024-01-15T09:30:00Z");
-        expect(response).toEqual("2024-01-15T09:30:00Z");
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnDate", async () => {
@@ -134,7 +134,7 @@ describe("PrimitiveClient", () => {
             .build();
 
         const response = await client.endpoints.primitive.getAndReturnDate("2023-01-15");
-        expect(response).toEqual("2023-01-15");
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnUUID", async () => {
@@ -153,7 +153,7 @@ describe("PrimitiveClient", () => {
             .build();
 
         const response = await client.endpoints.primitive.getAndReturnUuid("d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32");
-        expect(response).toEqual("d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32");
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnBase64", async () => {
@@ -172,6 +172,6 @@ describe("PrimitiveClient", () => {
             .build();
 
         const response = await client.endpoints.primitive.getAndReturnBase64("SGVsbG8gd29ybGQh");
-        expect(response).toEqual("SGVsbG8gd29ybGQh");
+        expect(response).toEqual(rawResponseBody);
     });
 });

--- a/seed/ts-sdk/exhaustive/retain-original-casing/tests/wire/endpoints/put.test.ts
+++ b/seed/ts-sdk/exhaustive/retain-original-casing/tests/wire/endpoints/put.test.ts
@@ -20,21 +20,6 @@ describe("PutClient", () => {
         const response = await client.endpoints.put.add({
             id: "id",
         });
-        expect(response).toEqual({
-            errors: [
-                {
-                    category: "API_ERROR",
-                    code: "INTERNAL_SERVER_ERROR",
-                    detail: "detail",
-                    field: "field",
-                },
-                {
-                    category: "API_ERROR",
-                    code: "INTERNAL_SERVER_ERROR",
-                    detail: "detail",
-                    field: "field",
-                },
-            ],
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 });

--- a/seed/ts-sdk/exhaustive/retain-original-casing/tests/wire/endpoints/union.test.ts
+++ b/seed/ts-sdk/exhaustive/retain-original-casing/tests/wire/endpoints/union.test.ts
@@ -24,10 +24,6 @@ describe("UnionClient", () => {
             name: "name",
             likesToWoof: true,
         });
-        expect(response).toEqual({
-            animal: "dog",
-            name: "name",
-            likesToWoof: true,
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 });

--- a/seed/ts-sdk/exhaustive/retain-original-casing/tests/wire/endpoints/urls.test.ts
+++ b/seed/ts-sdk/exhaustive/retain-original-casing/tests/wire/endpoints/urls.test.ts
@@ -13,7 +13,7 @@ describe("UrlsClient", () => {
         server.mockEndpoint().get("/urls/MixedCase").respondWith().statusCode(200).jsonBody(rawResponseBody).build();
 
         const response = await client.endpoints.urls.withMixedCase();
-        expect(response).toEqual("string");
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("noEndingSlash", async () => {
@@ -31,7 +31,7 @@ describe("UrlsClient", () => {
             .build();
 
         const response = await client.endpoints.urls.noEndingSlash();
-        expect(response).toEqual("string");
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("withEndingSlash", async () => {
@@ -49,7 +49,7 @@ describe("UrlsClient", () => {
             .build();
 
         const response = await client.endpoints.urls.withEndingSlash();
-        expect(response).toEqual("string");
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("withUnderscores", async () => {
@@ -67,6 +67,6 @@ describe("UrlsClient", () => {
             .build();
 
         const response = await client.endpoints.urls.withUnderscores();
-        expect(response).toEqual("string");
+        expect(response).toEqual(rawResponseBody);
     });
 });

--- a/seed/ts-sdk/exhaustive/retain-original-casing/tests/wire/inlinedRequests.test.ts
+++ b/seed/ts-sdk/exhaustive/retain-original-casing/tests/wire/inlinedRequests.test.ts
@@ -73,23 +73,7 @@ describe("InlinedRequestsClient", () => {
                 bigint: "1000000",
             },
         });
-        expect(response).toEqual({
-            string: "string",
-            integer: 1,
-            long: 1000000,
-            double: 1.1,
-            bool: true,
-            datetime: "2024-01-15T09:30:00Z",
-            date: "2023-01-15",
-            uuid: "d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32",
-            base64: "SGVsbG8gd29ybGQh",
-            list: ["list", "list"],
-            set: ["set"],
-            map: {
-                1: "map",
-            },
-            bigint: "1000000",
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("postWithObjectBodyandResponse (2)", async () => {

--- a/seed/ts-sdk/exhaustive/retain-original-casing/tests/wire/noAuth.test.ts
+++ b/seed/ts-sdk/exhaustive/retain-original-casing/tests/wire/noAuth.test.ts
@@ -23,7 +23,7 @@ describe("NoAuthClient", () => {
         const response = await client.noAuth.postWithNoAuth({
             key: "value",
         });
-        expect(response).toEqual(true);
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("postWithNoAuth (2)", async () => {

--- a/seed/ts-sdk/exhaustive/retain-original-casing/tests/wire/noReqBody.test.ts
+++ b/seed/ts-sdk/exhaustive/retain-original-casing/tests/wire/noReqBody.test.ts
@@ -27,23 +27,7 @@ describe("NoReqBodyClient", () => {
         server.mockEndpoint().get("/no-req-body").respondWith().statusCode(200).jsonBody(rawResponseBody).build();
 
         const response = await client.noReqBody.getWithNoRequestBody();
-        expect(response).toEqual({
-            string: "string",
-            integer: 1,
-            long: 1000000,
-            double: 1.1,
-            bool: true,
-            datetime: "2024-01-15T09:30:00Z",
-            date: "2023-01-15",
-            uuid: "d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32",
-            base64: "SGVsbG8gd29ybGQh",
-            list: ["list", "list"],
-            set: ["set"],
-            map: {
-                1: "map",
-            },
-            bigint: "1000000",
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("postWithNoRequestBody", async () => {
@@ -55,6 +39,6 @@ describe("NoReqBodyClient", () => {
         server.mockEndpoint().post("/no-req-body").respondWith().statusCode(200).jsonBody(rawResponseBody).build();
 
         const response = await client.noReqBody.postWithNoRequestBody();
-        expect(response).toEqual("string");
+        expect(response).toEqual(rawResponseBody);
     });
 });

--- a/seed/ts-sdk/exhaustive/use-jest/tests/wire/endpoints/container.test.ts
+++ b/seed/ts-sdk/exhaustive/use-jest/tests/wire/endpoints/container.test.ts
@@ -20,7 +20,7 @@ describe("ContainerClient", () => {
             .build();
 
         const response = await client.endpoints.container.getAndReturnListOfPrimitives(["string", "string"]);
-        expect(response).toEqual(["string", "string"]);
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnListOfObjects", async () => {
@@ -46,14 +46,7 @@ describe("ContainerClient", () => {
                 string: "string",
             },
         ]);
-        expect(response).toEqual([
-            {
-                string: "string",
-            },
-            {
-                string: "string",
-            },
-        ]);
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnSetOfPrimitives", async () => {
@@ -72,7 +65,7 @@ describe("ContainerClient", () => {
             .build();
 
         const response = await client.endpoints.container.getAndReturnSetOfPrimitives(["string"]);
-        expect(response).toEqual(["string"]);
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnSetOfObjects", async () => {
@@ -95,11 +88,7 @@ describe("ContainerClient", () => {
                 string: "string",
             },
         ]);
-        expect(response).toEqual([
-            {
-                string: "string",
-            },
-        ]);
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnMapPrimToPrim", async () => {
@@ -120,9 +109,7 @@ describe("ContainerClient", () => {
         const response = await client.endpoints.container.getAndReturnMapPrimToPrim({
             string: "string",
         });
-        expect(response).toEqual({
-            string: "string",
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnMapOfPrimToObject", async () => {
@@ -145,11 +132,7 @@ describe("ContainerClient", () => {
                 string: "string",
             },
         });
-        expect(response).toEqual({
-            string: {
-                string: "string",
-            },
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnMapOfPrimToUndiscriminatedUnion", async () => {
@@ -170,9 +153,7 @@ describe("ContainerClient", () => {
         const response = await client.endpoints.container.getAndReturnMapOfPrimToUndiscriminatedUnion({
             string: 1.1,
         });
-        expect(response).toEqual({
-            string: 1.1,
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnOptional", async () => {
@@ -193,8 +174,6 @@ describe("ContainerClient", () => {
         const response = await client.endpoints.container.getAndReturnOptional({
             string: "string",
         });
-        expect(response).toEqual({
-            string: "string",
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 });

--- a/seed/ts-sdk/exhaustive/use-jest/tests/wire/endpoints/enum.test.ts
+++ b/seed/ts-sdk/exhaustive/use-jest/tests/wire/endpoints/enum.test.ts
@@ -20,6 +20,6 @@ describe("EnumClient", () => {
             .build();
 
         const response = await client.endpoints.enum.getAndReturnEnum("SUNNY");
-        expect(response).toEqual("SUNNY");
+        expect(response).toEqual(rawResponseBody);
     });
 });

--- a/seed/ts-sdk/exhaustive/use-jest/tests/wire/endpoints/httpMethods.test.ts
+++ b/seed/ts-sdk/exhaustive/use-jest/tests/wire/endpoints/httpMethods.test.ts
@@ -13,7 +13,7 @@ describe("HttpMethodsClient", () => {
         server.mockEndpoint().get("/http-methods/id").respondWith().statusCode(200).jsonBody(rawResponseBody).build();
 
         const response = await client.endpoints.httpMethods.testGet("id");
-        expect(response).toEqual("string");
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("testPost", async () => {
@@ -48,23 +48,7 @@ describe("HttpMethodsClient", () => {
         const response = await client.endpoints.httpMethods.testPost({
             string: "string",
         });
-        expect(response).toEqual({
-            string: "string",
-            integer: 1,
-            long: 1000000,
-            double: 1.1,
-            bool: true,
-            datetime: "2024-01-15T09:30:00Z",
-            date: "2023-01-15",
-            uuid: "d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32",
-            base64: "SGVsbG8gd29ybGQh",
-            list: ["list", "list"],
-            set: ["set"],
-            map: {
-                1: "map",
-            },
-            bigint: "1000000",
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("testPut", async () => {
@@ -99,23 +83,7 @@ describe("HttpMethodsClient", () => {
         const response = await client.endpoints.httpMethods.testPut("id", {
             string: "string",
         });
-        expect(response).toEqual({
-            string: "string",
-            integer: 1,
-            long: 1000000,
-            double: 1.1,
-            bool: true,
-            datetime: "2024-01-15T09:30:00Z",
-            date: "2023-01-15",
-            uuid: "d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32",
-            base64: "SGVsbG8gd29ybGQh",
-            list: ["list", "list"],
-            set: ["set"],
-            map: {
-                1: "map",
-            },
-            bigint: "1000000",
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("testPatch", async () => {
@@ -178,23 +146,7 @@ describe("HttpMethodsClient", () => {
             },
             bigint: "1000000",
         });
-        expect(response).toEqual({
-            string: "string",
-            integer: 1,
-            long: 1000000,
-            double: 1.1,
-            bool: true,
-            datetime: "2024-01-15T09:30:00Z",
-            date: "2023-01-15",
-            uuid: "d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32",
-            base64: "SGVsbG8gd29ybGQh",
-            list: ["list", "list"],
-            set: ["set"],
-            map: {
-                1: "map",
-            },
-            bigint: "1000000",
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("testDelete", async () => {
@@ -212,6 +164,6 @@ describe("HttpMethodsClient", () => {
             .build();
 
         const response = await client.endpoints.httpMethods.testDelete("id");
-        expect(response).toEqual(true);
+        expect(response).toEqual(rawResponseBody);
     });
 });

--- a/seed/ts-sdk/exhaustive/use-jest/tests/wire/endpoints/object.test.ts
+++ b/seed/ts-sdk/exhaustive/use-jest/tests/wire/endpoints/object.test.ts
@@ -64,23 +64,7 @@ describe("ObjectClient", () => {
             },
             bigint: "1000000",
         });
-        expect(response).toEqual({
-            string: "string",
-            integer: 1,
-            long: 1000000,
-            double: 1.1,
-            bool: true,
-            datetime: "2024-01-15T09:30:00Z",
-            date: "2023-01-15",
-            uuid: "d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32",
-            base64: "SGVsbG8gd29ybGQh",
-            list: ["list", "list"],
-            set: ["set"],
-            map: {
-                1: "map",
-            },
-            bigint: "1000000",
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnWithRequiredField", async () => {
@@ -101,9 +85,7 @@ describe("ObjectClient", () => {
         const response = await client.endpoints.object.getAndReturnWithRequiredField({
             string: "string",
         });
-        expect(response).toEqual({
-            string: "string",
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnWithMapOfMap", async () => {
@@ -128,13 +110,7 @@ describe("ObjectClient", () => {
                 },
             },
         });
-        expect(response).toEqual({
-            map: {
-                map: {
-                    map: "map",
-                },
-            },
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnNestedWithOptionalField", async () => {
@@ -206,26 +182,7 @@ describe("ObjectClient", () => {
                 bigint: "1000000",
             },
         });
-        expect(response).toEqual({
-            string: "string",
-            NestedObject: {
-                string: "string",
-                integer: 1,
-                long: 1000000,
-                double: 1.1,
-                bool: true,
-                datetime: "2024-01-15T09:30:00Z",
-                date: "2023-01-15",
-                uuid: "d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32",
-                base64: "SGVsbG8gd29ybGQh",
-                list: ["list", "list"],
-                set: ["set"],
-                map: {
-                    1: "map",
-                },
-                bigint: "1000000",
-            },
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnNestedWithRequiredField", async () => {
@@ -297,26 +254,7 @@ describe("ObjectClient", () => {
                 bigint: "1000000",
             },
         });
-        expect(response).toEqual({
-            string: "string",
-            NestedObject: {
-                string: "string",
-                integer: 1,
-                long: 1000000,
-                double: 1.1,
-                bool: true,
-                datetime: "2024-01-15T09:30:00Z",
-                date: "2023-01-15",
-                uuid: "d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32",
-                base64: "SGVsbG8gd29ybGQh",
-                list: ["list", "list"],
-                set: ["set"],
-                map: {
-                    1: "map",
-                },
-                bigint: "1000000",
-            },
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnNestedWithRequiredFieldAsList", async () => {
@@ -430,26 +368,7 @@ describe("ObjectClient", () => {
                 },
             },
         ]);
-        expect(response).toEqual({
-            string: "string",
-            NestedObject: {
-                string: "string",
-                integer: 1,
-                long: 1000000,
-                double: 1.1,
-                bool: true,
-                datetime: "2024-01-15T09:30:00Z",
-                date: "2023-01-15",
-                uuid: "d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32",
-                base64: "SGVsbG8gd29ybGQh",
-                list: ["list", "list"],
-                set: ["set"],
-                map: {
-                    1: "map",
-                },
-                bigint: "1000000",
-            },
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnWithUnknownField", async () => {
@@ -472,11 +391,7 @@ describe("ObjectClient", () => {
                 $ref: "https://example.com/schema",
             },
         });
-        expect(response).toEqual({
-            unknown: {
-                $ref: "https://example.com/schema",
-            },
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnWithDocumentedUnknownType", async () => {
@@ -499,11 +414,7 @@ describe("ObjectClient", () => {
                 key: "value",
             },
         });
-        expect(response).toEqual({
-            documentedUnknownType: {
-                key: "value",
-            },
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnMapOfDocumentedUnknownType", async () => {
@@ -526,11 +437,7 @@ describe("ObjectClient", () => {
                 key: "value",
             },
         });
-        expect(response).toEqual({
-            string: {
-                key: "value",
-            },
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnWithDatetimeLikeString", async () => {
@@ -552,9 +459,6 @@ describe("ObjectClient", () => {
             datetimeLikeString: "2023-08-31T14:15:22Z",
             actualDatetime: "2023-08-31T14:15:22Z",
         });
-        expect(response).toEqual({
-            datetimeLikeString: "2023-08-31T14:15:22Z",
-            actualDatetime: "2023-08-31T14:15:22Z",
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 });

--- a/seed/ts-sdk/exhaustive/use-jest/tests/wire/endpoints/pagination.test.ts
+++ b/seed/ts-sdk/exhaustive/use-jest/tests/wire/endpoints/pagination.test.ts
@@ -18,17 +18,7 @@ describe("PaginationClient", () => {
             .jsonBody(rawResponseBody)
             .build();
 
-        const expected = {
-            items: [
-                {
-                    string: "string",
-                },
-                {
-                    string: "string",
-                },
-            ],
-            next: "next",
-        };
+        const expected = rawResponseBody;
         const page = await client.endpoints.pagination.listItems({
             cursor: "cursor",
             limit: 1,

--- a/seed/ts-sdk/exhaustive/use-jest/tests/wire/endpoints/params.test.ts
+++ b/seed/ts-sdk/exhaustive/use-jest/tests/wire/endpoints/params.test.ts
@@ -14,7 +14,7 @@ describe("ParamsClient", () => {
         server.mockEndpoint().get("/params/path/param").respondWith().statusCode(200).jsonBody(rawResponseBody).build();
 
         const response = await client.endpoints.params.getWithPath("param");
-        expect(response).toEqual("string");
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getWithInlinePath", async () => {
@@ -28,7 +28,7 @@ describe("ParamsClient", () => {
         const response = await client.endpoints.params.getWithInlinePath({
             param: "param",
         });
-        expect(response).toEqual("string");
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getWithQuery", async () => {
@@ -98,7 +98,7 @@ describe("ParamsClient", () => {
             .build();
 
         const response = await client.endpoints.params.modifyWithPath("param", "string");
-        expect(response).toEqual("string");
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("modifyWithInlinePath", async () => {
@@ -120,7 +120,7 @@ describe("ParamsClient", () => {
             param: "param",
             body: "string",
         });
-        expect(response).toEqual("string");
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getWithPathAndErrors (1)", async () => {
@@ -132,7 +132,7 @@ describe("ParamsClient", () => {
         server.mockEndpoint().get("/params/path/param").respondWith().statusCode(200).jsonBody(rawResponseBody).build();
 
         const response = await client.endpoints.params.getWithPathAndErrors("param");
-        expect(response).toEqual("string");
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getWithPathAndErrors (2)", async () => {

--- a/seed/ts-sdk/exhaustive/use-jest/tests/wire/endpoints/primitive.test.ts
+++ b/seed/ts-sdk/exhaustive/use-jest/tests/wire/endpoints/primitive.test.ts
@@ -20,7 +20,7 @@ describe("PrimitiveClient", () => {
             .build();
 
         const response = await client.endpoints.primitive.getAndReturnString("string");
-        expect(response).toEqual("string");
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnInt", async () => {
@@ -39,7 +39,7 @@ describe("PrimitiveClient", () => {
             .build();
 
         const response = await client.endpoints.primitive.getAndReturnInt(1);
-        expect(response).toEqual(1);
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnLong", async () => {
@@ -58,7 +58,7 @@ describe("PrimitiveClient", () => {
             .build();
 
         const response = await client.endpoints.primitive.getAndReturnLong(1000000);
-        expect(response).toEqual(1000000);
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnDouble", async () => {
@@ -77,7 +77,7 @@ describe("PrimitiveClient", () => {
             .build();
 
         const response = await client.endpoints.primitive.getAndReturnDouble(1.1);
-        expect(response).toEqual(1.1);
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnBool", async () => {
@@ -96,7 +96,7 @@ describe("PrimitiveClient", () => {
             .build();
 
         const response = await client.endpoints.primitive.getAndReturnBool(true);
-        expect(response).toEqual(true);
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnDatetime", async () => {
@@ -115,7 +115,7 @@ describe("PrimitiveClient", () => {
             .build();
 
         const response = await client.endpoints.primitive.getAndReturnDatetime("2024-01-15T09:30:00Z");
-        expect(response).toEqual("2024-01-15T09:30:00Z");
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnDate", async () => {
@@ -134,7 +134,7 @@ describe("PrimitiveClient", () => {
             .build();
 
         const response = await client.endpoints.primitive.getAndReturnDate("2023-01-15");
-        expect(response).toEqual("2023-01-15");
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnUUID", async () => {
@@ -153,7 +153,7 @@ describe("PrimitiveClient", () => {
             .build();
 
         const response = await client.endpoints.primitive.getAndReturnUuid("d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32");
-        expect(response).toEqual("d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32");
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnBase64", async () => {
@@ -172,6 +172,6 @@ describe("PrimitiveClient", () => {
             .build();
 
         const response = await client.endpoints.primitive.getAndReturnBase64("SGVsbG8gd29ybGQh");
-        expect(response).toEqual("SGVsbG8gd29ybGQh");
+        expect(response).toEqual(rawResponseBody);
     });
 });

--- a/seed/ts-sdk/exhaustive/use-jest/tests/wire/endpoints/put.test.ts
+++ b/seed/ts-sdk/exhaustive/use-jest/tests/wire/endpoints/put.test.ts
@@ -20,21 +20,6 @@ describe("PutClient", () => {
         const response = await client.endpoints.put.add({
             id: "id",
         });
-        expect(response).toEqual({
-            errors: [
-                {
-                    category: "API_ERROR",
-                    code: "INTERNAL_SERVER_ERROR",
-                    detail: "detail",
-                    field: "field",
-                },
-                {
-                    category: "API_ERROR",
-                    code: "INTERNAL_SERVER_ERROR",
-                    detail: "detail",
-                    field: "field",
-                },
-            ],
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 });

--- a/seed/ts-sdk/exhaustive/use-jest/tests/wire/endpoints/union.test.ts
+++ b/seed/ts-sdk/exhaustive/use-jest/tests/wire/endpoints/union.test.ts
@@ -24,10 +24,6 @@ describe("UnionClient", () => {
             name: "name",
             likesToWoof: true,
         });
-        expect(response).toEqual({
-            animal: "dog",
-            name: "name",
-            likesToWoof: true,
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 });

--- a/seed/ts-sdk/exhaustive/use-jest/tests/wire/endpoints/urls.test.ts
+++ b/seed/ts-sdk/exhaustive/use-jest/tests/wire/endpoints/urls.test.ts
@@ -13,7 +13,7 @@ describe("UrlsClient", () => {
         server.mockEndpoint().get("/urls/MixedCase").respondWith().statusCode(200).jsonBody(rawResponseBody).build();
 
         const response = await client.endpoints.urls.withMixedCase();
-        expect(response).toEqual("string");
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("noEndingSlash", async () => {
@@ -31,7 +31,7 @@ describe("UrlsClient", () => {
             .build();
 
         const response = await client.endpoints.urls.noEndingSlash();
-        expect(response).toEqual("string");
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("withEndingSlash", async () => {
@@ -49,7 +49,7 @@ describe("UrlsClient", () => {
             .build();
 
         const response = await client.endpoints.urls.withEndingSlash();
-        expect(response).toEqual("string");
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("withUnderscores", async () => {
@@ -67,6 +67,6 @@ describe("UrlsClient", () => {
             .build();
 
         const response = await client.endpoints.urls.withUnderscores();
-        expect(response).toEqual("string");
+        expect(response).toEqual(rawResponseBody);
     });
 });

--- a/seed/ts-sdk/exhaustive/use-jest/tests/wire/inlinedRequests.test.ts
+++ b/seed/ts-sdk/exhaustive/use-jest/tests/wire/inlinedRequests.test.ts
@@ -73,23 +73,7 @@ describe("InlinedRequestsClient", () => {
                 bigint: "1000000",
             },
         });
-        expect(response).toEqual({
-            string: "string",
-            integer: 1,
-            long: 1000000,
-            double: 1.1,
-            bool: true,
-            datetime: "2024-01-15T09:30:00Z",
-            date: "2023-01-15",
-            uuid: "d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32",
-            base64: "SGVsbG8gd29ybGQh",
-            list: ["list", "list"],
-            set: ["set"],
-            map: {
-                1: "map",
-            },
-            bigint: "1000000",
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("postWithObjectBodyandResponse (2)", async () => {

--- a/seed/ts-sdk/exhaustive/use-jest/tests/wire/noAuth.test.ts
+++ b/seed/ts-sdk/exhaustive/use-jest/tests/wire/noAuth.test.ts
@@ -23,7 +23,7 @@ describe("NoAuthClient", () => {
         const response = await client.noAuth.postWithNoAuth({
             key: "value",
         });
-        expect(response).toEqual(true);
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("postWithNoAuth (2)", async () => {

--- a/seed/ts-sdk/exhaustive/use-jest/tests/wire/noReqBody.test.ts
+++ b/seed/ts-sdk/exhaustive/use-jest/tests/wire/noReqBody.test.ts
@@ -27,23 +27,7 @@ describe("NoReqBodyClient", () => {
         server.mockEndpoint().get("/no-req-body").respondWith().statusCode(200).jsonBody(rawResponseBody).build();
 
         const response = await client.noReqBody.getWithNoRequestBody();
-        expect(response).toEqual({
-            string: "string",
-            integer: 1,
-            long: 1000000,
-            double: 1.1,
-            bool: true,
-            datetime: "2024-01-15T09:30:00Z",
-            date: "2023-01-15",
-            uuid: "d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32",
-            base64: "SGVsbG8gd29ybGQh",
-            list: ["list", "list"],
-            set: ["set"],
-            map: {
-                1: "map",
-            },
-            bigint: "1000000",
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("postWithNoRequestBody", async () => {
@@ -55,6 +39,6 @@ describe("NoReqBodyClient", () => {
         server.mockEndpoint().post("/no-req-body").respondWith().statusCode(200).jsonBody(rawResponseBody).build();
 
         const response = await client.noReqBody.postWithNoRequestBody();
-        expect(response).toEqual("string");
+        expect(response).toEqual(rawResponseBody);
     });
 });

--- a/seed/ts-sdk/exhaustive/web-stream-wrapper/tests/wire/endpoints/container.test.ts
+++ b/seed/ts-sdk/exhaustive/web-stream-wrapper/tests/wire/endpoints/container.test.ts
@@ -20,7 +20,7 @@ describe("ContainerClient", () => {
             .build();
 
         const response = await client.endpoints.container.getAndReturnListOfPrimitives(["string", "string"]);
-        expect(response).toEqual(["string", "string"]);
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnListOfObjects", async () => {
@@ -46,14 +46,7 @@ describe("ContainerClient", () => {
                 string: "string",
             },
         ]);
-        expect(response).toEqual([
-            {
-                string: "string",
-            },
-            {
-                string: "string",
-            },
-        ]);
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnSetOfPrimitives", async () => {
@@ -72,7 +65,7 @@ describe("ContainerClient", () => {
             .build();
 
         const response = await client.endpoints.container.getAndReturnSetOfPrimitives(["string"]);
-        expect(response).toEqual(["string"]);
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnSetOfObjects", async () => {
@@ -95,11 +88,7 @@ describe("ContainerClient", () => {
                 string: "string",
             },
         ]);
-        expect(response).toEqual([
-            {
-                string: "string",
-            },
-        ]);
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnMapPrimToPrim", async () => {
@@ -120,9 +109,7 @@ describe("ContainerClient", () => {
         const response = await client.endpoints.container.getAndReturnMapPrimToPrim({
             string: "string",
         });
-        expect(response).toEqual({
-            string: "string",
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnMapOfPrimToObject", async () => {
@@ -145,11 +132,7 @@ describe("ContainerClient", () => {
                 string: "string",
             },
         });
-        expect(response).toEqual({
-            string: {
-                string: "string",
-            },
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnMapOfPrimToUndiscriminatedUnion", async () => {
@@ -170,9 +153,7 @@ describe("ContainerClient", () => {
         const response = await client.endpoints.container.getAndReturnMapOfPrimToUndiscriminatedUnion({
             string: 1.1,
         });
-        expect(response).toEqual({
-            string: 1.1,
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnOptional", async () => {
@@ -193,8 +174,6 @@ describe("ContainerClient", () => {
         const response = await client.endpoints.container.getAndReturnOptional({
             string: "string",
         });
-        expect(response).toEqual({
-            string: "string",
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 });

--- a/seed/ts-sdk/exhaustive/web-stream-wrapper/tests/wire/endpoints/enum.test.ts
+++ b/seed/ts-sdk/exhaustive/web-stream-wrapper/tests/wire/endpoints/enum.test.ts
@@ -20,6 +20,6 @@ describe("EnumClient", () => {
             .build();
 
         const response = await client.endpoints.enum.getAndReturnEnum("SUNNY");
-        expect(response).toEqual("SUNNY");
+        expect(response).toEqual(rawResponseBody);
     });
 });

--- a/seed/ts-sdk/exhaustive/web-stream-wrapper/tests/wire/endpoints/httpMethods.test.ts
+++ b/seed/ts-sdk/exhaustive/web-stream-wrapper/tests/wire/endpoints/httpMethods.test.ts
@@ -13,7 +13,7 @@ describe("HttpMethodsClient", () => {
         server.mockEndpoint().get("/http-methods/id").respondWith().statusCode(200).jsonBody(rawResponseBody).build();
 
         const response = await client.endpoints.httpMethods.testGet("id");
-        expect(response).toEqual("string");
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("testPost", async () => {
@@ -48,23 +48,7 @@ describe("HttpMethodsClient", () => {
         const response = await client.endpoints.httpMethods.testPost({
             string: "string",
         });
-        expect(response).toEqual({
-            string: "string",
-            integer: 1,
-            long: 1000000,
-            double: 1.1,
-            bool: true,
-            datetime: "2024-01-15T09:30:00Z",
-            date: "2023-01-15",
-            uuid: "d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32",
-            base64: "SGVsbG8gd29ybGQh",
-            list: ["list", "list"],
-            set: ["set"],
-            map: {
-                1: "map",
-            },
-            bigint: "1000000",
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("testPut", async () => {
@@ -99,23 +83,7 @@ describe("HttpMethodsClient", () => {
         const response = await client.endpoints.httpMethods.testPut("id", {
             string: "string",
         });
-        expect(response).toEqual({
-            string: "string",
-            integer: 1,
-            long: 1000000,
-            double: 1.1,
-            bool: true,
-            datetime: "2024-01-15T09:30:00Z",
-            date: "2023-01-15",
-            uuid: "d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32",
-            base64: "SGVsbG8gd29ybGQh",
-            list: ["list", "list"],
-            set: ["set"],
-            map: {
-                1: "map",
-            },
-            bigint: "1000000",
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("testPatch", async () => {
@@ -178,23 +146,7 @@ describe("HttpMethodsClient", () => {
             },
             bigint: "1000000",
         });
-        expect(response).toEqual({
-            string: "string",
-            integer: 1,
-            long: 1000000,
-            double: 1.1,
-            bool: true,
-            datetime: "2024-01-15T09:30:00Z",
-            date: "2023-01-15",
-            uuid: "d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32",
-            base64: "SGVsbG8gd29ybGQh",
-            list: ["list", "list"],
-            set: ["set"],
-            map: {
-                1: "map",
-            },
-            bigint: "1000000",
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("testDelete", async () => {
@@ -212,6 +164,6 @@ describe("HttpMethodsClient", () => {
             .build();
 
         const response = await client.endpoints.httpMethods.testDelete("id");
-        expect(response).toEqual(true);
+        expect(response).toEqual(rawResponseBody);
     });
 });

--- a/seed/ts-sdk/exhaustive/web-stream-wrapper/tests/wire/endpoints/object.test.ts
+++ b/seed/ts-sdk/exhaustive/web-stream-wrapper/tests/wire/endpoints/object.test.ts
@@ -64,23 +64,7 @@ describe("ObjectClient", () => {
             },
             bigint: "1000000",
         });
-        expect(response).toEqual({
-            string: "string",
-            integer: 1,
-            long: 1000000,
-            double: 1.1,
-            bool: true,
-            datetime: "2024-01-15T09:30:00Z",
-            date: "2023-01-15",
-            uuid: "d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32",
-            base64: "SGVsbG8gd29ybGQh",
-            list: ["list", "list"],
-            set: ["set"],
-            map: {
-                1: "map",
-            },
-            bigint: "1000000",
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnWithRequiredField", async () => {
@@ -101,9 +85,7 @@ describe("ObjectClient", () => {
         const response = await client.endpoints.object.getAndReturnWithRequiredField({
             string: "string",
         });
-        expect(response).toEqual({
-            string: "string",
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnWithMapOfMap", async () => {
@@ -128,13 +110,7 @@ describe("ObjectClient", () => {
                 },
             },
         });
-        expect(response).toEqual({
-            map: {
-                map: {
-                    map: "map",
-                },
-            },
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnNestedWithOptionalField", async () => {
@@ -206,26 +182,7 @@ describe("ObjectClient", () => {
                 bigint: "1000000",
             },
         });
-        expect(response).toEqual({
-            string: "string",
-            NestedObject: {
-                string: "string",
-                integer: 1,
-                long: 1000000,
-                double: 1.1,
-                bool: true,
-                datetime: "2024-01-15T09:30:00Z",
-                date: "2023-01-15",
-                uuid: "d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32",
-                base64: "SGVsbG8gd29ybGQh",
-                list: ["list", "list"],
-                set: ["set"],
-                map: {
-                    1: "map",
-                },
-                bigint: "1000000",
-            },
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnNestedWithRequiredField", async () => {
@@ -297,26 +254,7 @@ describe("ObjectClient", () => {
                 bigint: "1000000",
             },
         });
-        expect(response).toEqual({
-            string: "string",
-            NestedObject: {
-                string: "string",
-                integer: 1,
-                long: 1000000,
-                double: 1.1,
-                bool: true,
-                datetime: "2024-01-15T09:30:00Z",
-                date: "2023-01-15",
-                uuid: "d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32",
-                base64: "SGVsbG8gd29ybGQh",
-                list: ["list", "list"],
-                set: ["set"],
-                map: {
-                    1: "map",
-                },
-                bigint: "1000000",
-            },
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnNestedWithRequiredFieldAsList", async () => {
@@ -430,26 +368,7 @@ describe("ObjectClient", () => {
                 },
             },
         ]);
-        expect(response).toEqual({
-            string: "string",
-            NestedObject: {
-                string: "string",
-                integer: 1,
-                long: 1000000,
-                double: 1.1,
-                bool: true,
-                datetime: "2024-01-15T09:30:00Z",
-                date: "2023-01-15",
-                uuid: "d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32",
-                base64: "SGVsbG8gd29ybGQh",
-                list: ["list", "list"],
-                set: ["set"],
-                map: {
-                    1: "map",
-                },
-                bigint: "1000000",
-            },
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnWithUnknownField", async () => {
@@ -472,11 +391,7 @@ describe("ObjectClient", () => {
                 $ref: "https://example.com/schema",
             },
         });
-        expect(response).toEqual({
-            unknown: {
-                $ref: "https://example.com/schema",
-            },
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnWithDocumentedUnknownType", async () => {
@@ -499,11 +414,7 @@ describe("ObjectClient", () => {
                 key: "value",
             },
         });
-        expect(response).toEqual({
-            documentedUnknownType: {
-                key: "value",
-            },
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnMapOfDocumentedUnknownType", async () => {
@@ -526,11 +437,7 @@ describe("ObjectClient", () => {
                 key: "value",
             },
         });
-        expect(response).toEqual({
-            string: {
-                key: "value",
-            },
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnWithDatetimeLikeString", async () => {
@@ -552,9 +459,6 @@ describe("ObjectClient", () => {
             datetimeLikeString: "2023-08-31T14:15:22Z",
             actualDatetime: "2023-08-31T14:15:22Z",
         });
-        expect(response).toEqual({
-            datetimeLikeString: "2023-08-31T14:15:22Z",
-            actualDatetime: "2023-08-31T14:15:22Z",
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 });

--- a/seed/ts-sdk/exhaustive/web-stream-wrapper/tests/wire/endpoints/pagination.test.ts
+++ b/seed/ts-sdk/exhaustive/web-stream-wrapper/tests/wire/endpoints/pagination.test.ts
@@ -18,17 +18,7 @@ describe("PaginationClient", () => {
             .jsonBody(rawResponseBody)
             .build();
 
-        const expected = {
-            items: [
-                {
-                    string: "string",
-                },
-                {
-                    string: "string",
-                },
-            ],
-            next: "next",
-        };
+        const expected = rawResponseBody;
         const page = await client.endpoints.pagination.listItems({
             cursor: "cursor",
             limit: 1,

--- a/seed/ts-sdk/exhaustive/web-stream-wrapper/tests/wire/endpoints/params.test.ts
+++ b/seed/ts-sdk/exhaustive/web-stream-wrapper/tests/wire/endpoints/params.test.ts
@@ -14,7 +14,7 @@ describe("ParamsClient", () => {
         server.mockEndpoint().get("/params/path/param").respondWith().statusCode(200).jsonBody(rawResponseBody).build();
 
         const response = await client.endpoints.params.getWithPath("param");
-        expect(response).toEqual("string");
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getWithInlinePath", async () => {
@@ -28,7 +28,7 @@ describe("ParamsClient", () => {
         const response = await client.endpoints.params.getWithInlinePath({
             param: "param",
         });
-        expect(response).toEqual("string");
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getWithQuery", async () => {
@@ -98,7 +98,7 @@ describe("ParamsClient", () => {
             .build();
 
         const response = await client.endpoints.params.modifyWithPath("param", "string");
-        expect(response).toEqual("string");
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("modifyWithInlinePath", async () => {
@@ -120,7 +120,7 @@ describe("ParamsClient", () => {
             param: "param",
             body: "string",
         });
-        expect(response).toEqual("string");
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getWithPathAndErrors (1)", async () => {
@@ -132,7 +132,7 @@ describe("ParamsClient", () => {
         server.mockEndpoint().get("/params/path/param").respondWith().statusCode(200).jsonBody(rawResponseBody).build();
 
         const response = await client.endpoints.params.getWithPathAndErrors("param");
-        expect(response).toEqual("string");
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getWithPathAndErrors (2)", async () => {

--- a/seed/ts-sdk/exhaustive/web-stream-wrapper/tests/wire/endpoints/primitive.test.ts
+++ b/seed/ts-sdk/exhaustive/web-stream-wrapper/tests/wire/endpoints/primitive.test.ts
@@ -20,7 +20,7 @@ describe("PrimitiveClient", () => {
             .build();
 
         const response = await client.endpoints.primitive.getAndReturnString("string");
-        expect(response).toEqual("string");
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnInt", async () => {
@@ -39,7 +39,7 @@ describe("PrimitiveClient", () => {
             .build();
 
         const response = await client.endpoints.primitive.getAndReturnInt(1);
-        expect(response).toEqual(1);
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnLong", async () => {
@@ -58,7 +58,7 @@ describe("PrimitiveClient", () => {
             .build();
 
         const response = await client.endpoints.primitive.getAndReturnLong(1000000);
-        expect(response).toEqual(1000000);
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnDouble", async () => {
@@ -77,7 +77,7 @@ describe("PrimitiveClient", () => {
             .build();
 
         const response = await client.endpoints.primitive.getAndReturnDouble(1.1);
-        expect(response).toEqual(1.1);
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnBool", async () => {
@@ -96,7 +96,7 @@ describe("PrimitiveClient", () => {
             .build();
 
         const response = await client.endpoints.primitive.getAndReturnBool(true);
-        expect(response).toEqual(true);
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnDatetime", async () => {
@@ -115,7 +115,7 @@ describe("PrimitiveClient", () => {
             .build();
 
         const response = await client.endpoints.primitive.getAndReturnDatetime("2024-01-15T09:30:00Z");
-        expect(response).toEqual("2024-01-15T09:30:00Z");
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnDate", async () => {
@@ -134,7 +134,7 @@ describe("PrimitiveClient", () => {
             .build();
 
         const response = await client.endpoints.primitive.getAndReturnDate("2023-01-15");
-        expect(response).toEqual("2023-01-15");
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnUUID", async () => {
@@ -153,7 +153,7 @@ describe("PrimitiveClient", () => {
             .build();
 
         const response = await client.endpoints.primitive.getAndReturnUuid("d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32");
-        expect(response).toEqual("d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32");
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("getAndReturnBase64", async () => {
@@ -172,6 +172,6 @@ describe("PrimitiveClient", () => {
             .build();
 
         const response = await client.endpoints.primitive.getAndReturnBase64("SGVsbG8gd29ybGQh");
-        expect(response).toEqual("SGVsbG8gd29ybGQh");
+        expect(response).toEqual(rawResponseBody);
     });
 });

--- a/seed/ts-sdk/exhaustive/web-stream-wrapper/tests/wire/endpoints/put.test.ts
+++ b/seed/ts-sdk/exhaustive/web-stream-wrapper/tests/wire/endpoints/put.test.ts
@@ -20,21 +20,6 @@ describe("PutClient", () => {
         const response = await client.endpoints.put.add({
             id: "id",
         });
-        expect(response).toEqual({
-            errors: [
-                {
-                    category: "API_ERROR",
-                    code: "INTERNAL_SERVER_ERROR",
-                    detail: "detail",
-                    field: "field",
-                },
-                {
-                    category: "API_ERROR",
-                    code: "INTERNAL_SERVER_ERROR",
-                    detail: "detail",
-                    field: "field",
-                },
-            ],
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 });

--- a/seed/ts-sdk/exhaustive/web-stream-wrapper/tests/wire/endpoints/union.test.ts
+++ b/seed/ts-sdk/exhaustive/web-stream-wrapper/tests/wire/endpoints/union.test.ts
@@ -24,10 +24,6 @@ describe("UnionClient", () => {
             name: "name",
             likesToWoof: true,
         });
-        expect(response).toEqual({
-            animal: "dog",
-            name: "name",
-            likesToWoof: true,
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 });

--- a/seed/ts-sdk/exhaustive/web-stream-wrapper/tests/wire/endpoints/urls.test.ts
+++ b/seed/ts-sdk/exhaustive/web-stream-wrapper/tests/wire/endpoints/urls.test.ts
@@ -13,7 +13,7 @@ describe("UrlsClient", () => {
         server.mockEndpoint().get("/urls/MixedCase").respondWith().statusCode(200).jsonBody(rawResponseBody).build();
 
         const response = await client.endpoints.urls.withMixedCase();
-        expect(response).toEqual("string");
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("noEndingSlash", async () => {
@@ -31,7 +31,7 @@ describe("UrlsClient", () => {
             .build();
 
         const response = await client.endpoints.urls.noEndingSlash();
-        expect(response).toEqual("string");
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("withEndingSlash", async () => {
@@ -49,7 +49,7 @@ describe("UrlsClient", () => {
             .build();
 
         const response = await client.endpoints.urls.withEndingSlash();
-        expect(response).toEqual("string");
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("withUnderscores", async () => {
@@ -67,6 +67,6 @@ describe("UrlsClient", () => {
             .build();
 
         const response = await client.endpoints.urls.withUnderscores();
-        expect(response).toEqual("string");
+        expect(response).toEqual(rawResponseBody);
     });
 });

--- a/seed/ts-sdk/exhaustive/web-stream-wrapper/tests/wire/inlinedRequests.test.ts
+++ b/seed/ts-sdk/exhaustive/web-stream-wrapper/tests/wire/inlinedRequests.test.ts
@@ -73,23 +73,7 @@ describe("InlinedRequestsClient", () => {
                 bigint: "1000000",
             },
         });
-        expect(response).toEqual({
-            string: "string",
-            integer: 1,
-            long: 1000000,
-            double: 1.1,
-            bool: true,
-            datetime: "2024-01-15T09:30:00Z",
-            date: "2023-01-15",
-            uuid: "d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32",
-            base64: "SGVsbG8gd29ybGQh",
-            list: ["list", "list"],
-            set: ["set"],
-            map: {
-                1: "map",
-            },
-            bigint: "1000000",
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("postWithObjectBodyandResponse (2)", async () => {

--- a/seed/ts-sdk/exhaustive/web-stream-wrapper/tests/wire/noAuth.test.ts
+++ b/seed/ts-sdk/exhaustive/web-stream-wrapper/tests/wire/noAuth.test.ts
@@ -23,7 +23,7 @@ describe("NoAuthClient", () => {
         const response = await client.noAuth.postWithNoAuth({
             key: "value",
         });
-        expect(response).toEqual(true);
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("postWithNoAuth (2)", async () => {

--- a/seed/ts-sdk/exhaustive/web-stream-wrapper/tests/wire/noReqBody.test.ts
+++ b/seed/ts-sdk/exhaustive/web-stream-wrapper/tests/wire/noReqBody.test.ts
@@ -27,23 +27,7 @@ describe("NoReqBodyClient", () => {
         server.mockEndpoint().get("/no-req-body").respondWith().statusCode(200).jsonBody(rawResponseBody).build();
 
         const response = await client.noReqBody.getWithNoRequestBody();
-        expect(response).toEqual({
-            string: "string",
-            integer: 1,
-            long: 1000000,
-            double: 1.1,
-            bool: true,
-            datetime: "2024-01-15T09:30:00Z",
-            date: "2023-01-15",
-            uuid: "d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32",
-            base64: "SGVsbG8gd29ybGQh",
-            list: ["list", "list"],
-            set: ["set"],
-            map: {
-                1: "map",
-            },
-            bigint: "1000000",
-        });
+        expect(response).toEqual(rawResponseBody);
     });
 
     test("postWithNoRequestBody", async () => {
@@ -55,6 +39,6 @@ describe("NoReqBodyClient", () => {
         server.mockEndpoint().post("/no-req-body").respondWith().statusCode(200).jsonBody(rawResponseBody).build();
 
         const response = await client.noReqBody.postWithNoRequestBody();
-        expect(response).toEqual("string");
+        expect(response).toEqual(rawResponseBody);
     });
 });


### PR DESCRIPTION
## Description

Fixes wire test failures for APIs with `noSerdeLayer: true` when the IR example shape contains fewer properties than the full JSON example (e.g. for inline types). The Payabli API triggered this: the IR's endpoint example shape for inline types like `BatchDetailResponseRecord` only included 34 of 55 properties, while `jsonExample` had all 55. The mock server sent the full raw JSON body, but the test assertion was built from the typed example (via `getGeneratedExample`), creating a mismatch.

## Changes Made

- Extended `getExpectedResponse` in `TestGenerator.ts` with an optional `rawResponseBody` parameter
- Inside the `ok` > `body` visitor branch, added a guard: when `!context.includeSerdeLayer` and `rawResponseBody` is provided, the raw body is used directly instead of building a typed example
- The `ok`/`error` visitor split naturally limits this to successful responses (no explicit `statusCode < 400` guard needed)
- The `neverThrowErrors` wrapper (`{ body: ..., ok: true, ... }`) is handled by the existing wrapping logic in `getExpectedResponse`
- Callsite is a simple pass-through of `rawResponseBody` to `getExpectedResponse`
- Updated `versions.yml` with 3.63.1 changelog entry
- Regenerated seed output for all 22 exhaustive fixture variants

## Important review notes

1. **Broader scope than the triggering bug**: This changes expected assertions for **all** non-serde-layer fixtures, not only inline types. This is correct because without a serde layer, the SDK always returns raw JSON, so `rawResponseBody` is always the right expectation. But worth verifying this is the desired behavior vs. a narrower fix targeting only inline types.
2. **No explicit `responseStatusCode < 400` guard**: The earlier revision had an inline guard; the refactored version relies on the `ok`/`error` visitor split inside `getExpectedResponse` to achieve the same effect. Error responses go through the `error` branch which never sees `rawResponseBody`.
3. **Serde-layer fixtures are unaffected**: The `serde-layer` and `bigint-serde-layer` fixtures show zero diff, confirming the condition correctly excludes them.

### Human review checklist
- [ ] Confirm relying on the `ok`/`error` visitor split (instead of an explicit `statusCode < 400` check) is the right boundary for applying `rawResponseBody`
- [ ] Verify `rawResponseBody` being `undefined` for non-body responses doesn't cause issues (the `!value` early return in the `body` handler runs first)
- [ ] Spot-check a few seed output diffs (e.g. `never-throw-errors`, `serde-layer`) to confirm expected behavior

## Testing
- [x] All 22 exhaustive seed test variants pass (`pnpm seed:local test --generator ts-sdk --fixture exhaustive`)
- [x] `pnpm format` passes with no changes
- [x] Verified serde-layer fixture is unchanged
- [x] Verified never-throw-errors fixture correctly uses `{ body: rawResponseBody, ... }` wrapper
- [x] Seed output identical after refactor (only `TestGenerator.ts` changed, no generated file diffs)

Link to Devin session: https://app.devin.ai/sessions/3e03c07395394f70a2930faafc3b7a4c
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/14775" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
