### PR TITLE
Disable Naming/VariableNumber rubocop rule by default

### DIFF
--- a/generators/ruby-v2/ast/src/custom-config/BaseRubyCustomConfigSchema.ts
+++ b/generators/ruby-v2/ast/src/custom-config/BaseRubyCustomConfigSchema.ts
@@ -33,9 +33,9 @@ export const BaseRubyCustomConfigSchema = z.object({
     useDefaultRequestParameterValues: z.boolean().optional(),
     omitFernHeaders: z.boolean().optional(),
     // RuboCop Naming/VariableNumber style for field names with numbers
-    // - "snake_case": requires underscores before numbers (e.g., recaptcha_v_2) - default
+    // - "snake_case": requires underscores before numbers (e.g., recaptcha_v_2)
     // - "normalcase": allows numbers without underscores (e.g., recaptcha_v2, office365)
-    // - "disabled": disables the cop entirely
+    // - "disabled": disables the cop entirely - default
     rubocopVariableNumberStyle: z.enum(["snake_case", "normalcase", "disabled"]).optional(),
     maxRetries: z.number().int().min(0).optional()
 });

--- a/generators/ruby-v2/base/src/project/RubocopFile.ts
+++ b/generators/ruby-v2/base/src/project/RubocopFile.ts
@@ -16,7 +16,7 @@ export class RubocopFile {
     }
 
     private getVariableNumberConfig(): string {
-        const style = this.context.customConfig.rubocopVariableNumberStyle ?? "normalcase";
+        const style = this.context.customConfig.rubocopVariableNumberStyle ?? "disabled";
 
         if (style === "disabled") {
             return `Naming/VariableNumber:

--- a/seed/ruby-sdk-v2/accept-header/.rubocop.yml
+++ b/seed/ruby-sdk-v2/accept-header/.rubocop.yml
@@ -45,7 +45,7 @@ Layout/LineLength:
   Enabled: false
 
 Naming/VariableNumber:
-  EnforcedStyle: normalcase
+  Enabled: false
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/alias-extends/.rubocop.yml
+++ b/seed/ruby-sdk-v2/alias-extends/.rubocop.yml
@@ -45,7 +45,7 @@ Layout/LineLength:
   Enabled: false
 
 Naming/VariableNumber:
-  EnforcedStyle: normalcase
+  Enabled: false
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/alias/.rubocop.yml
+++ b/seed/ruby-sdk-v2/alias/.rubocop.yml
@@ -45,7 +45,7 @@ Layout/LineLength:
   Enabled: false
 
 Naming/VariableNumber:
-  EnforcedStyle: normalcase
+  Enabled: false
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/any-auth/.rubocop.yml
+++ b/seed/ruby-sdk-v2/any-auth/.rubocop.yml
@@ -45,7 +45,7 @@ Layout/LineLength:
   Enabled: false
 
 Naming/VariableNumber:
-  EnforcedStyle: normalcase
+  Enabled: false
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/api-wide-base-path/.rubocop.yml
+++ b/seed/ruby-sdk-v2/api-wide-base-path/.rubocop.yml
@@ -45,7 +45,7 @@ Layout/LineLength:
   Enabled: false
 
 Naming/VariableNumber:
-  EnforcedStyle: normalcase
+  Enabled: false
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/audiences/.rubocop.yml
+++ b/seed/ruby-sdk-v2/audiences/.rubocop.yml
@@ -45,7 +45,7 @@ Layout/LineLength:
   Enabled: false
 
 Naming/VariableNumber:
-  EnforcedStyle: normalcase
+  Enabled: false
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/basic-auth-environment-variables/.rubocop.yml
+++ b/seed/ruby-sdk-v2/basic-auth-environment-variables/.rubocop.yml
@@ -45,7 +45,7 @@ Layout/LineLength:
   Enabled: false
 
 Naming/VariableNumber:
-  EnforcedStyle: normalcase
+  Enabled: false
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/basic-auth-pw-omitted/.rubocop.yml
+++ b/seed/ruby-sdk-v2/basic-auth-pw-omitted/.rubocop.yml
@@ -45,7 +45,7 @@ Layout/LineLength:
   Enabled: false
 
 Naming/VariableNumber:
-  EnforcedStyle: normalcase
+  Enabled: false
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/basic-auth-pw-omitted/wire-tests/.rubocop.yml
+++ b/seed/ruby-sdk-v2/basic-auth-pw-omitted/wire-tests/.rubocop.yml
@@ -45,7 +45,7 @@ Layout/LineLength:
   Enabled: false
 
 Naming/VariableNumber:
-  EnforcedStyle: normalcase
+  Enabled: false
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/basic-auth/.rubocop.yml
+++ b/seed/ruby-sdk-v2/basic-auth/.rubocop.yml
@@ -45,7 +45,7 @@ Layout/LineLength:
   Enabled: false
 
 Naming/VariableNumber:
-  EnforcedStyle: normalcase
+  Enabled: false
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/basic-auth/wire-tests/.rubocop.yml
+++ b/seed/ruby-sdk-v2/basic-auth/wire-tests/.rubocop.yml
@@ -45,7 +45,7 @@ Layout/LineLength:
   Enabled: false
 
 Naming/VariableNumber:
-  EnforcedStyle: normalcase
+  Enabled: false
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/bearer-token-environment-variable/.rubocop.yml
+++ b/seed/ruby-sdk-v2/bearer-token-environment-variable/.rubocop.yml
@@ -45,7 +45,7 @@ Layout/LineLength:
   Enabled: false
 
 Naming/VariableNumber:
-  EnforcedStyle: normalcase
+  Enabled: false
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/bytes-download/.rubocop.yml
+++ b/seed/ruby-sdk-v2/bytes-download/.rubocop.yml
@@ -45,7 +45,7 @@ Layout/LineLength:
   Enabled: false
 
 Naming/VariableNumber:
-  EnforcedStyle: normalcase
+  Enabled: false
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/bytes-upload/.rubocop.yml
+++ b/seed/ruby-sdk-v2/bytes-upload/.rubocop.yml
@@ -45,7 +45,7 @@ Layout/LineLength:
   Enabled: false
 
 Naming/VariableNumber:
-  EnforcedStyle: normalcase
+  Enabled: false
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/circular-references-advanced/.rubocop.yml
+++ b/seed/ruby-sdk-v2/circular-references-advanced/.rubocop.yml
@@ -45,7 +45,7 @@ Layout/LineLength:
   Enabled: false
 
 Naming/VariableNumber:
-  EnforcedStyle: normalcase
+  Enabled: false
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/circular-references/.rubocop.yml
+++ b/seed/ruby-sdk-v2/circular-references/.rubocop.yml
@@ -45,7 +45,7 @@ Layout/LineLength:
   Enabled: false
 
 Naming/VariableNumber:
-  EnforcedStyle: normalcase
+  Enabled: false
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/client-side-params/.rubocop.yml
+++ b/seed/ruby-sdk-v2/client-side-params/.rubocop.yml
@@ -45,7 +45,7 @@ Layout/LineLength:
   Enabled: false
 
 Naming/VariableNumber:
-  EnforcedStyle: normalcase
+  Enabled: false
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/content-type/.rubocop.yml
+++ b/seed/ruby-sdk-v2/content-type/.rubocop.yml
@@ -45,7 +45,7 @@ Layout/LineLength:
   Enabled: false
 
 Naming/VariableNumber:
-  EnforcedStyle: normalcase
+  Enabled: false
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/cross-package-type-names/.rubocop.yml
+++ b/seed/ruby-sdk-v2/cross-package-type-names/.rubocop.yml
@@ -45,7 +45,7 @@ Layout/LineLength:
   Enabled: false
 
 Naming/VariableNumber:
-  EnforcedStyle: normalcase
+  Enabled: false
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/dollar-string-examples/.rubocop.yml
+++ b/seed/ruby-sdk-v2/dollar-string-examples/.rubocop.yml
@@ -45,7 +45,7 @@ Layout/LineLength:
   Enabled: false
 
 Naming/VariableNumber:
-  EnforcedStyle: normalcase
+  Enabled: false
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/empty-clients/.rubocop.yml
+++ b/seed/ruby-sdk-v2/empty-clients/.rubocop.yml
@@ -45,7 +45,7 @@ Layout/LineLength:
   Enabled: false
 
 Naming/VariableNumber:
-  EnforcedStyle: normalcase
+  Enabled: false
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/endpoint-security-auth/.rubocop.yml
+++ b/seed/ruby-sdk-v2/endpoint-security-auth/.rubocop.yml
@@ -45,7 +45,7 @@ Layout/LineLength:
   Enabled: false
 
 Naming/VariableNumber:
-  EnforcedStyle: normalcase
+  Enabled: false
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/enum/.rubocop.yml
+++ b/seed/ruby-sdk-v2/enum/.rubocop.yml
@@ -45,7 +45,7 @@ Layout/LineLength:
   Enabled: false
 
 Naming/VariableNumber:
-  EnforcedStyle: normalcase
+  Enabled: false
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/error-property/.rubocop.yml
+++ b/seed/ruby-sdk-v2/error-property/.rubocop.yml
@@ -45,7 +45,7 @@ Layout/LineLength:
   Enabled: false
 
 Naming/VariableNumber:
-  EnforcedStyle: normalcase
+  Enabled: false
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/errors/.rubocop.yml
+++ b/seed/ruby-sdk-v2/errors/.rubocop.yml
@@ -45,7 +45,7 @@ Layout/LineLength:
   Enabled: false
 
 Naming/VariableNumber:
-  EnforcedStyle: normalcase
+  Enabled: false
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/examples/no-custom-config/.rubocop.yml
+++ b/seed/ruby-sdk-v2/examples/no-custom-config/.rubocop.yml
@@ -45,7 +45,7 @@ Layout/LineLength:
   Enabled: false
 
 Naming/VariableNumber:
-  EnforcedStyle: normalcase
+  Enabled: false
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/examples/omit-fern-headers/.rubocop.yml
+++ b/seed/ruby-sdk-v2/examples/omit-fern-headers/.rubocop.yml
@@ -45,7 +45,7 @@ Layout/LineLength:
   Enabled: false
 
 Naming/VariableNumber:
-  EnforcedStyle: normalcase
+  Enabled: false
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/examples/readme-config/.rubocop.yml
+++ b/seed/ruby-sdk-v2/examples/readme-config/.rubocop.yml
@@ -45,7 +45,7 @@ Layout/LineLength:
   Enabled: false
 
 Naming/VariableNumber:
-  EnforcedStyle: normalcase
+  Enabled: false
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/examples/require-paths/.rubocop.yml
+++ b/seed/ruby-sdk-v2/examples/require-paths/.rubocop.yml
@@ -45,7 +45,7 @@ Layout/LineLength:
   Enabled: false
 
 Naming/VariableNumber:
-  EnforcedStyle: normalcase
+  Enabled: false
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/examples/wire-tests/.rubocop.yml
+++ b/seed/ruby-sdk-v2/examples/wire-tests/.rubocop.yml
@@ -45,7 +45,7 @@ Layout/LineLength:
   Enabled: false
 
 Naming/VariableNumber:
-  EnforcedStyle: normalcase
+  Enabled: false
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/exhaustive/wire-tests/.rubocop.yml
+++ b/seed/ruby-sdk-v2/exhaustive/wire-tests/.rubocop.yml
@@ -45,7 +45,7 @@ Layout/LineLength:
   Enabled: false
 
 Naming/VariableNumber:
-  EnforcedStyle: normalcase
+  Enabled: false
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/extends/.rubocop.yml
+++ b/seed/ruby-sdk-v2/extends/.rubocop.yml
@@ -45,7 +45,7 @@ Layout/LineLength:
   Enabled: false
 
 Naming/VariableNumber:
-  EnforcedStyle: normalcase
+  Enabled: false
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/extra-properties/.rubocop.yml
+++ b/seed/ruby-sdk-v2/extra-properties/.rubocop.yml
@@ -45,7 +45,7 @@ Layout/LineLength:
   Enabled: false
 
 Naming/VariableNumber:
-  EnforcedStyle: normalcase
+  Enabled: false
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/file-download/.rubocop.yml
+++ b/seed/ruby-sdk-v2/file-download/.rubocop.yml
@@ -45,7 +45,7 @@ Layout/LineLength:
   Enabled: false
 
 Naming/VariableNumber:
-  EnforcedStyle: normalcase
+  Enabled: false
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/file-upload-openapi/.rubocop.yml
+++ b/seed/ruby-sdk-v2/file-upload-openapi/.rubocop.yml
@@ -45,7 +45,7 @@ Layout/LineLength:
   Enabled: false
 
 Naming/VariableNumber:
-  EnforcedStyle: normalcase
+  Enabled: false
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/file-upload/.rubocop.yml
+++ b/seed/ruby-sdk-v2/file-upload/.rubocop.yml
@@ -45,7 +45,7 @@ Layout/LineLength:
   Enabled: false
 
 Naming/VariableNumber:
-  EnforcedStyle: normalcase
+  Enabled: false
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/folders/.rubocop.yml
+++ b/seed/ruby-sdk-v2/folders/.rubocop.yml
@@ -45,7 +45,7 @@ Layout/LineLength:
   Enabled: false
 
 Naming/VariableNumber:
-  EnforcedStyle: normalcase
+  Enabled: false
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/header-auth-environment-variable/.rubocop.yml
+++ b/seed/ruby-sdk-v2/header-auth-environment-variable/.rubocop.yml
@@ -45,7 +45,7 @@ Layout/LineLength:
   Enabled: false
 
 Naming/VariableNumber:
-  EnforcedStyle: normalcase
+  Enabled: false
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/header-auth/.rubocop.yml
+++ b/seed/ruby-sdk-v2/header-auth/.rubocop.yml
@@ -45,7 +45,7 @@ Layout/LineLength:
   Enabled: false
 
 Naming/VariableNumber:
-  EnforcedStyle: normalcase
+  Enabled: false
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/http-head/.rubocop.yml
+++ b/seed/ruby-sdk-v2/http-head/.rubocop.yml
@@ -45,7 +45,7 @@ Layout/LineLength:
   Enabled: false
 
 Naming/VariableNumber:
-  EnforcedStyle: normalcase
+  Enabled: false
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/idempotency-headers/.rubocop.yml
+++ b/seed/ruby-sdk-v2/idempotency-headers/.rubocop.yml
@@ -45,7 +45,7 @@ Layout/LineLength:
   Enabled: false
 
 Naming/VariableNumber:
-  EnforcedStyle: normalcase
+  Enabled: false
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/imdb/.rubocop.yml
+++ b/seed/ruby-sdk-v2/imdb/.rubocop.yml
@@ -45,7 +45,7 @@ Layout/LineLength:
   Enabled: false
 
 Naming/VariableNumber:
-  EnforcedStyle: normalcase
+  Enabled: false
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/inferred-auth-explicit/.rubocop.yml
+++ b/seed/ruby-sdk-v2/inferred-auth-explicit/.rubocop.yml
@@ -45,7 +45,7 @@ Layout/LineLength:
   Enabled: false
 
 Naming/VariableNumber:
-  EnforcedStyle: normalcase
+  Enabled: false
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/inferred-auth-implicit-api-key/.rubocop.yml
+++ b/seed/ruby-sdk-v2/inferred-auth-implicit-api-key/.rubocop.yml
@@ -45,7 +45,7 @@ Layout/LineLength:
   Enabled: false
 
 Naming/VariableNumber:
-  EnforcedStyle: normalcase
+  Enabled: false
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/inferred-auth-implicit-no-expiry/.rubocop.yml
+++ b/seed/ruby-sdk-v2/inferred-auth-implicit-no-expiry/.rubocop.yml
@@ -45,7 +45,7 @@ Layout/LineLength:
   Enabled: false
 
 Naming/VariableNumber:
-  EnforcedStyle: normalcase
+  Enabled: false
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/inferred-auth-implicit-reference/.rubocop.yml
+++ b/seed/ruby-sdk-v2/inferred-auth-implicit-reference/.rubocop.yml
@@ -45,7 +45,7 @@ Layout/LineLength:
   Enabled: false
 
 Naming/VariableNumber:
-  EnforcedStyle: normalcase
+  Enabled: false
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/inferred-auth-implicit/.rubocop.yml
+++ b/seed/ruby-sdk-v2/inferred-auth-implicit/.rubocop.yml
@@ -45,7 +45,7 @@ Layout/LineLength:
   Enabled: false
 
 Naming/VariableNumber:
-  EnforcedStyle: normalcase
+  Enabled: false
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/license/.rubocop.yml
+++ b/seed/ruby-sdk-v2/license/.rubocop.yml
@@ -45,7 +45,7 @@ Layout/LineLength:
   Enabled: false
 
 Naming/VariableNumber:
-  EnforcedStyle: normalcase
+  Enabled: false
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/literal/.rubocop.yml
+++ b/seed/ruby-sdk-v2/literal/.rubocop.yml
@@ -45,7 +45,7 @@ Layout/LineLength:
   Enabled: false
 
 Naming/VariableNumber:
-  EnforcedStyle: normalcase
+  Enabled: false
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/literals-unions/.rubocop.yml
+++ b/seed/ruby-sdk-v2/literals-unions/.rubocop.yml
@@ -45,7 +45,7 @@ Layout/LineLength:
   Enabled: false
 
 Naming/VariableNumber:
-  EnforcedStyle: normalcase
+  Enabled: false
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/mixed-case/.rubocop.yml
+++ b/seed/ruby-sdk-v2/mixed-case/.rubocop.yml
@@ -45,7 +45,7 @@ Layout/LineLength:
   Enabled: false
 
 Naming/VariableNumber:
-  EnforcedStyle: normalcase
+  Enabled: false
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/mixed-file-directory/.rubocop.yml
+++ b/seed/ruby-sdk-v2/mixed-file-directory/.rubocop.yml
@@ -45,7 +45,7 @@ Layout/LineLength:
   Enabled: false
 
 Naming/VariableNumber:
-  EnforcedStyle: normalcase
+  Enabled: false
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/multi-line-docs/.rubocop.yml
+++ b/seed/ruby-sdk-v2/multi-line-docs/.rubocop.yml
@@ -45,7 +45,7 @@ Layout/LineLength:
   Enabled: false
 
 Naming/VariableNumber:
-  EnforcedStyle: normalcase
+  Enabled: false
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/multi-url-environment-no-default/.rubocop.yml
+++ b/seed/ruby-sdk-v2/multi-url-environment-no-default/.rubocop.yml
@@ -45,7 +45,7 @@ Layout/LineLength:
   Enabled: false
 
 Naming/VariableNumber:
-  EnforcedStyle: normalcase
+  Enabled: false
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/multi-url-environment/.rubocop.yml
+++ b/seed/ruby-sdk-v2/multi-url-environment/.rubocop.yml
@@ -45,7 +45,7 @@ Layout/LineLength:
   Enabled: false
 
 Naming/VariableNumber:
-  EnforcedStyle: normalcase
+  Enabled: false
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/multiple-request-bodies/.rubocop.yml
+++ b/seed/ruby-sdk-v2/multiple-request-bodies/.rubocop.yml
@@ -45,7 +45,7 @@ Layout/LineLength:
   Enabled: false
 
 Naming/VariableNumber:
-  EnforcedStyle: normalcase
+  Enabled: false
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/no-content-response/.rubocop.yml
+++ b/seed/ruby-sdk-v2/no-content-response/.rubocop.yml
@@ -45,7 +45,7 @@ Layout/LineLength:
   Enabled: false
 
 Naming/VariableNumber:
-  EnforcedStyle: normalcase
+  Enabled: false
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/no-environment/.rubocop.yml
+++ b/seed/ruby-sdk-v2/no-environment/.rubocop.yml
@@ -45,7 +45,7 @@ Layout/LineLength:
   Enabled: false
 
 Naming/VariableNumber:
-  EnforcedStyle: normalcase
+  Enabled: false
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/no-retries/.rubocop.yml
+++ b/seed/ruby-sdk-v2/no-retries/.rubocop.yml
@@ -45,7 +45,7 @@ Layout/LineLength:
   Enabled: false
 
 Naming/VariableNumber:
-  EnforcedStyle: normalcase
+  Enabled: false
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/null-type/.rubocop.yml
+++ b/seed/ruby-sdk-v2/null-type/.rubocop.yml
@@ -45,7 +45,7 @@ Layout/LineLength:
   Enabled: false
 
 Naming/VariableNumber:
-  EnforcedStyle: normalcase
+  Enabled: false
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/nullable-allof-extends/.rubocop.yml
+++ b/seed/ruby-sdk-v2/nullable-allof-extends/.rubocop.yml
@@ -45,7 +45,7 @@ Layout/LineLength:
   Enabled: false
 
 Naming/VariableNumber:
-  EnforcedStyle: normalcase
+  Enabled: false
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/nullable-optional/.rubocop.yml
+++ b/seed/ruby-sdk-v2/nullable-optional/.rubocop.yml
@@ -45,7 +45,7 @@ Layout/LineLength:
   Enabled: false
 
 Naming/VariableNumber:
-  EnforcedStyle: normalcase
+  Enabled: false
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/nullable-request-body/.rubocop.yml
+++ b/seed/ruby-sdk-v2/nullable-request-body/.rubocop.yml
@@ -45,7 +45,7 @@ Layout/LineLength:
   Enabled: false
 
 Naming/VariableNumber:
-  EnforcedStyle: normalcase
+  Enabled: false
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/nullable/.rubocop.yml
+++ b/seed/ruby-sdk-v2/nullable/.rubocop.yml
@@ -45,7 +45,7 @@ Layout/LineLength:
   Enabled: false
 
 Naming/VariableNumber:
-  EnforcedStyle: normalcase
+  Enabled: false
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/oauth-client-credentials-custom/.rubocop.yml
+++ b/seed/ruby-sdk-v2/oauth-client-credentials-custom/.rubocop.yml
@@ -45,7 +45,7 @@ Layout/LineLength:
   Enabled: false
 
 Naming/VariableNumber:
-  EnforcedStyle: normalcase
+  Enabled: false
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/oauth-client-credentials-default/.rubocop.yml
+++ b/seed/ruby-sdk-v2/oauth-client-credentials-default/.rubocop.yml
@@ -45,7 +45,7 @@ Layout/LineLength:
   Enabled: false
 
 Naming/VariableNumber:
-  EnforcedStyle: normalcase
+  Enabled: false
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/oauth-client-credentials-environment-variables/.rubocop.yml
+++ b/seed/ruby-sdk-v2/oauth-client-credentials-environment-variables/.rubocop.yml
@@ -45,7 +45,7 @@ Layout/LineLength:
   Enabled: false
 
 Naming/VariableNumber:
-  EnforcedStyle: normalcase
+  Enabled: false
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/oauth-client-credentials-mandatory-auth/.rubocop.yml
+++ b/seed/ruby-sdk-v2/oauth-client-credentials-mandatory-auth/.rubocop.yml
@@ -45,7 +45,7 @@ Layout/LineLength:
   Enabled: false
 
 Naming/VariableNumber:
-  EnforcedStyle: normalcase
+  Enabled: false
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/oauth-client-credentials-nested-root/.rubocop.yml
+++ b/seed/ruby-sdk-v2/oauth-client-credentials-nested-root/.rubocop.yml
@@ -45,7 +45,7 @@ Layout/LineLength:
   Enabled: false
 
 Naming/VariableNumber:
-  EnforcedStyle: normalcase
+  Enabled: false
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/oauth-client-credentials-openapi/.rubocop.yml
+++ b/seed/ruby-sdk-v2/oauth-client-credentials-openapi/.rubocop.yml
@@ -45,7 +45,7 @@ Layout/LineLength:
   Enabled: false
 
 Naming/VariableNumber:
-  EnforcedStyle: normalcase
+  Enabled: false
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/oauth-client-credentials-reference/.rubocop.yml
+++ b/seed/ruby-sdk-v2/oauth-client-credentials-reference/.rubocop.yml
@@ -45,7 +45,7 @@ Layout/LineLength:
   Enabled: false
 
 Naming/VariableNumber:
-  EnforcedStyle: normalcase
+  Enabled: false
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/oauth-client-credentials-with-variables/.rubocop.yml
+++ b/seed/ruby-sdk-v2/oauth-client-credentials-with-variables/.rubocop.yml
@@ -45,7 +45,7 @@ Layout/LineLength:
   Enabled: false
 
 Naming/VariableNumber:
-  EnforcedStyle: normalcase
+  Enabled: false
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/oauth-client-credentials/.rubocop.yml
+++ b/seed/ruby-sdk-v2/oauth-client-credentials/.rubocop.yml
@@ -45,7 +45,7 @@ Layout/LineLength:
   Enabled: false
 
 Naming/VariableNumber:
-  EnforcedStyle: normalcase
+  Enabled: false
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/object/.rubocop.yml
+++ b/seed/ruby-sdk-v2/object/.rubocop.yml
@@ -45,7 +45,7 @@ Layout/LineLength:
   Enabled: false
 
 Naming/VariableNumber:
-  EnforcedStyle: normalcase
+  Enabled: false
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/objects-with-imports/.rubocop.yml
+++ b/seed/ruby-sdk-v2/objects-with-imports/.rubocop.yml
@@ -45,7 +45,7 @@ Layout/LineLength:
   Enabled: false
 
 Naming/VariableNumber:
-  EnforcedStyle: normalcase
+  Enabled: false
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/optional/.rubocop.yml
+++ b/seed/ruby-sdk-v2/optional/.rubocop.yml
@@ -45,7 +45,7 @@ Layout/LineLength:
   Enabled: false
 
 Naming/VariableNumber:
-  EnforcedStyle: normalcase
+  Enabled: false
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/package-yml/.rubocop.yml
+++ b/seed/ruby-sdk-v2/package-yml/.rubocop.yml
@@ -45,7 +45,7 @@ Layout/LineLength:
   Enabled: false
 
 Naming/VariableNumber:
-  EnforcedStyle: normalcase
+  Enabled: false
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/pagination-custom/.rubocop.yml
+++ b/seed/ruby-sdk-v2/pagination-custom/.rubocop.yml
@@ -45,7 +45,7 @@ Layout/LineLength:
   Enabled: false
 
 Naming/VariableNumber:
-  EnforcedStyle: normalcase
+  Enabled: false
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/pagination-uri-path/.rubocop.yml
+++ b/seed/ruby-sdk-v2/pagination-uri-path/.rubocop.yml
@@ -45,7 +45,7 @@ Layout/LineLength:
   Enabled: false
 
 Naming/VariableNumber:
-  EnforcedStyle: normalcase
+  Enabled: false
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/pagination/.rubocop.yml
+++ b/seed/ruby-sdk-v2/pagination/.rubocop.yml
@@ -45,7 +45,7 @@ Layout/LineLength:
   Enabled: false
 
 Naming/VariableNumber:
-  EnforcedStyle: normalcase
+  Enabled: false
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/path-parameters/.rubocop.yml
+++ b/seed/ruby-sdk-v2/path-parameters/.rubocop.yml
@@ -45,7 +45,7 @@ Layout/LineLength:
   Enabled: false
 
 Naming/VariableNumber:
-  EnforcedStyle: normalcase
+  Enabled: false
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/plain-text/.rubocop.yml
+++ b/seed/ruby-sdk-v2/plain-text/.rubocop.yml
@@ -45,7 +45,7 @@ Layout/LineLength:
   Enabled: false
 
 Naming/VariableNumber:
-  EnforcedStyle: normalcase
+  Enabled: false
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/property-access/.rubocop.yml
+++ b/seed/ruby-sdk-v2/property-access/.rubocop.yml
@@ -45,7 +45,7 @@ Layout/LineLength:
   Enabled: false
 
 Naming/VariableNumber:
-  EnforcedStyle: normalcase
+  Enabled: false
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/public-object/.rubocop.yml
+++ b/seed/ruby-sdk-v2/public-object/.rubocop.yml
@@ -45,7 +45,7 @@ Layout/LineLength:
   Enabled: false
 
 Naming/VariableNumber:
-  EnforcedStyle: normalcase
+  Enabled: false
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/query-param-name-conflict/.rubocop.yml
+++ b/seed/ruby-sdk-v2/query-param-name-conflict/.rubocop.yml
@@ -45,7 +45,7 @@ Layout/LineLength:
   Enabled: false
 
 Naming/VariableNumber:
-  EnforcedStyle: normalcase
+  Enabled: false
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/query-parameters-openapi-as-objects/.rubocop.yml
+++ b/seed/ruby-sdk-v2/query-parameters-openapi-as-objects/.rubocop.yml
@@ -45,7 +45,7 @@ Layout/LineLength:
   Enabled: false
 
 Naming/VariableNumber:
-  EnforcedStyle: normalcase
+  Enabled: false
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/query-parameters-openapi/.rubocop.yml
+++ b/seed/ruby-sdk-v2/query-parameters-openapi/.rubocop.yml
@@ -45,7 +45,7 @@ Layout/LineLength:
   Enabled: false
 
 Naming/VariableNumber:
-  EnforcedStyle: normalcase
+  Enabled: false
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/query-parameters/.rubocop.yml
+++ b/seed/ruby-sdk-v2/query-parameters/.rubocop.yml
@@ -45,7 +45,7 @@ Layout/LineLength:
   Enabled: false
 
 Naming/VariableNumber:
-  EnforcedStyle: normalcase
+  Enabled: false
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/request-parameters/.rubocop.yml
+++ b/seed/ruby-sdk-v2/request-parameters/.rubocop.yml
@@ -45,7 +45,7 @@ Layout/LineLength:
   Enabled: false
 
 Naming/VariableNumber:
-  EnforcedStyle: normalcase
+  Enabled: false
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/required-nullable/.rubocop.yml
+++ b/seed/ruby-sdk-v2/required-nullable/.rubocop.yml
@@ -45,7 +45,7 @@ Layout/LineLength:
   Enabled: false
 
 Naming/VariableNumber:
-  EnforcedStyle: normalcase
+  Enabled: false
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/reserved-keywords/.rubocop.yml
+++ b/seed/ruby-sdk-v2/reserved-keywords/.rubocop.yml
@@ -45,7 +45,7 @@ Layout/LineLength:
   Enabled: false
 
 Naming/VariableNumber:
-  EnforcedStyle: normalcase
+  Enabled: false
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/response-property/.rubocop.yml
+++ b/seed/ruby-sdk-v2/response-property/.rubocop.yml
@@ -45,7 +45,7 @@ Layout/LineLength:
   Enabled: false
 
 Naming/VariableNumber:
-  EnforcedStyle: normalcase
+  Enabled: false
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/ruby-reserved-word-properties/.rubocop.yml
+++ b/seed/ruby-sdk-v2/ruby-reserved-word-properties/.rubocop.yml
@@ -45,7 +45,7 @@ Layout/LineLength:
   Enabled: false
 
 Naming/VariableNumber:
-  EnforcedStyle: normalcase
+  Enabled: false
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/schemaless-request-body-examples/.rubocop.yml
+++ b/seed/ruby-sdk-v2/schemaless-request-body-examples/.rubocop.yml
@@ -45,7 +45,7 @@ Layout/LineLength:
   Enabled: false
 
 Naming/VariableNumber:
-  EnforcedStyle: normalcase
+  Enabled: false
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/server-sent-event-examples/.rubocop.yml
+++ b/seed/ruby-sdk-v2/server-sent-event-examples/.rubocop.yml
@@ -45,7 +45,7 @@ Layout/LineLength:
   Enabled: false
 
 Naming/VariableNumber:
-  EnforcedStyle: normalcase
+  Enabled: false
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/server-sent-events-openapi/.rubocop.yml
+++ b/seed/ruby-sdk-v2/server-sent-events-openapi/.rubocop.yml
@@ -45,7 +45,7 @@ Layout/LineLength:
   Enabled: false
 
 Naming/VariableNumber:
-  EnforcedStyle: normalcase
+  Enabled: false
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/server-sent-events/.rubocop.yml
+++ b/seed/ruby-sdk-v2/server-sent-events/.rubocop.yml
@@ -45,7 +45,7 @@ Layout/LineLength:
   Enabled: false
 
 Naming/VariableNumber:
-  EnforcedStyle: normalcase
+  Enabled: false
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/server-url-templating/.rubocop.yml
+++ b/seed/ruby-sdk-v2/server-url-templating/.rubocop.yml
@@ -45,7 +45,7 @@ Layout/LineLength:
   Enabled: false
 
 Naming/VariableNumber:
-  EnforcedStyle: normalcase
+  Enabled: false
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/simple-api/.rubocop.yml
+++ b/seed/ruby-sdk-v2/simple-api/.rubocop.yml
@@ -45,7 +45,7 @@ Layout/LineLength:
   Enabled: false
 
 Naming/VariableNumber:
-  EnforcedStyle: normalcase
+  Enabled: false
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/simple-fhir/.rubocop.yml
+++ b/seed/ruby-sdk-v2/simple-fhir/.rubocop.yml
@@ -45,7 +45,7 @@ Layout/LineLength:
   Enabled: false
 
 Naming/VariableNumber:
-  EnforcedStyle: normalcase
+  Enabled: false
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/single-url-environment-default/.rubocop.yml
+++ b/seed/ruby-sdk-v2/single-url-environment-default/.rubocop.yml
@@ -45,7 +45,7 @@ Layout/LineLength:
   Enabled: false
 
 Naming/VariableNumber:
-  EnforcedStyle: normalcase
+  Enabled: false
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/single-url-environment-no-default/.rubocop.yml
+++ b/seed/ruby-sdk-v2/single-url-environment-no-default/.rubocop.yml
@@ -45,7 +45,7 @@ Layout/LineLength:
   Enabled: false
 
 Naming/VariableNumber:
-  EnforcedStyle: normalcase
+  Enabled: false
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/streaming-parameter/.rubocop.yml
+++ b/seed/ruby-sdk-v2/streaming-parameter/.rubocop.yml
@@ -45,7 +45,7 @@ Layout/LineLength:
   Enabled: false
 
 Naming/VariableNumber:
-  EnforcedStyle: normalcase
+  Enabled: false
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/streaming/.rubocop.yml
+++ b/seed/ruby-sdk-v2/streaming/.rubocop.yml
@@ -45,7 +45,7 @@ Layout/LineLength:
   Enabled: false
 
 Naming/VariableNumber:
-  EnforcedStyle: normalcase
+  Enabled: false
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/trace/.rubocop.yml
+++ b/seed/ruby-sdk-v2/trace/.rubocop.yml
@@ -45,7 +45,7 @@ Layout/LineLength:
   Enabled: false
 
 Naming/VariableNumber:
-  EnforcedStyle: normalcase
+  Enabled: false
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/undiscriminated-union-with-response-property/.rubocop.yml
+++ b/seed/ruby-sdk-v2/undiscriminated-union-with-response-property/.rubocop.yml
@@ -45,7 +45,7 @@ Layout/LineLength:
   Enabled: false
 
 Naming/VariableNumber:
-  EnforcedStyle: normalcase
+  Enabled: false
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/undiscriminated-unions/.rubocop.yml
+++ b/seed/ruby-sdk-v2/undiscriminated-unions/.rubocop.yml
@@ -45,7 +45,7 @@ Layout/LineLength:
   Enabled: false
 
 Naming/VariableNumber:
-  EnforcedStyle: normalcase
+  Enabled: false
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/unions-with-local-date/.rubocop.yml
+++ b/seed/ruby-sdk-v2/unions-with-local-date/.rubocop.yml
@@ -45,7 +45,7 @@ Layout/LineLength:
   Enabled: false
 
 Naming/VariableNumber:
-  EnforcedStyle: normalcase
+  Enabled: false
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/unions/.rubocop.yml
+++ b/seed/ruby-sdk-v2/unions/.rubocop.yml
@@ -45,7 +45,7 @@ Layout/LineLength:
   Enabled: false
 
 Naming/VariableNumber:
-  EnforcedStyle: normalcase
+  Enabled: false
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/unknown/.rubocop.yml
+++ b/seed/ruby-sdk-v2/unknown/.rubocop.yml
@@ -45,7 +45,7 @@ Layout/LineLength:
   Enabled: false
 
 Naming/VariableNumber:
-  EnforcedStyle: normalcase
+  Enabled: false
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/url-form-encoded/.rubocop.yml
+++ b/seed/ruby-sdk-v2/url-form-encoded/.rubocop.yml
@@ -45,7 +45,7 @@ Layout/LineLength:
   Enabled: false
 
 Naming/VariableNumber:
-  EnforcedStyle: normalcase
+  Enabled: false
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/validation/.rubocop.yml
+++ b/seed/ruby-sdk-v2/validation/.rubocop.yml
@@ -45,7 +45,7 @@ Layout/LineLength:
   Enabled: false
 
 Naming/VariableNumber:
-  EnforcedStyle: normalcase
+  Enabled: false
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/variables/.rubocop.yml
+++ b/seed/ruby-sdk-v2/variables/.rubocop.yml
@@ -45,7 +45,7 @@ Layout/LineLength:
   Enabled: false
 
 Naming/VariableNumber:
-  EnforcedStyle: normalcase
+  Enabled: false
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/version-no-default/.rubocop.yml
+++ b/seed/ruby-sdk-v2/version-no-default/.rubocop.yml
@@ -45,7 +45,7 @@ Layout/LineLength:
   Enabled: false
 
 Naming/VariableNumber:
-  EnforcedStyle: normalcase
+  Enabled: false
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/version/.rubocop.yml
+++ b/seed/ruby-sdk-v2/version/.rubocop.yml
@@ -45,7 +45,7 @@ Layout/LineLength:
   Enabled: false
 
 Naming/VariableNumber:
-  EnforcedStyle: normalcase
+  Enabled: false
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/webhook-audience/.rubocop.yml
+++ b/seed/ruby-sdk-v2/webhook-audience/.rubocop.yml
@@ -45,7 +45,7 @@ Layout/LineLength:
   Enabled: false
 
 Naming/VariableNumber:
-  EnforcedStyle: normalcase
+  Enabled: false
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/webhooks/.rubocop.yml
+++ b/seed/ruby-sdk-v2/webhooks/.rubocop.yml
@@ -45,7 +45,7 @@ Layout/LineLength:
   Enabled: false
 
 Naming/VariableNumber:
-  EnforcedStyle: normalcase
+  Enabled: false
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/websocket-bearer-auth/.rubocop.yml
+++ b/seed/ruby-sdk-v2/websocket-bearer-auth/.rubocop.yml
@@ -45,7 +45,7 @@ Layout/LineLength:
   Enabled: false
 
 Naming/VariableNumber:
-  EnforcedStyle: normalcase
+  Enabled: false
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/websocket-inferred-auth/.rubocop.yml
+++ b/seed/ruby-sdk-v2/websocket-inferred-auth/.rubocop.yml
@@ -45,7 +45,7 @@ Layout/LineLength:
   Enabled: false
 
 Naming/VariableNumber:
-  EnforcedStyle: normalcase
+  Enabled: false
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/websocket-multi-url/.rubocop.yml
+++ b/seed/ruby-sdk-v2/websocket-multi-url/.rubocop.yml
@@ -45,7 +45,7 @@ Layout/LineLength:
   Enabled: false
 
 Naming/VariableNumber:
-  EnforcedStyle: normalcase
+  Enabled: false
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/websocket/.rubocop.yml
+++ b/seed/ruby-sdk-v2/websocket/.rubocop.yml
@@ -45,7 +45,7 @@ Layout/LineLength:
   Enabled: false
 
 Naming/VariableNumber:
-  EnforcedStyle: normalcase
+  Enabled: false
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/x-fern-default/.rubocop.yml
+++ b/seed/ruby-sdk-v2/x-fern-default/.rubocop.yml
@@ -45,7 +45,7 @@ Layout/LineLength:
   Enabled: false
 
 Naming/VariableNumber:
-  EnforcedStyle: normalcase
+  Enabled: false
 
 Style/Documentation:
   Enabled: false


### PR DESCRIPTION
## Description

Refs https://github.com/VapiAI/server-sdk-ruby/actions/runs/24156813920/job/70531139633

Changes the default `Naming/VariableNumber` RuboCop setting in the Ruby v2 generator from `EnforcedStyle: normalcase` to `Enabled: false`.

The `normalcase` style causes lint failures on generated field names like `:secret_is_base_64` (snake_cased from `secretIsBase64` in the API spec). Fixing the casing converter would be a breaking change, so the safer approach is to disable the cop by default. Users can still opt into `normalcase` or `snake_case` via the `rubocopVariableNumberStyle` custom config option.

## Changes Made
- Changed default `rubocopVariableNumberStyle` from `"normalcase"` to `"disabled"` in `RubocopFile.ts`
- Updated comment in `BaseRubyCustomConfigSchema.ts` to reflect new default
- Updated all seed `.rubocop.yml` fixtures (122 files) to match new output

## Testing
- [x] Verified locally that `bundle exec rubocop` passes with zero offenses on the [failing VapiAI repo](https://github.com/VapiAI/server-sdk-ruby) after this change
- [ ] Unit tests added/updated — no new tests; existing seed snapshots cover this

## Review Checklist
- Verify the `getVariableNumberConfig()` method in `RubocopFile.ts` still handles all three enum values correctly (the `"normalcase"` and `"snake_case"` paths are unchanged, just no longer the default)
- Confirm no seed fixtures explicitly test the `rubocopVariableNumberStyle` custom config — if any do, they should remain unchanged

Link to Devin session: https://app.devin.ai/sessions/a3e49b3a1be04a3d8af94395364ac8e0
Requested by: @Ryan-Amirthan