### PR TITLE
fix(csharp): dynamic snips edge case; `EndpointSnippetRequest` without ID

### DIFF
--- a/generators/csharp/dynamic-snippets/src/EndpointSnippetGenerator.ts
+++ b/generators/csharp/dynamic-snippets/src/EndpointSnippetGenerator.ts
@@ -79,11 +79,13 @@ export class EndpointSnippetGenerator extends WithGeneration {
         snippet: FernIr.dynamic.EndpointSnippetRequest;
         options: Options;
     }): ast.AstNode {
-        // if we're actually passed the examples, we need to
-        // check that the endpoint that we're generating has an example that matches the snippet
+        // If we're passed endpoint examples and the snippet includes an id (i.e. it's an
+        // EndpointExample, not just an EndpointSnippetRequest), verify the id matches one of
+        // the examples. Snippets without an id are user-provided requests and skip this check.
         if (
             endpoint.examples &&
-            !endpoint.examples?.find((each) => is.DynamicIR.EndpointExample(snippet) && each.id === snippet.id)
+            is.DynamicIR.EndpointExample(snippet) &&
+            !endpoint.examples.find((each) => each.id === snippet.id)
         ) {
             // the dsg expects us to just throw when there is nothing to generate.
             throw new Error("Endpoint does not have an example that matches the snippet");

--- a/generators/csharp/dynamic-snippets/src/__test__/DynamicSnippetsGenerator.test.ts
+++ b/generators/csharp/dynamic-snippets/src/__test__/DynamicSnippetsGenerator.test.ts
@@ -1,6 +1,9 @@
-import { DynamicSnippetsTestRunner } from "@fern-api/browser-compatible-base-generator";
+import { DynamicSnippetsTestRunner, Style } from "@fern-api/browser-compatible-base-generator";
+import { FernIr } from "@fern-api/dynamic-ir-sdk";
 import { AbsoluteFilePath, join } from "@fern-api/path-utils";
+import { readFileSync } from "fs";
 
+import { DynamicSnippetsGenerator } from "../DynamicSnippetsGenerator.js";
 import { buildDynamicSnippetsGenerator } from "./utils/buildDynamicSnippetsGenerator.js";
 import { buildGeneratorConfig } from "./utils/buildGeneratorConfig.js";
 
@@ -15,6 +18,71 @@ describe("snippets (default)", () => {
 const DYNAMIC_IR_TEST_DEFINITIONS_DIRECTORY = AbsoluteFilePath.of(
     `${__dirname}/../../../../../packages/cli/generation/ir-generator-tests/src/dynamic-snippets/__test__/test-definitions`
 );
+
+describe("snippets (endpoint with examples)", () => {
+    test("generates snippet for EndpointSnippetRequest when endpoint has examples", async () => {
+        const irFilepath = AbsoluteFilePath.of(join(DYNAMIC_IR_TEST_DEFINITIONS_DIRECTORY, "imdb.json"));
+        const ir: FernIr.dynamic.DynamicIntermediateRepresentation = JSON.parse(readFileSync(irFilepath, "utf-8"));
+
+        // Inject examples onto the POST /movies/create-movie endpoint so the guard is exercised.
+        for (const endpoint of Object.values(ir.endpoints)) {
+            if (endpoint.location.path === "/movies/create-movie" && endpoint.location.method === "POST") {
+                endpoint.examples = [
+                    {
+                        id: "example-1",
+                        name: undefined,
+                        endpoint: endpoint.location,
+                        baseURL: undefined,
+                        environment: undefined,
+                        auth: {
+                            type: "bearer",
+                            token: "<token>"
+                        },
+                        pathParameters: undefined,
+                        queryParameters: undefined,
+                        headers: undefined,
+                        requestBody: {
+                            title: "Example Movie",
+                            rating: 7.5
+                        }
+                    }
+                ];
+            }
+        }
+
+        const generator = new DynamicSnippetsGenerator({
+            ir,
+            config: buildGeneratorConfig(),
+            options: { style: Style.Concise }
+        });
+
+        // Call generate with a plain EndpointSnippetRequest (no id).
+        // Before the fix, this threw "Endpoint does not have an example that matches the snippet".
+        const response = await generator.generate({
+            endpoint: {
+                method: "POST",
+                path: "/movies/create-movie"
+            },
+            baseURL: undefined,
+            environment: undefined,
+            auth: {
+                type: "bearer",
+                token: "<YOUR_API_KEY>"
+            },
+            pathParameters: undefined,
+            queryParameters: undefined,
+            headers: undefined,
+            requestBody: {
+                title: "The Matrix",
+                rating: 8.2
+            }
+        });
+
+        expect(response.errors).toBeUndefined();
+        expect(response.snippet).toBeTruthy();
+        expect(response.snippet).toMatchSnapshot();
+    });
+});
 
 describe("snippets (use-undiscriminated-unions)", () => {
     const generator = buildDynamicSnippetsGenerator({

--- a/generators/csharp/dynamic-snippets/src/__test__/__snapshots__/DynamicSnippetsGenerator.test.ts.snap
+++ b/generators/csharp/dynamic-snippets/src/__test__/__snapshots__/DynamicSnippetsGenerator.test.ts.snap
@@ -703,6 +703,23 @@ exports[`snippets (default) > single-url-environment-default > 'invalid environm
 ]"
 `;
 
+exports[`snippets (endpoint with examples) > generates snippet for EndpointSnippetRequest when endpoint has examples 1`] = `
+"using Acme;
+using Acme.Imdb;
+
+var client = new AcmeClient(
+    token: "<YOUR_API_KEY>"
+);
+
+await client.Imdb.CreateMovieAsync(
+    new CreateMovieRequest {
+        Title = "The Matrix",
+        Rating = 8.2
+    }
+);
+"
+`;
+
 exports[`snippets (use-undiscriminated-unions) > POST /container/map-prim-to-union (mixed values) 1`] = `
 "using Acme;
 using System.Collections.Generic;

--- a/generators/csharp/sdk/versions.yml
+++ b/generators/csharp/sdk/versions.yml
@@ -1,4 +1,15 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 2.59.2
+  changelogEntry:
+    - summary: |
+        Fix dynamic snippet generation failing with "Endpoint does not have an
+        example that matches the snippet" when the endpoint has examples but the
+        request is a plain `EndpointSnippetRequest` without an `id`. The guard now
+        only validates the example match when the snippet includes an `id`.
+      type: fix
+  createdAt: "2026-04-09"
+  irVersion: 66
+
 - version: 2.59.1
   changelogEntry:
     - summary: |


### PR DESCRIPTION
I'm lazy, so Claude's (correct) summary:

## Summary

- Fix C# dynamic snippet generation throwing `"Endpoint does not have an example that matches the snippet"` when the endpoint has examples but the caller passes a plain `EndpointSnippetRequest` (no `id`)
- The `buildCodeBlock` guard used `is.DynamicIR.EndpointExample(snippet)` inside the `find` callback, which always returned `false` for requests without `id`, causing `find` to never match and the error to always throw
- Moved the `EndpointExample` type check into the outer `if` condition so the guard is skipped entirely for user-provided requests that lack an `id`

## Context

`EndpointExample` extends `EndpointSnippetRequest` with an `id` field. When snippets packages (e.g. customer-specific DSG wrappers) call `generate()` with a plain `EndpointSnippetRequest`, the `id` is absent. The other four language generators (TypeScript, Python, Java, Go) don't have this guard, so only C# was affected.

This is a separate issue from the undiscriminated union fix in #14847 — that fix landed in 2.59.1 but C# never reached the union-matching code due to this guard throwing first.

## Test plan

- [x] Added test that loads an IR with examples injected on an endpoint, then calls `generate` with a plain `EndpointSnippetRequest` (no `id`) — verifies it produces a valid snippet instead of throwing
- [x] All 35 existing dynamic snippet tests continue to pass
- [x] `pnpm turbo run compile --filter @fern-api/csharp-dynamic-snippets` passes