### PR TITLE
fix(go): use type-only import for FernGeneratorExec to fix bundle regression

### DIFF
--- a/generators/go-v2/dynamic-snippets/src/context/DynamicSnippetsGeneratorContext.ts
+++ b/generators/go-v2/dynamic-snippets/src/context/DynamicSnippetsGeneratorContext.ts
@@ -1,6 +1,6 @@
 import {
     AbstractDynamicSnippetsGeneratorContext,
-    FernGeneratorExec
+    type FernGeneratorExec
 } from "@fern-api/browser-compatible-base-generator";
 import { assertNever } from "@fern-api/core-utils";
 import type { FernIr } from "@fern-api/dynamic-ir-sdk";
@@ -219,10 +219,11 @@ export class DynamicSnippetsGeneratorContext extends AbstractDynamicSnippetsGene
             customConfig: generatorConfig.customConfig ?? config.customConfig,
             output: {
                 ...config.output,
-                mode: FernGeneratorExec.OutputMode.github({
+                mode: {
+                    type: "github",
                     version: publishInfo.version,
                     repoUrl: publishInfo.repoUrl
-                })
+                } as FernGeneratorExec.OutputMode
             }
         };
     }

--- a/generators/go/sdk/versions.yml
+++ b/generators/go/sdk/versions.yml
@@ -1,4 +1,16 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 1.34.2
+  changelogEntry:
+    - summary: |
+        Fix dynamic snippet NPM package bundle pulling in Node-only `form-data`
+        dependency via a runtime import of `FernGeneratorExec.OutputMode.github()`.
+        The output mode is now constructed as a plain object literal with a
+        type-only import, preventing `Dynamic require of "fs" is not supported`
+        errors in browser/ESM environments.
+      type: fix
+  createdAt: "2026-04-09"
+  irVersion: 66
+
 - version: 1.34.1
   changelogEntry:
     - summary: |


### PR DESCRIPTION
## Description

Fixes a bundle regression introduced in v1.34.1 where the `@fern-api/go-dynamic-snippets` NPM package fails in ESM/browser environments with `Dynamic require of "fs" is not supported`.

## Changes Made

- Changed `FernGeneratorExec` from a runtime import back to a **type-only** import
- Replaced `FernGeneratorExec.OutputMode.github({...})` factory call with a **plain object literal** + type assertion
- Added version `1.34.2` to `versions.yml` to trigger a new NPM publish

### Root cause

PR #14813 changed `type FernGeneratorExec` → `FernGeneratorExec` (value import) so it could call `FernGeneratorExec.OutputMode.github()`. This factory function lives in `@fern-fern/generator-exec-sdk`, which transitively pulls in `form-data` → `require("fs")` into the bundle. When `fern-platform` imports the bundled package in its vitest (ESM) test suite, the CJS `require("fs")` call fails.

## ⚠️ Review checklist

- [ ] **Verify that `config.output.mode._visit()` is never called** downstream (e.g. in `resolveRootImportPath` or anywhere that consumes the config). The plain object literal omits the `_visit` helper that the SDK factory would normally attach. The `as FernGeneratorExec.OutputMode` cast hides this gap from the type checker.
- [ ] Confirm the object shape (`{ type: "github", version, repoUrl }`) is sufficient for all consumers of this config's `output.mode`

## Testing

- [x] `pnpm --filter @fern-api/go-dynamic-snippets compile` — passes
- [x] `pnpm --filter @fern-api/go-dynamic-snippets test` — all 96 tests pass
- [x] Verified `fern-platform` snippets tests pass with `1.34.0-rc.0` (pre-regression) and fail with `1.34.1` (regression), confirming this is the correct fix path

Link to Devin session: https://app.devin.ai/sessions/da475ac82f754e50b67b0d219f6bb052
Requested by: @iamnamananand996