### PR TITLE
chore(ci): replace fragile grep/awk version extraction with yq

### DIFF
--- a/.github/workflows/publish-cli.yml
+++ b/.github/workflows/publish-cli.yml
@@ -225,7 +225,7 @@ jobs:
             echo "CLI_VERSION=${{ inputs.version }}" >> $GITHUB_OUTPUT
           else
             # Automatic publish - extract from versions.yml
-            version=$(head -n 20 packages/cli/cli/versions.yml | grep -m 1 "version:" | awk '{print $3}')
+            version=$(yq '.[0].version' packages/cli/cli/versions.yml)
             echo "CLI_VERSION=${version}" >> $GITHUB_OUTPUT
           fi
 


### PR DESCRIPTION
## Description

Replace a fragile `grep`/`awk` pattern for extracting the CLI version from `versions.yml` with a proper YAML query using `yq` (pre-installed on `ubuntu-latest`).

## Changes Made

- In the `bulk-update-cli` job, replaced:
  ```bash
  version=$(head -n 20 packages/cli/cli/versions.yml | grep -m 1 "version:" | awk '{print $3}')
  ```
  with:
  ```bash
  version=$(yq '.[0].version' packages/cli/cli/versions.yml)
  ```

**Why:** The old `grep "version:"` pattern also matches `irVersion:` lines (since `"version:"` is a substring). While `grep -m 1` currently picks up the correct line because `version:` appears before `irVersion:` in each entry, this is order-dependent and fragile. Using `yq` properly parses the YAML and directly reads `.[0].version`.

## Review Checklist
- [ ] Confirm `yq` is pre-installed on `ubuntu-latest` runners ([it is](https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2404-Readme.md))
- [ ] Confirm `.[0].version` matches the array-of-objects structure in `packages/cli/cli/versions.yml`

## Testing
- [ ] Manual review — this is a CI-only change that cannot be tested locally
- No other jobs in this workflow use the same `grep`/`awk` pattern

Link to Devin session: https://app.devin.ai/sessions/7de29af33dd94752b8267744bbe3e89b
Requested by: @pgragg