### PR TITLE
chore(internal): bump @fern-api/generator-cli from 0.9.3 to 0.9.4

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -37,8 +37,8 @@ catalogs:
       specifier: 0.0.6-2ee1b7e28
       version: 0.0.6-2ee1b7e28
     '@fern-api/generator-cli':
-      specifier: 0.9.3
-      version: 0.9.3
+      specifier: 0.9.4
+      version: 0.9.4
     '@fern-api/venus-api-sdk':
       specifier: 0.17.3-3-gf696595
       version: 0.17.3-3-gf696595
@@ -630,7 +630,7 @@ importers:
         version: link:packages/configs
       '@fern-api/generator-cli':
         specifier: 'catalog:'
-        version: 0.9.3
+        version: 0.9.4
       '@rolldown/binding-darwin-arm64':
         specifier: 'catalog:'
         version: 1.0.0-rc.5
@@ -696,7 +696,7 @@ importers:
         version: link:../../packages/commons/fs-utils
       '@fern-api/generator-cli':
         specifier: 'catalog:'
-        version: 0.9.3
+        version: 0.9.4
       '@fern-api/ir-sdk':
         specifier: workspace:*
         version: link:../../packages/ir-sdk
@@ -2427,7 +2427,7 @@ importers:
         version: link:../../../packages/commons/fs-utils
       '@fern-api/generator-cli':
         specifier: 'catalog:'
-        version: 0.9.3
+        version: 0.9.4
       '@fern-api/logger':
         specifier: workspace:*
         version: link:../../../packages/cli/logger
@@ -4886,12 +4886,6 @@ importers:
       yargs:
         specifier: ^17.4.1
         version: 17.7.2
-
-  packages/cli/cli/dist/prod-unminified:
-    dependencies:
-      '@boundaryml/baml':
-        specifier: 'catalog:'
-        version: 0.219.0
 
   packages/cli/config:
     devDependencies:
@@ -9303,8 +9297,8 @@ packages:
   '@fern-api/fdr-sdk@0.145.12-b50d999d1':
     resolution: {integrity: sha512-qTHoosyHoHFqXM/ZcHjdiAw5tByBo1mxcfMLkId9qZ4LRSw/hJmybQEa00k7dstirNnG5DvBta6Kwq74F8NfjQ==}
 
-  '@fern-api/generator-cli@0.9.3':
-    resolution: {integrity: sha512-4Om5HsQG8mNF31OaqCuF+2Iut+mkTegpruTB4eAKTa6d3E0SmJmx50AEUR297THjgL3Ef7j45SSR6er+K7RkdA==}
+  '@fern-api/generator-cli@0.9.4':
+    resolution: {integrity: sha512-VBA8FVLwtX/EymumqhMNW8VIhxiaWpoOoN5ghjosCASBNBRH6uHm6NRPikDZYwNa8F+4q/sEW+AoiPVofSx54Q==}
     hasBin: true
 
   '@fern-api/logger@0.4.24-rc1':
@@ -9312,11 +9306,6 @@ packages:
 
   '@fern-api/replay@0.10.1':
     resolution: {integrity: sha512-WjBT2GiEnsYlybLOLE13Cy0z389+45s+zN7RAf1AcxnCmc2P/JVtPwxVUReoVlFtnAxlyb3YMGPsKdsYIN+maw==}
-    engines: {node: '>=18'}
-    hasBin: true
-
-  '@fern-api/replay@0.9.1':
-    resolution: {integrity: sha512-RpK1UIO8qBfRL5TbyHsfDOCTyr2DPDI2XqBUDl3YOr4Mn+4EWS8C65R/k/UkJthn2KsCa57QxSvtWAxftpwljA==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -16327,9 +16316,9 @@ snapshots:
       - encoding
       - typescript
 
-  '@fern-api/generator-cli@0.9.3':
+  '@fern-api/generator-cli@0.9.4':
     dependencies:
-      '@fern-api/replay': 0.9.1
+      '@fern-api/replay': 0.10.1
       '@octokit/rest': 22.0.1
       es-toolkit: 1.45.1
       tmp-promise: 3.0.3
@@ -16342,15 +16331,6 @@ snapshots:
       chalk: 5.6.2
 
   '@fern-api/replay@0.10.1':
-    dependencies:
-      minimatch: 10.2.5
-      node-diff3: 3.2.0
-      simple-git: 3.35.2
-      yaml: 2.8.3
-    transitivePeerDependencies:
-      - supports-color
-
-  '@fern-api/replay@0.9.1':
     dependencies:
       minimatch: 10.2.5
       node-diff3: 3.2.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -61,7 +61,7 @@ catalog:
   "@fern-api/docs-parsers": 0.0.65
   "@fern-api/fai-sdk": 0.0.6-2ee1b7e28
   "@fern-api/fdr-sdk": 1.1.13-c1ad12a2b8
-  "@fern-api/generator-cli": 0.9.3
+  "@fern-api/generator-cli": 0.9.4
   "@fern-api/ui-core-utils": 0.129.4-b6c699ad2
   "@fern-api/venus-api-sdk": 0.17.3-3-gf696595
   "@fern-fern/docs-config": 0.0.80


### PR DESCRIPTION
## Description

Bumps the `@fern-api/generator-cli` catalog dependency from 0.9.3 → 0.9.4, which upgrades the transitive `@fern-api/replay` dependency from 0.9.1 → 0.10.1. This completes the Python SDK generator 5.3.7 release (versions.yml entry already on main).

## Changes Made

- Updated `@fern-api/generator-cli` version in `pnpm-workspace.yaml` catalog from 0.9.3 to 0.9.4
- Regenerated `pnpm-lock.yaml` to reflect the new version across all consumers

## Review Checklist

- [ ] Verify the lockfile diff looks clean (note: includes removal of a stale `packages/cli/cli/dist/prod-unminified` entry — appears to be unrelated lockfile cleanup from `pnpm install`)
- [ ] Confirm `@fern-api/replay` 0.9.1 → 0.10.1 transitive bump is expected

Link to Devin session: https://app.devin.ai/sessions/b2245d2e84cd4adab6017b70bc9be1f0
Requested by: @tstanmay13