### PR TITLE
chore(cli): Add publish-cli-docker workflow and Dockerfile

### DIFF
--- a/.github/workflows/publish-cli-docker.yml
+++ b/.github/workflows/publish-cli-docker.yml
@@ -1,0 +1,60 @@
+name: Publish CLI Docker Image
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "The CLI version to install in the Docker image"
+        required: true
+        type: string
+      is_dev:
+        description: "Whether to publish the dev image (fernapi/fern-dev)"
+        required: false
+        type: boolean
+        default: false
+
+env:
+  DO_NOT_TRACK: "1"
+  DOCKER_BUILDKIT: 1
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v6
+
+      - name: Determine image name and package
+        id: config
+        run: |
+          if [ "${{ inputs.is_dev }}" = "true" ]; then
+            echo "image=fernapi/fern-dev" >> $GITHUB_OUTPUT
+            echo "package=@fern-api/fern-api-dev" >> $GITHUB_OUTPUT
+          else
+            echo "image=fernapi/fern" >> $GITHUB_OUTPUT
+            echo "package=fern-api" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v4
+        with:
+          username: fernapi
+          password: ${{ secrets.FERN_API_DOCKERHUB_PASSWORD }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: ./docker/cli/Dockerfile
+          build-args: |
+            FERN_PACKAGE=${{ steps.config.outputs.package }}
+            FERN_VERSION=${{ inputs.version }}
+          push: true
+          tags: |
+            ${{ steps.config.outputs.image }}:${{ inputs.version }}
+            ${{ steps.config.outputs.image }}:latest
+          cache-from: type=gha
+          cache-to: type=gha,mode=min

--- a/docker/cli/Dockerfile
+++ b/docker/cli/Dockerfile
@@ -1,0 +1,10 @@
+FROM node:lts-slim
+
+ARG FERN_PACKAGE=fern-api
+ARG FERN_VERSION=latest
+
+RUN npm install -g ${FERN_PACKAGE}@${FERN_VERSION}
+
+WORKDIR /app
+
+ENTRYPOINT ["sh", "-c"]


### PR DESCRIPTION
## Description

Adds a GitHub Actions workflow and Dockerfile for building and publishing Docker images with the Fern CLI pre-installed. These images will be used in customer GitHub Actions workflows (via `container: image:`) to speed up CI runs by eliminating the need for Node.js setup and CLI installation steps.

## Changes Made

- **`.github/workflows/publish-cli-docker.yml`**: New `workflow_dispatch` workflow that builds and pushes Docker images to Docker Hub. Uses an `is_dev` input to determine the image name and npm package:
  - **Prod**: `fernapi/fern:<version>` + `fernapi/fern:latest` (installs `fern-api`)
  - **Dev**: `fernapi/fern-dev:<version>` + `fernapi/fern-dev:latest` (installs `@fern-api/fern-api-dev`)
- **`docker/cli/Dockerfile`**: Minimal Dockerfile based on `node:lts-slim` that installs the Fern CLI globally via npm. Uses build args `FERN_PACKAGE` and `FERN_VERSION` for flexibility.

A companion PR in `fern-api/fern-platform` updates the docs-starter workflow templates to use these new container images.

## Human Review Checklist

- [ ] Verify the `FERN_API_DOCKERHUB_PASSWORD` secret exists in this repo's GitHub settings
- [ ] Confirm `actions/checkout@v6` is intentional (most existing workflows use `@v4`)
- [ ] Confirm the `ENTRYPOINT ["sh", "-c"]` is appropriate for GitHub Actions `container:` usage (where `run:` steps need a shell to execute commands)

## Testing

- [ ] This is a `workflow_dispatch` workflow — it can be manually triggered after merge to verify the build/push works end-to-end
- [ ] No unit tests applicable (infrastructure-only change)

Link to Devin session: https://app.devin.ai/sessions/108178400dee4972847d7376d8028fec
Requested by: @pgragg