### PR TITLE
chore(generator-cli): upgrade @fern-api/replay to 0.10.1

### DIFF
--- a/packages/generator-cli/package.json
+++ b/packages/generator-cli/package.json
@@ -24,7 +24,7 @@
   "files": ["bin", "dist", "lib"],
   "dependencies": {
     "@fern-api/core-utils": "workspace:*",
-    "@fern-api/replay": "^0.9.1",
+    "@fern-api/replay": "^0.10.0",
     "@octokit/rest": "catalog:",
     "es-toolkit": "catalog:",
     "tmp-promise": "catalog:"

--- a/packages/generator-cli/package.json
+++ b/packages/generator-cli/package.json
@@ -24,7 +24,7 @@
   "files": ["bin", "dist", "lib"],
   "dependencies": {
     "@fern-api/core-utils": "workspace:*",
-    "@fern-api/replay": "^0.10.0",
+    "@fern-api/replay": "^0.10.1",
     "@octokit/rest": "catalog:",
     "es-toolkit": "catalog:",
     "tmp-promise": "catalog:"

--- a/packages/generator-cli/versions.yml
+++ b/packages/generator-cli/versions.yml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=../../versions-yml.schema.json
 - changelogEntry:
     - summary: |
-        Upgrade @fern-api/replay to 0.10.0.
+        Upgrade @fern-api/replay to 0.10.1.
       type: chore
   createdAt: "2026-04-09"
   version: 0.9.4

--- a/packages/generator-cli/versions.yml
+++ b/packages/generator-cli/versions.yml
@@ -1,6 +1,13 @@
 # yaml-language-server: $schema=../../versions-yml.schema.json
 - changelogEntry:
     - summary: |
+        Upgrade @fern-api/replay to 0.10.0.
+      type: chore
+  createdAt: "2026-04-09"
+  version: 0.9.4
+
+- changelogEntry:
+    - summary: |
         Add .gitattributes with linguist-generated markers for replay lockfile. Sync .fernignore entries with fern-replay to include .fern/replay.yml and .gitattributes.
       type: fix
   createdAt: "2026-04-07"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7795,8 +7795,8 @@ importers:
         specifier: workspace:*
         version: link:../commons/core-utils
       '@fern-api/replay':
-        specifier: ^0.9.1
-        version: 0.9.1
+        specifier: ^0.10.0
+        version: 0.10.0
       '@octokit/rest':
         specifier: 'catalog:'
         version: 22.0.1
@@ -9303,6 +9303,11 @@ packages:
 
   '@fern-api/logger@0.4.24-rc1':
     resolution: {integrity: sha512-yh0E2F3K3IPnJZcE4dv+u8I51iKgTgv/reinKo4K5YmYEG1iLtw5vBEYMOPkQmsYFPAKIh++OMB/6TrsahMWew==}
+
+  '@fern-api/replay@0.10.0':
+    resolution: {integrity: sha512-BKrXgraasWC7FfeHQl7KZVeNFPZN8H1oOdi+5DQS4Zt+BOSYsDoQwYYoSglFrS/gyBvZ0DNeF+qEGrPYxQIsow==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   '@fern-api/replay@0.9.1':
     resolution: {integrity: sha512-RpK1UIO8qBfRL5TbyHsfDOCTyr2DPDI2XqBUDl3YOr4Mn+4EWS8C65R/k/UkJthn2KsCa57QxSvtWAxftpwljA==}
@@ -16333,6 +16338,15 @@ snapshots:
     dependencies:
       '@fern-api/core-utils': 0.4.24-rc1
       chalk: 5.6.2
+
+  '@fern-api/replay@0.10.0':
+    dependencies:
+      minimatch: 10.2.5
+      node-diff3: 3.2.0
+      simple-git: 3.35.2
+      yaml: 2.8.3
+    transitivePeerDependencies:
+      - supports-color
 
   '@fern-api/replay@0.9.1':
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7795,8 +7795,8 @@ importers:
         specifier: workspace:*
         version: link:../commons/core-utils
       '@fern-api/replay':
-        specifier: ^0.10.0
-        version: 0.10.0
+        specifier: ^0.10.1
+        version: 0.10.1
       '@octokit/rest':
         specifier: 'catalog:'
         version: 22.0.1
@@ -9304,8 +9304,8 @@ packages:
   '@fern-api/logger@0.4.24-rc1':
     resolution: {integrity: sha512-yh0E2F3K3IPnJZcE4dv+u8I51iKgTgv/reinKo4K5YmYEG1iLtw5vBEYMOPkQmsYFPAKIh++OMB/6TrsahMWew==}
 
-  '@fern-api/replay@0.10.0':
-    resolution: {integrity: sha512-BKrXgraasWC7FfeHQl7KZVeNFPZN8H1oOdi+5DQS4Zt+BOSYsDoQwYYoSglFrS/gyBvZ0DNeF+qEGrPYxQIsow==}
+  '@fern-api/replay@0.10.1':
+    resolution: {integrity: sha512-WjBT2GiEnsYlybLOLE13Cy0z389+45s+zN7RAf1AcxnCmc2P/JVtPwxVUReoVlFtnAxlyb3YMGPsKdsYIN+maw==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -16339,7 +16339,7 @@ snapshots:
       '@fern-api/core-utils': 0.4.24-rc1
       chalk: 5.6.2
 
-  '@fern-api/replay@0.10.0':
+  '@fern-api/replay@0.10.1':
     dependencies:
       minimatch: 10.2.5
       node-diff3: 3.2.0


### PR DESCRIPTION
## Description

Upgrades the `@fern-api/replay` dependency in `generator-cli` from `^0.9.1` to `^0.10.1`.

## Changes Made

- Bumped `@fern-api/replay` from `^0.9.1` to `^0.10.1` in `packages/generator-cli/package.json`
- Added changelog entry for generator-cli version `0.9.4`
- Updated `pnpm-lock.yaml`

## Human Review Checklist

- [ ] Verify that `@fern-api/replay` 0.10.1 has no breaking API changes requiring code updates in generator-cli (no source code was modified in this PR)
- [ ] Confirm version `0.9.4` is the correct next version for generator-cli

## Testing

- [ ] Dependency installs successfully (`pnpm install` passed)
- [ ] No source code changes — relies on replay's own backward compatibility

Link to Devin session: https://app.devin.ai/sessions/0909cf8b8414438b8a101f852df64f70
Requested by: @tstanmay13