### PR TITLE
chore(python): upgrade generator-cli to 0.9.4

### DIFF
--- a/generators/python/sdk/versions.yml
+++ b/generators/python/sdk/versions.yml
@@ -1,5 +1,13 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 # For unreleased changes, use unreleased.yml
+- version: 5.3.7
+  changelogEntry:
+    - summary: |
+        Upgrade @fern-api/generator-cli to 0.9.4 which upgrades @fern-api/replay to 0.10.1.
+      type: chore
+  createdAt: "2026-04-09"
+  irVersion: 65
+
 - version: 5.3.6
   changelogEntry:
     - summary: |


### PR DESCRIPTION
## Description

Bumps the Python SDK generator version to 5.3.7 to absorb `@fern-api/generator-cli` 0.9.4, which upgrades `@fern-api/replay` from 0.9.1 to 0.10.1.

Related: a companion PR in `fern-api/fiddle` upgrades the Dockerfile pin to `@fern-api/generator-cli@0.9.4`.

## Changes Made

- Added version 5.3.7 entry to `generators/python/sdk/versions.yml` to trigger a new Docker image publish

## Human Review Checklist

- [ ] Confirm `@fern-api/generator-cli` 0.9.4 is published on npm
- [ ] Verify `@fern-api/replay` 0.10.1 has no breaking changes affecting the Python generator (no source code was modified)
- [ ] Confirm 5.3.7 is the correct next version for the Python SDK generator

## Testing

- No source code changes — relies on replay's own backward compatibility
- New Docker image will install the latest generator-cli at build time via `npm install -g`

Link to Devin session: https://app.devin.ai/sessions/02c188300ff74966a9303358795553f8
Requested by: @tstanmay13