### PR TITLE
fix(python): wire tests use `package_path` for imports

### DIFF
--- a/generators/python-v2/browser-compatible-base/src/custom-config/BasePythonCustomConfigSchema.ts
+++ b/generators/python-v2/browser-compatible-base/src/custom-config/BasePythonCustomConfigSchema.ts
@@ -11,6 +11,7 @@ export const BasePythonCustomConfigSchema = z.object({
     client: ClientConfig.optional(),
     improved_imports: z.boolean().optional().default(true),
     package_name: z.string().optional(),
+    package_path: z.string().optional(),
     pydantic_config: PydanticConfig.optional(),
     use_typeddict_requests: z.boolean().optional(),
 

--- a/generators/python-v2/dynamic-snippets/src/context/DynamicSnippetsGeneratorContext.ts
+++ b/generators/python-v2/dynamic-snippets/src/context/DynamicSnippetsGeneratorContext.ts
@@ -200,6 +200,10 @@ export class DynamicSnippetsGeneratorContext extends AbstractDynamicSnippetsGene
         if (this.customConfig.use_api_name_in_package) {
             return [cleanOrganizationName, this.getApiName()];
         }
+        if (this.customConfig.package_path != null) {
+            const pathSegments = this.customConfig.package_path.replace(/\//g, ".").split(".");
+            return [cleanOrganizationName, ...pathSegments];
+        }
         return [cleanOrganizationName];
     }
 

--- a/generators/python/sdk/versions.yml
+++ b/generators/python/sdk/versions.yml
@@ -1,5 +1,17 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 # For unreleased changes, use unreleased.yml
+- version: 5.3.6
+  changelogEntry:
+    - summary: |
+        Fix wire test and snippet imports ignoring `package_path` config. When `package_path`
+        was set (e.g. `package_path: myorganization`), generated wire tests and README/reference
+        snippets would import types from the root package (e.g. `from auth0 import OrgBranding`)
+        instead of the nested module (e.g. `from auth0.myorganization import OrgBranding`),
+        causing mypy and pytest failures.
+      type: fix
+  createdAt: "2026-04-09"
+  irVersion: 65
+
 - version: 5.3.5
   changelogEntry:
     - summary: |

--- a/seed/python-sdk/exhaustive/package-path/README.md
+++ b/seed/python-sdk/exhaustive/package-path/README.md
@@ -35,7 +35,7 @@ A full reference for this library is available [here](./reference.md).
 Instantiate and use the client with the following:
 
 ```python
-from seed import SeedExhaustive
+from seed.matryoshka.doll.structure import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
@@ -56,7 +56,6 @@ The SDK also exports an `async` client so that you can make non-blocking calls t
 
 ```python
 import asyncio
-from seed import SeedExhaustive
 
 from seed.matryoshka.doll.structure import AsyncSeedExhaustive
 
@@ -98,7 +97,7 @@ except ApiError as e:
 Paginated requests will return a `SyncPager` or `AsyncPager`, which can be used as generators for the underlying object.
 
 ```python
-from seed import SeedExhaustive
+from seed.matryoshka.doll.structure import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",

--- a/seed/python-sdk/exhaustive/package-path/reference.md
+++ b/seed/python-sdk/exhaustive/package-path/reference.md
@@ -13,7 +13,7 @@
 <dd>
 
 ```python
-from seed import SeedExhaustive
+from seed.matryoshka.doll.structure import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
@@ -74,8 +74,8 @@ client.endpoints.container.get_and_return_list_of_primitives(
 <dd>
 
 ```python
-from seed import SeedExhaustive
-from seed.types.object import ObjectWithRequiredField
+from seed.matryoshka.doll.structure import SeedExhaustive
+from seed.matryoshka.doll.structure.types.object import ObjectWithRequiredField
 
 client = SeedExhaustive(
     token="<token>",
@@ -140,7 +140,7 @@ client.endpoints.container.get_and_return_list_of_objects(
 <dd>
 
 ```python
-from seed import SeedExhaustive
+from seed.matryoshka.doll.structure import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
@@ -200,8 +200,8 @@ client.endpoints.container.get_and_return_set_of_primitives(
 <dd>
 
 ```python
-from seed import SeedExhaustive
-from seed.types.object import ObjectWithRequiredField
+from seed.matryoshka.doll.structure import SeedExhaustive
+from seed.matryoshka.doll.structure.types.object import ObjectWithRequiredField
 
 client = SeedExhaustive(
     token="<token>",
@@ -263,7 +263,7 @@ client.endpoints.container.get_and_return_set_of_objects(
 <dd>
 
 ```python
-from seed import SeedExhaustive
+from seed.matryoshka.doll.structure import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
@@ -323,8 +323,8 @@ client.endpoints.container.get_and_return_map_prim_to_prim(
 <dd>
 
 ```python
-from seed import SeedExhaustive
-from seed.types.object import ObjectWithRequiredField
+from seed.matryoshka.doll.structure import SeedExhaustive
+from seed.matryoshka.doll.structure.types.object import ObjectWithRequiredField
 
 client = SeedExhaustive(
     token="<token>",
@@ -386,7 +386,7 @@ client.endpoints.container.get_and_return_map_of_prim_to_object(
 <dd>
 
 ```python
-from seed import SeedExhaustive
+from seed.matryoshka.doll.structure import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
@@ -446,8 +446,8 @@ client.endpoints.container.get_and_return_map_of_prim_to_undiscriminated_union(
 <dd>
 
 ```python
-from seed import SeedExhaustive
-from seed.types.object import ObjectWithRequiredField
+from seed.matryoshka.doll.structure import SeedExhaustive
+from seed.matryoshka.doll.structure.types.object import ObjectWithRequiredField
 
 client = SeedExhaustive(
     token="<token>",
@@ -508,7 +508,7 @@ client.endpoints.container.get_and_return_optional(
 <dd>
 
 ```python
-from seed import SeedExhaustive
+from seed.matryoshka.doll.structure import SeedExhaustive
 import datetime
 import uuid
 
@@ -587,7 +587,7 @@ client.endpoints.content_type.post_json_patch_content_type(
 <dd>
 
 ```python
-from seed import SeedExhaustive
+from seed.matryoshka.doll.structure import SeedExhaustive
 import datetime
 import uuid
 
@@ -667,7 +667,7 @@ client.endpoints.content_type.post_json_patch_content_with_charset_type(
 <dd>
 
 ```python
-from seed import SeedExhaustive
+from seed.matryoshka.doll.structure import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
@@ -726,7 +726,7 @@ client.endpoints.enum.get_and_return_enum(
 <dd>
 
 ```python
-from seed import SeedExhaustive
+from seed.matryoshka.doll.structure import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
@@ -784,7 +784,7 @@ client.endpoints.http_methods.test_get(
 <dd>
 
 ```python
-from seed import SeedExhaustive
+from seed.matryoshka.doll.structure import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
@@ -842,7 +842,7 @@ client.endpoints.http_methods.test_post(
 <dd>
 
 ```python
-from seed import SeedExhaustive
+from seed.matryoshka.doll.structure import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
@@ -909,7 +909,7 @@ client.endpoints.http_methods.test_put(
 <dd>
 
 ```python
-from seed import SeedExhaustive
+from seed.matryoshka.doll.structure import SeedExhaustive
 import datetime
 import uuid
 
@@ -997,7 +997,7 @@ client.endpoints.http_methods.test_patch(
 <dd>
 
 ```python
-from seed import SeedExhaustive
+from seed.matryoshka.doll.structure import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
@@ -1056,7 +1056,7 @@ client.endpoints.http_methods.test_delete(
 <dd>
 
 ```python
-from seed import SeedExhaustive
+from seed.matryoshka.doll.structure import SeedExhaustive
 import datetime
 import uuid
 
@@ -1135,7 +1135,7 @@ client.endpoints.object.get_and_return_with_optional_field(
 <dd>
 
 ```python
-from seed import SeedExhaustive
+from seed.matryoshka.doll.structure import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
@@ -1193,7 +1193,7 @@ client.endpoints.object.get_and_return_with_required_field(
 <dd>
 
 ```python
-from seed import SeedExhaustive
+from seed.matryoshka.doll.structure import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
@@ -1255,8 +1255,8 @@ client.endpoints.object.get_and_return_with_map_of_map(
 <dd>
 
 ```python
-from seed import SeedExhaustive
-from seed.types.object import ObjectWithOptionalField
+from seed.matryoshka.doll.structure import SeedExhaustive
+from seed.matryoshka.doll.structure.types.object import ObjectWithOptionalField
 import datetime
 import uuid
 
@@ -1338,8 +1338,8 @@ client.endpoints.object.get_and_return_nested_with_optional_field(
 <dd>
 
 ```python
-from seed import SeedExhaustive
-from seed.types.object import ObjectWithOptionalField
+from seed.matryoshka.doll.structure import SeedExhaustive
+from seed.matryoshka.doll.structure.types.object import ObjectWithOptionalField
 import datetime
 import uuid
 
@@ -1430,8 +1430,8 @@ client.endpoints.object.get_and_return_nested_with_required_field(
 <dd>
 
 ```python
-from seed import SeedExhaustive
-from seed.types.object import NestedObjectWithRequiredField, ObjectWithOptionalField
+from seed.matryoshka.doll.structure import SeedExhaustive
+from seed.matryoshka.doll.structure.types.object import NestedObjectWithRequiredField, ObjectWithOptionalField
 import datetime
 import uuid
 
@@ -1542,7 +1542,7 @@ client.endpoints.object.get_and_return_nested_with_required_field_as_list(
 <dd>
 
 ```python
-from seed import SeedExhaustive
+from seed.matryoshka.doll.structure import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
@@ -1600,7 +1600,7 @@ client.endpoints.object.get_and_return_with_unknown_field(
 <dd>
 
 ```python
-from seed import SeedExhaustive
+from seed.matryoshka.doll.structure import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
@@ -1658,7 +1658,7 @@ client.endpoints.object.get_and_return_with_documented_unknown_type(
 <dd>
 
 ```python
-from seed import SeedExhaustive
+from seed.matryoshka.doll.structure import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
@@ -1734,7 +1734,7 @@ without being converted to "2023-08-31T14:15:22.000Z".
 <dd>
 
 ```python
-from seed import SeedExhaustive
+from seed.matryoshka.doll.structure import SeedExhaustive
 import datetime
 
 client = SeedExhaustive(
@@ -1809,7 +1809,7 @@ List items with cursor pagination
 <dd>
 
 ```python
-from seed import SeedExhaustive
+from seed.matryoshka.doll.structure import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
@@ -1891,7 +1891,7 @@ GET with path param
 <dd>
 
 ```python
-from seed import SeedExhaustive
+from seed.matryoshka.doll.structure import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
@@ -1963,7 +1963,7 @@ GET with path param
 <dd>
 
 ```python
-from seed import SeedExhaustive
+from seed.matryoshka.doll.structure import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
@@ -2035,7 +2035,7 @@ GET with query param
 <dd>
 
 ```python
-from seed import SeedExhaustive
+from seed.matryoshka.doll.structure import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
@@ -2116,7 +2116,7 @@ GET with multiple of same query param
 <dd>
 
 ```python
-from seed import SeedExhaustive
+from seed.matryoshka.doll.structure import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
@@ -2197,7 +2197,7 @@ GET with path and query params
 <dd>
 
 ```python
-from seed import SeedExhaustive
+from seed.matryoshka.doll.structure import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
@@ -2278,7 +2278,7 @@ GET with path and query params
 <dd>
 
 ```python
-from seed import SeedExhaustive
+from seed.matryoshka.doll.structure import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
@@ -2359,7 +2359,7 @@ PUT to update with path param
 <dd>
 
 ```python
-from seed import SeedExhaustive
+from seed.matryoshka.doll.structure import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
@@ -2440,7 +2440,7 @@ PUT to update with path param
 <dd>
 
 ```python
-from seed import SeedExhaustive
+from seed.matryoshka.doll.structure import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
@@ -2521,7 +2521,7 @@ POST bytes with path param returning object
 <dd>
 
 ```python
-from seed import SeedExhaustive
+from seed.matryoshka.doll.structure import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
@@ -2601,7 +2601,7 @@ GET with boolean path param
 <dd>
 
 ```python
-from seed import SeedExhaustive
+from seed.matryoshka.doll.structure import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
@@ -2673,7 +2673,7 @@ GET with path param that can throw errors
 <dd>
 
 ```python
-from seed import SeedExhaustive
+from seed.matryoshka.doll.structure import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
@@ -2732,7 +2732,7 @@ client.endpoints.params.get_with_path(
 <dd>
 
 ```python
-from seed import SeedExhaustive
+from seed.matryoshka.doll.structure import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
@@ -2790,7 +2790,7 @@ client.endpoints.primitive.get_and_return_string(
 <dd>
 
 ```python
-from seed import SeedExhaustive
+from seed.matryoshka.doll.structure import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
@@ -2848,7 +2848,7 @@ client.endpoints.primitive.get_and_return_int(
 <dd>
 
 ```python
-from seed import SeedExhaustive
+from seed.matryoshka.doll.structure import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
@@ -2906,7 +2906,7 @@ client.endpoints.primitive.get_and_return_long(
 <dd>
 
 ```python
-from seed import SeedExhaustive
+from seed.matryoshka.doll.structure import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
@@ -2964,7 +2964,7 @@ client.endpoints.primitive.get_and_return_double(
 <dd>
 
 ```python
-from seed import SeedExhaustive
+from seed.matryoshka.doll.structure import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
@@ -3022,7 +3022,7 @@ client.endpoints.primitive.get_and_return_bool(
 <dd>
 
 ```python
-from seed import SeedExhaustive
+from seed.matryoshka.doll.structure import SeedExhaustive
 import datetime
 
 client = SeedExhaustive(
@@ -3081,7 +3081,7 @@ client.endpoints.primitive.get_and_return_datetime(
 <dd>
 
 ```python
-from seed import SeedExhaustive
+from seed.matryoshka.doll.structure import SeedExhaustive
 import datetime
 
 client = SeedExhaustive(
@@ -3140,7 +3140,7 @@ client.endpoints.primitive.get_and_return_date(
 <dd>
 
 ```python
-from seed import SeedExhaustive
+from seed.matryoshka.doll.structure import SeedExhaustive
 import uuid
 
 client = SeedExhaustive(
@@ -3199,7 +3199,7 @@ client.endpoints.primitive.get_and_return_uuid(
 <dd>
 
 ```python
-from seed import SeedExhaustive
+from seed.matryoshka.doll.structure import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
@@ -3258,7 +3258,7 @@ client.endpoints.primitive.get_and_return_base64(
 <dd>
 
 ```python
-from seed import SeedExhaustive
+from seed.matryoshka.doll.structure import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
@@ -3317,8 +3317,8 @@ client.endpoints.put.add(
 <dd>
 
 ```python
-from seed import SeedExhaustive
-from seed.types.union import Animal_Dog
+from seed.matryoshka.doll.structure import SeedExhaustive
+from seed.matryoshka.doll.structure.types.union import Animal_Dog
 
 client = SeedExhaustive(
     token="<token>",
@@ -3380,7 +3380,7 @@ client.endpoints.union.get_and_return_union(
 <dd>
 
 ```python
-from seed import SeedExhaustive
+from seed.matryoshka.doll.structure import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
@@ -3428,7 +3428,7 @@ client.endpoints.urls.with_mixed_case()
 <dd>
 
 ```python
-from seed import SeedExhaustive
+from seed.matryoshka.doll.structure import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
@@ -3476,7 +3476,7 @@ client.endpoints.urls.no_ending_slash()
 <dd>
 
 ```python
-from seed import SeedExhaustive
+from seed.matryoshka.doll.structure import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
@@ -3524,7 +3524,7 @@ client.endpoints.urls.with_ending_slash()
 <dd>
 
 ```python
-from seed import SeedExhaustive
+from seed.matryoshka.doll.structure import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
@@ -3587,8 +3587,8 @@ POST with custom object in request body, response is an object
 <dd>
 
 ```python
-from seed import SeedExhaustive
-from seed.types.object import ObjectWithOptionalField
+from seed.matryoshka.doll.structure import SeedExhaustive
+from seed.matryoshka.doll.structure.types.object import ObjectWithOptionalField
 import datetime
 import uuid
 
@@ -3702,7 +3702,7 @@ POST request with no auth
 <dd>
 
 ```python
-from seed import SeedExhaustive
+from seed.matryoshka.doll.structure import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
@@ -3761,7 +3761,7 @@ client.no_auth.post_with_no_auth(
 <dd>
 
 ```python
-from seed import SeedExhaustive
+from seed.matryoshka.doll.structure import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
@@ -3809,7 +3809,7 @@ client.no_req_body.get_with_no_request_body()
 <dd>
 
 ```python
-from seed import SeedExhaustive
+from seed.matryoshka.doll.structure import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",
@@ -3858,7 +3858,7 @@ client.no_req_body.post_with_no_request_body()
 <dd>
 
 ```python
-from seed import SeedExhaustive
+from seed.matryoshka.doll.structure import SeedExhaustive
 
 client = SeedExhaustive(
     token="<token>",


### PR DESCRIPTION
## Description
Wire tests wouldn't take into account `package_path` in the config to give the most qualified possible imports in wire tests, which was fine unless customers changed the __init__.py to not re-export types at top-level. Now wire tests import from the fully specified `from seed.matryoshka.doll.structure import SeedExhaustive` instead of `from Seed import SeedExhaustive`, for instance.

## Changes Made
Feed `package_path` into the base config schema so the dynamic snippet generator can use it during import.

## Testing
The `exhaustive:package_path` fixture shows the changes in the README.md and reference.md
- [X] Unit tests added/updated
- [X] Manual testing completed
