### PR TITLE
chore(deps): bump @fern-api/venus-api-sdk to 0.22.34

### DIFF
--- a/packages/cli/auth/src/orgs/checkOrganizationMembership.ts
+++ b/packages/cli/auth/src/orgs/checkOrganizationMembership.ts
@@ -1,6 +1,4 @@
 import { createVenusService } from "@fern-api/core";
-import { FernVenusApi } from "@fern-api/venus-api-sdk";
-
 import { FernUserToken } from "../FernToken";
 
 export type OrganizationCheckResult =
@@ -19,14 +17,14 @@ export async function checkOrganizationMembership({
     const venus = createVenusService({ token: token.value });
 
     // First check if the user is a member of the organization.
-    const isMemberResponse = await venus.organization.isMember(FernVenusApi.OrganizationId(organization));
+    const isMemberResponse = await venus.organization.isMember(organization);
     if (isMemberResponse.ok && isMemberResponse.body) {
         return { type: "member" };
     }
 
     // Either the isMember call failed or the user is not a member.
     // Check whether the org exists at all.
-    const getResponse = await venus.organization.get(FernVenusApi.OrganizationId(organization));
+    const getResponse = await venus.organization.get(organization);
     if (getResponse.ok) {
         // Org exists but user is not a member.
         return { type: "no-access" };

--- a/packages/cli/auth/src/orgs/createOrganizationIfDoesNotExist.ts
+++ b/packages/cli/auth/src/orgs/createOrganizationIfDoesNotExist.ts
@@ -1,7 +1,5 @@
 import { createVenusService } from "@fern-api/core";
 import { TaskContext } from "@fern-api/task-context";
-import { FernVenusApi } from "@fern-api/venus-api-sdk";
-
 import { FernUserToken } from "../FernToken.js";
 import { getOrganizationNameValidationError } from "./getOrganizationNameValidationError.js";
 
@@ -15,7 +13,7 @@ export async function createOrganizationIfDoesNotExist({
     context: TaskContext;
 }): Promise<boolean> {
     const venus = createVenusService({ token: token.value });
-    const getOrganizationResponse = await venus.organization.get(FernVenusApi.OrganizationId(organization));
+    const getOrganizationResponse = await venus.organization.get(organization);
 
     if (getOrganizationResponse.ok) {
         return false;
@@ -27,7 +25,7 @@ export async function createOrganizationIfDoesNotExist({
         context.failAndThrow(validationError);
     }
     const createOrganizationResponse = await venus.organization.create({
-        organizationId: FernVenusApi.OrganizationId(organization)
+        organizationId: organization
     });
     if (!createOrganizationResponse.ok) {
         context.failAndThrow(`Failed to create organization: ${organization}`, createOrganizationResponse.error);

--- a/packages/cli/auth/src/users/getCurrentUser.ts
+++ b/packages/cli/auth/src/users/getCurrentUser.ts
@@ -1,6 +1,6 @@
 import { createVenusService } from "@fern-api/core";
 import { TaskContext } from "@fern-api/task-context";
-import { FernVenusApi } from "@fern-api/venus-api-sdk";
+import type { FernVenusApi } from "@fern-api/venus-api-sdk";
 
 import { FernUserToken } from "../FernToken.js";
 

--- a/packages/cli/cli-v2/src/commands/auth/token/command.ts
+++ b/packages/cli/cli-v2/src/commands/auth/token/command.ts
@@ -1,6 +1,5 @@
 import { createOrganizationIfDoesNotExist } from "@fern-api/auth";
 import { createVenusService } from "@fern-api/core";
-import { FernVenusApi } from "@fern-api/venus-api-sdk";
 import type { Argv } from "yargs";
 
 import { TaskContextAdapter } from "../../../context/adapter/TaskContextAdapter.js";
@@ -32,7 +31,7 @@ export class TokenCommand {
 
         const venus = createVenusService({ token: token.value });
         const response = await venus.registry.generateRegistryTokens({
-            organizationId: FernVenusApi.OrganizationId(orgId)
+            organizationId: orgId
         });
         if (response.ok) {
             // Output raw token (no newline for piping compatibility).

--- a/packages/cli/cli-v2/src/commands/auth/token/command.ts
+++ b/packages/cli/cli-v2/src/commands/auth/token/command.ts
@@ -48,6 +48,12 @@ export class TokenCommand {
                 process.stderr.write(`${Icons.error} You do not have access to organization "${orgId}".\n`);
                 throw CliError.exit();
             },
+            missingOrgPermissionsError: () => {
+                process.stderr.write(
+                    `${Icons.error} You do not have the required permissions in organization "${orgId}".\n`
+                );
+                throw CliError.exit();
+            },
             _other: () => {
                 process.stderr.write(
                     `${Icons.error} Failed to generate token.\n` +

--- a/packages/cli/cli/src/commands/token/token.ts
+++ b/packages/cli/cli/src/commands/token/token.ts
@@ -2,7 +2,6 @@ import { createOrganizationIfDoesNotExist } from "@fern-api/auth";
 import { createVenusService } from "@fern-api/core";
 import { askToLogin } from "@fern-api/login";
 import { TaskContext } from "@fern-api/task-context";
-import { FernVenusApi } from "@fern-api/venus-api-sdk";
 import chalk from "chalk";
 
 export async function generateToken({
@@ -18,7 +17,7 @@ export async function generateToken({
     }
     const venus = createVenusService({ token: token.value });
     const response = await venus.registry.generateRegistryTokens({
-        organizationId: FernVenusApi.OrganizationId(orgId)
+        organizationId: orgId
     });
     if (response.ok) {
         taskContext.logger.info(chalk.green(`Generated a FERN_TOKEN for ${orgId}: ${response.body.npm.token}`));

--- a/packages/cli/cli/src/commands/token/token.ts
+++ b/packages/cli/cli/src/commands/token/token.ts
@@ -32,6 +32,10 @@ export async function generateToken({
             taskContext.failAndThrow(
                 `Failed to create token because you are not in the ${orgId} organization. Please reach out to support@buildwithfern.com`
             ),
+        missingOrgPermissionsError: () =>
+            taskContext.failAndThrow(
+                `Failed to create token because you do not have the required permissions in the ${orgId} organization. Please reach out to support@buildwithfern.com`
+            ),
         _other: () => taskContext.failAndThrow("Failed to create token. Please reach out to support@buildwithfern.com")
     });
 }

--- a/packages/cli/generation/local-generation/local-workspace-runner/src/runLocalGenerationForWorkspace.ts
+++ b/packages/cli/generation/local-generation/local-workspace-runner/src/runLocalGenerationForWorkspace.ts
@@ -18,7 +18,7 @@ import { FernIr, PublishTarget } from "@fern-api/ir-sdk";
 import { OSSWorkspace } from "@fern-api/lazy-fern-workspace";
 import { getDynamicGeneratorConfig } from "@fern-api/remote-workspace-runner";
 import { TaskContext } from "@fern-api/task-context";
-import { FernVenusApi } from "@fern-api/venus-api-sdk";
+import type { FernVenusApi } from "@fern-api/venus-api-sdk";
 import {
     AbstractAPIWorkspace,
     getBaseOpenAPIWorkspaceSettingsFromGeneratorInvocation
@@ -173,9 +173,7 @@ export async function runLocalGenerationForWorkspace({
                     }
                 }
 
-                const organization = await venus.organization.get(
-                    FernVenusApi.OrganizationId(projectConfig.organization)
-                );
+                const organization = await venus.organization.get(projectConfig.organization);
 
                 if (generatorInvocation.absolutePathToLocalOutput == null && !organization.ok) {
                     interactiveTaskContext.failWithoutThrowing(

--- a/packages/cli/generation/remote-generation/remote-workspace-runner/src/runRemoteGenerationForGenerator.ts
+++ b/packages/cli/generation/remote-generation/remote-workspace-runner/src/runRemoteGenerationForGenerator.ts
@@ -16,7 +16,6 @@ import { getOriginalName } from "@fern-api/ir-utils";
 import { detectAirGappedMode } from "@fern-api/lazy-fern-workspace";
 import { convertIrToFdrApi } from "@fern-api/register";
 import { InteractiveTaskContext } from "@fern-api/task-context";
-import { FernVenusApi } from "@fern-api/venus-api-sdk";
 import { FernWorkspace, IdentifiableSource } from "@fern-api/workspace-loader";
 import { FernFiddle } from "@fern-fern/fiddle-sdk";
 import { createAndStartJob } from "./createAndStartJob.js";
@@ -143,7 +142,7 @@ export async function runRemoteGenerationForGenerator({
 
     const venus = createVenusService({ token: token.value });
     if (!isAirGapped) {
-        const orgResponse = await venus.organization.get(FernVenusApi.OrganizationId(projectConfig.organization));
+        const orgResponse = await venus.organization.get(projectConfig.organization);
 
         if (orgResponse.ok) {
             if (orgResponse.body.isWhitelabled) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -40,8 +40,8 @@ catalogs:
       specifier: 0.9.4
       version: 0.9.4
     '@fern-api/venus-api-sdk':
-      specifier: 0.17.3-3-gf696595
-      version: 0.17.3-3-gf696595
+      specifier: 0.22.34
+      version: 0.22.34
     '@fern-fern/docs-config':
       specifier: 0.0.80
       version: 0.0.80
@@ -4226,7 +4226,7 @@ importers:
         version: link:../task-context
       '@fern-api/venus-api-sdk':
         specifier: 'catalog:'
-        version: 0.17.3-3-gf696595
+        version: 0.22.34
       jsonwebtoken:
         specifier: 'catalog:'
         version: 9.0.3
@@ -4410,7 +4410,7 @@ importers:
         version: link:../task-context
       '@fern-api/venus-api-sdk':
         specifier: 'catalog:'
-        version: 0.17.3-3-gf696595
+        version: 0.22.34
       '@fern-api/workspace-loader':
         specifier: workspace:*
         version: link:../workspace/loader
@@ -4795,7 +4795,7 @@ importers:
         version: link:../task-context
       '@fern-api/venus-api-sdk':
         specifier: 'catalog:'
-        version: 0.17.3-3-gf696595
+        version: 0.22.34
       '@fern-api/workspace-loader':
         specifier: workspace:*
         version: link:../workspace/loader
@@ -6050,7 +6050,7 @@ importers:
         version: link:../../../../../generators/typescript-v2/dynamic-snippets
       '@fern-api/venus-api-sdk':
         specifier: 'catalog:'
-        version: 0.17.3-3-gf696595
+        version: 0.22.34
       '@fern-api/workspace-loader':
         specifier: workspace:*
         version: link:../../../workspace/loader
@@ -6207,7 +6207,7 @@ importers:
         version: link:../../../task-context
       '@fern-api/venus-api-sdk':
         specifier: 'catalog:'
-        version: 0.17.3-3-gf696595
+        version: 0.22.34
       '@fern-api/workspace-loader':
         specifier: workspace:*
         version: link:../../../workspace/loader
@@ -7765,7 +7765,7 @@ importers:
         version: 0.145.12-b50d999d1(typescript@5.9.3)
       '@fern-api/venus-api-sdk':
         specifier: 'catalog:'
-        version: 0.17.3-3-gf696595
+        version: 0.22.34
       '@fern-fern/fdr-test-sdk':
         specifier: 'catalog:'
         version: 0.0.5297
@@ -9312,8 +9312,8 @@ packages:
   '@fern-api/ui-core-utils@0.145.12-b50d999d1':
     resolution: {integrity: sha512-S1sE+Fs6kc/7F1Gzwsz7sZlAhMLIsaMeVDQ68038YXfzsLhrsg3DEVPvil5T3KxH/qV80Uso25q1D1W/LwXo6Q==}
 
-  '@fern-api/venus-api-sdk@0.17.3-3-gf696595':
-    resolution: {integrity: sha512-JwtEDPtlrayTOTc4NR9opF4bD1LQtz222h1UnKseAv6Saopg2iHvxoGSf0SQfHA8i8atw+eJMNbHBWWTPdbBrA==}
+  '@fern-api/venus-api-sdk@0.22.34':
+    resolution: {integrity: sha512-21J/+zvL/v2LlCsVcBu7uM6k0Ej7Tz+2Tg6qZkUNH5TS0wmU6CyQ3lURE9jwiDRnw/bpNNkVXGuu9R7Vmvyi6Q==}
     engines: {node: '>=18.0.0'}
 
   '@fern-fern/docs-config@0.0.80':
@@ -16347,7 +16347,7 @@ snapshots:
       title: 3.5.3
       ua-parser-js: 1.0.41
 
-  '@fern-api/venus-api-sdk@0.17.3-3-gf696595': {}
+  '@fern-api/venus-api-sdk@0.22.34': {}
 
   '@fern-fern/docs-config@0.0.80': {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -63,7 +63,7 @@ catalog:
   "@fern-api/fdr-sdk": 1.1.13-c1ad12a2b8
   "@fern-api/generator-cli": 0.9.4
   "@fern-api/ui-core-utils": 0.129.4-b6c699ad2
-  "@fern-api/venus-api-sdk": 0.17.3-3-gf696595
+  "@fern-api/venus-api-sdk": 0.22.34
   "@fern-fern/docs-config": 0.0.80
   "@fern-fern/fdr-test-sdk": ^0.0.5297
   "@fern-fern/fiddle-sdk": 0.0.775


### PR DESCRIPTION
## Description

Linear ticket: Refs [FER-8580](https://linear.app/buildwithfern/issue/FER-8580/cli-v2-add-the-org-sub-command)

Bumps `@fern-api/venus-api-sdk` from `0.17.3-3-gf696595` to `0.22.34` in the pnpm catalog. The new version includes the `apiKeys` resource (`create`, `getTokensForOrganization`, `getTokenMetadata`, `revokeToken`, `revokeTokenById`), which is a prerequisite for implementing the `fern org token create/list/revoke` CLI commands.

## Changes Made

- Updated `@fern-api/venus-api-sdk` version in `pnpm-workspace.yaml` catalog (affects 6 consuming packages)
- Adapted to **breaking type change**: `OrganizationId` changed from a branded type with a constructor function (`FernVenusApi.OrganizationId(x)`) to a plain `string` type alias — replaced all wrapper calls with direct string arguments in 7 source files:
  - `checkOrganizationMembership.ts` (2 call sites)
  - `createOrganizationIfDoesNotExist.ts` (2 call sites)
  - `runLocalGenerationForWorkspace.ts` (1 call site)
  - `runRemoteGenerationForGenerator.ts` (1 call site)
  - `cli/src/commands/token/token.ts` (1 call site)
  - `cli-v2/src/commands/auth/token/command.ts` (1 call site)
- Removed now-unused `FernVenusApi` value imports; converted remaining imports to `type`-only where applicable (`getCurrentUser.ts`, `runLocalGenerationForWorkspace.ts`)
- Added `missingOrgPermissionsError` handler to `_visit` calls on `generateRegistryTokens` errors in both `cli/src/commands/token/token.ts` and `cli-v2/src/commands/auth/token/command.ts` (new error variant in SDK 0.22.34)

## Testing

- [x] `pnpm install` completes successfully
- [x] `biome check` passes (4261 files, no issues)
- [x] `pnpm format` — no changes needed
- [ ] Full CI suite

## Human Review Checklist

- [ ] Confirm `response.body.npm.token` shape in `generateRegistryTokens` response is unchanged between SDK versions — this is used in both token commands and any shape change would be a silent runtime failure
- [ ] Verify the new `missingOrgPermissionsError` messages are appropriate for CLI (`token.ts`) and cli-v2 (`command.ts`)
- [ ] Spot-check that no other files reference `FernVenusApi.OrganizationId` (grep was used, but worth confirming)
- [ ] Confirm the `FernVenusApi` import removal in `runRemoteGenerationForGenerator.ts` is safe (was only used for `OrganizationId`)

Link to Devin session: https://app.devin.ai/sessions/88362feffe364fa6b4b4f82a847a97b7
Requested by: @iamnamananand996