### PR TITLE
chore(generator-cli): upgrade @fern-api/replay to 0.10.2 (pinned), bump python SDK to 5.3.9

### DIFF
--- a/generators/python/sdk/versions.yml
+++ b/generators/python/sdk/versions.yml
@@ -1,5 +1,13 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 # For unreleased changes, use unreleased.yml
+- version: 5.3.9
+  changelogEntry:
+    - summary: |
+        Bump generator-cli to 0.9.5 which upgrades @fern-api/replay to 0.10.2.
+      type: chore
+  createdAt: "2026-04-10"
+  irVersion: 65
+
 - version: 5.3.8
   changelogEntry:
     - summary: |

--- a/packages/generator-cli/package.json
+++ b/packages/generator-cli/package.json
@@ -24,7 +24,7 @@
   "files": ["bin", "dist", "lib"],
   "dependencies": {
     "@fern-api/core-utils": "workspace:*",
-    "@fern-api/replay": "^0.10.1",
+    "@fern-api/replay": "0.10.2",
     "@octokit/rest": "catalog:",
     "es-toolkit": "catalog:",
     "tmp-promise": "catalog:"

--- a/packages/generator-cli/versions.yml
+++ b/packages/generator-cli/versions.yml
@@ -1,6 +1,13 @@
 # yaml-language-server: $schema=../../versions-yml.schema.json
 - changelogEntry:
     - summary: |
+        Upgrade @fern-api/replay to 0.10.2 (pinned).
+      type: chore
+  createdAt: "2026-04-10"
+  version: 0.9.5
+
+- changelogEntry:
+    - summary: |
         Upgrade @fern-api/replay to 0.10.1.
       type: chore
   createdAt: "2026-04-09"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7795,8 +7795,8 @@ importers:
         specifier: workspace:*
         version: link:../commons/core-utils
       '@fern-api/replay':
-        specifier: ^0.10.1
-        version: 0.10.1
+        specifier: 0.10.2
+        version: 0.10.2
       '@octokit/rest':
         specifier: 'catalog:'
         version: 22.0.1
@@ -9306,6 +9306,11 @@ packages:
 
   '@fern-api/replay@0.10.1':
     resolution: {integrity: sha512-WjBT2GiEnsYlybLOLE13Cy0z389+45s+zN7RAf1AcxnCmc2P/JVtPwxVUReoVlFtnAxlyb3YMGPsKdsYIN+maw==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  '@fern-api/replay@0.10.2':
+    resolution: {integrity: sha512-lUkmqtHqQw5H6Zm6efC+qYcOAVJ+XbeVs+BR/X1Ug39DjupaIjxUT3ADBks0A/2wtWQmkxb1ZSEUdc+J4kBT1g==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -16331,6 +16336,15 @@ snapshots:
       chalk: 5.6.2
 
   '@fern-api/replay@0.10.1':
+    dependencies:
+      minimatch: 10.2.5
+      node-diff3: 3.2.0
+      simple-git: 3.35.2
+      yaml: 2.8.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@fern-api/replay@0.10.2':
     dependencies:
       minimatch: 10.2.5
       node-diff3: 3.2.0


### PR DESCRIPTION
## Description

Upgrades `@fern-api/replay` to the latest version (0.10.2) in `generator-cli` and pins it to an exact version (removes the `^` caret). Bumps `generator-cli` to 0.9.5 and the Python SDK generator to 5.3.9 to track this change.

## Changes Made

- **`packages/generator-cli/package.json`**: `@fern-api/replay` changed from `^0.10.1` → `0.10.2` (pinned, no caret)
- **`packages/generator-cli/versions.yml`**: New entry for version `0.9.5`
- **`generators/python/sdk/versions.yml`**: New entry for version `5.3.9` referencing the generator-cli bump
- **`pnpm-lock.yaml`**: Updated to resolve `@fern-api/replay@0.10.2`

## Reviewer Checklist

- [ ] Confirm pinning (removing `^`) is the desired behavior — future `pnpm install` will not auto-upgrade replay
- [ ] Verify version sequence: generator-cli 0.9.4 → 0.9.5, Python SDK 5.3.8 → 5.3.9
- [ ] **Ordering note**: A companion PR in `fern-api/fiddle` bumps the Dockerfile to `@fern-api/generator-cli@0.9.5`. That PR should be merged only **after** generator-cli 0.9.5 is published to npm from this PR.

## Testing

- No code logic changes; dependency version bump only
- Lockfile resolves cleanly (`pnpm install` succeeded)

Link to Devin session: https://app.devin.ai/sessions/97bbc3e45f7e47bea6541c0503d031c1
Requested by: @tstanmay13