### PR TITLE
fix(go): resolve dynamic snippet import paths from dynamic IR config

### DIFF
--- a/generators/go-v2/dynamic-snippets/src/context/DynamicSnippetsGeneratorContext.ts
+++ b/generators/go-v2/dynamic-snippets/src/context/DynamicSnippetsGeneratorContext.ts
@@ -1,6 +1,6 @@
 import {
     AbstractDynamicSnippetsGeneratorContext,
-    type FernGeneratorExec
+    FernGeneratorExec
 } from "@fern-api/browser-compatible-base-generator";
 import { assertNever } from "@fern-api/core-utils";
 import type { FernIr } from "@fern-api/dynamic-ir-sdk";
@@ -27,11 +27,15 @@ export class DynamicSnippetsGeneratorContext extends AbstractDynamicSnippetsGene
     }) {
         super({ ir, config });
         this.ir = ir;
-        this.customConfig = config.customConfig != null ? (config.customConfig as BaseGoCustomConfigSchema) : undefined;
+        const effectiveConfig = this.buildEffectiveConfig({ ir, config });
+        this.customConfig =
+            effectiveConfig.customConfig != null
+                ? (effectiveConfig.customConfig as BaseGoCustomConfigSchema)
+                : undefined;
         this.dynamicTypeMapper = new DynamicTypeMapper({ context: this });
         this.dynamicTypeInstantiationMapper = new DynamicTypeInstantiationMapper({ context: this });
         this.filePropertyMapper = new FilePropertyMapper({ context: this });
-        this.rootImportPath = resolveRootImportPath({ config, customConfig: this.customConfig });
+        this.rootImportPath = resolveRootImportPath({ config: effectiveConfig, customConfig: this.customConfig });
     }
 
     public clone(): DynamicSnippetsGeneratorContext {
@@ -181,6 +185,46 @@ export class DynamicSnippetsGeneratorContext extends AbstractDynamicSnippetsGene
             name: `Environments.${this.getTypeName(name)}`,
             importPath: this.rootImportPath
         });
+    }
+
+    /**
+     * Builds an effective FernGeneratorExec.GeneratorConfig by incorporating
+     * Go-specific publish info from the dynamic IR's generatorConfig.
+     *
+     * The dynamic IR contains the authoritative generator config (including
+     * repoUrl and version for Go). This method ensures the snippet generator
+     * uses that config directly, rather than depending on an external conversion
+     * layer (e.g. FDR) to correctly populate the FernGeneratorExec config.
+     */
+    private buildEffectiveConfig({
+        ir,
+        config
+    }: {
+        ir: FernIr.dynamic.DynamicIntermediateRepresentation;
+        config: FernGeneratorExec.GeneratorConfig;
+    }): FernGeneratorExec.GeneratorConfig {
+        const generatorConfig = ir.generatorConfig;
+        if (generatorConfig == null) {
+            return config;
+        }
+        if (generatorConfig.outputConfig.type !== "publish") {
+            return config;
+        }
+        const publishInfo = generatorConfig.outputConfig.value;
+        if (publishInfo.type !== "go") {
+            return config;
+        }
+        return {
+            ...config,
+            customConfig: generatorConfig.customConfig ?? config.customConfig,
+            output: {
+                ...config.output,
+                mode: FernGeneratorExec.OutputMode.github({
+                    version: publishInfo.version,
+                    repoUrl: publishInfo.repoUrl
+                })
+            }
+        };
     }
 
     public static chainMethods(

--- a/generators/go/sdk/versions.yml
+++ b/generators/go/sdk/versions.yml
@@ -7,6 +7,19 @@
   createdAt: "2026-04-01"
   irVersion: 66
 
+- version: 1.33.6
+  changelogEntry:
+    - summary: |
+        Fix dynamic snippet import path resolution to use Go publish info from
+        the dynamic IR's generatorConfig directly, rather than depending solely
+        on the externally-constructed FernGeneratorExec config. This ensures
+        the correct repoUrl and version are used for import paths even when the
+        external config conversion layer does not populate them correctly,
+        eliminating the spurious `/v` suffix in generated Go snippet imports.
+      type: fix
+  createdAt: "2026-04-09"
+  irVersion: 61
+
 - version: 1.33.5
   changelogEntry:
     - summary: |


### PR DESCRIPTION
## Description

Follows up on #14767. The previous fix handled empty version strings in `parseMajorVersion`, but the `/v` suffix continued to appear in generated Go snippets because the dynamic snippet generator was relying solely on the externally-constructed `FernGeneratorExec.GeneratorConfig` (populated by the FDR conversion layer) rather than reading Go publish info directly from the dynamic IR.

## Changes Made

- Added `buildEffectiveConfig` method to `DynamicSnippetsGeneratorContext` that extracts `repoUrl` and `version` from `ir.generatorConfig` when Go publish info is available, and constructs a proper `FernGeneratorExec.GeneratorConfig` from it
- Changed `FernGeneratorExec` import from type-only to value import (needed to call `FernGeneratorExec.OutputMode.github()` at runtime)
- Updated `versions.yml` with v1.33.6 changelog entry

The snippet generator now uses the dynamic IR's `generatorConfig` as the authoritative source for Go import path resolution, falling back to the external config when the IR doesn't contain Go publish info.

## Review Checklist

- [ ] **`customConfig` override**: `buildEffectiveConfig` also overrides `customConfig` from the IR's generatorConfig (`generatorConfig.customConfig ?? config.customConfig`). Verify this is the correct precedence — it means the IR's customConfig takes priority over the externally-provided one, which could affect `packageName`, `union`, `inlineFileProperties`, etc.
- [ ] **`OutputMode.github` assumption**: The method maps Go publish info to `FernGeneratorExec.OutputMode.github(...)`. Confirm this is the correct mode for how `resolveRootImportPath` reads `repoUrl` and `version`.
- [ ] **`clone()` correctness**: `clone()` passes `this.config` (the original), but `buildEffectiveConfig` re-runs in the new constructor, so the clone should produce the same result.

## Testing

- [ ] Unit tests added/updated
- [x] Lint (`pnpm run check`) and format (`pnpm format`) pass
- [x] Pre-existing type errors confirmed unrelated to this change
- [ ] Manual testing with Payroc dynamic IR (not feasible without FDR environment)

Link to Devin session: https://app.devin.ai/sessions/da475ac82f754e50b67b0d219f6bb052
Requested by: @iamnamananand996