### PR TITLE
chore(python): bump Python SDK generator to 5.3.8

### DIFF
--- a/generators/python/sdk/versions.yml
+++ b/generators/python/sdk/versions.yml
@@ -1,5 +1,13 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 # For unreleased changes, use unreleased.yml
+- version: 5.3.8
+  changelogEntry:
+    - summary: |
+        Upgrade @fern-api/generator-cli to 0.9.4 which upgrades @fern-api/replay to 0.10.1.
+      type: chore
+  createdAt: "2026-04-09"
+  irVersion: 65
+
 - version: 5.3.7
   changelogEntry:
     - summary: |

--- a/generators/python/sdk/versions.yml
+++ b/generators/python/sdk/versions.yml
@@ -3,7 +3,7 @@
 - version: 5.3.8
   changelogEntry:
     - summary: |
-        Upgrade @fern-api/generator-cli to 0.9.4 which upgrades @fern-api/replay to 0.10.1.
+        Bump generator-cli to 0.9.4.
       type: chore
   createdAt: "2026-04-09"
   irVersion: 65


### PR DESCRIPTION
## Description

Adds a new Python SDK generator version 5.3.8 to pick up the `@fern-api/generator-cli` 0.9.4 catalog bump that was merged in #14865. Version 5.3.7 was released before the catalog bump landed, so it was built with generator-cli 0.9.3. This release ensures 0.9.4 (and its transitive `@fern-api/replay` 0.10.1 upgrade) is actually baked into the published generator image.

## Changes Made

- Added version 5.3.8 entry to `generators/python/sdk/versions.yml` with a chore changelog entry

## Review Checklist

- [ ] Confirm that 5.3.8 having the same changelog summary as 5.3.7 is acceptable (both describe the generator-cli 0.9.4 upgrade, but only 5.3.8 will actually ship with it)

Link to Devin session: https://app.devin.ai/sessions/b2245d2e84cd4adab6017b70bc9be1f0
Requested by: @tstanmay13