### PR TITLE
chore(generator-cli): remove .fern/replay.yml from REPLAY_FERNIGNORE_ENTRIES

### DIFF
--- a/packages/generator-cli/src/__test__/replay-pure.test.ts
+++ b/packages/generator-cli/src/__test__/replay-pure.test.ts
@@ -396,9 +396,8 @@ describe("parseCommitMessageForPR", () => {
 describe("fernignore", () => {
     it("REPLAY_FERNIGNORE_ENTRIES contains expected values", () => {
         expect(REPLAY_FERNIGNORE_ENTRIES).toContain(".fern/replay.lock");
-        expect(REPLAY_FERNIGNORE_ENTRIES).toContain(".fern/replay.yml");
         expect(REPLAY_FERNIGNORE_ENTRIES).toContain(".gitattributes");
-        expect(REPLAY_FERNIGNORE_ENTRIES.length).toBeGreaterThanOrEqual(3);
+        expect(REPLAY_FERNIGNORE_ENTRIES.length).toBeGreaterThanOrEqual(2);
     });
 
     it("creates .fernignore with entries when no file exists, returns true", async () => {

--- a/packages/generator-cli/src/replay/fernignore.ts
+++ b/packages/generator-cli/src/replay/fernignore.ts
@@ -2,7 +2,7 @@ import { existsSync, readFileSync, writeFileSync } from "fs";
 import { readFile, writeFile } from "fs/promises";
 import { join } from "path";
 
-export const REPLAY_FERNIGNORE_ENTRIES = [".fern/replay.lock", ".fern/replay.yml", ".gitattributes"];
+export const REPLAY_FERNIGNORE_ENTRIES = [".fern/replay.lock", ".gitattributes"];
 
 const GITATTRIBUTES_ENTRIES = [".fern/replay.lock linguist-generated=true"];
 


### PR DESCRIPTION
## Description

Removes `.fern/replay.yml` from the list of files that `fern replay init` adds to `.fernignore`.

## Changes Made

- Removed `.fern/replay.yml` from the `REPLAY_FERNIGNORE_ENTRIES` constant in `fernignore.ts`, reducing it from 3 entries to 2 (`.fern/replay.lock` and `.gitattributes`)
- Updated the corresponding test assertions in `replay-pure.test.ts`

## Human Review Checklist

- [ ] Confirm `.fern/replay.yml` no longer needs to be preserved across generations (i.e., it's fine for `fern generate` to overwrite it)
- [ ] Verify no downstream consumers (e.g., fiddle server-side) explicitly depend on `.fern/replay.yml` being in the fernignore entries list

## Testing

- [x] Unit tests updated
- [x] Lint (`biome check`) passes

Link to Devin session: https://app.devin.ai/sessions/48f13de8b82c444db51e0a931c798a3d
Requested by: @tstanmay13