### PR TITLE
fix(csharp): skip literal properties in snippet object initializers when generateLiterals is enabled

### DIFF
--- a/generators/csharp/base/src/context/GeneratorContext.ts
+++ b/generators/csharp/base/src/context/GeneratorContext.ts
@@ -668,6 +668,10 @@ export abstract class GeneratorContext extends AbstractGeneratorContext {
         return undefined;
     }
 
+    public isLiteralValue(typeReference: TypeReference): boolean {
+        return this.getLiteralValue(typeReference) != null;
+    }
+
     public getLiteralValue(typeReference: TypeReference): string | boolean | undefined {
         if (typeReference.type === "container" && typeReference.container.type === "literal") {
             const literal = typeReference.container.literal;

--- a/generators/csharp/model/src/object/ObjectGenerator.ts
+++ b/generators/csharp/model/src/object/ObjectGenerator.ts
@@ -183,7 +183,7 @@ export class ObjectGenerator extends FileGenerator<CSharpFile, ModelGeneratorCon
                 ...(this.objectDeclaration.extendedProperties ?? [])
             ];
             for (const prop of allProps) {
-                if (this.context.getLiteralValue(prop.valueType) != null) {
+                if (this.context.isLiteralValue(prop.valueType)) {
                     literalPropertyWireValues.add(getWireValue(prop.name));
                 }
             }

--- a/generators/csharp/model/src/object/ObjectGenerator.ts
+++ b/generators/csharp/model/src/object/ObjectGenerator.ts
@@ -173,19 +173,37 @@ export class ObjectGenerator extends FileGenerator<CSharpFile, ModelGeneratorCon
         exampleObject: ExampleObjectType;
         parseDatetimes: boolean;
     }): ast.CodeBlock {
-        const args = exampleObject.properties.map((exampleProperty) => {
-            const propertyName = this.getPropertyName({
-                className: this.classReference.name,
-                objectProperty: exampleProperty.name
+        // When generateLiterals is enabled, collect wire values of literal properties so we
+        // can skip them in the object initializer. Their default `= new()` already sets the
+        // correct value and assigning a plain string would cause a CS0029 compilation error.
+        const literalPropertyWireValues = new Set<string>();
+        if (this.generation.settings.generateLiterals) {
+            const allProps = [
+                ...this.objectDeclaration.properties,
+                ...(this.objectDeclaration.extendedProperties ?? [])
+            ];
+            for (const prop of allProps) {
+                if (this.context.getLiteralValue(prop.valueType) != null) {
+                    literalPropertyWireValues.add(getWireValue(prop.name));
+                }
+            }
+        }
+
+        const args = exampleObject.properties
+            .filter((exampleProperty) => !literalPropertyWireValues.has(getWireValue(exampleProperty.name)))
+            .map((exampleProperty) => {
+                const propertyName = this.getPropertyName({
+                    className: this.classReference.name,
+                    objectProperty: exampleProperty.name
+                });
+                const assignment = this.exampleGenerator.getSnippetForTypeReference({
+                    exampleTypeReference: exampleProperty.value,
+                    parseDatetimes
+                });
+                // todo: considering filtering out "assignments" are are actually just null so that null properties
+                // are completely excluded from object initializers
+                return { name: propertyName, assignment };
             });
-            const assignment = this.exampleGenerator.getSnippetForTypeReference({
-                exampleTypeReference: exampleProperty.value,
-                parseDatetimes
-            });
-            // todo: considering filtering out "assignments" are are actually just null so that null properties
-            // are completely excluded from object initializers
-            return { name: propertyName, assignment };
-        });
 
         // Include default values for required properties missing from the example
         // so the generated object initializer compiles without CS9035 errors.
@@ -196,6 +214,10 @@ export class ObjectGenerator extends FileGenerator<CSharpFile, ModelGeneratorCon
         ];
         for (const property of allProperties) {
             if (providedWireValues.has(getWireValue(property.name))) {
+                continue;
+            }
+            // Skip literal properties when generateLiterals is enabled; they have correct defaults.
+            if (literalPropertyWireValues.has(getWireValue(property.name))) {
                 continue;
             }
             if (this.isRequiredProperty(property.valueType)) {

--- a/generators/csharp/model/versions.yml
+++ b/generators/csharp/model/versions.yml
@@ -1,4 +1,16 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 0.9.1-rc.0
+  changelogEntry:
+    - summary: |
+        Fix snippet generation to skip literal properties in object initializers
+        when `generate-literals` is enabled. Previously, the generator emitted
+        plain string/boolean assignments for `TypeLiteral` properties, causing
+        CS0029 compilation errors. Literal properties now rely on their `= new()`
+        default initializer.
+      type: fix
+  createdAt: "2026-04-09"
+  irVersion: 66
+
 - version: 0.9.0-rc.0
   changelogEntry:
     - summary: |

--- a/generators/csharp/sdk/src/wrapped-request/WrappedRequestGenerator.ts
+++ b/generators/csharp/sdk/src/wrapped-request/WrappedRequestGenerator.ts
@@ -351,7 +351,10 @@ export class WrappedRequestGenerator extends FileGenerator<CSharpFile, SdkGenera
         // would cause a CS0029 compilation error.
         const literalBodyPropertyWireValues = new Set<string>();
         if (this.generation.settings.generateLiterals && this.endpoint.requestBody?.type === "inlinedRequestBody") {
-            for (const prop of this.endpoint.requestBody.properties) {
+            for (const prop of [
+                ...this.endpoint.requestBody.properties,
+                ...(this.endpoint.requestBody.extendedProperties ?? [])
+            ]) {
                 if (this.context.getLiteralValue(prop.valueType) != null) {
                     literalBodyPropertyWireValues.add(getWireValue(prop.name));
                 }

--- a/generators/csharp/sdk/src/wrapped-request/WrappedRequestGenerator.ts
+++ b/generators/csharp/sdk/src/wrapped-request/WrappedRequestGenerator.ts
@@ -355,7 +355,7 @@ export class WrappedRequestGenerator extends FileGenerator<CSharpFile, SdkGenera
                 ...this.endpoint.requestBody.properties,
                 ...(this.endpoint.requestBody.extendedProperties ?? [])
             ]) {
-                if (this.context.getLiteralValue(prop.valueType) != null) {
+                if (this.context.isLiteralValue(prop.valueType)) {
                     literalBodyPropertyWireValues.add(getWireValue(prop.name));
                 }
             }

--- a/generators/csharp/sdk/src/wrapped-request/WrappedRequestGenerator.ts
+++ b/generators/csharp/sdk/src/wrapped-request/WrappedRequestGenerator.ts
@@ -345,6 +345,19 @@ export class WrappedRequestGenerator extends FileGenerator<CSharpFile, SdkGenera
             });
         }
 
+        // When generateLiterals is enabled, collect wire values of literal properties from
+        // the endpoint's inlined request body so we can skip them in the object initializer.
+        // Their default `= new()` already sets the correct value and assigning a plain string
+        // would cause a CS0029 compilation error.
+        const literalBodyPropertyWireValues = new Set<string>();
+        if (this.generation.settings.generateLiterals && this.endpoint.requestBody?.type === "inlinedRequestBody") {
+            for (const prop of this.endpoint.requestBody.properties) {
+                if (this.context.getLiteralValue(prop.valueType) != null) {
+                    literalBodyPropertyWireValues.add(getWireValue(prop.name));
+                }
+            }
+        }
+
         example.request?._visit({
             reference: (reference) => {
                 orderedFields.push({
@@ -357,6 +370,9 @@ export class WrappedRequestGenerator extends FileGenerator<CSharpFile, SdkGenera
             },
             inlinedRequestBody: (inlinedRequestBody) => {
                 for (const property of inlinedRequestBody.properties) {
+                    if (literalBodyPropertyWireValues.has(getWireValue(property.name))) {
+                        continue;
+                    }
                     orderedFields.push({
                         name: property.name,
                         value: this.exampleGenerator.getSnippetForTypeReference({

--- a/generators/csharp/sdk/versions.yml
+++ b/generators/csharp/sdk/versions.yml
@@ -1,4 +1,16 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 2.59.3
+  changelogEntry:
+    - summary: |
+        Fix mock server test and snippet generation to skip literal properties
+        in object initializers when `generate-literals` is enabled. Previously,
+        the generator emitted plain string/boolean assignments for `TypeLiteral`
+        properties, causing CS0029 compilation errors. Literal properties now
+        rely on their `= new()` default initializer.
+      type: fix
+  createdAt: "2026-04-09"
+  irVersion: 66
+
 - version: 2.59.2
   changelogEntry:
     - summary: |

--- a/seed/csharp-sdk/literal/readonly-constants/.fern/metadata.json
+++ b/seed/csharp-sdk/literal/readonly-constants/.fern/metadata.json
@@ -1,7 +1,7 @@
 {
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-csharp-sdk",
-  "generatorVersion": "local",
+  "generatorVersion": "latest",
   "generatorConfig": {
     "generate-literals": true
   },

--- a/seed/csharp-sdk/literal/readonly-constants/reference.md
+++ b/seed/csharp-sdk/literal/readonly-constants/reference.md
@@ -65,15 +65,9 @@ await client.Inlined.SendAsync(
     new SendLiteralsInlinedRequest
     {
         Temperature = 10.1,
-        Prompt = "You are a helpful assistant",
         Context = "You're super wise",
-        AliasedContext = "You're super wise",
         MaybeContext = "You're super wise",
-        ObjectWithLiteral = new ATopLevelLiteral
-        {
-            NestedLiteral = new ANestedLiteral { MyLiteral = "How super cool" },
-        },
-        Stream = false,
+        ObjectWithLiteral = new ATopLevelLiteral { NestedLiteral = new ANestedLiteral() },
         Query = "What is the weather today",
     }
 );
@@ -215,20 +209,12 @@ await client.Query.SendAsync(
 await client.Reference.SendAsync(
     new SendRequest
     {
-        Prompt = "You are a helpful assistant",
-        Stream = false,
-        Context = "You're super wise",
         Query = "What is the weather today",
         ContainerObject = new ContainerObject
         {
             NestedObjects = new List<NestedObjectWithLiterals>()
             {
-                new NestedObjectWithLiterals
-                {
-                    Literal1 = "literal1",
-                    Literal2 = "literal2",
-                    StrProp = "strProp",
-                },
+                new NestedObjectWithLiterals { StrProp = "strProp" },
             },
         },
     }

--- a/seed/csharp-sdk/literal/readonly-constants/snippet.json
+++ b/seed/csharp-sdk/literal/readonly-constants/snippet.json
@@ -22,7 +22,7 @@
             },
             "snippet": {
                 "type": "csharp",
-                "client": "using SeedLiteral;\n\nvar client = new SeedLiteralClient();\nawait client.Inlined.SendAsync(\n    new SendLiteralsInlinedRequest\n    {\n        Temperature = 10.1,\n        Prompt = \"You are a helpful assistant\",\n        Context = \"You're super wise\",\n        AliasedContext = \"You're super wise\",\n        MaybeContext = \"You're super wise\",\n        ObjectWithLiteral = new ATopLevelLiteral\n        {\n            NestedLiteral = new ANestedLiteral { MyLiteral = \"How super cool\" },\n        },\n        Stream = false,\n        Query = \"What is the weather today\",\n    }\n);\n"
+                "client": "using SeedLiteral;\n\nvar client = new SeedLiteralClient();\nawait client.Inlined.SendAsync(\n    new SendLiteralsInlinedRequest\n    {\n        Temperature = 10.1,\n        Context = \"You're super wise\",\n        MaybeContext = \"You're super wise\",\n        ObjectWithLiteral = new ATopLevelLiteral { NestedLiteral = new ANestedLiteral() },\n        Query = \"What is the weather today\",\n    }\n);\n"
             }
         },
         {
@@ -58,7 +58,7 @@
             },
             "snippet": {
                 "type": "csharp",
-                "client": "using SeedLiteral;\n\nvar client = new SeedLiteralClient();\nawait client.Reference.SendAsync(\n    new SendRequest\n    {\n        Prompt = \"You are a helpful assistant\",\n        Stream = false,\n        Context = \"You're super wise\",\n        Query = \"What is the weather today\",\n        ContainerObject = new ContainerObject\n        {\n            NestedObjects = new List<NestedObjectWithLiterals>()\n            {\n                new NestedObjectWithLiterals\n                {\n                    Literal1 = \"literal1\",\n                    Literal2 = \"literal2\",\n                    StrProp = \"strProp\",\n                },\n            },\n        },\n    }\n);\n"
+                "client": "using SeedLiteral;\n\nvar client = new SeedLiteralClient();\nawait client.Reference.SendAsync(\n    new SendRequest\n    {\n        Query = \"What is the weather today\",\n        ContainerObject = new ContainerObject\n        {\n            NestedObjects = new List<NestedObjectWithLiterals>()\n            {\n                new NestedObjectWithLiterals { StrProp = \"strProp\" },\n            },\n        },\n    }\n);\n"
             }
         }
     ]

--- a/seed/csharp-sdk/literal/readonly-constants/src/SeedLiteral.Test/Unit/MockServer/Inlined/SendTest.cs
+++ b/seed/csharp-sdk/literal/readonly-constants/src/SeedLiteral.Test/Unit/MockServer/Inlined/SendTest.cs
@@ -55,17 +55,11 @@ public class SendTest : BaseMockServerTest
         var response = await Client.Inlined.SendAsync(
             new SendLiteralsInlinedRequest
             {
-                Prompt = "You are a helpful assistant",
                 Context = "You're super wise",
                 Query = "query",
                 Temperature = 1.1,
-                Stream = false,
-                AliasedContext = "You're super wise",
                 MaybeContext = "You're super wise",
-                ObjectWithLiteral = new ATopLevelLiteral
-                {
-                    NestedLiteral = new ANestedLiteral { MyLiteral = "How super cool" },
-                },
+                ObjectWithLiteral = new ATopLevelLiteral { NestedLiteral = new ANestedLiteral() },
             }
         );
         JsonAssert.AreEqual(response, mockResponse);
@@ -118,15 +112,9 @@ public class SendTest : BaseMockServerTest
             new SendLiteralsInlinedRequest
             {
                 Temperature = 10.1,
-                Prompt = "You are a helpful assistant",
                 Context = "You're super wise",
-                AliasedContext = "You're super wise",
                 MaybeContext = "You're super wise",
-                ObjectWithLiteral = new ATopLevelLiteral
-                {
-                    NestedLiteral = new ANestedLiteral { MyLiteral = "How super cool" },
-                },
-                Stream = false,
+                ObjectWithLiteral = new ATopLevelLiteral { NestedLiteral = new ANestedLiteral() },
                 Query = "What is the weather today",
             }
         );

--- a/seed/csharp-sdk/literal/readonly-constants/src/SeedLiteral.Test/Unit/MockServer/Reference/SendTest.cs
+++ b/seed/csharp-sdk/literal/readonly-constants/src/SeedLiteral.Test/Unit/MockServer/Reference/SendTest.cs
@@ -63,28 +63,14 @@ public class SendTest : BaseMockServerTest
         var response = await Client.Reference.SendAsync(
             new SendRequest
             {
-                Prompt = "You are a helpful assistant",
                 Query = "query",
-                Stream = false,
-                Ending = "$ending",
-                Context = "You're super wise",
                 MaybeContext = "You're super wise",
                 ContainerObject = new ContainerObject
                 {
                     NestedObjects = new List<NestedObjectWithLiterals>()
                     {
-                        new NestedObjectWithLiterals
-                        {
-                            Literal1 = "literal1",
-                            Literal2 = "literal2",
-                            StrProp = "strProp",
-                        },
-                        new NestedObjectWithLiterals
-                        {
-                            Literal1 = "literal1",
-                            Literal2 = "literal2",
-                            StrProp = "strProp",
-                        },
+                        new NestedObjectWithLiterals { StrProp = "strProp" },
+                        new NestedObjectWithLiterals { StrProp = "strProp" },
                     },
                 },
             }
@@ -139,20 +125,12 @@ public class SendTest : BaseMockServerTest
         var response = await Client.Reference.SendAsync(
             new SendRequest
             {
-                Prompt = "You are a helpful assistant",
-                Stream = false,
-                Context = "You're super wise",
                 Query = "What is the weather today",
                 ContainerObject = new ContainerObject
                 {
                     NestedObjects = new List<NestedObjectWithLiterals>()
                     {
-                        new NestedObjectWithLiterals
-                        {
-                            Literal1 = "literal1",
-                            Literal2 = "literal2",
-                            StrProp = "strProp",
-                        },
+                        new NestedObjectWithLiterals { StrProp = "strProp" },
                     },
                 },
             }

--- a/seed/csharp-sdk/literal/readonly-constants/src/SeedLiteral/Inlined/InlinedClient.cs
+++ b/seed/csharp-sdk/literal/readonly-constants/src/SeedLiteral/Inlined/InlinedClient.cs
@@ -83,15 +83,9 @@ public partial class InlinedClient : IInlinedClient
     ///     new SendLiteralsInlinedRequest
     ///     {
     ///         Temperature = 10.1,
-    ///         Prompt = "You are a helpful assistant",
     ///         Context = "You're super wise",
-    ///         AliasedContext = "You're super wise",
     ///         MaybeContext = "You're super wise",
-    ///         ObjectWithLiteral = new ATopLevelLiteral
-    ///         {
-    ///             NestedLiteral = new ANestedLiteral { MyLiteral = "How super cool" },
-    ///         },
-    ///         Stream = false,
+    ///         ObjectWithLiteral = new ATopLevelLiteral { NestedLiteral = new ANestedLiteral() },
     ///         Query = "What is the weather today",
     ///     }
     /// );

--- a/seed/csharp-sdk/literal/readonly-constants/src/SeedLiteral/Reference/ReferenceClient.cs
+++ b/seed/csharp-sdk/literal/readonly-constants/src/SeedLiteral/Reference/ReferenceClient.cs
@@ -82,20 +82,12 @@ public partial class ReferenceClient : IReferenceClient
     /// await client.Reference.SendAsync(
     ///     new SendRequest
     ///     {
-    ///         Prompt = "You are a helpful assistant",
-    ///         Stream = false,
-    ///         Context = "You're super wise",
     ///         Query = "What is the weather today",
     ///         ContainerObject = new ContainerObject
     ///         {
     ///             NestedObjects = new List&lt;NestedObjectWithLiterals&gt;()
     ///             {
-    ///                 new NestedObjectWithLiterals
-    ///                 {
-    ///                     Literal1 = "literal1",
-    ///                     Literal2 = "literal2",
-    ///                     StrProp = "strProp",
-    ///                 },
+    ///                 new NestedObjectWithLiterals { StrProp = "strProp" },
     ///             },
     ///         },
     ///     }

--- a/seed/csharp-sdk/websocket/with-websockets/.fern/metadata.json
+++ b/seed/csharp-sdk/websocket/with-websockets/.fern/metadata.json
@@ -1,7 +1,7 @@
 {
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-csharp-sdk",
-  "generatorVersion": "local",
+  "generatorVersion": "latest",
   "generatorConfig": {
     "generate-literals": true,
     "experimental-enable-websockets": true


### PR DESCRIPTION
## Description

Refs #19261

When the `generate-literals` config option is enabled (or via the deprecated `experimental-readonly-constants`), the C# generator emits `TypeLiteral` readonly structs for literal properties instead of plain strings. However, the snippet generators (used for mock server tests and code examples) were still emitting string assignments like `Type = "session_settings"` for these properties, causing **CS0029 compilation errors** because `TypeLiteral` has implicit conversion *to* `string` but not *from* `string`.

This was reported by HumeAI whose C# SDK CI is blocked ([HumeAI/hume-dotnet-sdk#53](https://github.com/HumeAI/hume-dotnet-sdk/pull/53)).

## Changes Made

- **`GeneratorContext.isLiteralValue`** (new): Added a boolean convenience method wrapping `getLiteralValue(...) != null` so call sites read more clearly.
- **`ObjectGenerator.doGenerateSnippet`**: When `generateLiterals` is enabled, collect wire values of all literal properties (including `extendedProperties`) from the object declaration via `isLiteralValue`, then filter them out of the object initializer. Also skip them in the "default values for missing required properties" loop.
- **`WrappedRequestGenerator.doGenerateSnippet`**: Same approach for inlined request body properties — collect literal property wire values from the endpoint's request body declaration (including `extendedProperties`) and skip them during example snippet generation.
- **Seed output regenerated** for `literal:readonly-constants` fixture, demonstrating the fix across mock server tests, code snippets, reference docs, and client XML doc examples.

In both cases, omitting the property is correct because the generated field already has `= new()` as its default initializer, which sets the only valid literal value.

### Seed diff highlights

The `literal:readonly-constants` seed output now omits literal properties from object initializers. For example in `SendTest.cs`:
```diff
 new SendLiteralsInlinedRequest
 {
-    Prompt = "You are a helpful assistant",
     Context = "You're super wise",
     Query = "query",
     Temperature = 1.1,
-    Stream = false,
-    AliasedContext = "You're super wise",
     MaybeContext = "You're super wise",
-    ObjectWithLiteral = new ATopLevelLiteral
-    {
-        NestedLiteral = new ANestedLiteral { MyLiteral = "How super cool" },
-    },
+    ObjectWithLiteral = new ATopLevelLiteral { NestedLiteral = new ANestedLiteral() },
 }
```

## Testing

- [ ] Unit tests added/updated
- [x] Manual lint/typecheck passes (`pnpm run check`)
- [x] Seed output regenerated for `literal:readonly-constants` and `websocket:with-websockets` fixtures

### 🔍 Key areas for human review

1. **Recursive all-literal objects**: This PR skips direct literal-typed properties but still includes objects whose subtree is entirely literal (e.g. `ObjectWithLiteral = new ATopLevelLiteral { NestedLiteral = new ANestedLiteral() }`). These are required properties without `= new()` defaults, so the compiler needs them. A follow-up could detect "all-literal" object trees and either skip them or give them default initializers at the generator level.
2. **Completeness**: Are there other snippet generation paths beyond `ObjectGenerator` and `WrappedRequestGenerator` that could emit string assignments for `TypeLiteral` properties?
3. **Seed output correctness**: Verify the seed diff — literal properties (`Prompt`, `Stream`, `AliasedContext`, `Literal1`, `Literal2`, `MyLiteral`, `Context`, `Ending`) are omitted while non-literal properties (`Temperature`, `Query`, `MaybeContext`, `StrProp`) are preserved.

Link to Devin session: https://app.devin.ai/sessions/d14d656ef74644d2b22a573ee1c96caa
Requested by: @Swimburger
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/14863" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
