### PR TITLE
fix(typescript, java, go, csharp): check error count in findMatchingUndiscriminatedUnionType for TS, Java, Go, C#

### DIFF
--- a/generators/csharp/dynamic-snippets/src/__test__/__snapshots__/DynamicSnippetsGenerator.test.ts.snap
+++ b/generators/csharp/dynamic-snippets/src/__test__/__snapshots__/DynamicSnippetsGenerator.test.ts.snap
@@ -276,32 +276,29 @@ await client.Endpoints.Container.GetAndReturnListOfPrimitivesAsync(
 `;
 
 exports[`snippets (default) > exhaustive > 'POST /container/map-prim-to-union (mi…' 1`] = `
-"[
-  {
-    "severity": "CRITICAL",
-    "path": [
-      "requestBody",
-      "test2"
-    ],
-    "message": "Expected number, got boolean"
-  },
-  {
-    "severity": "CRITICAL",
-    "path": [
-      "requestBody",
-      "test3"
-    ],
-    "message": "Expected number, got string"
-  },
-  {
-    "severity": "CRITICAL",
-    "path": [
-      "requestBody",
-      "test4"
-    ],
-    "message": "Expected number, got object"
-  }
-]"
+"using Acme;
+using System.Collections.Generic;
+using OneOf;
+
+var client = new AcmeClient(
+    token: "<YOUR_API_KEY>"
+);
+
+await client.Endpoints.Container.GetAndReturnMapOfPrimToUndiscriminatedUnionAsync(
+    new Dictionary<string, OneOf<double, bool, string, IEnumerable<string>>>(){
+        ["test"] = 0,
+        ["test2"] = true,
+        ["test3"] = "Test",
+        ["test4"] = new List<string>(){
+            "1",
+            "1",
+            "1",
+            "1",
+        }
+        ,
+    }
+);
+"
 `;
 
 exports[`snippets (default) > file-upload > 'POST /' 1`] = `
@@ -718,6 +715,15 @@ var client = new AcmeClient(
 await client.Endpoints.Container.GetAndReturnMapOfPrimToUndiscriminatedUnionAsync(
     new Dictionary<string, MixedType>(){
         ["test"] = 0,
+        ["test2"] = true,
+        ["test3"] = "Test",
+        ["test4"] = new List<string>(){
+            "1",
+            "1",
+            "1",
+            "1",
+        }
+        ,
     }
 );
 "

--- a/generators/csharp/dynamic-snippets/src/context/DynamicLiteralMapper.ts
+++ b/generators/csharp/dynamic-snippets/src/context/DynamicLiteralMapper.ts
@@ -657,10 +657,16 @@ export class DynamicLiteralMapper extends WithGeneration {
         value: unknown;
     }): { valueTypeReference: FernIr.dynamic.TypeReference; typeLiteral: ast.Literal } | undefined {
         for (const typeReference of undiscriminatedUnion.types) {
+            const errorsBefore = this.context.errors.size();
             try {
                 const typeLiteral = this.convert({ typeReference, value });
+                if (is.Literal.nop(typeLiteral) || this.context.errors.size() > errorsBefore) {
+                    this.context.errors.truncate(errorsBefore);
+                    continue;
+                }
                 return { valueTypeReference: typeReference, typeLiteral };
             } catch (e) {
+                this.context.errors.truncate(errorsBefore);
                 continue;
             }
         }

--- a/generators/csharp/sdk/versions.yml
+++ b/generators/csharp/sdk/versions.yml
@@ -1,4 +1,18 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 2.59.1
+  changelogEntry:
+    - summary: |
+        Fix undiscriminated union variant matching in dynamic snippets selecting
+        incorrect variants when errors are added during conversion. The matcher
+        now checks whether errors were added (via `errors.size() > errorsBefore`)
+        alongside the existing `isNop` check, and adds a missing `nop` check that
+        was causing the first variant to be unconditionally returned. This prevents
+        empty objects from being returned for union fields like `options` in
+        generated code snippets.
+      type: fix
+  createdAt: "2026-04-09"
+  irVersion: 66
+
 - version: 2.59.0
   changelogEntry:
     - summary: |

--- a/generators/go-v2/dynamic-snippets/src/__test__/__snapshots__/DynamicSnippetsGenerator.test.ts.snap
+++ b/generators/go-v2/dynamic-snippets/src/__test__/__snapshots__/DynamicSnippetsGenerator.test.ts.snap
@@ -378,56 +378,47 @@ func do() {
 `;
 
 exports[`snippets (default) > exhaustive > 'POST /container/map-prim-to-union (mi…' 1`] = `
-"[
-  {
-    "severity": "CRITICAL",
-    "path": [
-      "requestBody",
-      "test2"
-    ],
-    "message": "Expected number, got boolean"
-  },
-  {
-    "severity": "CRITICAL",
-    "path": [
-      "requestBody",
-      "test3"
-    ],
-    "message": "Expected number, got string"
-  },
-  {
-    "severity": "CRITICAL",
-    "path": [
-      "requestBody",
-      "test3"
-    ],
-    "message": "Expected boolean, got string"
-  },
-  {
-    "severity": "CRITICAL",
-    "path": [
-      "requestBody",
-      "test4"
-    ],
-    "message": "Expected number, got object"
-  },
-  {
-    "severity": "CRITICAL",
-    "path": [
-      "requestBody",
-      "test4"
-    ],
-    "message": "Expected boolean, got object"
-  },
-  {
-    "severity": "CRITICAL",
-    "path": [
-      "requestBody",
-      "test4"
-    ],
-    "message": "Expected string, got object"
-  }
-]"
+"package example
+
+import (
+	context "context"
+
+	client "github.com/acme/acme-go/client"
+	option "github.com/acme/acme-go/option"
+	types "github.com/acme/acme-go/types"
+)
+
+func do() {
+	client := client.NewClient(
+		option.WithToken(
+			"<YOUR_API_KEY>",
+		),
+	)
+	request := map[string]*types.MixedType{
+		"test": &types.MixedType{
+			Double: 0,
+		},
+		"test2": &types.MixedType{
+			Boolean: true,
+		},
+		"test3": &types.MixedType{
+			String: "Test",
+		},
+		"test4": &types.MixedType{
+			StringList: []string{
+				"1",
+				"1",
+				"1",
+				"1",
+			},
+		},
+	}
+	client.Endpoints.Container.GetAndReturnMapOfPrimToUndiscriminatedUnion(
+		context.TODO(),
+		request,
+	)
+}
+"
 `;
 
 exports[`snippets (default) > file-upload > 'POST /' 1`] = `
@@ -1359,56 +1350,47 @@ func do() {
 `;
 
 exports[`snippets (exportAllRequestsAtRoot) > exhaustive > 'POST /container/map-prim-to-union (mi…' 1`] = `
-"[
-  {
-    "severity": "CRITICAL",
-    "path": [
-      "requestBody",
-      "test2"
-    ],
-    "message": "Expected number, got boolean"
-  },
-  {
-    "severity": "CRITICAL",
-    "path": [
-      "requestBody",
-      "test3"
-    ],
-    "message": "Expected number, got string"
-  },
-  {
-    "severity": "CRITICAL",
-    "path": [
-      "requestBody",
-      "test3"
-    ],
-    "message": "Expected boolean, got string"
-  },
-  {
-    "severity": "CRITICAL",
-    "path": [
-      "requestBody",
-      "test4"
-    ],
-    "message": "Expected number, got object"
-  },
-  {
-    "severity": "CRITICAL",
-    "path": [
-      "requestBody",
-      "test4"
-    ],
-    "message": "Expected boolean, got object"
-  },
-  {
-    "severity": "CRITICAL",
-    "path": [
-      "requestBody",
-      "test4"
-    ],
-    "message": "Expected string, got object"
-  }
-]"
+"package example
+
+import (
+	context "context"
+
+	client "github.com/acme/acme-go/client"
+	option "github.com/acme/acme-go/option"
+	types "github.com/acme/acme-go/types"
+)
+
+func do() {
+	client := client.NewClient(
+		option.WithToken(
+			"<YOUR_API_KEY>",
+		),
+	)
+	request := map[string]*types.MixedType{
+		"test": &types.MixedType{
+			Double: 0,
+		},
+		"test2": &types.MixedType{
+			Boolean: true,
+		},
+		"test3": &types.MixedType{
+			String: "Test",
+		},
+		"test4": &types.MixedType{
+			StringList: []string{
+				"1",
+				"1",
+				"1",
+				"1",
+			},
+		},
+	}
+	client.Endpoints.Container.GetAndReturnMapOfPrimToUndiscriminatedUnion(
+		context.TODO(),
+		request,
+	)
+}
+"
 `;
 
 exports[`snippets (exportAllRequestsAtRoot) > file-upload > 'POST /' 1`] = `
@@ -2340,56 +2322,47 @@ func do() {
 `;
 
 exports[`snippets (exportedClientName) > exhaustive > 'POST /container/map-prim-to-union (mi…' 1`] = `
-"[
-  {
-    "severity": "CRITICAL",
-    "path": [
-      "requestBody",
-      "test2"
-    ],
-    "message": "Expected number, got boolean"
-  },
-  {
-    "severity": "CRITICAL",
-    "path": [
-      "requestBody",
-      "test3"
-    ],
-    "message": "Expected number, got string"
-  },
-  {
-    "severity": "CRITICAL",
-    "path": [
-      "requestBody",
-      "test3"
-    ],
-    "message": "Expected boolean, got string"
-  },
-  {
-    "severity": "CRITICAL",
-    "path": [
-      "requestBody",
-      "test4"
-    ],
-    "message": "Expected number, got object"
-  },
-  {
-    "severity": "CRITICAL",
-    "path": [
-      "requestBody",
-      "test4"
-    ],
-    "message": "Expected boolean, got object"
-  },
-  {
-    "severity": "CRITICAL",
-    "path": [
-      "requestBody",
-      "test4"
-    ],
-    "message": "Expected string, got object"
-  }
-]"
+"package example
+
+import (
+	context "context"
+
+	client "github.com/acme/acme-go/client"
+	option "github.com/acme/acme-go/option"
+	types "github.com/acme/acme-go/types"
+)
+
+func do() {
+	client := client.NewFernClient(
+		option.WithToken(
+			"<YOUR_API_KEY>",
+		),
+	)
+	request := map[string]*types.MixedType{
+		"test": &types.MixedType{
+			Double: 0,
+		},
+		"test2": &types.MixedType{
+			Boolean: true,
+		},
+		"test3": &types.MixedType{
+			String: "Test",
+		},
+		"test4": &types.MixedType{
+			StringList: []string{
+				"1",
+				"1",
+				"1",
+				"1",
+			},
+		},
+	}
+	client.Endpoints.Container.GetAndReturnMapOfPrimToUndiscriminatedUnion(
+		context.TODO(),
+		request,
+	)
+}
+"
 `;
 
 exports[`snippets (exportedClientName) > file-upload > 'POST /' 1`] = `

--- a/generators/go-v2/dynamic-snippets/src/context/DynamicTypeInstantiationMapper.ts
+++ b/generators/go-v2/dynamic-snippets/src/context/DynamicTypeInstantiationMapper.ts
@@ -578,14 +578,16 @@ export class DynamicTypeInstantiationMapper {
         value: unknown;
     }): { valueTypeReference: FernIr.dynamic.TypeReference; typeInstantiation: go.TypeInstantiation } | undefined {
         for (const typeReference of undiscriminatedUnion.types) {
+            const errorsBefore = this.context.errors.size();
             try {
                 const typeInstantiation = this.convert({ typeReference, value });
-                // Skip types that result in nop() - this means the value didn't match the type
-                if (go.TypeInstantiation.isNop(typeInstantiation)) {
+                if (go.TypeInstantiation.isNop(typeInstantiation) || this.context.errors.size() > errorsBefore) {
+                    this.context.errors.truncate(errorsBefore);
                     continue;
                 }
                 return { valueTypeReference: typeReference, typeInstantiation };
             } catch (e) {
+                this.context.errors.truncate(errorsBefore);
                 continue;
             }
         }

--- a/generators/go/sdk/versions.yml
+++ b/generators/go/sdk/versions.yml
@@ -1,4 +1,16 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 1.34.3
+  changelogEntry:
+    - summary: |
+        Fix undiscriminated union variant matching in dynamic snippets selecting
+        incorrect variants when errors are added during conversion. The matcher
+        now checks whether errors were added (via `errors.size() > errorsBefore`)
+        alongside the existing `isNop` check, preventing empty objects from being
+        returned for union fields like `options` in generated code snippets.
+      type: fix
+  createdAt: "2026-04-09"
+  irVersion: 66
+
 - version: 1.34.2
   changelogEntry:
     - summary: |

--- a/generators/java-v2/dynamic-snippets/src/context/DynamicTypeLiteralMapper.ts
+++ b/generators/java-v2/dynamic-snippets/src/context/DynamicTypeLiteralMapper.ts
@@ -1,5 +1,5 @@
 import { Severity } from "@fern-api/browser-compatible-base-generator";
-import { assertNever, extractErrorMessage } from "@fern-api/core-utils";
+import { assertNever } from "@fern-api/core-utils";
 import { FernIr } from "@fern-api/dynamic-ir-sdk";
 import { java } from "@fern-api/java-ast";
 
@@ -691,20 +691,16 @@ export class DynamicTypeLiteralMapper {
         undiscriminatedUnion: FernIr.dynamic.UndiscriminatedUnionType;
         value: unknown;
     }): { valueTypeReference: FernIr.dynamic.TypeReference; typeInstantiation: java.TypeLiteral } | undefined {
-        const attemptedVariants: string[] = [];
-        const variantErrors: string[] = [];
-
         for (const typeReference of undiscriminatedUnion.types) {
             const errorsBefore = this.context.errors.size();
             try {
-                attemptedVariants.push(JSON.stringify(typeReference));
                 const typeInstantiation = this.convert({
                     typeReference,
                     value,
                     inUndiscriminatedUnion: true
                 });
 
-                if (java.TypeLiteral.isNop(typeInstantiation)) {
+                if (java.TypeLiteral.isNop(typeInstantiation) || this.context.errors.size() > errorsBefore) {
                     this.context.errors.truncate(errorsBefore);
                     continue;
                 }
@@ -712,26 +708,15 @@ export class DynamicTypeLiteralMapper {
                 return { valueTypeReference: typeReference, typeInstantiation };
             } catch (e) {
                 this.context.errors.truncate(errorsBefore);
-                variantErrors.push(`Type ${JSON.stringify(typeReference)}: ${extractErrorMessage(e)}`);
                 continue;
             }
         }
 
         this.context.errors.add({
             severity: Severity.Critical,
-            message: `None of the types in the undiscriminated union matched the given "${typeof value}" value. Tried ${attemptedVariants.length} variants. Errors: ${variantErrors.join("; ")}`
+            message: `None of the types in the undiscriminated union matched the given "${typeof value}" value`
         });
-
-        // Instead of returning undefined (which causes invalid code generation),
-        // throw an error to fail fast with a clear message
-        const unionName = undiscriminatedUnion.declaration.name ?? "UnknownUnion";
-        const detailedErrors = variantErrors.map((error, index) => `  ${index + 1}. ${error}`).join("\n");
-        throw new Error(
-            `Failed to match undiscriminated union "${unionName}" for ${typeof value} value.\n` +
-                `Value: ${JSON.stringify(value)}\n` +
-                `Attempted ${attemptedVariants.length} variants:\n${detailedErrors}\n\n` +
-                `This prevents invalid snippet code generation that would cause formatter errors.`
-        );
+        return undefined;
     }
 
     private getUndiscriminatedUnionFieldName({

--- a/generators/java/sdk/versions.yml
+++ b/generators/java/sdk/versions.yml
@@ -1,4 +1,16 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 4.1.3
+  changelogEntry:
+    - summary: |
+        Fix undiscriminated union variant matching in dynamic snippets selecting
+        incorrect variants when errors are added during conversion. The matcher
+        now checks whether errors were added (via `errors.size() > errorsBefore`)
+        alongside the existing `isNop` check, preventing empty objects from being
+        returned for union fields like `options` in generated code snippets.
+      type: fix
+  createdAt: "2026-04-09"
+  irVersion: 65
+
 - version: 4.1.2
   changelogEntry:
     - summary: |

--- a/generators/typescript-v2/dynamic-snippets/src/context/DynamicTypeLiteralMapper.ts
+++ b/generators/typescript-v2/dynamic-snippets/src/context/DynamicTypeLiteralMapper.ts
@@ -566,7 +566,7 @@ export class DynamicTypeLiteralMapper {
             const errorsBefore = this.context.errors.size();
             try {
                 const result = this.convert({ typeReference, value, convertOpts });
-                if (ts.TypeLiteral.isNop(result)) {
+                if (ts.TypeLiteral.isNop(result) || this.context.errors.size() > errorsBefore) {
                     this.context.errors.truncate(errorsBefore);
                     continue;
                 }

--- a/generators/typescript/sdk/versions.yml
+++ b/generators/typescript/sdk/versions.yml
@@ -1,4 +1,16 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 3.63.3
+  changelogEntry:
+    - summary: |
+        Fix undiscriminated union variant matching in dynamic snippets selecting
+        incorrect variants when errors are added during conversion. The matcher
+        now checks whether errors were added (via `errors.size() > errorsBefore`)
+        alongside the existing `isNop` check, preventing empty objects from being
+        returned for union fields like `options` in generated code snippets.
+      type: fix
+  createdAt: "2026-04-09"
+  irVersion: 66
+
 - version: 3.63.2
   changelogEntry:
     - summary: |


### PR DESCRIPTION
## Description

Refs: Customer issue where `options` (a `oneOf` field modeled as an undiscriminated union) renders as `{}` in generated code snippets for TypeScript, Java, Go, and C#.

Ports the Python dynamic snippets fix to all other languages. The Python generator already had the correct behavior after v0.0.5, but the other language generators were still broken.

## Changes Made

The root cause is in `findMatchingUndiscriminatedUnionType` across all non-Python dynamic snippet packages. When iterating union variants to find a match, the code only checked whether the conversion returned `nop`. However, a variant can match *structurally* (e.g., an object with all-optional fields converts to a non-nop empty object `{}`) while still being the **wrong** variant — indicated by errors added during conversion (e.g., for missing required fields on the correct variant).

The fix adds `this.context.errors.size() > errorsBefore` as a rejection condition alongside the existing `isNop` check, matching the Python generator's pattern:

- **TypeScript** (`typescript-v2/dynamic-snippets`): Added error count check to existing `isNop` condition
- **Go** (`go-v2/dynamic-snippets`): Added `errorsBefore` tracking, error count check, and `truncate` calls
- **C#** (`csharp/dynamic-snippets`): Added `errorsBefore` tracking, `is.Literal.nop()` check (previously missing entirely — was accepting the first variant unconditionally), error count check, and `truncate` calls
- **Java** (`java-v2/dynamic-snippets`): Added error count check; simplified by removing verbose error logging/throwing workaround that was masking the real issue; removed unused `extractErrorMessage` import

Updated snapshot tests for **C#** (2 snapshots) and **Go** (3 snapshots) — these previously captured error arrays (e.g., `"Expected number, got boolean"`) for mixed-type union maps and now correctly produce valid code snippets with all union variants resolved.

### Version bumps

Added `versions.yml` changelog entries (patch, `fix`) for all four generators:

| Generator | Version |
|-----------|---------|
| TypeScript | 3.63.3 |
| Java | 4.1.3 |
| Go | 1.34.3 |
| C# | 2.59.1 |

## Human review checklist

1. **Java behavior change**: Previously threw an error when no variant matched; now returns `undefined` (consistent with all other languages). The caller already handles `undefined` → `nop()`. Verify this doesn't break any downstream consumers.
2. **C# was the most broken**: It had no `nop` check or error tracking at all — it unconditionally returned the first variant's conversion result. This is the largest behavioral change.
3. **Java error message simplified**: The detailed variant-by-variant error logging (`attemptedVariants`, `variantErrors`) was removed in favor of the simpler message used by all other languages. This loses some diagnostic detail but aligns the implementations.
4. **irVersion values**: TS/Go/C# use irVersion 66 (matching their latest entries), Java uses 65 (matching its latest). Verify these are correct.

## Testing
- [x] Snapshot tests updated (C# and Go `map-prim-to-union` mixed values)
- [x] All snapshot tests pass locally (C# 34/34, Go 96/96, Java 32/32, TS 32/32)
- [x] Lint/typecheck passes (`pnpm run check`)
- [ ] Manual testing with auth0-myorg-snippets to confirm `options` field renders correctly

Link to Devin session: https://app.devin.ai/sessions/d5cbcb909c0d4af685b1ed626b81cb1d
Requested by: @patrickthornton
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/14847" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
