### PR TITLE
feat(cli-v2): add org token and member sub-commands

### DIFF
--- a/packages/cli/cli-v2/src/commands/org/command.ts
+++ b/packages/cli/cli-v2/src/commands/org/command.ts
@@ -4,7 +4,14 @@ import type { GlobalArgs } from "../../context/GlobalArgs.js";
 import { commandGroup } from "../_internal/commandGroup.js";
 import { addCreateCommand } from "./create/index.js";
 import { addListCommand } from "./list/index.js";
+import { addMemberCommand } from "./member/index.js";
+import { addTokenCommand } from "./token/index.js";
 
 export function addOrgCommand(cli: Argv<GlobalArgs>): void {
-    commandGroup(cli, "org", "Manage your organizations", [addCreateCommand, addListCommand]);
+    commandGroup(cli, "org", "Manage your organizations", [
+        addCreateCommand,
+        addListCommand,
+        addMemberCommand,
+        addTokenCommand
+    ]);
 }

--- a/packages/cli/cli-v2/src/commands/org/member/add/__test__/command.test.ts
+++ b/packages/cli/cli-v2/src/commands/org/member/add/__test__/command.test.ts
@@ -84,7 +84,7 @@ describe("InviteMemberCommand", () => {
         const mockGet = vi.fn().mockResolvedValue({
             ok: false,
             error: {
-                _visit: (visitor: any) => visitor.unauthorizedError()
+                _visit: (visitor: { unauthorizedError: () => void }) => visitor.unauthorizedError()
             }
         });
         vi.mocked(createVenusService).mockReturnValue({
@@ -107,7 +107,7 @@ describe("InviteMemberCommand", () => {
         const mockInviteUser = vi.fn().mockResolvedValue({
             ok: false,
             error: {
-                _visit: (visitor: any) => visitor.unauthorizedError()
+                _visit: (visitor: { unauthorizedError: () => void }) => visitor.unauthorizedError()
             }
         });
         vi.mocked(createVenusService).mockReturnValue({
@@ -128,7 +128,7 @@ describe("InviteMemberCommand", () => {
         const mockInviteUser = vi.fn().mockResolvedValue({
             ok: false,
             error: {
-                _visit: (visitor: any) => visitor.userIdDoesNotExistError()
+                _visit: (visitor: { userIdDoesNotExistError: () => void }) => visitor.userIdDoesNotExistError()
             }
         });
         vi.mocked(createVenusService).mockReturnValue({
@@ -149,7 +149,7 @@ describe("InviteMemberCommand", () => {
         const mockInviteUser = vi.fn().mockResolvedValue({
             ok: false,
             error: {
-                _visit: (visitor: any) => visitor._other()
+                _visit: (visitor: { _other: () => void }) => visitor._other()
             }
         });
         vi.mocked(createVenusService).mockReturnValue({

--- a/packages/cli/cli-v2/src/commands/org/member/add/__test__/command.test.ts
+++ b/packages/cli/cli-v2/src/commands/org/member/add/__test__/command.test.ts
@@ -1,0 +1,132 @@
+import type { Logger } from "@fern-api/logger";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { CliError } from "../../../../../errors/CliError.js";
+import { InviteMemberCommand } from "../command.js";
+
+vi.mock("@fern-api/core", () => ({
+    createVenusService: vi.fn()
+}));
+
+vi.mock("../../../../../ui/withSpinner.js", () => ({
+    withSpinner: vi.fn(({ operation }: { operation: () => Promise<unknown> }) => operation())
+}));
+
+function createMockLogger(): Logger {
+    return {
+        disable: vi.fn(),
+        enable: vi.fn(),
+        trace: vi.fn(),
+        debug: vi.fn(),
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+        log: vi.fn()
+    };
+}
+
+function createMockContext(tokenType: "user" | "organization" = "user") {
+    return {
+        stdout: createMockLogger(),
+        stderr: createMockLogger(),
+        getTokenOrPrompt: vi.fn().mockResolvedValue({ type: tokenType, value: "test-token" })
+    } as unknown as import("../../../../../context/Context.js").Context;
+}
+
+describe("InviteMemberCommand", () => {
+    let cmd: InviteMemberCommand;
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+        cmd = new InviteMemberCommand();
+    });
+
+    it("should invite a member successfully", async () => {
+        const { createVenusService } = await import("@fern-api/core");
+        const mockInviteUser = vi.fn().mockResolvedValue({ ok: true });
+        vi.mocked(createVenusService).mockReturnValue({
+            organization: { inviteUser: mockInviteUser }
+        } as ReturnType<typeof createVenusService>);
+
+        const context = createMockContext();
+        await cmd.handle(context, { email: "user@example.com", org: "acme" } as InviteMemberCommand.Args);
+
+        expect(mockInviteUser).toHaveBeenCalledWith({
+            emailAddress: "user@example.com",
+            auth0OrgId: "acme"
+        });
+        expect(context.stderr.info).toHaveBeenCalledWith(expect.stringContaining("Invited"));
+    });
+
+    it("should reject organization tokens", async () => {
+        const context = createMockContext("organization");
+
+        await expect(
+            cmd.handle(context, { email: "user@example.com", org: "acme" } as InviteMemberCommand.Args)
+        ).rejects.toThrow(CliError);
+
+        expect(context.stderr.error).toHaveBeenCalledWith(
+            expect.stringContaining("Organization tokens cannot manage members")
+        );
+    });
+
+    it("should handle UnauthorizedError", async () => {
+        const { createVenusService } = await import("@fern-api/core");
+        const mockInviteUser = vi.fn().mockResolvedValue({
+            ok: false,
+            error: {
+                _visit: (visitor: Record<string, () => void>) => visitor.unauthorizedError()
+            }
+        });
+        vi.mocked(createVenusService).mockReturnValue({
+            organization: { inviteUser: mockInviteUser }
+        } as ReturnType<typeof createVenusService>);
+
+        const context = createMockContext();
+        await expect(
+            cmd.handle(context, { email: "user@example.com", org: "acme" } as InviteMemberCommand.Args)
+        ).rejects.toThrow(CliError);
+
+        expect(context.stderr.error).toHaveBeenCalledWith(expect.stringContaining("do not have permission to invite"));
+    });
+
+    it("should handle UserIdDoesNotExistError", async () => {
+        const { createVenusService } = await import("@fern-api/core");
+        const mockInviteUser = vi.fn().mockResolvedValue({
+            ok: false,
+            error: {
+                _visit: (visitor: Record<string, () => void>) => visitor.userIdDoesNotExistError()
+            }
+        });
+        vi.mocked(createVenusService).mockReturnValue({
+            organization: { inviteUser: mockInviteUser }
+        } as ReturnType<typeof createVenusService>);
+
+        const context = createMockContext();
+        await expect(
+            cmd.handle(context, { email: "user@example.com", org: "acme" } as InviteMemberCommand.Args)
+        ).rejects.toThrow(CliError);
+
+        expect(context.stderr.error).toHaveBeenCalledWith(expect.stringContaining("No user found with email"));
+    });
+
+    it("should handle unknown errors", async () => {
+        const { createVenusService } = await import("@fern-api/core");
+        const mockInviteUser = vi.fn().mockResolvedValue({
+            ok: false,
+            error: {
+                _visit: (visitor: Record<string, () => void>) => visitor._other()
+            }
+        });
+        vi.mocked(createVenusService).mockReturnValue({
+            organization: { inviteUser: mockInviteUser }
+        } as ReturnType<typeof createVenusService>);
+
+        const context = createMockContext();
+        await expect(
+            cmd.handle(context, { email: "user@example.com", org: "acme" } as InviteMemberCommand.Args)
+        ).rejects.toThrow(CliError);
+
+        expect(context.stderr.error).toHaveBeenCalledWith(expect.stringContaining("Failed to invite member"));
+    });
+});

--- a/packages/cli/cli-v2/src/commands/org/member/add/__test__/command.test.ts
+++ b/packages/cli/cli-v2/src/commands/org/member/add/__test__/command.test.ts
@@ -33,6 +33,13 @@ function createMockContext(tokenType: "user" | "organization" = "user") {
     } as unknown as import("../../../../../context/Context.js").Context;
 }
 
+function mockOrgLookupSuccess() {
+    return vi.fn().mockResolvedValue({
+        ok: true,
+        body: { auth0Id: "org_abc123" }
+    });
+}
+
 describe("InviteMemberCommand", () => {
     let cmd: InviteMemberCommand;
 
@@ -43,17 +50,19 @@ describe("InviteMemberCommand", () => {
 
     it("should invite a member successfully", async () => {
         const { createVenusService } = await import("@fern-api/core");
+        const mockGet = mockOrgLookupSuccess();
         const mockInviteUser = vi.fn().mockResolvedValue({ ok: true });
         vi.mocked(createVenusService).mockReturnValue({
-            organization: { inviteUser: mockInviteUser }
+            organization: { get: mockGet, inviteUser: mockInviteUser }
         } as ReturnType<typeof createVenusService>);
 
         const context = createMockContext();
         await cmd.handle(context, { email: "user@example.com", org: "acme" } as InviteMemberCommand.Args);
 
+        expect(mockGet).toHaveBeenCalledWith("acme");
         expect(mockInviteUser).toHaveBeenCalledWith({
             emailAddress: "user@example.com",
-            auth0OrgId: "acme"
+            auth0OrgId: "org_abc123"
         });
         expect(context.stderr.info).toHaveBeenCalledWith(expect.stringContaining("Invited"));
     });
@@ -70,8 +79,31 @@ describe("InviteMemberCommand", () => {
         );
     });
 
-    it("should handle UnauthorizedError", async () => {
+    it("should handle org lookup failure", async () => {
         const { createVenusService } = await import("@fern-api/core");
+        const mockGet = vi.fn().mockResolvedValue({
+            ok: false,
+            error: {
+                _visit: (visitor: Record<string, () => void>) => visitor.unauthorizedError()
+            }
+        });
+        vi.mocked(createVenusService).mockReturnValue({
+            organization: { get: mockGet }
+        } as ReturnType<typeof createVenusService>);
+
+        const context = createMockContext();
+        await expect(
+            cmd.handle(context, { email: "user@example.com", org: "acme" } as InviteMemberCommand.Args)
+        ).rejects.toThrow(CliError);
+
+        expect(context.stderr.error).toHaveBeenCalledWith(
+            expect.stringContaining("do not have access to organization")
+        );
+    });
+
+    it("should handle UnauthorizedError from inviteUser", async () => {
+        const { createVenusService } = await import("@fern-api/core");
+        const mockGet = mockOrgLookupSuccess();
         const mockInviteUser = vi.fn().mockResolvedValue({
             ok: false,
             error: {
@@ -79,7 +111,7 @@ describe("InviteMemberCommand", () => {
             }
         });
         vi.mocked(createVenusService).mockReturnValue({
-            organization: { inviteUser: mockInviteUser }
+            organization: { get: mockGet, inviteUser: mockInviteUser }
         } as ReturnType<typeof createVenusService>);
 
         const context = createMockContext();
@@ -92,6 +124,7 @@ describe("InviteMemberCommand", () => {
 
     it("should handle UserIdDoesNotExistError", async () => {
         const { createVenusService } = await import("@fern-api/core");
+        const mockGet = mockOrgLookupSuccess();
         const mockInviteUser = vi.fn().mockResolvedValue({
             ok: false,
             error: {
@@ -99,7 +132,7 @@ describe("InviteMemberCommand", () => {
             }
         });
         vi.mocked(createVenusService).mockReturnValue({
-            organization: { inviteUser: mockInviteUser }
+            organization: { get: mockGet, inviteUser: mockInviteUser }
         } as ReturnType<typeof createVenusService>);
 
         const context = createMockContext();
@@ -112,6 +145,7 @@ describe("InviteMemberCommand", () => {
 
     it("should handle unknown errors", async () => {
         const { createVenusService } = await import("@fern-api/core");
+        const mockGet = mockOrgLookupSuccess();
         const mockInviteUser = vi.fn().mockResolvedValue({
             ok: false,
             error: {
@@ -119,7 +153,7 @@ describe("InviteMemberCommand", () => {
             }
         });
         vi.mocked(createVenusService).mockReturnValue({
-            organization: { inviteUser: mockInviteUser }
+            organization: { get: mockGet, inviteUser: mockInviteUser }
         } as ReturnType<typeof createVenusService>);
 
         const context = createMockContext();

--- a/packages/cli/cli-v2/src/commands/org/member/add/__test__/command.test.ts
+++ b/packages/cli/cli-v2/src/commands/org/member/add/__test__/command.test.ts
@@ -54,7 +54,7 @@ describe("InviteMemberCommand", () => {
         const mockInviteUser = vi.fn().mockResolvedValue({ ok: true });
         vi.mocked(createVenusService).mockReturnValue({
             organization: { get: mockGet, inviteUser: mockInviteUser }
-        } as ReturnType<typeof createVenusService>);
+        } as unknown as ReturnType<typeof createVenusService>);
 
         const context = createMockContext();
         await cmd.handle(context, { email: "user@example.com", org: "acme" } as InviteMemberCommand.Args);
@@ -84,12 +84,12 @@ describe("InviteMemberCommand", () => {
         const mockGet = vi.fn().mockResolvedValue({
             ok: false,
             error: {
-                _visit: (visitor: Record<string, () => void>) => visitor.unauthorizedError()
+                _visit: (visitor: any) => visitor.unauthorizedError()
             }
         });
         vi.mocked(createVenusService).mockReturnValue({
             organization: { get: mockGet }
-        } as ReturnType<typeof createVenusService>);
+        } as unknown as ReturnType<typeof createVenusService>);
 
         const context = createMockContext();
         await expect(
@@ -107,12 +107,12 @@ describe("InviteMemberCommand", () => {
         const mockInviteUser = vi.fn().mockResolvedValue({
             ok: false,
             error: {
-                _visit: (visitor: Record<string, () => void>) => visitor.unauthorizedError()
+                _visit: (visitor: any) => visitor.unauthorizedError()
             }
         });
         vi.mocked(createVenusService).mockReturnValue({
             organization: { get: mockGet, inviteUser: mockInviteUser }
-        } as ReturnType<typeof createVenusService>);
+        } as unknown as ReturnType<typeof createVenusService>);
 
         const context = createMockContext();
         await expect(
@@ -128,12 +128,12 @@ describe("InviteMemberCommand", () => {
         const mockInviteUser = vi.fn().mockResolvedValue({
             ok: false,
             error: {
-                _visit: (visitor: Record<string, () => void>) => visitor.userIdDoesNotExistError()
+                _visit: (visitor: any) => visitor.userIdDoesNotExistError()
             }
         });
         vi.mocked(createVenusService).mockReturnValue({
             organization: { get: mockGet, inviteUser: mockInviteUser }
-        } as ReturnType<typeof createVenusService>);
+        } as unknown as ReturnType<typeof createVenusService>);
 
         const context = createMockContext();
         await expect(
@@ -149,12 +149,12 @@ describe("InviteMemberCommand", () => {
         const mockInviteUser = vi.fn().mockResolvedValue({
             ok: false,
             error: {
-                _visit: (visitor: Record<string, () => void>) => visitor._other()
+                _visit: (visitor: any) => visitor._other()
             }
         });
         vi.mocked(createVenusService).mockReturnValue({
             organization: { get: mockGet, inviteUser: mockInviteUser }
-        } as ReturnType<typeof createVenusService>);
+        } as unknown as ReturnType<typeof createVenusService>);
 
         const context = createMockContext();
         await expect(

--- a/packages/cli/cli-v2/src/commands/org/member/add/__test__/command.test.ts
+++ b/packages/cli/cli-v2/src/commands/org/member/add/__test__/command.test.ts
@@ -67,6 +67,27 @@ describe("InviteMemberCommand", () => {
         expect(context.stderr.info).toHaveBeenCalledWith(expect.stringContaining("Invited"));
     });
 
+    it("should output JSON when --json flag is set", async () => {
+        const { createVenusService } = await import("@fern-api/core");
+        const mockGet = mockOrgLookupSuccess();
+        const mockInviteUser = vi.fn().mockResolvedValue({ ok: true });
+        vi.mocked(createVenusService).mockReturnValue({
+            organization: { get: mockGet, inviteUser: mockInviteUser }
+        } as unknown as ReturnType<typeof createVenusService>);
+
+        const context = createMockContext();
+        await cmd.handle(context, {
+            email: "user@example.com",
+            org: "acme",
+            json: true
+        } as InviteMemberCommand.Args);
+
+        expect(context.stdout.info).toHaveBeenCalledWith(
+            JSON.stringify({ success: true, email: "user@example.com", org: "acme" }, null, 2)
+        );
+        expect(context.stderr.info).not.toHaveBeenCalled();
+    });
+
     it("should reject organization tokens", async () => {
         const context = createMockContext("organization");
 

--- a/packages/cli/cli-v2/src/commands/org/member/add/command.ts
+++ b/packages/cli/cli-v2/src/commands/org/member/add/command.ts
@@ -28,12 +28,28 @@ export class AddMemberCommand {
 
         const venus = createVenusService({ token: token.value });
 
+        const orgLookup = await venus.organization.get(args.org);
+        if (!orgLookup.ok) {
+            orgLookup.error._visit({
+                unauthorizedError: () => {
+                    context.stderr.error(`${Icons.error} You do not have access to organization "${args.org}".`);
+                    throw CliError.exit();
+                },
+                _other: () => {
+                    context.stderr.error(`${Icons.error} Organization "${args.org}" was not found.`);
+                    throw CliError.exit();
+                }
+            });
+            return;
+        }
+        const auth0OrgId = orgLookup.body.auth0Id;
+
         const response = await withSpinner({
             message: `Inviting "${args.email}" to organization "${args.org}"`,
             operation: () =>
                 venus.organization.inviteUser({
                     emailAddress: args.email,
-                    auth0OrgId: args.org
+                    auth0OrgId
                 })
         });
 
@@ -82,7 +98,7 @@ export function addAddMemberCommand(cli: Argv<GlobalArgs>): void {
                 .positional("org", {
                     type: "string",
                     demandOption: true,
-                    description: "Organization ID"
+                    description: "Organization name (e.g. acme)"
                 })
                 .example(
                     "$0 org member add user@example.com acme",

--- a/packages/cli/cli-v2/src/commands/org/member/add/command.ts
+++ b/packages/cli/cli-v2/src/commands/org/member/add/command.ts
@@ -8,15 +8,15 @@ import { Icons } from "../../../../ui/format.js";
 import { withSpinner } from "../../../../ui/withSpinner.js";
 import { command } from "../../../_internal/command.js";
 
-export declare namespace AddMemberCommand {
+export declare namespace InviteMemberCommand {
     export interface Args extends GlobalArgs {
         email: string;
         org: string;
     }
 }
 
-export class AddMemberCommand {
-    public async handle(context: Context, args: AddMemberCommand.Args): Promise<void> {
+export class InviteMemberCommand {
+    public async handle(context: Context, args: InviteMemberCommand.Args): Promise<void> {
         const token = await context.getTokenOrPrompt();
 
         if (token.type === "organization") {
@@ -80,16 +80,16 @@ export class AddMemberCommand {
     }
 }
 
-export function addAddMemberCommand(cli: Argv<GlobalArgs>): void {
-    const cmd = new AddMemberCommand();
+export function addInviteMemberCommand(cli: Argv<GlobalArgs>): void {
+    const cmd = new InviteMemberCommand();
     command(
         cli,
-        "add <email> <org>",
+        "invite <email> <org>",
         "Invite a user to an organization",
-        (context, args) => cmd.handle(context, args as AddMemberCommand.Args),
+        (context, args) => cmd.handle(context, args as InviteMemberCommand.Args),
         (yargs) =>
             yargs
-                .usage("\nUsage:\n  $0 org member add <email> <org>")
+                .usage("\nUsage:\n  $0 org member invite <email> <org>")
                 .positional("email", {
                     type: "string",
                     demandOption: true,
@@ -101,7 +101,7 @@ export function addAddMemberCommand(cli: Argv<GlobalArgs>): void {
                     description: "Organization name (e.g. acme)"
                 })
                 .example(
-                    "$0 org member add user@example.com acme",
+                    "$0 org member invite user@example.com acme",
                     "# Invite user@example.com to the 'acme' organization"
                 )
     );

--- a/packages/cli/cli-v2/src/commands/org/member/add/command.ts
+++ b/packages/cli/cli-v2/src/commands/org/member/add/command.ts
@@ -19,6 +19,13 @@ export class AddMemberCommand {
     public async handle(context: Context, args: AddMemberCommand.Args): Promise<void> {
         const token = await context.getTokenOrPrompt();
 
+        if (token.type === "organization") {
+            context.stderr.error(
+                `${Icons.error} Organization tokens cannot manage members. Unset the FERN_TOKEN environment variable and run 'fern auth login' to manage members.`
+            );
+            throw CliError.exit();
+        }
+
         const venus = createVenusService({ token: token.value });
 
         const response = await withSpinner({

--- a/packages/cli/cli-v2/src/commands/org/member/add/command.ts
+++ b/packages/cli/cli-v2/src/commands/org/member/add/command.ts
@@ -1,0 +1,85 @@
+import { createVenusService } from "@fern-api/core";
+import type { Argv } from "yargs";
+
+import type { Context } from "../../../../context/Context.js";
+import type { GlobalArgs } from "../../../../context/GlobalArgs.js";
+import { CliError } from "../../../../errors/CliError.js";
+import { Icons } from "../../../../ui/format.js";
+import { withSpinner } from "../../../../ui/withSpinner.js";
+import { command } from "../../../_internal/command.js";
+
+export declare namespace AddMemberCommand {
+    export interface Args extends GlobalArgs {
+        email: string;
+        org: string;
+    }
+}
+
+export class AddMemberCommand {
+    public async handle(context: Context, args: AddMemberCommand.Args): Promise<void> {
+        const token = await context.getTokenOrPrompt();
+
+        const venus = createVenusService({ token: token.value });
+
+        const response = await withSpinner({
+            message: `Inviting "${args.email}" to organization "${args.org}"`,
+            operation: () =>
+                venus.organization.inviteUser({
+                    emailAddress: args.email,
+                    auth0OrgId: args.org
+                })
+        });
+
+        if (response.ok) {
+            context.stderr.info(`${Icons.success} Invited "${args.email}" to organization "${args.org}".`);
+            return;
+        }
+
+        response.error._visit({
+            unauthorizedError: () => {
+                context.stderr.error(
+                    `${Icons.error} You do not have permission to invite members to organization "${args.org}".`
+                );
+                throw CliError.exit();
+            },
+            userIdDoesNotExistError: () => {
+                context.stderr.error(`${Icons.error} No user found with email "${args.email}".`);
+                throw CliError.exit();
+            },
+            _other: () => {
+                context.stderr.error(
+                    `${Icons.error} Failed to invite member.\n` +
+                        `\n  Please contact support@buildwithfern.com for assistance.`
+                );
+                throw CliError.exit();
+            }
+        });
+    }
+}
+
+export function addAddMemberCommand(cli: Argv<GlobalArgs>): void {
+    const cmd = new AddMemberCommand();
+    command(
+        cli,
+        "add <email> <org>",
+        "Invite a user to an organization",
+        (context, args) => cmd.handle(context, args as AddMemberCommand.Args),
+        (yargs) =>
+            yargs
+                .usage("\nUsage:\n  $0 org member add <email> <org>")
+                .positional("email", {
+                    type: "string",
+                    demandOption: true,
+                    description: "Email address of the user to invite"
+                })
+                .positional("org", {
+                    type: "string",
+                    demandOption: true,
+                    description: "Organization ID"
+                })
+                .example(
+                    "$0 org member add user@example.com acme",
+                    "# Invite user@example.com to the 'acme' organization"
+                )
+    );
+}

--- a/packages/cli/cli-v2/src/commands/org/member/add/command.ts
+++ b/packages/cli/cli-v2/src/commands/org/member/add/command.ts
@@ -12,6 +12,7 @@ export declare namespace InviteMemberCommand {
     export interface Args extends GlobalArgs {
         email: string;
         org: string;
+        json: boolean;
     }
 }
 
@@ -54,7 +55,11 @@ export class InviteMemberCommand {
         });
 
         if (response.ok) {
-            context.stderr.info(`${Icons.success} Invited "${args.email}" to organization "${args.org}".`);
+            if (args.json) {
+                context.stdout.info(JSON.stringify({ success: true, email: args.email, org: args.org }, null, 2));
+            } else {
+                context.stderr.info(`${Icons.success} Invited "${args.email}" to organization "${args.org}".`);
+            }
             return;
         }
 
@@ -99,6 +104,11 @@ export function addInviteMemberCommand(cli: Argv<GlobalArgs>): void {
                     type: "string",
                     demandOption: true,
                     description: "Organization name (e.g. acme)"
+                })
+                .option("json", {
+                    type: "boolean",
+                    default: false,
+                    description: "Output as JSON"
                 })
                 .example(
                     "$0 org member invite user@example.com acme",

--- a/packages/cli/cli-v2/src/commands/org/member/add/index.ts
+++ b/packages/cli/cli-v2/src/commands/org/member/add/index.ts
@@ -1,0 +1,1 @@
+export { addAddMemberCommand } from "./command.js";

--- a/packages/cli/cli-v2/src/commands/org/member/add/index.ts
+++ b/packages/cli/cli-v2/src/commands/org/member/add/index.ts
@@ -1,1 +1,1 @@
-export { addAddMemberCommand } from "./command.js";
+export { addInviteMemberCommand } from "./command.js";

--- a/packages/cli/cli-v2/src/commands/org/member/command.ts
+++ b/packages/cli/cli-v2/src/commands/org/member/command.ts
@@ -2,13 +2,13 @@ import type { Argv } from "yargs";
 
 import type { GlobalArgs } from "../../../context/GlobalArgs.js";
 import { commandGroup } from "../../_internal/commandGroup.js";
-import { addAddMemberCommand } from "./add/index.js";
+import { addInviteMemberCommand } from "./add/index.js";
 import { addListMembersCommand } from "./list/index.js";
 import { addRemoveMemberCommand } from "./remove/index.js";
 
 export function addMemberCommand(cli: Argv<GlobalArgs>): void {
     commandGroup(cli, "member", "Manage organization members", [
-        addAddMemberCommand,
+        addInviteMemberCommand,
         addListMembersCommand,
         addRemoveMemberCommand
     ]);

--- a/packages/cli/cli-v2/src/commands/org/member/command.ts
+++ b/packages/cli/cli-v2/src/commands/org/member/command.ts
@@ -1,0 +1,15 @@
+import type { Argv } from "yargs";
+
+import type { GlobalArgs } from "../../../context/GlobalArgs.js";
+import { commandGroup } from "../../_internal/commandGroup.js";
+import { addAddMemberCommand } from "./add/index.js";
+import { addListMembersCommand } from "./list/index.js";
+import { addRemoveMemberCommand } from "./remove/index.js";
+
+export function addMemberCommand(cli: Argv<GlobalArgs>): void {
+    commandGroup(cli, "member", "Manage organization members", [
+        addAddMemberCommand,
+        addListMembersCommand,
+        addRemoveMemberCommand
+    ]);
+}

--- a/packages/cli/cli-v2/src/commands/org/member/index.ts
+++ b/packages/cli/cli-v2/src/commands/org/member/index.ts
@@ -1,0 +1,1 @@
+export { addMemberCommand } from "./command.js";

--- a/packages/cli/cli-v2/src/commands/org/member/list/__test__/command.test.ts
+++ b/packages/cli/cli-v2/src/commands/org/member/list/__test__/command.test.ts
@@ -63,6 +63,36 @@ describe("ListMembersCommand", () => {
         expect(context.stdout.info).toHaveBeenCalledTimes(2);
     });
 
+    it("should output JSON when --json flag is set", async () => {
+        const { createVenusService } = await import("@fern-api/core");
+        const mockGet = vi.fn().mockResolvedValue({
+            ok: true,
+            body: {
+                users: [
+                    { userId: "user1", displayName: "Alice", emailAddress: "alice@example.com" },
+                    { userId: "user2", displayName: "Bob", emailAddress: null }
+                ]
+            }
+        });
+        vi.mocked(createVenusService).mockReturnValue({
+            organization: { get: mockGet }
+        } as unknown as ReturnType<typeof createVenusService>);
+
+        const context = createMockContext();
+        await cmd.handle(context, { org: "acme", json: true } as ListMembersCommand.Args);
+
+        expect(context.stdout.info).toHaveBeenCalledWith(
+            JSON.stringify(
+                [
+                    { userId: "user1", displayName: "Alice", email: "alice@example.com" },
+                    { userId: "user2", displayName: "Bob", email: null }
+                ],
+                null,
+                2
+            )
+        );
+    });
+
     it("should show empty message when no members", async () => {
         const { createVenusService } = await import("@fern-api/core");
         const mockGet = vi.fn().mockResolvedValue({

--- a/packages/cli/cli-v2/src/commands/org/member/list/__test__/command.test.ts
+++ b/packages/cli/cli-v2/src/commands/org/member/list/__test__/command.test.ts
@@ -54,7 +54,7 @@ describe("ListMembersCommand", () => {
         });
         vi.mocked(createVenusService).mockReturnValue({
             organization: { get: mockGet }
-        } as ReturnType<typeof createVenusService>);
+        } as unknown as ReturnType<typeof createVenusService>);
 
         const context = createMockContext();
         await cmd.handle(context, { org: "acme" } as ListMembersCommand.Args);
@@ -71,7 +71,7 @@ describe("ListMembersCommand", () => {
         });
         vi.mocked(createVenusService).mockReturnValue({
             organization: { get: mockGet }
-        } as ReturnType<typeof createVenusService>);
+        } as unknown as ReturnType<typeof createVenusService>);
 
         const context = createMockContext();
         await cmd.handle(context, { org: "acme" } as ListMembersCommand.Args);
@@ -94,12 +94,12 @@ describe("ListMembersCommand", () => {
         const mockGet = vi.fn().mockResolvedValue({
             ok: false,
             error: {
-                _visit: (visitor: Record<string, () => void>) => visitor.unauthorizedError()
+                _visit: (visitor: any) => visitor.unauthorizedError()
             }
         });
         vi.mocked(createVenusService).mockReturnValue({
             organization: { get: mockGet }
-        } as ReturnType<typeof createVenusService>);
+        } as unknown as ReturnType<typeof createVenusService>);
 
         const context = createMockContext();
         await expect(cmd.handle(context, { org: "acme" } as ListMembersCommand.Args)).rejects.toThrow(CliError);
@@ -114,12 +114,12 @@ describe("ListMembersCommand", () => {
         const mockGet = vi.fn().mockResolvedValue({
             ok: false,
             error: {
-                _visit: (visitor: Record<string, () => void>) => visitor._other()
+                _visit: (visitor: any) => visitor._other()
             }
         });
         vi.mocked(createVenusService).mockReturnValue({
             organization: { get: mockGet }
-        } as ReturnType<typeof createVenusService>);
+        } as unknown as ReturnType<typeof createVenusService>);
 
         const context = createMockContext();
         await expect(cmd.handle(context, { org: "acme" } as ListMembersCommand.Args)).rejects.toThrow(CliError);

--- a/packages/cli/cli-v2/src/commands/org/member/list/__test__/command.test.ts
+++ b/packages/cli/cli-v2/src/commands/org/member/list/__test__/command.test.ts
@@ -94,7 +94,7 @@ describe("ListMembersCommand", () => {
         const mockGet = vi.fn().mockResolvedValue({
             ok: false,
             error: {
-                _visit: (visitor: any) => visitor.unauthorizedError()
+                _visit: (visitor: { unauthorizedError: () => void }) => visitor.unauthorizedError()
             }
         });
         vi.mocked(createVenusService).mockReturnValue({
@@ -114,7 +114,7 @@ describe("ListMembersCommand", () => {
         const mockGet = vi.fn().mockResolvedValue({
             ok: false,
             error: {
-                _visit: (visitor: any) => visitor._other()
+                _visit: (visitor: { _other: () => void }) => visitor._other()
             }
         });
         vi.mocked(createVenusService).mockReturnValue({

--- a/packages/cli/cli-v2/src/commands/org/member/list/__test__/command.test.ts
+++ b/packages/cli/cli-v2/src/commands/org/member/list/__test__/command.test.ts
@@ -1,0 +1,129 @@
+import type { Logger } from "@fern-api/logger";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { CliError } from "../../../../../errors/CliError.js";
+import { ListMembersCommand } from "../command.js";
+
+vi.mock("@fern-api/core", () => ({
+    createVenusService: vi.fn()
+}));
+
+vi.mock("../../../../../ui/withSpinner.js", () => ({
+    withSpinner: vi.fn(({ operation }: { operation: () => Promise<unknown> }) => operation())
+}));
+
+function createMockLogger(): Logger {
+    return {
+        disable: vi.fn(),
+        enable: vi.fn(),
+        trace: vi.fn(),
+        debug: vi.fn(),
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+        log: vi.fn()
+    };
+}
+
+function createMockContext(tokenType: "user" | "organization" = "user") {
+    return {
+        stdout: createMockLogger(),
+        stderr: createMockLogger(),
+        getTokenOrPrompt: vi.fn().mockResolvedValue({ type: tokenType, value: "test-token" })
+    } as unknown as import("../../../../../context/Context.js").Context;
+}
+
+describe("ListMembersCommand", () => {
+    let cmd: ListMembersCommand;
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+        cmd = new ListMembersCommand();
+    });
+
+    it("should list members successfully", async () => {
+        const { createVenusService } = await import("@fern-api/core");
+        const mockGet = vi.fn().mockResolvedValue({
+            ok: true,
+            body: {
+                users: [
+                    { userId: "user1", displayName: "Alice", emailAddress: "alice@example.com" },
+                    { userId: "user2", displayName: "Bob", emailAddress: null }
+                ]
+            }
+        });
+        vi.mocked(createVenusService).mockReturnValue({
+            organization: { get: mockGet }
+        } as ReturnType<typeof createVenusService>);
+
+        const context = createMockContext();
+        await cmd.handle(context, { org: "acme" } as ListMembersCommand.Args);
+
+        expect(mockGet).toHaveBeenCalledWith("acme");
+        expect(context.stdout.info).toHaveBeenCalledTimes(2);
+    });
+
+    it("should show empty message when no members", async () => {
+        const { createVenusService } = await import("@fern-api/core");
+        const mockGet = vi.fn().mockResolvedValue({
+            ok: true,
+            body: { users: [] }
+        });
+        vi.mocked(createVenusService).mockReturnValue({
+            organization: { get: mockGet }
+        } as ReturnType<typeof createVenusService>);
+
+        const context = createMockContext();
+        await cmd.handle(context, { org: "acme" } as ListMembersCommand.Args);
+
+        expect(context.stderr.info).toHaveBeenCalledWith(expect.stringContaining("No members found"));
+    });
+
+    it("should reject organization tokens", async () => {
+        const context = createMockContext("organization");
+
+        await expect(cmd.handle(context, { org: "acme" } as ListMembersCommand.Args)).rejects.toThrow(CliError);
+
+        expect(context.stderr.error).toHaveBeenCalledWith(
+            expect.stringContaining("Organization tokens cannot list members")
+        );
+    });
+
+    it("should handle UnauthorizedError", async () => {
+        const { createVenusService } = await import("@fern-api/core");
+        const mockGet = vi.fn().mockResolvedValue({
+            ok: false,
+            error: {
+                _visit: (visitor: Record<string, () => void>) => visitor.unauthorizedError()
+            }
+        });
+        vi.mocked(createVenusService).mockReturnValue({
+            organization: { get: mockGet }
+        } as ReturnType<typeof createVenusService>);
+
+        const context = createMockContext();
+        await expect(cmd.handle(context, { org: "acme" } as ListMembersCommand.Args)).rejects.toThrow(CliError);
+
+        expect(context.stderr.error).toHaveBeenCalledWith(
+            expect.stringContaining("do not have access to organization")
+        );
+    });
+
+    it("should handle unknown errors", async () => {
+        const { createVenusService } = await import("@fern-api/core");
+        const mockGet = vi.fn().mockResolvedValue({
+            ok: false,
+            error: {
+                _visit: (visitor: Record<string, () => void>) => visitor._other()
+            }
+        });
+        vi.mocked(createVenusService).mockReturnValue({
+            organization: { get: mockGet }
+        } as ReturnType<typeof createVenusService>);
+
+        const context = createMockContext();
+        await expect(cmd.handle(context, { org: "acme" } as ListMembersCommand.Args)).rejects.toThrow(CliError);
+
+        expect(context.stderr.error).toHaveBeenCalledWith(expect.stringContaining("Failed to list members"));
+    });
+});

--- a/packages/cli/cli-v2/src/commands/org/member/list/command.ts
+++ b/packages/cli/cli-v2/src/commands/org/member/list/command.ts
@@ -54,7 +54,7 @@ export class ListMembersCommand {
         if (members.length === 0) {
             context.stderr.info(`${Icons.info} No members found in organization "${args.org}".`);
             context.stderr.info("");
-            context.stderr.info("  To invite someone, run: fern org member add <email> <org>");
+            context.stderr.info("  To invite someone, run: fern org member invite <email> <org>");
             return;
         }
 

--- a/packages/cli/cli-v2/src/commands/org/member/list/command.ts
+++ b/packages/cli/cli-v2/src/commands/org/member/list/command.ts
@@ -18,6 +18,13 @@ export class ListMembersCommand {
     public async handle(context: Context, args: ListMembersCommand.Args): Promise<void> {
         const token = await context.getTokenOrPrompt();
 
+        if (token.type === "organization") {
+            context.stderr.error(
+                `${Icons.error} Organization tokens cannot list members. Unset the FERN_TOKEN environment variable and run 'fern auth login' to list members.`
+            );
+            throw CliError.exit();
+        }
+
         const venus = createVenusService({ token: token.value });
 
         const response = await withSpinner({
@@ -53,7 +60,7 @@ export class ListMembersCommand {
 
         for (const member of members) {
             const email = member.emailAddress != null ? `  ${Colors.dim(`<${member.emailAddress}>`)}` : "";
-            context.stdout.info(`${member.displayName}${email}`);
+            context.stdout.info(`${Colors.dim(member.userId)}  ${member.displayName}${email}`);
         }
     }
 }

--- a/packages/cli/cli-v2/src/commands/org/member/list/command.ts
+++ b/packages/cli/cli-v2/src/commands/org/member/list/command.ts
@@ -78,7 +78,7 @@ export function addListMembersCommand(cli: Argv<GlobalArgs>): void {
                 .positional("org", {
                     type: "string",
                     demandOption: true,
-                    description: "Organization ID"
+                    description: "Organization name (e.g. acme)"
                 })
                 .example("$0 org member list acme", "# List all members of the 'acme' organization")
     );

--- a/packages/cli/cli-v2/src/commands/org/member/list/command.ts
+++ b/packages/cli/cli-v2/src/commands/org/member/list/command.ts
@@ -1,0 +1,78 @@
+import { createVenusService } from "@fern-api/core";
+import type { Argv } from "yargs";
+
+import type { Context } from "../../../../context/Context.js";
+import type { GlobalArgs } from "../../../../context/GlobalArgs.js";
+import { CliError } from "../../../../errors/CliError.js";
+import { Colors, Icons } from "../../../../ui/format.js";
+import { withSpinner } from "../../../../ui/withSpinner.js";
+import { command } from "../../../_internal/command.js";
+
+export declare namespace ListMembersCommand {
+    export interface Args extends GlobalArgs {
+        org: string;
+    }
+}
+
+export class ListMembersCommand {
+    public async handle(context: Context, args: ListMembersCommand.Args): Promise<void> {
+        const token = await context.getTokenOrPrompt();
+
+        const venus = createVenusService({ token: token.value });
+
+        const response = await withSpinner({
+            message: `Fetching members of organization "${args.org}"`,
+            operation: () => venus.organization.get(args.org)
+        });
+
+        if (!response.ok) {
+            response.error._visit({
+                unauthorizedError: () => {
+                    context.stderr.error(`${Icons.error} You do not have access to organization "${args.org}".`);
+                    throw CliError.exit();
+                },
+                _other: () => {
+                    context.stderr.error(
+                        `${Icons.error} Failed to list members.\n` +
+                            `\n  Please contact support@buildwithfern.com for assistance.`
+                    );
+                    throw CliError.exit();
+                }
+            });
+            return;
+        }
+
+        const members = response.body.users;
+
+        if (members.length === 0) {
+            context.stderr.info(`${Icons.info} No members found in organization "${args.org}".`);
+            context.stderr.info("");
+            context.stderr.info("  To invite someone, run: fern org member add <email> <org>");
+            return;
+        }
+
+        for (const member of members) {
+            const email = member.emailAddress != null ? `  ${Colors.dim(`<${member.emailAddress}>`)}` : "";
+            context.stdout.info(`${member.displayName}${email}`);
+        }
+    }
+}
+
+export function addListMembersCommand(cli: Argv<GlobalArgs>): void {
+    const cmd = new ListMembersCommand();
+    command(
+        cli,
+        "list <org>",
+        "List members of an organization",
+        (context, args) => cmd.handle(context, args as ListMembersCommand.Args),
+        (yargs) =>
+            yargs
+                .usage("\nUsage:\n  $0 org member list <org>")
+                .positional("org", {
+                    type: "string",
+                    demandOption: true,
+                    description: "Organization ID"
+                })
+                .example("$0 org member list acme", "# List all members of the 'acme' organization")
+    );
+}

--- a/packages/cli/cli-v2/src/commands/org/member/list/command.ts
+++ b/packages/cli/cli-v2/src/commands/org/member/list/command.ts
@@ -11,6 +11,7 @@ import { command } from "../../../_internal/command.js";
 export declare namespace ListMembersCommand {
     export interface Args extends GlobalArgs {
         org: string;
+        json: boolean;
     }
 }
 
@@ -51,6 +52,21 @@ export class ListMembersCommand {
 
         const members = response.body.users;
 
+        if (args.json) {
+            context.stdout.info(
+                JSON.stringify(
+                    members.map((m) => ({
+                        userId: m.userId,
+                        displayName: m.displayName,
+                        email: m.emailAddress ?? null
+                    })),
+                    null,
+                    2
+                )
+            );
+            return;
+        }
+
         if (members.length === 0) {
             context.stderr.info(`${Icons.info} No members found in organization "${args.org}".`);
             context.stderr.info("");
@@ -79,6 +95,11 @@ export function addListMembersCommand(cli: Argv<GlobalArgs>): void {
                     type: "string",
                     demandOption: true,
                     description: "Organization name (e.g. acme)"
+                })
+                .option("json", {
+                    type: "boolean",
+                    default: false,
+                    description: "Output as JSON"
                 })
                 .example("$0 org member list acme", "# List all members of the 'acme' organization")
     );

--- a/packages/cli/cli-v2/src/commands/org/member/list/index.ts
+++ b/packages/cli/cli-v2/src/commands/org/member/list/index.ts
@@ -1,0 +1,1 @@
+export { addListMembersCommand } from "./command.js";

--- a/packages/cli/cli-v2/src/commands/org/member/remove/__test__/command.test.ts
+++ b/packages/cli/cli-v2/src/commands/org/member/remove/__test__/command.test.ts
@@ -33,6 +33,13 @@ function createMockContext(tokenType: "user" | "organization" = "user") {
     } as unknown as import("../../../../../context/Context.js").Context;
 }
 
+function mockOrgLookupSuccess() {
+    return vi.fn().mockResolvedValue({
+        ok: true,
+        body: { auth0Id: "org_abc123" }
+    });
+}
+
 describe("RemoveMemberCommand", () => {
     let cmd: RemoveMemberCommand;
 
@@ -43,17 +50,19 @@ describe("RemoveMemberCommand", () => {
 
     it("should remove a member successfully", async () => {
         const { createVenusService } = await import("@fern-api/core");
+        const mockGet = mockOrgLookupSuccess();
         const mockRemoveUser = vi.fn().mockResolvedValue({ ok: true });
         vi.mocked(createVenusService).mockReturnValue({
-            organization: { removeUser: mockRemoveUser }
+            organization: { get: mockGet, removeUser: mockRemoveUser }
         } as ReturnType<typeof createVenusService>);
 
         const context = createMockContext();
-        await cmd.handle(context, { "user-id": "user123", org: "acme" } as RemoveMemberCommand.Args);
+        await cmd.handle(context, { userId: "user123", org: "acme" } as RemoveMemberCommand.Args);
 
+        expect(mockGet).toHaveBeenCalledWith("acme");
         expect(mockRemoveUser).toHaveBeenCalledWith({
             userId: "user123",
-            auth0OrgId: "acme"
+            auth0OrgId: "org_abc123"
         });
         expect(context.stderr.info).toHaveBeenCalledWith(expect.stringContaining("Removed user"));
     });
@@ -62,7 +71,7 @@ describe("RemoveMemberCommand", () => {
         const context = createMockContext("organization");
 
         await expect(
-            cmd.handle(context, { "user-id": "user123", org: "acme" } as RemoveMemberCommand.Args)
+            cmd.handle(context, { userId: "user123", org: "acme" } as RemoveMemberCommand.Args)
         ).rejects.toThrow(CliError);
 
         expect(context.stderr.error).toHaveBeenCalledWith(
@@ -70,8 +79,29 @@ describe("RemoveMemberCommand", () => {
         );
     });
 
-    it("should handle UnauthorizedError", async () => {
+    it("should handle org lookup failure", async () => {
         const { createVenusService } = await import("@fern-api/core");
+        const mockGet = vi.fn().mockResolvedValue({
+            ok: false,
+            error: {
+                _visit: (visitor: Record<string, () => void>) => visitor._other()
+            }
+        });
+        vi.mocked(createVenusService).mockReturnValue({
+            organization: { get: mockGet }
+        } as ReturnType<typeof createVenusService>);
+
+        const context = createMockContext();
+        await expect(
+            cmd.handle(context, { userId: "user123", org: "acme" } as RemoveMemberCommand.Args)
+        ).rejects.toThrow(CliError);
+
+        expect(context.stderr.error).toHaveBeenCalledWith(expect.stringContaining("was not found"));
+    });
+
+    it("should handle UnauthorizedError from removeUser", async () => {
+        const { createVenusService } = await import("@fern-api/core");
+        const mockGet = mockOrgLookupSuccess();
         const mockRemoveUser = vi.fn().mockResolvedValue({
             ok: false,
             error: {
@@ -79,12 +109,12 @@ describe("RemoveMemberCommand", () => {
             }
         });
         vi.mocked(createVenusService).mockReturnValue({
-            organization: { removeUser: mockRemoveUser }
+            organization: { get: mockGet, removeUser: mockRemoveUser }
         } as ReturnType<typeof createVenusService>);
 
         const context = createMockContext();
         await expect(
-            cmd.handle(context, { "user-id": "user123", org: "acme" } as RemoveMemberCommand.Args)
+            cmd.handle(context, { userId: "user123", org: "acme" } as RemoveMemberCommand.Args)
         ).rejects.toThrow(CliError);
 
         expect(context.stderr.error).toHaveBeenCalledWith(
@@ -94,6 +124,7 @@ describe("RemoveMemberCommand", () => {
 
     it("should handle UserIdDoesNotExistError", async () => {
         const { createVenusService } = await import("@fern-api/core");
+        const mockGet = mockOrgLookupSuccess();
         const mockRemoveUser = vi.fn().mockResolvedValue({
             ok: false,
             error: {
@@ -101,12 +132,12 @@ describe("RemoveMemberCommand", () => {
             }
         });
         vi.mocked(createVenusService).mockReturnValue({
-            organization: { removeUser: mockRemoveUser }
+            organization: { get: mockGet, removeUser: mockRemoveUser }
         } as ReturnType<typeof createVenusService>);
 
         const context = createMockContext();
         await expect(
-            cmd.handle(context, { "user-id": "user123", org: "acme" } as RemoveMemberCommand.Args)
+            cmd.handle(context, { userId: "user123", org: "acme" } as RemoveMemberCommand.Args)
         ).rejects.toThrow(CliError);
 
         expect(context.stderr.error).toHaveBeenCalledWith(expect.stringContaining("was not found"));
@@ -114,6 +145,7 @@ describe("RemoveMemberCommand", () => {
 
     it("should handle unknown errors", async () => {
         const { createVenusService } = await import("@fern-api/core");
+        const mockGet = mockOrgLookupSuccess();
         const mockRemoveUser = vi.fn().mockResolvedValue({
             ok: false,
             error: {
@@ -121,12 +153,12 @@ describe("RemoveMemberCommand", () => {
             }
         });
         vi.mocked(createVenusService).mockReturnValue({
-            organization: { removeUser: mockRemoveUser }
+            organization: { get: mockGet, removeUser: mockRemoveUser }
         } as ReturnType<typeof createVenusService>);
 
         const context = createMockContext();
         await expect(
-            cmd.handle(context, { "user-id": "user123", org: "acme" } as RemoveMemberCommand.Args)
+            cmd.handle(context, { userId: "user123", org: "acme" } as RemoveMemberCommand.Args)
         ).rejects.toThrow(CliError);
 
         expect(context.stderr.error).toHaveBeenCalledWith(expect.stringContaining("Failed to remove member"));

--- a/packages/cli/cli-v2/src/commands/org/member/remove/__test__/command.test.ts
+++ b/packages/cli/cli-v2/src/commands/org/member/remove/__test__/command.test.ts
@@ -67,6 +67,23 @@ describe("RemoveMemberCommand", () => {
         expect(context.stderr.info).toHaveBeenCalledWith(expect.stringContaining("Removed user"));
     });
 
+    it("should output JSON when --json flag is set", async () => {
+        const { createVenusService } = await import("@fern-api/core");
+        const mockGet = mockOrgLookupSuccess();
+        const mockRemoveUser = vi.fn().mockResolvedValue({ ok: true });
+        vi.mocked(createVenusService).mockReturnValue({
+            organization: { get: mockGet, removeUser: mockRemoveUser }
+        } as unknown as ReturnType<typeof createVenusService>);
+
+        const context = createMockContext();
+        await cmd.handle(context, { userId: "user123", org: "acme", json: true } as RemoveMemberCommand.Args);
+
+        expect(context.stdout.info).toHaveBeenCalledWith(
+            JSON.stringify({ success: true, userId: "user123", org: "acme" }, null, 2)
+        );
+        expect(context.stderr.info).not.toHaveBeenCalled();
+    });
+
     it("should reject organization tokens", async () => {
         const context = createMockContext("organization");
 

--- a/packages/cli/cli-v2/src/commands/org/member/remove/__test__/command.test.ts
+++ b/packages/cli/cli-v2/src/commands/org/member/remove/__test__/command.test.ts
@@ -1,0 +1,134 @@
+import type { Logger } from "@fern-api/logger";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { CliError } from "../../../../../errors/CliError.js";
+import { RemoveMemberCommand } from "../command.js";
+
+vi.mock("@fern-api/core", () => ({
+    createVenusService: vi.fn()
+}));
+
+vi.mock("../../../../../ui/withSpinner.js", () => ({
+    withSpinner: vi.fn(({ operation }: { operation: () => Promise<unknown> }) => operation())
+}));
+
+function createMockLogger(): Logger {
+    return {
+        disable: vi.fn(),
+        enable: vi.fn(),
+        trace: vi.fn(),
+        debug: vi.fn(),
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+        log: vi.fn()
+    };
+}
+
+function createMockContext(tokenType: "user" | "organization" = "user") {
+    return {
+        stdout: createMockLogger(),
+        stderr: createMockLogger(),
+        getTokenOrPrompt: vi.fn().mockResolvedValue({ type: tokenType, value: "test-token" })
+    } as unknown as import("../../../../../context/Context.js").Context;
+}
+
+describe("RemoveMemberCommand", () => {
+    let cmd: RemoveMemberCommand;
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+        cmd = new RemoveMemberCommand();
+    });
+
+    it("should remove a member successfully", async () => {
+        const { createVenusService } = await import("@fern-api/core");
+        const mockRemoveUser = vi.fn().mockResolvedValue({ ok: true });
+        vi.mocked(createVenusService).mockReturnValue({
+            organization: { removeUser: mockRemoveUser }
+        } as ReturnType<typeof createVenusService>);
+
+        const context = createMockContext();
+        await cmd.handle(context, { "user-id": "user123", org: "acme" } as RemoveMemberCommand.Args);
+
+        expect(mockRemoveUser).toHaveBeenCalledWith({
+            userId: "user123",
+            auth0OrgId: "acme"
+        });
+        expect(context.stderr.info).toHaveBeenCalledWith(expect.stringContaining("Removed user"));
+    });
+
+    it("should reject organization tokens", async () => {
+        const context = createMockContext("organization");
+
+        await expect(
+            cmd.handle(context, { "user-id": "user123", org: "acme" } as RemoveMemberCommand.Args)
+        ).rejects.toThrow(CliError);
+
+        expect(context.stderr.error).toHaveBeenCalledWith(
+            expect.stringContaining("Organization tokens cannot remove members")
+        );
+    });
+
+    it("should handle UnauthorizedError", async () => {
+        const { createVenusService } = await import("@fern-api/core");
+        const mockRemoveUser = vi.fn().mockResolvedValue({
+            ok: false,
+            error: {
+                _visit: (visitor: Record<string, () => void>) => visitor.unauthorizedError()
+            }
+        });
+        vi.mocked(createVenusService).mockReturnValue({
+            organization: { removeUser: mockRemoveUser }
+        } as ReturnType<typeof createVenusService>);
+
+        const context = createMockContext();
+        await expect(
+            cmd.handle(context, { "user-id": "user123", org: "acme" } as RemoveMemberCommand.Args)
+        ).rejects.toThrow(CliError);
+
+        expect(context.stderr.error).toHaveBeenCalledWith(
+            expect.stringContaining("do not have permission to remove members")
+        );
+    });
+
+    it("should handle UserIdDoesNotExistError", async () => {
+        const { createVenusService } = await import("@fern-api/core");
+        const mockRemoveUser = vi.fn().mockResolvedValue({
+            ok: false,
+            error: {
+                _visit: (visitor: Record<string, () => void>) => visitor.userIdDoesNotExistError()
+            }
+        });
+        vi.mocked(createVenusService).mockReturnValue({
+            organization: { removeUser: mockRemoveUser }
+        } as ReturnType<typeof createVenusService>);
+
+        const context = createMockContext();
+        await expect(
+            cmd.handle(context, { "user-id": "user123", org: "acme" } as RemoveMemberCommand.Args)
+        ).rejects.toThrow(CliError);
+
+        expect(context.stderr.error).toHaveBeenCalledWith(expect.stringContaining("was not found"));
+    });
+
+    it("should handle unknown errors", async () => {
+        const { createVenusService } = await import("@fern-api/core");
+        const mockRemoveUser = vi.fn().mockResolvedValue({
+            ok: false,
+            error: {
+                _visit: (visitor: Record<string, () => void>) => visitor._other()
+            }
+        });
+        vi.mocked(createVenusService).mockReturnValue({
+            organization: { removeUser: mockRemoveUser }
+        } as ReturnType<typeof createVenusService>);
+
+        const context = createMockContext();
+        await expect(
+            cmd.handle(context, { "user-id": "user123", org: "acme" } as RemoveMemberCommand.Args)
+        ).rejects.toThrow(CliError);
+
+        expect(context.stderr.error).toHaveBeenCalledWith(expect.stringContaining("Failed to remove member"));
+    });
+});

--- a/packages/cli/cli-v2/src/commands/org/member/remove/__test__/command.test.ts
+++ b/packages/cli/cli-v2/src/commands/org/member/remove/__test__/command.test.ts
@@ -54,7 +54,7 @@ describe("RemoveMemberCommand", () => {
         const mockRemoveUser = vi.fn().mockResolvedValue({ ok: true });
         vi.mocked(createVenusService).mockReturnValue({
             organization: { get: mockGet, removeUser: mockRemoveUser }
-        } as ReturnType<typeof createVenusService>);
+        } as unknown as ReturnType<typeof createVenusService>);
 
         const context = createMockContext();
         await cmd.handle(context, { userId: "user123", org: "acme" } as RemoveMemberCommand.Args);
@@ -84,12 +84,12 @@ describe("RemoveMemberCommand", () => {
         const mockGet = vi.fn().mockResolvedValue({
             ok: false,
             error: {
-                _visit: (visitor: Record<string, () => void>) => visitor._other()
+                _visit: (visitor: any) => visitor._other()
             }
         });
         vi.mocked(createVenusService).mockReturnValue({
             organization: { get: mockGet }
-        } as ReturnType<typeof createVenusService>);
+        } as unknown as ReturnType<typeof createVenusService>);
 
         const context = createMockContext();
         await expect(
@@ -105,12 +105,12 @@ describe("RemoveMemberCommand", () => {
         const mockRemoveUser = vi.fn().mockResolvedValue({
             ok: false,
             error: {
-                _visit: (visitor: Record<string, () => void>) => visitor.unauthorizedError()
+                _visit: (visitor: any) => visitor.unauthorizedError()
             }
         });
         vi.mocked(createVenusService).mockReturnValue({
             organization: { get: mockGet, removeUser: mockRemoveUser }
-        } as ReturnType<typeof createVenusService>);
+        } as unknown as ReturnType<typeof createVenusService>);
 
         const context = createMockContext();
         await expect(
@@ -128,12 +128,12 @@ describe("RemoveMemberCommand", () => {
         const mockRemoveUser = vi.fn().mockResolvedValue({
             ok: false,
             error: {
-                _visit: (visitor: Record<string, () => void>) => visitor.userIdDoesNotExistError()
+                _visit: (visitor: any) => visitor.userIdDoesNotExistError()
             }
         });
         vi.mocked(createVenusService).mockReturnValue({
             organization: { get: mockGet, removeUser: mockRemoveUser }
-        } as ReturnType<typeof createVenusService>);
+        } as unknown as ReturnType<typeof createVenusService>);
 
         const context = createMockContext();
         await expect(
@@ -149,12 +149,12 @@ describe("RemoveMemberCommand", () => {
         const mockRemoveUser = vi.fn().mockResolvedValue({
             ok: false,
             error: {
-                _visit: (visitor: Record<string, () => void>) => visitor._other()
+                _visit: (visitor: any) => visitor._other()
             }
         });
         vi.mocked(createVenusService).mockReturnValue({
             organization: { get: mockGet, removeUser: mockRemoveUser }
-        } as ReturnType<typeof createVenusService>);
+        } as unknown as ReturnType<typeof createVenusService>);
 
         const context = createMockContext();
         await expect(

--- a/packages/cli/cli-v2/src/commands/org/member/remove/__test__/command.test.ts
+++ b/packages/cli/cli-v2/src/commands/org/member/remove/__test__/command.test.ts
@@ -84,7 +84,7 @@ describe("RemoveMemberCommand", () => {
         const mockGet = vi.fn().mockResolvedValue({
             ok: false,
             error: {
-                _visit: (visitor: any) => visitor._other()
+                _visit: (visitor: { _other: () => void }) => visitor._other()
             }
         });
         vi.mocked(createVenusService).mockReturnValue({
@@ -105,7 +105,7 @@ describe("RemoveMemberCommand", () => {
         const mockRemoveUser = vi.fn().mockResolvedValue({
             ok: false,
             error: {
-                _visit: (visitor: any) => visitor.unauthorizedError()
+                _visit: (visitor: { unauthorizedError: () => void }) => visitor.unauthorizedError()
             }
         });
         vi.mocked(createVenusService).mockReturnValue({
@@ -128,7 +128,7 @@ describe("RemoveMemberCommand", () => {
         const mockRemoveUser = vi.fn().mockResolvedValue({
             ok: false,
             error: {
-                _visit: (visitor: any) => visitor.userIdDoesNotExistError()
+                _visit: (visitor: { userIdDoesNotExistError: () => void }) => visitor.userIdDoesNotExistError()
             }
         });
         vi.mocked(createVenusService).mockReturnValue({
@@ -149,7 +149,7 @@ describe("RemoveMemberCommand", () => {
         const mockRemoveUser = vi.fn().mockResolvedValue({
             ok: false,
             error: {
-                _visit: (visitor: any) => visitor._other()
+                _visit: (visitor: { _other: () => void }) => visitor._other()
             }
         });
         vi.mocked(createVenusService).mockReturnValue({

--- a/packages/cli/cli-v2/src/commands/org/member/remove/command.ts
+++ b/packages/cli/cli-v2/src/commands/org/member/remove/command.ts
@@ -10,7 +10,7 @@ import { command } from "../../../_internal/command.js";
 
 export declare namespace RemoveMemberCommand {
     export interface Args extends GlobalArgs {
-        "user-id": string;
+        userId: string;
         org: string;
     }
 }
@@ -28,14 +28,29 @@ export class RemoveMemberCommand {
 
         const venus = createVenusService({ token: token.value });
 
-        const userId = args["user-id"];
+        const orgLookup = await venus.organization.get(args.org);
+        if (!orgLookup.ok) {
+            orgLookup.error._visit({
+                unauthorizedError: () => {
+                    context.stderr.error(`${Icons.error} You do not have access to organization "${args.org}".`);
+                    throw CliError.exit();
+                },
+                _other: () => {
+                    context.stderr.error(`${Icons.error} Organization "${args.org}" was not found.`);
+                    throw CliError.exit();
+                }
+            });
+            return;
+        }
+        const auth0OrgId = orgLookup.body.auth0Id;
+        const userId = args.userId;
 
         const response = await withSpinner({
             message: `Removing user "${userId}" from organization "${args.org}"`,
             operation: () =>
                 venus.organization.removeUser({
                     userId,
-                    auth0OrgId: args.org
+                    auth0OrgId
                 })
         });
 
@@ -84,7 +99,7 @@ export function addRemoveMemberCommand(cli: Argv<GlobalArgs>): void {
                 .positional("org", {
                     type: "string",
                     demandOption: true,
-                    description: "Organization ID"
+                    description: "Organization name (e.g. acme)"
                 })
                 .example("$0 org member remove user123 acme", "# Remove user 'user123' from the 'acme' organization")
     );

--- a/packages/cli/cli-v2/src/commands/org/member/remove/command.ts
+++ b/packages/cli/cli-v2/src/commands/org/member/remove/command.ts
@@ -12,6 +12,7 @@ export declare namespace RemoveMemberCommand {
     export interface Args extends GlobalArgs {
         userId: string;
         org: string;
+        json: boolean;
     }
 }
 
@@ -55,7 +56,11 @@ export class RemoveMemberCommand {
         });
 
         if (response.ok) {
-            context.stderr.info(`${Icons.success} Removed user "${userId}" from organization "${args.org}".`);
+            if (args.json) {
+                context.stdout.info(JSON.stringify({ success: true, userId, org: args.org }, null, 2));
+            } else {
+                context.stderr.info(`${Icons.success} Removed user "${userId}" from organization "${args.org}".`);
+            }
             return;
         }
 
@@ -100,6 +105,11 @@ export function addRemoveMemberCommand(cli: Argv<GlobalArgs>): void {
                     type: "string",
                     demandOption: true,
                     description: "Organization name (e.g. acme)"
+                })
+                .option("json", {
+                    type: "boolean",
+                    default: false,
+                    description: "Output as JSON"
                 })
                 .example("$0 org member remove user123 acme", "# Remove user 'user123' from the 'acme' organization")
     );

--- a/packages/cli/cli-v2/src/commands/org/member/remove/command.ts
+++ b/packages/cli/cli-v2/src/commands/org/member/remove/command.ts
@@ -19,6 +19,13 @@ export class RemoveMemberCommand {
     public async handle(context: Context, args: RemoveMemberCommand.Args): Promise<void> {
         const token = await context.getTokenOrPrompt();
 
+        if (token.type === "organization") {
+            context.stderr.error(
+                `${Icons.error} Organization tokens cannot remove members. Unset the FERN_TOKEN environment variable and run 'fern auth login' to remove members.`
+            );
+            throw CliError.exit();
+        }
+
         const venus = createVenusService({ token: token.value });
 
         const userId = args["user-id"];

--- a/packages/cli/cli-v2/src/commands/org/member/remove/command.ts
+++ b/packages/cli/cli-v2/src/commands/org/member/remove/command.ts
@@ -1,0 +1,84 @@
+import { createVenusService } from "@fern-api/core";
+import type { Argv } from "yargs";
+
+import type { Context } from "../../../../context/Context.js";
+import type { GlobalArgs } from "../../../../context/GlobalArgs.js";
+import { CliError } from "../../../../errors/CliError.js";
+import { Icons } from "../../../../ui/format.js";
+import { withSpinner } from "../../../../ui/withSpinner.js";
+import { command } from "../../../_internal/command.js";
+
+export declare namespace RemoveMemberCommand {
+    export interface Args extends GlobalArgs {
+        "user-id": string;
+        org: string;
+    }
+}
+
+export class RemoveMemberCommand {
+    public async handle(context: Context, args: RemoveMemberCommand.Args): Promise<void> {
+        const token = await context.getTokenOrPrompt();
+
+        const venus = createVenusService({ token: token.value });
+
+        const userId = args["user-id"];
+
+        const response = await withSpinner({
+            message: `Removing user "${userId}" from organization "${args.org}"`,
+            operation: () =>
+                venus.organization.removeUser({
+                    userId,
+                    auth0OrgId: args.org
+                })
+        });
+
+        if (response.ok) {
+            context.stderr.info(`${Icons.success} Removed user "${userId}" from organization "${args.org}".`);
+            return;
+        }
+
+        response.error._visit({
+            unauthorizedError: () => {
+                context.stderr.error(
+                    `${Icons.error} You do not have permission to remove members from organization "${args.org}".`
+                );
+                throw CliError.exit();
+            },
+            userIdDoesNotExistError: () => {
+                context.stderr.error(`${Icons.error} User "${userId}" was not found.`);
+                throw CliError.exit();
+            },
+            _other: () => {
+                context.stderr.error(
+                    `${Icons.error} Failed to remove member.\n` +
+                        `\n  Please contact support@buildwithfern.com for assistance.`
+                );
+                throw CliError.exit();
+            }
+        });
+    }
+}
+
+export function addRemoveMemberCommand(cli: Argv<GlobalArgs>): void {
+    const cmd = new RemoveMemberCommand();
+    command(
+        cli,
+        "remove <user-id> <org>",
+        "Remove a user from an organization",
+        (context, args) => cmd.handle(context, args as RemoveMemberCommand.Args),
+        (yargs) =>
+            yargs
+                .usage("\nUsage:\n  $0 org member remove <user-id> <org>")
+                .positional("user-id", {
+                    type: "string",
+                    demandOption: true,
+                    description: "User ID to remove"
+                })
+                .positional("org", {
+                    type: "string",
+                    demandOption: true,
+                    description: "Organization ID"
+                })
+                .example("$0 org member remove user123 acme", "# Remove user 'user123' from the 'acme' organization")
+    );
+}

--- a/packages/cli/cli-v2/src/commands/org/member/remove/index.ts
+++ b/packages/cli/cli-v2/src/commands/org/member/remove/index.ts
@@ -1,0 +1,1 @@
+export { addRemoveMemberCommand } from "./command.js";

--- a/packages/cli/cli-v2/src/commands/org/token/command.ts
+++ b/packages/cli/cli-v2/src/commands/org/token/command.ts
@@ -1,0 +1,15 @@
+import type { Argv } from "yargs";
+
+import type { GlobalArgs } from "../../../context/GlobalArgs.js";
+import { commandGroup } from "../../_internal/commandGroup.js";
+import { addCreateTokenCommand } from "./create/index.js";
+import { addListTokensCommand } from "./list/index.js";
+import { addRevokeTokenCommand } from "./revoke/index.js";
+
+export function addTokenCommand(cli: Argv<GlobalArgs>): void {
+    commandGroup(cli, "token", "Manage organization API tokens", [
+        addCreateTokenCommand,
+        addListTokensCommand,
+        addRevokeTokenCommand
+    ]);
+}

--- a/packages/cli/cli-v2/src/commands/org/token/create/__test__/command.test.ts
+++ b/packages/cli/cli-v2/src/commands/org/token/create/__test__/command.test.ts
@@ -73,6 +73,27 @@ describe("CreateTokenCommand", () => {
         expect(context.stdout.info).toHaveBeenCalledWith("fern_abc123");
     });
 
+    it("should output JSON when --json flag is set", async () => {
+        const { createVenusService } = await import("@fern-api/core");
+        const mockGet = mockOrgLookupSuccess();
+        const mockCreate = vi.fn().mockResolvedValue({
+            ok: true,
+            body: { tokenId: "tok_123", token: "fern_abc123" }
+        });
+        vi.mocked(createVenusService).mockReturnValue({
+            organization: { get: mockGet },
+            apiKeys: { create: mockCreate }
+        } as unknown as ReturnType<typeof createVenusService>);
+
+        const context = createMockContext();
+        await cmd.handle(context, { org: "acme", description: "CI token", json: true } as CreateTokenCommand.Args);
+
+        expect(context.stdout.info).toHaveBeenCalledWith(
+            JSON.stringify({ tokenId: "tok_123", token: "fern_abc123" }, null, 2)
+        );
+        expect(context.stderr.info).not.toHaveBeenCalled();
+    });
+
     it("should reject organization tokens", async () => {
         const context = createMockContext("organization");
 

--- a/packages/cli/cli-v2/src/commands/org/token/create/__test__/command.test.ts
+++ b/packages/cli/cli-v2/src/commands/org/token/create/__test__/command.test.ts
@@ -1,0 +1,131 @@
+import type { Logger } from "@fern-api/logger";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { CliError } from "../../../../../errors/CliError.js";
+import { CreateTokenCommand } from "../command.js";
+
+vi.mock("@fern-api/core", () => ({
+    createVenusService: vi.fn()
+}));
+
+vi.mock("../../../../../ui/withSpinner.js", () => ({
+    withSpinner: vi.fn(({ operation }: { operation: () => Promise<unknown> }) => operation())
+}));
+
+function createMockLogger(): Logger {
+    return {
+        disable: vi.fn(),
+        enable: vi.fn(),
+        trace: vi.fn(),
+        debug: vi.fn(),
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+        log: vi.fn()
+    };
+}
+
+function createMockContext(tokenType: "user" | "organization" = "user") {
+    return {
+        stdout: createMockLogger(),
+        stderr: createMockLogger(),
+        getTokenOrPrompt: vi.fn().mockResolvedValue({ type: tokenType, value: "test-token" })
+    } as unknown as import("../../../../../context/Context.js").Context;
+}
+
+describe("CreateTokenCommand", () => {
+    let cmd: CreateTokenCommand;
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+        cmd = new CreateTokenCommand();
+    });
+
+    it("should create a token successfully", async () => {
+        const { createVenusService } = await import("@fern-api/core");
+        const mockCreate = vi.fn().mockResolvedValue({
+            ok: true,
+            body: { tokenId: "tok_123", token: "fern_abc123" }
+        });
+        vi.mocked(createVenusService).mockReturnValue({
+            apiKeys: { create: mockCreate }
+        } as ReturnType<typeof createVenusService>);
+
+        const context = createMockContext();
+        await cmd.handle(context, { org: "acme", description: "CI token" } as CreateTokenCommand.Args);
+
+        expect(mockCreate).toHaveBeenCalledWith({
+            organizationId: "acme",
+            description: "CI token"
+        });
+        expect(context.stderr.info).toHaveBeenCalledWith(expect.stringContaining("Token created successfully"));
+        expect(context.stderr.info).toHaveBeenCalledWith(expect.stringContaining("tok_123"));
+        expect(context.stderr.info).toHaveBeenCalledWith(expect.stringContaining("fern_abc123"));
+    });
+
+    it("should reject organization tokens", async () => {
+        const context = createMockContext("organization");
+
+        await expect(cmd.handle(context, { org: "acme" } as CreateTokenCommand.Args)).rejects.toThrow(CliError);
+
+        expect(context.stderr.error).toHaveBeenCalledWith(
+            expect.stringContaining("Organization tokens cannot manage API tokens")
+        );
+    });
+
+    it("should handle UnauthorizedError", async () => {
+        const { createVenusService } = await import("@fern-api/core");
+        const mockCreate = vi.fn().mockResolvedValue({
+            ok: false,
+            error: {
+                _visit: (visitor: Record<string, () => void>) => visitor.unauthorizedError()
+            }
+        });
+        vi.mocked(createVenusService).mockReturnValue({
+            apiKeys: { create: mockCreate }
+        } as ReturnType<typeof createVenusService>);
+
+        const context = createMockContext();
+        await expect(cmd.handle(context, { org: "acme" } as CreateTokenCommand.Args)).rejects.toThrow(CliError);
+
+        expect(context.stderr.error).toHaveBeenCalledWith(
+            expect.stringContaining("do not have access to organization")
+        );
+    });
+
+    it("should handle OrganizationNotFoundError", async () => {
+        const { createVenusService } = await import("@fern-api/core");
+        const mockCreate = vi.fn().mockResolvedValue({
+            ok: false,
+            error: {
+                _visit: (visitor: Record<string, () => void>) => visitor.organizationNotFoundError()
+            }
+        });
+        vi.mocked(createVenusService).mockReturnValue({
+            apiKeys: { create: mockCreate }
+        } as ReturnType<typeof createVenusService>);
+
+        const context = createMockContext();
+        await expect(cmd.handle(context, { org: "acme" } as CreateTokenCommand.Args)).rejects.toThrow(CliError);
+
+        expect(context.stderr.error).toHaveBeenCalledWith(expect.stringContaining("was not found"));
+    });
+
+    it("should handle unknown errors", async () => {
+        const { createVenusService } = await import("@fern-api/core");
+        const mockCreate = vi.fn().mockResolvedValue({
+            ok: false,
+            error: {
+                _visit: (visitor: Record<string, () => void>) => visitor._other()
+            }
+        });
+        vi.mocked(createVenusService).mockReturnValue({
+            apiKeys: { create: mockCreate }
+        } as ReturnType<typeof createVenusService>);
+
+        const context = createMockContext();
+        await expect(cmd.handle(context, { org: "acme" } as CreateTokenCommand.Args)).rejects.toThrow(CliError);
+
+        expect(context.stderr.error).toHaveBeenCalledWith(expect.stringContaining("Failed to create token"));
+    });
+});

--- a/packages/cli/cli-v2/src/commands/org/token/create/__test__/command.test.ts
+++ b/packages/cli/cli-v2/src/commands/org/token/create/__test__/command.test.ts
@@ -58,7 +58,7 @@ describe("CreateTokenCommand", () => {
         vi.mocked(createVenusService).mockReturnValue({
             organization: { get: mockGet },
             apiKeys: { create: mockCreate }
-        } as ReturnType<typeof createVenusService>);
+        } as unknown as ReturnType<typeof createVenusService>);
 
         const context = createMockContext();
         await cmd.handle(context, { org: "acme", description: "CI token" } as CreateTokenCommand.Args);
@@ -88,12 +88,12 @@ describe("CreateTokenCommand", () => {
         const mockGet = vi.fn().mockResolvedValue({
             ok: false,
             error: {
-                _visit: (visitor: Record<string, () => void>) => visitor._other()
+                _visit: (visitor: any) => visitor._other()
             }
         });
         vi.mocked(createVenusService).mockReturnValue({
             organization: { get: mockGet }
-        } as ReturnType<typeof createVenusService>);
+        } as unknown as ReturnType<typeof createVenusService>);
 
         const context = createMockContext();
         await expect(cmd.handle(context, { org: "acme" } as CreateTokenCommand.Args)).rejects.toThrow(CliError);
@@ -107,13 +107,13 @@ describe("CreateTokenCommand", () => {
         const mockCreate = vi.fn().mockResolvedValue({
             ok: false,
             error: {
-                _visit: (visitor: Record<string, () => void>) => visitor.unauthorizedError()
+                _visit: (visitor: any) => visitor.unauthorizedError()
             }
         });
         vi.mocked(createVenusService).mockReturnValue({
             organization: { get: mockGet },
             apiKeys: { create: mockCreate }
-        } as ReturnType<typeof createVenusService>);
+        } as unknown as ReturnType<typeof createVenusService>);
 
         const context = createMockContext();
         await expect(cmd.handle(context, { org: "acme" } as CreateTokenCommand.Args)).rejects.toThrow(CliError);
@@ -129,13 +129,13 @@ describe("CreateTokenCommand", () => {
         const mockCreate = vi.fn().mockResolvedValue({
             ok: false,
             error: {
-                _visit: (visitor: Record<string, () => void>) => visitor.organizationNotFoundError()
+                _visit: (visitor: any) => visitor.organizationNotFoundError()
             }
         });
         vi.mocked(createVenusService).mockReturnValue({
             organization: { get: mockGet },
             apiKeys: { create: mockCreate }
-        } as ReturnType<typeof createVenusService>);
+        } as unknown as ReturnType<typeof createVenusService>);
 
         const context = createMockContext();
         await expect(cmd.handle(context, { org: "acme" } as CreateTokenCommand.Args)).rejects.toThrow(CliError);
@@ -149,13 +149,13 @@ describe("CreateTokenCommand", () => {
         const mockCreate = vi.fn().mockResolvedValue({
             ok: false,
             error: {
-                _visit: (visitor: Record<string, () => void>) => visitor._other()
+                _visit: (visitor: any) => visitor._other()
             }
         });
         vi.mocked(createVenusService).mockReturnValue({
             organization: { get: mockGet },
             apiKeys: { create: mockCreate }
-        } as ReturnType<typeof createVenusService>);
+        } as unknown as ReturnType<typeof createVenusService>);
 
         const context = createMockContext();
         await expect(cmd.handle(context, { org: "acme" } as CreateTokenCommand.Args)).rejects.toThrow(CliError);

--- a/packages/cli/cli-v2/src/commands/org/token/create/__test__/command.test.ts
+++ b/packages/cli/cli-v2/src/commands/org/token/create/__test__/command.test.ts
@@ -33,6 +33,13 @@ function createMockContext(tokenType: "user" | "organization" = "user") {
     } as unknown as import("../../../../../context/Context.js").Context;
 }
 
+function mockOrgLookupSuccess() {
+    return vi.fn().mockResolvedValue({
+        ok: true,
+        body: { auth0Id: "org_abc123" }
+    });
+}
+
 describe("CreateTokenCommand", () => {
     let cmd: CreateTokenCommand;
 
@@ -43,24 +50,27 @@ describe("CreateTokenCommand", () => {
 
     it("should create a token successfully", async () => {
         const { createVenusService } = await import("@fern-api/core");
+        const mockGet = mockOrgLookupSuccess();
         const mockCreate = vi.fn().mockResolvedValue({
             ok: true,
             body: { tokenId: "tok_123", token: "fern_abc123" }
         });
         vi.mocked(createVenusService).mockReturnValue({
+            organization: { get: mockGet },
             apiKeys: { create: mockCreate }
         } as ReturnType<typeof createVenusService>);
 
         const context = createMockContext();
         await cmd.handle(context, { org: "acme", description: "CI token" } as CreateTokenCommand.Args);
 
+        expect(mockGet).toHaveBeenCalledWith("acme");
         expect(mockCreate).toHaveBeenCalledWith({
-            organizationId: "acme",
+            organizationId: "org_abc123",
             description: "CI token"
         });
         expect(context.stderr.info).toHaveBeenCalledWith(expect.stringContaining("Token created successfully"));
         expect(context.stderr.info).toHaveBeenCalledWith(expect.stringContaining("tok_123"));
-        expect(context.stderr.info).toHaveBeenCalledWith(expect.stringContaining("fern_abc123"));
+        expect(context.stdout.info).toHaveBeenCalledWith("fern_abc123");
     });
 
     it("should reject organization tokens", async () => {
@@ -73,8 +83,27 @@ describe("CreateTokenCommand", () => {
         );
     });
 
-    it("should handle UnauthorizedError", async () => {
+    it("should handle org lookup failure", async () => {
         const { createVenusService } = await import("@fern-api/core");
+        const mockGet = vi.fn().mockResolvedValue({
+            ok: false,
+            error: {
+                _visit: (visitor: Record<string, () => void>) => visitor._other()
+            }
+        });
+        vi.mocked(createVenusService).mockReturnValue({
+            organization: { get: mockGet }
+        } as ReturnType<typeof createVenusService>);
+
+        const context = createMockContext();
+        await expect(cmd.handle(context, { org: "acme" } as CreateTokenCommand.Args)).rejects.toThrow(CliError);
+
+        expect(context.stderr.error).toHaveBeenCalledWith(expect.stringContaining("was not found"));
+    });
+
+    it("should handle UnauthorizedError from apiKeys.create", async () => {
+        const { createVenusService } = await import("@fern-api/core");
+        const mockGet = mockOrgLookupSuccess();
         const mockCreate = vi.fn().mockResolvedValue({
             ok: false,
             error: {
@@ -82,6 +111,7 @@ describe("CreateTokenCommand", () => {
             }
         });
         vi.mocked(createVenusService).mockReturnValue({
+            organization: { get: mockGet },
             apiKeys: { create: mockCreate }
         } as ReturnType<typeof createVenusService>);
 
@@ -95,6 +125,7 @@ describe("CreateTokenCommand", () => {
 
     it("should handle OrganizationNotFoundError", async () => {
         const { createVenusService } = await import("@fern-api/core");
+        const mockGet = mockOrgLookupSuccess();
         const mockCreate = vi.fn().mockResolvedValue({
             ok: false,
             error: {
@@ -102,6 +133,7 @@ describe("CreateTokenCommand", () => {
             }
         });
         vi.mocked(createVenusService).mockReturnValue({
+            organization: { get: mockGet },
             apiKeys: { create: mockCreate }
         } as ReturnType<typeof createVenusService>);
 
@@ -113,6 +145,7 @@ describe("CreateTokenCommand", () => {
 
     it("should handle unknown errors", async () => {
         const { createVenusService } = await import("@fern-api/core");
+        const mockGet = mockOrgLookupSuccess();
         const mockCreate = vi.fn().mockResolvedValue({
             ok: false,
             error: {
@@ -120,6 +153,7 @@ describe("CreateTokenCommand", () => {
             }
         });
         vi.mocked(createVenusService).mockReturnValue({
+            organization: { get: mockGet },
             apiKeys: { create: mockCreate }
         } as ReturnType<typeof createVenusService>);
 

--- a/packages/cli/cli-v2/src/commands/org/token/create/__test__/command.test.ts
+++ b/packages/cli/cli-v2/src/commands/org/token/create/__test__/command.test.ts
@@ -88,7 +88,7 @@ describe("CreateTokenCommand", () => {
         const mockGet = vi.fn().mockResolvedValue({
             ok: false,
             error: {
-                _visit: (visitor: any) => visitor._other()
+                _visit: (visitor: { _other: () => void }) => visitor._other()
             }
         });
         vi.mocked(createVenusService).mockReturnValue({
@@ -107,7 +107,7 @@ describe("CreateTokenCommand", () => {
         const mockCreate = vi.fn().mockResolvedValue({
             ok: false,
             error: {
-                _visit: (visitor: any) => visitor.unauthorizedError()
+                _visit: (visitor: { unauthorizedError: () => void }) => visitor.unauthorizedError()
             }
         });
         vi.mocked(createVenusService).mockReturnValue({
@@ -129,7 +129,7 @@ describe("CreateTokenCommand", () => {
         const mockCreate = vi.fn().mockResolvedValue({
             ok: false,
             error: {
-                _visit: (visitor: any) => visitor.organizationNotFoundError()
+                _visit: (visitor: { organizationNotFoundError: () => void }) => visitor.organizationNotFoundError()
             }
         });
         vi.mocked(createVenusService).mockReturnValue({
@@ -149,7 +149,7 @@ describe("CreateTokenCommand", () => {
         const mockCreate = vi.fn().mockResolvedValue({
             ok: false,
             error: {
-                _visit: (visitor: any) => visitor._other()
+                _visit: (visitor: { _other: () => void }) => visitor._other()
             }
         });
         vi.mocked(createVenusService).mockReturnValue({

--- a/packages/cli/cli-v2/src/commands/org/token/create/command.ts
+++ b/packages/cli/cli-v2/src/commands/org/token/create/command.ts
@@ -28,11 +28,27 @@ export class CreateTokenCommand {
 
         const venus = createVenusService({ token: token.value });
 
+        const orgLookup = await venus.organization.get(args.org);
+        if (!orgLookup.ok) {
+            orgLookup.error._visit({
+                unauthorizedError: () => {
+                    context.stderr.error(`${Icons.error} You do not have access to organization "${args.org}".`);
+                    throw CliError.exit();
+                },
+                _other: () => {
+                    context.stderr.error(`${Icons.error} Organization "${args.org}" was not found.`);
+                    throw CliError.exit();
+                }
+            });
+            return;
+        }
+        const auth0OrgId = orgLookup.body.auth0Id;
+
         const response = await withSpinner({
             message: `Creating token for organization "${args.org}"`,
             operation: () =>
                 venus.apiKeys.create({
-                    organizationId: args.org,
+                    organizationId: auth0OrgId,
                     description: args.description
                 })
         });
@@ -41,9 +57,9 @@ export class CreateTokenCommand {
             context.stderr.info(`${Icons.success} Token created successfully`);
             context.stderr.info("");
             context.stderr.info(`  Token ID: ${response.body.tokenId}`);
-            context.stderr.info(`  Token:    ${response.body.token}`);
-            context.stderr.info("");
             context.stderr.info("  Save this token now. You won't be able to see it again.");
+            context.stderr.info("");
+            context.stdout.info(response.body.token);
             return;
         }
 
@@ -80,7 +96,7 @@ export function addCreateTokenCommand(cli: Argv<GlobalArgs>): void {
                 .positional("org", {
                     type: "string",
                     demandOption: true,
-                    description: "Organization ID"
+                    description: "Organization name (e.g. acme)"
                 })
                 .option("description", {
                     type: "string",

--- a/packages/cli/cli-v2/src/commands/org/token/create/command.ts
+++ b/packages/cli/cli-v2/src/commands/org/token/create/command.ts
@@ -12,6 +12,7 @@ export declare namespace CreateTokenCommand {
     export interface Args extends GlobalArgs {
         org: string;
         description?: string;
+        json: boolean;
     }
 }
 
@@ -54,12 +55,18 @@ export class CreateTokenCommand {
         });
 
         if (response.ok) {
-            context.stderr.info(`${Icons.success} Token created successfully`);
-            context.stderr.info("");
-            context.stderr.info(`  Token ID: ${response.body.tokenId}`);
-            context.stderr.info("  Save this token now. You won't be able to see it again.");
-            context.stderr.info("");
-            context.stdout.info(response.body.token);
+            if (args.json) {
+                context.stdout.info(
+                    JSON.stringify({ tokenId: response.body.tokenId, token: response.body.token }, null, 2)
+                );
+            } else {
+                context.stderr.info(`${Icons.success} Token created successfully`);
+                context.stderr.info("");
+                context.stderr.info(`  Token ID: ${response.body.tokenId}`);
+                context.stderr.info("  Save this token now. You won't be able to see it again.");
+                context.stderr.info("");
+                context.stdout.info(response.body.token);
+            }
             return;
         }
 
@@ -101,6 +108,11 @@ export function addCreateTokenCommand(cli: Argv<GlobalArgs>): void {
                 .option("description", {
                     type: "string",
                     description: "Description for the token"
+                })
+                .option("json", {
+                    type: "boolean",
+                    default: false,
+                    description: "Output as JSON"
                 })
                 .example("$0 org token create acme", "# Create a token for the 'acme' organization")
                 .example('$0 org token create acme --description "CI token"', "# Create a token with a description")

--- a/packages/cli/cli-v2/src/commands/org/token/create/command.ts
+++ b/packages/cli/cli-v2/src/commands/org/token/create/command.ts
@@ -1,0 +1,85 @@
+import { createVenusService } from "@fern-api/core";
+import type { Argv } from "yargs";
+
+import type { Context } from "../../../../context/Context.js";
+import type { GlobalArgs } from "../../../../context/GlobalArgs.js";
+import { CliError } from "../../../../errors/CliError.js";
+import { Icons } from "../../../../ui/format.js";
+import { withSpinner } from "../../../../ui/withSpinner.js";
+import { command } from "../../../_internal/command.js";
+
+export declare namespace CreateTokenCommand {
+    export interface Args extends GlobalArgs {
+        org: string;
+        description?: string;
+    }
+}
+
+export class CreateTokenCommand {
+    public async handle(context: Context, args: CreateTokenCommand.Args): Promise<void> {
+        const token = await context.getTokenOrPrompt();
+
+        const venus = createVenusService({ token: token.value });
+
+        const response = await withSpinner({
+            message: `Creating token for organization "${args.org}"`,
+            operation: () =>
+                venus.apiKeys.create({
+                    organizationId: args.org,
+                    description: args.description
+                })
+        });
+
+        if (response.ok) {
+            context.stderr.info(`${Icons.success} Token created successfully`);
+            context.stderr.info("");
+            context.stderr.info(`  Token ID: ${response.body.tokenId}`);
+            context.stderr.info(`  Token:    ${response.body.token}`);
+            context.stderr.info("");
+            context.stderr.info("  Save this token now. You won't be able to see it again.");
+            return;
+        }
+
+        response.error._visit({
+            unauthorizedError: () => {
+                context.stderr.error(`${Icons.error} You do not have access to organization "${args.org}".`);
+                throw CliError.exit();
+            },
+            organizationNotFoundError: () => {
+                context.stderr.error(`${Icons.error} Organization "${args.org}" was not found.`);
+                throw CliError.exit();
+            },
+            _other: () => {
+                context.stderr.error(
+                    `${Icons.error} Failed to create token.\n` +
+                        `\n  Please contact support@buildwithfern.com for assistance.`
+                );
+                throw CliError.exit();
+            }
+        });
+    }
+}
+
+export function addCreateTokenCommand(cli: Argv<GlobalArgs>): void {
+    const cmd = new CreateTokenCommand();
+    command(
+        cli,
+        "create <org>",
+        "Create an organization API token",
+        (context, args) => cmd.handle(context, args as CreateTokenCommand.Args),
+        (yargs) =>
+            yargs
+                .usage("\nUsage:\n  $0 org token create <org>")
+                .positional("org", {
+                    type: "string",
+                    demandOption: true,
+                    description: "Organization ID"
+                })
+                .option("description", {
+                    type: "string",
+                    description: "Description for the token"
+                })
+                .example("$0 org token create acme", "# Create a token for the 'acme' organization")
+                .example('$0 org token create acme --description "CI token"', "# Create a token with a description")
+    );
+}

--- a/packages/cli/cli-v2/src/commands/org/token/create/command.ts
+++ b/packages/cli/cli-v2/src/commands/org/token/create/command.ts
@@ -19,6 +19,13 @@ export class CreateTokenCommand {
     public async handle(context: Context, args: CreateTokenCommand.Args): Promise<void> {
         const token = await context.getTokenOrPrompt();
 
+        if (token.type === "organization") {
+            context.stderr.error(
+                `${Icons.error} Organization tokens cannot manage API tokens. Unset the FERN_TOKEN environment variable and run 'fern auth login' to manage tokens.`
+            );
+            throw CliError.exit();
+        }
+
         const venus = createVenusService({ token: token.value });
 
         const response = await withSpinner({

--- a/packages/cli/cli-v2/src/commands/org/token/create/index.ts
+++ b/packages/cli/cli-v2/src/commands/org/token/create/index.ts
@@ -1,0 +1,1 @@
+export { addCreateTokenCommand } from "./command.js";

--- a/packages/cli/cli-v2/src/commands/org/token/index.ts
+++ b/packages/cli/cli-v2/src/commands/org/token/index.ts
@@ -1,0 +1,1 @@
+export { addTokenCommand } from "./command.js";

--- a/packages/cli/cli-v2/src/commands/org/token/list/__test__/command.test.ts
+++ b/packages/cli/cli-v2/src/commands/org/token/list/__test__/command.test.ts
@@ -33,6 +33,13 @@ function createMockContext(tokenType: "user" | "organization" = "user") {
     } as unknown as import("../../../../../context/Context.js").Context;
 }
 
+function mockOrgLookupSuccess() {
+    return vi.fn().mockResolvedValue({
+        ok: true,
+        body: { auth0Id: "org_abc123" }
+    });
+}
+
 describe("ListTokensCommand", () => {
     let cmd: ListTokensCommand;
 
@@ -43,6 +50,7 @@ describe("ListTokensCommand", () => {
 
     it("should list tokens successfully", async () => {
         const { createVenusService } = await import("@fern-api/core");
+        const mockGet = mockOrgLookupSuccess();
         const mockGetTokens = vi.fn().mockResolvedValue({
             ok: true,
             body: [
@@ -61,23 +69,27 @@ describe("ListTokensCommand", () => {
             ]
         });
         vi.mocked(createVenusService).mockReturnValue({
+            organization: { get: mockGet },
             apiKeys: { getTokensForOrganization: mockGetTokens }
         } as ReturnType<typeof createVenusService>);
 
         const context = createMockContext();
         await cmd.handle(context, { org: "acme" } as ListTokensCommand.Args);
 
-        expect(mockGetTokens).toHaveBeenCalledWith("acme");
+        expect(mockGet).toHaveBeenCalledWith("acme");
+        expect(mockGetTokens).toHaveBeenCalledWith("org_abc123");
         expect(context.stdout.info).toHaveBeenCalledTimes(2);
     });
 
     it("should show empty message when no tokens", async () => {
         const { createVenusService } = await import("@fern-api/core");
+        const mockGet = mockOrgLookupSuccess();
         const mockGetTokens = vi.fn().mockResolvedValue({
             ok: true,
             body: []
         });
         vi.mocked(createVenusService).mockReturnValue({
+            organization: { get: mockGet },
             apiKeys: { getTokensForOrganization: mockGetTokens }
         } as ReturnType<typeof createVenusService>);
 
@@ -97,8 +109,29 @@ describe("ListTokensCommand", () => {
         );
     });
 
-    it("should handle UnauthorizedError", async () => {
+    it("should handle org lookup failure", async () => {
         const { createVenusService } = await import("@fern-api/core");
+        const mockGet = vi.fn().mockResolvedValue({
+            ok: false,
+            error: {
+                _visit: (visitor: Record<string, () => void>) => visitor.unauthorizedError()
+            }
+        });
+        vi.mocked(createVenusService).mockReturnValue({
+            organization: { get: mockGet }
+        } as ReturnType<typeof createVenusService>);
+
+        const context = createMockContext();
+        await expect(cmd.handle(context, { org: "acme" } as ListTokensCommand.Args)).rejects.toThrow(CliError);
+
+        expect(context.stderr.error).toHaveBeenCalledWith(
+            expect.stringContaining("do not have access to organization")
+        );
+    });
+
+    it("should handle UnauthorizedError from getTokensForOrganization", async () => {
+        const { createVenusService } = await import("@fern-api/core");
+        const mockGet = mockOrgLookupSuccess();
         const mockGetTokens = vi.fn().mockResolvedValue({
             ok: false,
             error: {
@@ -106,6 +139,7 @@ describe("ListTokensCommand", () => {
             }
         });
         vi.mocked(createVenusService).mockReturnValue({
+            organization: { get: mockGet },
             apiKeys: { getTokensForOrganization: mockGetTokens }
         } as ReturnType<typeof createVenusService>);
 
@@ -119,6 +153,7 @@ describe("ListTokensCommand", () => {
 
     it("should handle OrganizationNotFoundError", async () => {
         const { createVenusService } = await import("@fern-api/core");
+        const mockGet = mockOrgLookupSuccess();
         const mockGetTokens = vi.fn().mockResolvedValue({
             ok: false,
             error: {
@@ -126,6 +161,7 @@ describe("ListTokensCommand", () => {
             }
         });
         vi.mocked(createVenusService).mockReturnValue({
+            organization: { get: mockGet },
             apiKeys: { getTokensForOrganization: mockGetTokens }
         } as ReturnType<typeof createVenusService>);
 
@@ -137,6 +173,7 @@ describe("ListTokensCommand", () => {
 
     it("should handle unknown errors", async () => {
         const { createVenusService } = await import("@fern-api/core");
+        const mockGet = mockOrgLookupSuccess();
         const mockGetTokens = vi.fn().mockResolvedValue({
             ok: false,
             error: {
@@ -144,6 +181,7 @@ describe("ListTokensCommand", () => {
             }
         });
         vi.mocked(createVenusService).mockReturnValue({
+            organization: { get: mockGet },
             apiKeys: { getTokensForOrganization: mockGetTokens }
         } as ReturnType<typeof createVenusService>);
 

--- a/packages/cli/cli-v2/src/commands/org/token/list/__test__/command.test.ts
+++ b/packages/cli/cli-v2/src/commands/org/token/list/__test__/command.test.ts
@@ -71,7 +71,7 @@ describe("ListTokensCommand", () => {
         vi.mocked(createVenusService).mockReturnValue({
             organization: { get: mockGet },
             apiKeys: { getTokensForOrganization: mockGetTokens }
-        } as ReturnType<typeof createVenusService>);
+        } as unknown as ReturnType<typeof createVenusService>);
 
         const context = createMockContext();
         await cmd.handle(context, { org: "acme" } as ListTokensCommand.Args);
@@ -91,7 +91,7 @@ describe("ListTokensCommand", () => {
         vi.mocked(createVenusService).mockReturnValue({
             organization: { get: mockGet },
             apiKeys: { getTokensForOrganization: mockGetTokens }
-        } as ReturnType<typeof createVenusService>);
+        } as unknown as ReturnType<typeof createVenusService>);
 
         const context = createMockContext();
         await cmd.handle(context, { org: "acme" } as ListTokensCommand.Args);
@@ -114,12 +114,12 @@ describe("ListTokensCommand", () => {
         const mockGet = vi.fn().mockResolvedValue({
             ok: false,
             error: {
-                _visit: (visitor: Record<string, () => void>) => visitor.unauthorizedError()
+                _visit: (visitor: any) => visitor.unauthorizedError()
             }
         });
         vi.mocked(createVenusService).mockReturnValue({
             organization: { get: mockGet }
-        } as ReturnType<typeof createVenusService>);
+        } as unknown as ReturnType<typeof createVenusService>);
 
         const context = createMockContext();
         await expect(cmd.handle(context, { org: "acme" } as ListTokensCommand.Args)).rejects.toThrow(CliError);
@@ -135,13 +135,13 @@ describe("ListTokensCommand", () => {
         const mockGetTokens = vi.fn().mockResolvedValue({
             ok: false,
             error: {
-                _visit: (visitor: Record<string, () => void>) => visitor.unauthorizedError()
+                _visit: (visitor: any) => visitor.unauthorizedError()
             }
         });
         vi.mocked(createVenusService).mockReturnValue({
             organization: { get: mockGet },
             apiKeys: { getTokensForOrganization: mockGetTokens }
-        } as ReturnType<typeof createVenusService>);
+        } as unknown as ReturnType<typeof createVenusService>);
 
         const context = createMockContext();
         await expect(cmd.handle(context, { org: "acme" } as ListTokensCommand.Args)).rejects.toThrow(CliError);
@@ -157,13 +157,13 @@ describe("ListTokensCommand", () => {
         const mockGetTokens = vi.fn().mockResolvedValue({
             ok: false,
             error: {
-                _visit: (visitor: Record<string, () => void>) => visitor.organizationNotFoundError()
+                _visit: (visitor: any) => visitor.organizationNotFoundError()
             }
         });
         vi.mocked(createVenusService).mockReturnValue({
             organization: { get: mockGet },
             apiKeys: { getTokensForOrganization: mockGetTokens }
-        } as ReturnType<typeof createVenusService>);
+        } as unknown as ReturnType<typeof createVenusService>);
 
         const context = createMockContext();
         await expect(cmd.handle(context, { org: "acme" } as ListTokensCommand.Args)).rejects.toThrow(CliError);
@@ -177,13 +177,13 @@ describe("ListTokensCommand", () => {
         const mockGetTokens = vi.fn().mockResolvedValue({
             ok: false,
             error: {
-                _visit: (visitor: Record<string, () => void>) => visitor._other()
+                _visit: (visitor: any) => visitor._other()
             }
         });
         vi.mocked(createVenusService).mockReturnValue({
             organization: { get: mockGet },
             apiKeys: { getTokensForOrganization: mockGetTokens }
-        } as ReturnType<typeof createVenusService>);
+        } as unknown as ReturnType<typeof createVenusService>);
 
         const context = createMockContext();
         await expect(cmd.handle(context, { org: "acme" } as ListTokensCommand.Args)).rejects.toThrow(CliError);

--- a/packages/cli/cli-v2/src/commands/org/token/list/__test__/command.test.ts
+++ b/packages/cli/cli-v2/src/commands/org/token/list/__test__/command.test.ts
@@ -114,7 +114,7 @@ describe("ListTokensCommand", () => {
         const mockGet = vi.fn().mockResolvedValue({
             ok: false,
             error: {
-                _visit: (visitor: any) => visitor.unauthorizedError()
+                _visit: (visitor: { unauthorizedError: () => void }) => visitor.unauthorizedError()
             }
         });
         vi.mocked(createVenusService).mockReturnValue({
@@ -135,7 +135,7 @@ describe("ListTokensCommand", () => {
         const mockGetTokens = vi.fn().mockResolvedValue({
             ok: false,
             error: {
-                _visit: (visitor: any) => visitor.unauthorizedError()
+                _visit: (visitor: { unauthorizedError: () => void }) => visitor.unauthorizedError()
             }
         });
         vi.mocked(createVenusService).mockReturnValue({
@@ -157,7 +157,7 @@ describe("ListTokensCommand", () => {
         const mockGetTokens = vi.fn().mockResolvedValue({
             ok: false,
             error: {
-                _visit: (visitor: any) => visitor.organizationNotFoundError()
+                _visit: (visitor: { organizationNotFoundError: () => void }) => visitor.organizationNotFoundError()
             }
         });
         vi.mocked(createVenusService).mockReturnValue({
@@ -177,7 +177,7 @@ describe("ListTokensCommand", () => {
         const mockGetTokens = vi.fn().mockResolvedValue({
             ok: false,
             error: {
-                _visit: (visitor: any) => visitor._other()
+                _visit: (visitor: { _other: () => void }) => visitor._other()
             }
         });
         vi.mocked(createVenusService).mockReturnValue({

--- a/packages/cli/cli-v2/src/commands/org/token/list/__test__/command.test.ts
+++ b/packages/cli/cli-v2/src/commands/org/token/list/__test__/command.test.ts
@@ -1,0 +1,155 @@
+import type { Logger } from "@fern-api/logger";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { CliError } from "../../../../../errors/CliError.js";
+import { ListTokensCommand } from "../command.js";
+
+vi.mock("@fern-api/core", () => ({
+    createVenusService: vi.fn()
+}));
+
+vi.mock("../../../../../ui/withSpinner.js", () => ({
+    withSpinner: vi.fn(({ operation }: { operation: () => Promise<unknown> }) => operation())
+}));
+
+function createMockLogger(): Logger {
+    return {
+        disable: vi.fn(),
+        enable: vi.fn(),
+        trace: vi.fn(),
+        debug: vi.fn(),
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+        log: vi.fn()
+    };
+}
+
+function createMockContext(tokenType: "user" | "organization" = "user") {
+    return {
+        stdout: createMockLogger(),
+        stderr: createMockLogger(),
+        getTokenOrPrompt: vi.fn().mockResolvedValue({ type: tokenType, value: "test-token" })
+    } as unknown as import("../../../../../context/Context.js").Context;
+}
+
+describe("ListTokensCommand", () => {
+    let cmd: ListTokensCommand;
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+        cmd = new ListTokensCommand();
+    });
+
+    it("should list tokens successfully", async () => {
+        const { createVenusService } = await import("@fern-api/core");
+        const mockGetTokens = vi.fn().mockResolvedValue({
+            ok: true,
+            body: [
+                {
+                    tokenId: "tok_1",
+                    status: { type: "active" },
+                    createdTime: new Date("2026-01-01"),
+                    description: "CI token"
+                },
+                {
+                    tokenId: "tok_2",
+                    status: { type: "revoked" },
+                    createdTime: new Date("2026-02-01"),
+                    description: null
+                }
+            ]
+        });
+        vi.mocked(createVenusService).mockReturnValue({
+            apiKeys: { getTokensForOrganization: mockGetTokens }
+        } as ReturnType<typeof createVenusService>);
+
+        const context = createMockContext();
+        await cmd.handle(context, { org: "acme" } as ListTokensCommand.Args);
+
+        expect(mockGetTokens).toHaveBeenCalledWith("acme");
+        expect(context.stdout.info).toHaveBeenCalledTimes(2);
+    });
+
+    it("should show empty message when no tokens", async () => {
+        const { createVenusService } = await import("@fern-api/core");
+        const mockGetTokens = vi.fn().mockResolvedValue({
+            ok: true,
+            body: []
+        });
+        vi.mocked(createVenusService).mockReturnValue({
+            apiKeys: { getTokensForOrganization: mockGetTokens }
+        } as ReturnType<typeof createVenusService>);
+
+        const context = createMockContext();
+        await cmd.handle(context, { org: "acme" } as ListTokensCommand.Args);
+
+        expect(context.stderr.info).toHaveBeenCalledWith(expect.stringContaining("No tokens found"));
+    });
+
+    it("should reject organization tokens", async () => {
+        const context = createMockContext("organization");
+
+        await expect(cmd.handle(context, { org: "acme" } as ListTokensCommand.Args)).rejects.toThrow(CliError);
+
+        expect(context.stderr.error).toHaveBeenCalledWith(
+            expect.stringContaining("Organization tokens cannot list API tokens")
+        );
+    });
+
+    it("should handle UnauthorizedError", async () => {
+        const { createVenusService } = await import("@fern-api/core");
+        const mockGetTokens = vi.fn().mockResolvedValue({
+            ok: false,
+            error: {
+                _visit: (visitor: Record<string, () => void>) => visitor.unauthorizedError()
+            }
+        });
+        vi.mocked(createVenusService).mockReturnValue({
+            apiKeys: { getTokensForOrganization: mockGetTokens }
+        } as ReturnType<typeof createVenusService>);
+
+        const context = createMockContext();
+        await expect(cmd.handle(context, { org: "acme" } as ListTokensCommand.Args)).rejects.toThrow(CliError);
+
+        expect(context.stderr.error).toHaveBeenCalledWith(
+            expect.stringContaining("do not have access to organization")
+        );
+    });
+
+    it("should handle OrganizationNotFoundError", async () => {
+        const { createVenusService } = await import("@fern-api/core");
+        const mockGetTokens = vi.fn().mockResolvedValue({
+            ok: false,
+            error: {
+                _visit: (visitor: Record<string, () => void>) => visitor.organizationNotFoundError()
+            }
+        });
+        vi.mocked(createVenusService).mockReturnValue({
+            apiKeys: { getTokensForOrganization: mockGetTokens }
+        } as ReturnType<typeof createVenusService>);
+
+        const context = createMockContext();
+        await expect(cmd.handle(context, { org: "acme" } as ListTokensCommand.Args)).rejects.toThrow(CliError);
+
+        expect(context.stderr.error).toHaveBeenCalledWith(expect.stringContaining("was not found"));
+    });
+
+    it("should handle unknown errors", async () => {
+        const { createVenusService } = await import("@fern-api/core");
+        const mockGetTokens = vi.fn().mockResolvedValue({
+            ok: false,
+            error: {
+                _visit: (visitor: Record<string, () => void>) => visitor._other()
+            }
+        });
+        vi.mocked(createVenusService).mockReturnValue({
+            apiKeys: { getTokensForOrganization: mockGetTokens }
+        } as ReturnType<typeof createVenusService>);
+
+        const context = createMockContext();
+        await expect(cmd.handle(context, { org: "acme" } as ListTokensCommand.Args)).rejects.toThrow(CliError);
+
+        expect(context.stderr.error).toHaveBeenCalledWith(expect.stringContaining("Failed to list tokens"));
+    });
+});

--- a/packages/cli/cli-v2/src/commands/org/token/list/__test__/command.test.ts
+++ b/packages/cli/cli-v2/src/commands/org/token/list/__test__/command.test.ts
@@ -81,6 +81,44 @@ describe("ListTokensCommand", () => {
         expect(context.stdout.info).toHaveBeenCalledTimes(2);
     });
 
+    it("should output JSON when --json flag is set", async () => {
+        const { createVenusService } = await import("@fern-api/core");
+        const mockGet = mockOrgLookupSuccess();
+        const mockGetTokens = vi.fn().mockResolvedValue({
+            ok: true,
+            body: [
+                {
+                    tokenId: "tok_1",
+                    status: { type: "active" },
+                    createdTime: new Date("2026-01-01T00:00:00.000Z"),
+                    description: "CI token"
+                }
+            ]
+        });
+        vi.mocked(createVenusService).mockReturnValue({
+            organization: { get: mockGet },
+            apiKeys: { getTokensForOrganization: mockGetTokens }
+        } as unknown as ReturnType<typeof createVenusService>);
+
+        const context = createMockContext();
+        await cmd.handle(context, { org: "acme", json: true } as ListTokensCommand.Args);
+
+        expect(context.stdout.info).toHaveBeenCalledWith(
+            JSON.stringify(
+                [
+                    {
+                        tokenId: "tok_1",
+                        status: "active",
+                        createdTime: "2026-01-01T00:00:00.000Z",
+                        description: "CI token"
+                    }
+                ],
+                null,
+                2
+            )
+        );
+    });
+
     it("should show empty message when no tokens", async () => {
         const { createVenusService } = await import("@fern-api/core");
         const mockGet = mockOrgLookupSuccess();

--- a/packages/cli/cli-v2/src/commands/org/token/list/command.ts
+++ b/packages/cli/cli-v2/src/commands/org/token/list/command.ts
@@ -1,0 +1,89 @@
+import { createVenusService } from "@fern-api/core";
+import type { Argv } from "yargs";
+
+import type { Context } from "../../../../context/Context.js";
+import type { GlobalArgs } from "../../../../context/GlobalArgs.js";
+import { CliError } from "../../../../errors/CliError.js";
+import { Colors, Icons } from "../../../../ui/format.js";
+import { withSpinner } from "../../../../ui/withSpinner.js";
+import { command } from "../../../_internal/command.js";
+
+export declare namespace ListTokensCommand {
+    export interface Args extends GlobalArgs {
+        org: string;
+    }
+}
+
+export class ListTokensCommand {
+    public async handle(context: Context, args: ListTokensCommand.Args): Promise<void> {
+        const token = await context.getTokenOrPrompt();
+
+        const venus = createVenusService({ token: token.value });
+
+        const response = await withSpinner({
+            message: `Fetching tokens for organization "${args.org}"`,
+            operation: () => venus.apiKeys.getTokensForOrganization(args.org)
+        });
+
+        if (!response.ok) {
+            response.error._visit({
+                unauthorizedError: () => {
+                    context.stderr.error(`${Icons.error} You do not have access to organization "${args.org}".`);
+                    throw CliError.exit();
+                },
+                organizationNotFoundError: () => {
+                    context.stderr.error(`${Icons.error} Organization "${args.org}" was not found.`);
+                    throw CliError.exit();
+                },
+                _other: () => {
+                    context.stderr.error(
+                        `${Icons.error} Failed to list tokens.\n` +
+                            `\n  Please contact support@buildwithfern.com for assistance.`
+                    );
+                    throw CliError.exit();
+                }
+            });
+            return;
+        }
+
+        const tokens = response.body;
+
+        if (tokens.length === 0) {
+            context.stderr.info(`${Icons.info} No tokens found for organization "${args.org}".`);
+            context.stderr.info("");
+            context.stderr.info("  To create one, run: fern org token create <org>");
+            return;
+        }
+
+        for (const meta of tokens) {
+            const status =
+                meta.status.type === "active"
+                    ? Colors.green("active")
+                    : meta.status.type === "revoked"
+                      ? Colors.red("revoked")
+                      : Colors.dim("expired");
+            const description = meta.description != null ? `  ${Colors.dim(meta.description)}` : "";
+            const created = meta.createdTime.toLocaleDateString();
+            context.stdout.info(`${meta.tokenId}  ${status}  ${Colors.dim(created)}${description}`);
+        }
+    }
+}
+
+export function addListTokensCommand(cli: Argv<GlobalArgs>): void {
+    const cmd = new ListTokensCommand();
+    command(
+        cli,
+        "list <org>",
+        "List tokens for an organization",
+        (context, args) => cmd.handle(context, args as ListTokensCommand.Args),
+        (yargs) =>
+            yargs
+                .usage("\nUsage:\n  $0 org token list <org>")
+                .positional("org", {
+                    type: "string",
+                    demandOption: true,
+                    description: "Organization ID"
+                })
+                .example("$0 org token list acme", "# List all tokens for the 'acme' organization")
+    );
+}

--- a/packages/cli/cli-v2/src/commands/org/token/list/command.ts
+++ b/packages/cli/cli-v2/src/commands/org/token/list/command.ts
@@ -65,9 +65,9 @@ export class ListTokensCommand {
         for (const meta of tokens) {
             const status =
                 meta.status.type === "active"
-                    ? Colors.green("active")
+                    ? Colors.success("active")
                     : meta.status.type === "revoked"
-                      ? Colors.red("revoked")
+                      ? Colors.error("revoked")
                       : Colors.dim("expired");
             const description = meta.description != null ? `  ${Colors.dim(meta.description)}` : "";
             const created = meta.createdTime.toLocaleDateString();

--- a/packages/cli/cli-v2/src/commands/org/token/list/command.ts
+++ b/packages/cli/cli-v2/src/commands/org/token/list/command.ts
@@ -18,6 +18,13 @@ export class ListTokensCommand {
     public async handle(context: Context, args: ListTokensCommand.Args): Promise<void> {
         const token = await context.getTokenOrPrompt();
 
+        if (token.type === "organization") {
+            context.stderr.error(
+                `${Icons.error} Organization tokens cannot list API tokens. Unset the FERN_TOKEN environment variable and run 'fern auth login' to list tokens.`
+            );
+            throw CliError.exit();
+        }
+
         const venus = createVenusService({ token: token.value });
 
         const response = await withSpinner({

--- a/packages/cli/cli-v2/src/commands/org/token/list/command.ts
+++ b/packages/cli/cli-v2/src/commands/org/token/list/command.ts
@@ -12,6 +12,7 @@ import { command } from "../../../_internal/command.js";
 export declare namespace ListTokensCommand {
     export interface Args extends GlobalArgs {
         org: string;
+        json: boolean;
     }
 }
 
@@ -72,6 +73,22 @@ export class ListTokensCommand {
 
         const tokens = response.body;
 
+        if (args.json) {
+            context.stdout.info(
+                JSON.stringify(
+                    tokens.map((t) => ({
+                        tokenId: t.tokenId,
+                        status: t.status.type,
+                        createdTime: t.createdTime.toISOString(),
+                        description: t.description ?? null
+                    })),
+                    null,
+                    2
+                )
+            );
+            return;
+        }
+
         if (tokens.length === 0) {
             context.stderr.info(`${Icons.info} No tokens found for organization "${args.org}".`);
             context.stderr.info("");
@@ -115,6 +132,11 @@ export function addListTokensCommand(cli: Argv<GlobalArgs>): void {
                     type: "string",
                     demandOption: true,
                     description: "Organization name (e.g. acme)"
+                })
+                .option("json", {
+                    type: "boolean",
+                    default: false,
+                    description: "Output as JSON"
                 })
                 .example("$0 org token list acme", "# List all tokens for the 'acme' organization")
     );

--- a/packages/cli/cli-v2/src/commands/org/token/list/command.ts
+++ b/packages/cli/cli-v2/src/commands/org/token/list/command.ts
@@ -1,4 +1,5 @@
 import { createVenusService } from "@fern-api/core";
+import { assertNever } from "@fern-api/core-utils";
 import type { Argv } from "yargs";
 
 import type { Context } from "../../../../context/Context.js";
@@ -27,9 +28,25 @@ export class ListTokensCommand {
 
         const venus = createVenusService({ token: token.value });
 
+        const orgLookup = await venus.organization.get(args.org);
+        if (!orgLookup.ok) {
+            orgLookup.error._visit({
+                unauthorizedError: () => {
+                    context.stderr.error(`${Icons.error} You do not have access to organization "${args.org}".`);
+                    throw CliError.exit();
+                },
+                _other: () => {
+                    context.stderr.error(`${Icons.error} Organization "${args.org}" was not found.`);
+                    throw CliError.exit();
+                }
+            });
+            return;
+        }
+        const auth0OrgId = orgLookup.body.auth0Id;
+
         const response = await withSpinner({
             message: `Fetching tokens for organization "${args.org}"`,
-            operation: () => venus.apiKeys.getTokensForOrganization(args.org)
+            operation: () => venus.apiKeys.getTokensForOrganization(auth0OrgId)
         });
 
         if (!response.ok) {
@@ -63,12 +80,20 @@ export class ListTokensCommand {
         }
 
         for (const meta of tokens) {
-            const status =
-                meta.status.type === "active"
-                    ? Colors.success("active")
-                    : meta.status.type === "revoked"
-                      ? Colors.error("revoked")
-                      : Colors.dim("expired");
+            let status: string;
+            switch (meta.status.type) {
+                case "active":
+                    status = Colors.success("active");
+                    break;
+                case "revoked":
+                    status = Colors.error("revoked");
+                    break;
+                case "expired":
+                    status = Colors.dim("expired");
+                    break;
+                default:
+                    assertNever(meta.status);
+            }
             const description = meta.description != null ? `  ${Colors.dim(meta.description)}` : "";
             const created = meta.createdTime.toLocaleDateString();
             context.stdout.info(`${meta.tokenId}  ${status}  ${Colors.dim(created)}${description}`);
@@ -89,7 +114,7 @@ export function addListTokensCommand(cli: Argv<GlobalArgs>): void {
                 .positional("org", {
                     type: "string",
                     demandOption: true,
-                    description: "Organization ID"
+                    description: "Organization name (e.g. acme)"
                 })
                 .example("$0 org token list acme", "# List all tokens for the 'acme' organization")
     );

--- a/packages/cli/cli-v2/src/commands/org/token/list/index.ts
+++ b/packages/cli/cli-v2/src/commands/org/token/list/index.ts
@@ -1,0 +1,1 @@
+export { addListTokensCommand } from "./command.js";

--- a/packages/cli/cli-v2/src/commands/org/token/revoke/__test__/command.test.ts
+++ b/packages/cli/cli-v2/src/commands/org/token/revoke/__test__/command.test.ts
@@ -55,6 +55,22 @@ describe("RevokeTokenCommand", () => {
         expect(context.stderr.info).toHaveBeenCalledWith(expect.stringContaining("has been revoked"));
     });
 
+    it("should output JSON when --json flag is set", async () => {
+        const { createVenusService } = await import("@fern-api/core");
+        const mockRevoke = vi.fn().mockResolvedValue({ ok: true });
+        vi.mocked(createVenusService).mockReturnValue({
+            apiKeys: { revokeTokenById: mockRevoke }
+        } as unknown as ReturnType<typeof createVenusService>);
+
+        const context = createMockContext();
+        await cmd.handle(context, { tokenId: "tok_123", json: true } as RevokeTokenCommand.Args);
+
+        expect(context.stdout.info).toHaveBeenCalledWith(
+            JSON.stringify({ success: true, tokenId: "tok_123" }, null, 2)
+        );
+        expect(context.stderr.info).not.toHaveBeenCalled();
+    });
+
     it("should reject organization tokens", async () => {
         const context = createMockContext("organization");
 

--- a/packages/cli/cli-v2/src/commands/org/token/revoke/__test__/command.test.ts
+++ b/packages/cli/cli-v2/src/commands/org/token/revoke/__test__/command.test.ts
@@ -46,7 +46,7 @@ describe("RevokeTokenCommand", () => {
         const mockRevoke = vi.fn().mockResolvedValue({ ok: true });
         vi.mocked(createVenusService).mockReturnValue({
             apiKeys: { revokeTokenById: mockRevoke }
-        } as ReturnType<typeof createVenusService>);
+        } as unknown as ReturnType<typeof createVenusService>);
 
         const context = createMockContext();
         await cmd.handle(context, { tokenId: "tok_123" } as RevokeTokenCommand.Args);
@@ -70,12 +70,12 @@ describe("RevokeTokenCommand", () => {
         const mockRevoke = vi.fn().mockResolvedValue({
             ok: false,
             error: {
-                _visit: (visitor: Record<string, () => void>) => visitor.unauthorizedError()
+                _visit: (visitor: any) => visitor.unauthorizedError()
             }
         });
         vi.mocked(createVenusService).mockReturnValue({
             apiKeys: { revokeTokenById: mockRevoke }
-        } as ReturnType<typeof createVenusService>);
+        } as unknown as ReturnType<typeof createVenusService>);
 
         const context = createMockContext();
         await expect(cmd.handle(context, { tokenId: "tok_123" } as RevokeTokenCommand.Args)).rejects.toThrow(CliError);
@@ -88,12 +88,12 @@ describe("RevokeTokenCommand", () => {
         const mockRevoke = vi.fn().mockResolvedValue({
             ok: false,
             error: {
-                _visit: (visitor: Record<string, () => void>) => visitor.tokenNotFoundError()
+                _visit: (visitor: any) => visitor.tokenNotFoundError()
             }
         });
         vi.mocked(createVenusService).mockReturnValue({
             apiKeys: { revokeTokenById: mockRevoke }
-        } as ReturnType<typeof createVenusService>);
+        } as unknown as ReturnType<typeof createVenusService>);
 
         const context = createMockContext();
         await expect(cmd.handle(context, { tokenId: "tok_123" } as RevokeTokenCommand.Args)).rejects.toThrow(CliError);
@@ -106,12 +106,12 @@ describe("RevokeTokenCommand", () => {
         const mockRevoke = vi.fn().mockResolvedValue({
             ok: false,
             error: {
-                _visit: (visitor: Record<string, () => void>) => visitor._other()
+                _visit: (visitor: any) => visitor._other()
             }
         });
         vi.mocked(createVenusService).mockReturnValue({
             apiKeys: { revokeTokenById: mockRevoke }
-        } as ReturnType<typeof createVenusService>);
+        } as unknown as ReturnType<typeof createVenusService>);
 
         const context = createMockContext();
         await expect(cmd.handle(context, { tokenId: "tok_123" } as RevokeTokenCommand.Args)).rejects.toThrow(CliError);

--- a/packages/cli/cli-v2/src/commands/org/token/revoke/__test__/command.test.ts
+++ b/packages/cli/cli-v2/src/commands/org/token/revoke/__test__/command.test.ts
@@ -1,0 +1,129 @@
+import type { Logger } from "@fern-api/logger";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { CliError } from "../../../../../errors/CliError.js";
+import { RevokeTokenCommand } from "../command.js";
+
+vi.mock("@fern-api/core", () => ({
+    createVenusService: vi.fn()
+}));
+
+vi.mock("../../../../../ui/withSpinner.js", () => ({
+    withSpinner: vi.fn(({ operation }: { operation: () => Promise<unknown> }) => operation())
+}));
+
+function createMockLogger(): Logger {
+    return {
+        disable: vi.fn(),
+        enable: vi.fn(),
+        trace: vi.fn(),
+        debug: vi.fn(),
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+        log: vi.fn()
+    };
+}
+
+function createMockContext(tokenType: "user" | "organization" = "user") {
+    return {
+        stdout: createMockLogger(),
+        stderr: createMockLogger(),
+        getTokenOrPrompt: vi.fn().mockResolvedValue({ type: tokenType, value: "test-token" })
+    } as unknown as import("../../../../../context/Context.js").Context;
+}
+
+describe("RevokeTokenCommand", () => {
+    let cmd: RevokeTokenCommand;
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+        cmd = new RevokeTokenCommand();
+    });
+
+    it("should revoke a token successfully", async () => {
+        const { createVenusService } = await import("@fern-api/core");
+        const mockRevoke = vi.fn().mockResolvedValue({ ok: true });
+        vi.mocked(createVenusService).mockReturnValue({
+            apiKeys: { revokeTokenById: mockRevoke }
+        } as ReturnType<typeof createVenusService>);
+
+        const context = createMockContext();
+        await cmd.handle(context, { "token-id": "tok_123" } as RevokeTokenCommand.Args);
+
+        expect(mockRevoke).toHaveBeenCalledWith("tok_123");
+        expect(context.stderr.info).toHaveBeenCalledWith(expect.stringContaining("has been revoked"));
+    });
+
+    it("should reject organization tokens", async () => {
+        const context = createMockContext("organization");
+
+        await expect(cmd.handle(context, { "token-id": "tok_123" } as RevokeTokenCommand.Args)).rejects.toThrow(
+            CliError
+        );
+
+        expect(context.stderr.error).toHaveBeenCalledWith(
+            expect.stringContaining("Organization tokens cannot revoke API tokens")
+        );
+    });
+
+    it("should handle UnauthorizedError", async () => {
+        const { createVenusService } = await import("@fern-api/core");
+        const mockRevoke = vi.fn().mockResolvedValue({
+            ok: false,
+            error: {
+                _visit: (visitor: Record<string, () => void>) => visitor.unauthorizedError()
+            }
+        });
+        vi.mocked(createVenusService).mockReturnValue({
+            apiKeys: { revokeTokenById: mockRevoke }
+        } as ReturnType<typeof createVenusService>);
+
+        const context = createMockContext();
+        await expect(cmd.handle(context, { "token-id": "tok_123" } as RevokeTokenCommand.Args)).rejects.toThrow(
+            CliError
+        );
+
+        expect(context.stderr.error).toHaveBeenCalledWith(expect.stringContaining("not authorized to revoke"));
+    });
+
+    it("should handle TokenNotFoundError", async () => {
+        const { createVenusService } = await import("@fern-api/core");
+        const mockRevoke = vi.fn().mockResolvedValue({
+            ok: false,
+            error: {
+                _visit: (visitor: Record<string, () => void>) => visitor.tokenNotFoundError()
+            }
+        });
+        vi.mocked(createVenusService).mockReturnValue({
+            apiKeys: { revokeTokenById: mockRevoke }
+        } as ReturnType<typeof createVenusService>);
+
+        const context = createMockContext();
+        await expect(cmd.handle(context, { "token-id": "tok_123" } as RevokeTokenCommand.Args)).rejects.toThrow(
+            CliError
+        );
+
+        expect(context.stderr.error).toHaveBeenCalledWith(expect.stringContaining("was not found"));
+    });
+
+    it("should handle unknown errors", async () => {
+        const { createVenusService } = await import("@fern-api/core");
+        const mockRevoke = vi.fn().mockResolvedValue({
+            ok: false,
+            error: {
+                _visit: (visitor: Record<string, () => void>) => visitor._other()
+            }
+        });
+        vi.mocked(createVenusService).mockReturnValue({
+            apiKeys: { revokeTokenById: mockRevoke }
+        } as ReturnType<typeof createVenusService>);
+
+        const context = createMockContext();
+        await expect(cmd.handle(context, { "token-id": "tok_123" } as RevokeTokenCommand.Args)).rejects.toThrow(
+            CliError
+        );
+
+        expect(context.stderr.error).toHaveBeenCalledWith(expect.stringContaining("Failed to revoke token"));
+    });
+});

--- a/packages/cli/cli-v2/src/commands/org/token/revoke/__test__/command.test.ts
+++ b/packages/cli/cli-v2/src/commands/org/token/revoke/__test__/command.test.ts
@@ -70,7 +70,7 @@ describe("RevokeTokenCommand", () => {
         const mockRevoke = vi.fn().mockResolvedValue({
             ok: false,
             error: {
-                _visit: (visitor: any) => visitor.unauthorizedError()
+                _visit: (visitor: { unauthorizedError: () => void }) => visitor.unauthorizedError()
             }
         });
         vi.mocked(createVenusService).mockReturnValue({
@@ -88,7 +88,7 @@ describe("RevokeTokenCommand", () => {
         const mockRevoke = vi.fn().mockResolvedValue({
             ok: false,
             error: {
-                _visit: (visitor: any) => visitor.tokenNotFoundError()
+                _visit: (visitor: { tokenNotFoundError: () => void }) => visitor.tokenNotFoundError()
             }
         });
         vi.mocked(createVenusService).mockReturnValue({
@@ -106,7 +106,7 @@ describe("RevokeTokenCommand", () => {
         const mockRevoke = vi.fn().mockResolvedValue({
             ok: false,
             error: {
-                _visit: (visitor: any) => visitor._other()
+                _visit: (visitor: { _other: () => void }) => visitor._other()
             }
         });
         vi.mocked(createVenusService).mockReturnValue({

--- a/packages/cli/cli-v2/src/commands/org/token/revoke/__test__/command.test.ts
+++ b/packages/cli/cli-v2/src/commands/org/token/revoke/__test__/command.test.ts
@@ -49,7 +49,7 @@ describe("RevokeTokenCommand", () => {
         } as ReturnType<typeof createVenusService>);
 
         const context = createMockContext();
-        await cmd.handle(context, { "token-id": "tok_123" } as RevokeTokenCommand.Args);
+        await cmd.handle(context, { tokenId: "tok_123" } as RevokeTokenCommand.Args);
 
         expect(mockRevoke).toHaveBeenCalledWith("tok_123");
         expect(context.stderr.info).toHaveBeenCalledWith(expect.stringContaining("has been revoked"));
@@ -58,9 +58,7 @@ describe("RevokeTokenCommand", () => {
     it("should reject organization tokens", async () => {
         const context = createMockContext("organization");
 
-        await expect(cmd.handle(context, { "token-id": "tok_123" } as RevokeTokenCommand.Args)).rejects.toThrow(
-            CliError
-        );
+        await expect(cmd.handle(context, { tokenId: "tok_123" } as RevokeTokenCommand.Args)).rejects.toThrow(CliError);
 
         expect(context.stderr.error).toHaveBeenCalledWith(
             expect.stringContaining("Organization tokens cannot revoke API tokens")
@@ -80,9 +78,7 @@ describe("RevokeTokenCommand", () => {
         } as ReturnType<typeof createVenusService>);
 
         const context = createMockContext();
-        await expect(cmd.handle(context, { "token-id": "tok_123" } as RevokeTokenCommand.Args)).rejects.toThrow(
-            CliError
-        );
+        await expect(cmd.handle(context, { tokenId: "tok_123" } as RevokeTokenCommand.Args)).rejects.toThrow(CliError);
 
         expect(context.stderr.error).toHaveBeenCalledWith(expect.stringContaining("not authorized to revoke"));
     });
@@ -100,9 +96,7 @@ describe("RevokeTokenCommand", () => {
         } as ReturnType<typeof createVenusService>);
 
         const context = createMockContext();
-        await expect(cmd.handle(context, { "token-id": "tok_123" } as RevokeTokenCommand.Args)).rejects.toThrow(
-            CliError
-        );
+        await expect(cmd.handle(context, { tokenId: "tok_123" } as RevokeTokenCommand.Args)).rejects.toThrow(CliError);
 
         expect(context.stderr.error).toHaveBeenCalledWith(expect.stringContaining("was not found"));
     });
@@ -120,9 +114,7 @@ describe("RevokeTokenCommand", () => {
         } as ReturnType<typeof createVenusService>);
 
         const context = createMockContext();
-        await expect(cmd.handle(context, { "token-id": "tok_123" } as RevokeTokenCommand.Args)).rejects.toThrow(
-            CliError
-        );
+        await expect(cmd.handle(context, { tokenId: "tok_123" } as RevokeTokenCommand.Args)).rejects.toThrow(CliError);
 
         expect(context.stderr.error).toHaveBeenCalledWith(expect.stringContaining("Failed to revoke token"));
     });

--- a/packages/cli/cli-v2/src/commands/org/token/revoke/command.ts
+++ b/packages/cli/cli-v2/src/commands/org/token/revoke/command.ts
@@ -10,7 +10,7 @@ import { command } from "../../../_internal/command.js";
 
 export declare namespace RevokeTokenCommand {
     export interface Args extends GlobalArgs {
-        "token-id": string;
+        tokenId: string;
     }
 }
 
@@ -27,7 +27,7 @@ export class RevokeTokenCommand {
 
         const venus = createVenusService({ token: token.value });
 
-        const tokenId = args["token-id"];
+        const tokenId = args.tokenId;
 
         const response = await withSpinner({
             message: `Revoking token "${tokenId}"`,

--- a/packages/cli/cli-v2/src/commands/org/token/revoke/command.ts
+++ b/packages/cli/cli-v2/src/commands/org/token/revoke/command.ts
@@ -1,0 +1,72 @@
+import { createVenusService } from "@fern-api/core";
+import type { Argv } from "yargs";
+
+import type { Context } from "../../../../context/Context.js";
+import type { GlobalArgs } from "../../../../context/GlobalArgs.js";
+import { CliError } from "../../../../errors/CliError.js";
+import { Icons } from "../../../../ui/format.js";
+import { withSpinner } from "../../../../ui/withSpinner.js";
+import { command } from "../../../_internal/command.js";
+
+export declare namespace RevokeTokenCommand {
+    export interface Args extends GlobalArgs {
+        "token-id": string;
+    }
+}
+
+export class RevokeTokenCommand {
+    public async handle(context: Context, args: RevokeTokenCommand.Args): Promise<void> {
+        const token = await context.getTokenOrPrompt();
+
+        const venus = createVenusService({ token: token.value });
+
+        const tokenId = args["token-id"];
+
+        const response = await withSpinner({
+            message: `Revoking token "${tokenId}"`,
+            operation: () => venus.apiKeys.revokeTokenById(tokenId)
+        });
+
+        if (response.ok) {
+            context.stderr.info(`${Icons.success} Token "${tokenId}" has been revoked.`);
+            return;
+        }
+
+        response.error._visit({
+            unauthorizedError: () => {
+                context.stderr.error(`${Icons.error} You are not authorized to revoke this token.`);
+                throw CliError.exit();
+            },
+            tokenNotFoundError: () => {
+                context.stderr.error(`${Icons.error} Token "${tokenId}" was not found.`);
+                throw CliError.exit();
+            },
+            _other: () => {
+                context.stderr.error(
+                    `${Icons.error} Failed to revoke token.\n` +
+                        `\n  Please contact support@buildwithfern.com for assistance.`
+                );
+                throw CliError.exit();
+            }
+        });
+    }
+}
+
+export function addRevokeTokenCommand(cli: Argv<GlobalArgs>): void {
+    const cmd = new RevokeTokenCommand();
+    command(
+        cli,
+        "revoke <token-id>",
+        "Revoke an organization API token",
+        (context, args) => cmd.handle(context, args as RevokeTokenCommand.Args),
+        (yargs) =>
+            yargs
+                .usage("\nUsage:\n  $0 org token revoke <token-id>")
+                .positional("token-id", {
+                    type: "string",
+                    demandOption: true,
+                    description: "Token ID to revoke"
+                })
+                .example("$0 org token revoke abc123", "# Revoke the token with ID 'abc123'")
+    );
+}

--- a/packages/cli/cli-v2/src/commands/org/token/revoke/command.ts
+++ b/packages/cli/cli-v2/src/commands/org/token/revoke/command.ts
@@ -11,6 +11,7 @@ import { command } from "../../../_internal/command.js";
 export declare namespace RevokeTokenCommand {
     export interface Args extends GlobalArgs {
         tokenId: string;
+        json: boolean;
     }
 }
 
@@ -35,7 +36,11 @@ export class RevokeTokenCommand {
         });
 
         if (response.ok) {
-            context.stderr.info(`${Icons.success} Token "${tokenId}" has been revoked.`);
+            if (args.json) {
+                context.stdout.info(JSON.stringify({ success: true, tokenId }, null, 2));
+            } else {
+                context.stderr.info(`${Icons.success} Token "${tokenId}" has been revoked.`);
+            }
             return;
         }
 
@@ -73,6 +78,11 @@ export function addRevokeTokenCommand(cli: Argv<GlobalArgs>): void {
                     type: "string",
                     demandOption: true,
                     description: "Token ID to revoke"
+                })
+                .option("json", {
+                    type: "boolean",
+                    default: false,
+                    description: "Output as JSON"
                 })
                 .example("$0 org token revoke abc123", "# Revoke the token with ID 'abc123'")
     );

--- a/packages/cli/cli-v2/src/commands/org/token/revoke/command.ts
+++ b/packages/cli/cli-v2/src/commands/org/token/revoke/command.ts
@@ -18,6 +18,13 @@ export class RevokeTokenCommand {
     public async handle(context: Context, args: RevokeTokenCommand.Args): Promise<void> {
         const token = await context.getTokenOrPrompt();
 
+        if (token.type === "organization") {
+            context.stderr.error(
+                `${Icons.error} Organization tokens cannot revoke API tokens. Unset the FERN_TOKEN environment variable and run 'fern auth login' to revoke tokens.`
+            );
+            throw CliError.exit();
+        }
+
         const venus = createVenusService({ token: token.value });
 
         const tokenId = args["token-id"];

--- a/packages/cli/cli-v2/src/commands/org/token/revoke/index.ts
+++ b/packages/cli/cli-v2/src/commands/org/token/revoke/index.ts
@@ -1,0 +1,1 @@
+export { addRevokeTokenCommand } from "./command.js";


### PR DESCRIPTION
## Description
Linear ticket: Refs FER-8580
<!-- Prerequisite PR #14882 bumped the Venus SDK to 0.22.34, exposing the `apiKeys` resource used by token commands -->

Implements the remaining `fern org` sub-commands: `token` (create/list/revoke) and `member` (invite/list/remove). All 6 commands call existing Venus API endpoints — no backend changes needed.

## Changes Made
- **`fern org token create <org>`** — creates an org-scoped API key via `venus.apiKeys.create()`, with optional `--description`
- **`fern org token list <org>`** — lists tokens with color-coded status (active/revoked/expired), date, and description via `venus.apiKeys.getTokensForOrganization()`
- **`fern org token revoke <token-id>`** — revokes by token ID via `venus.apiKeys.revokeTokenById()`
- **`fern org member invite <email> <org>`** — invites a user via `venus.organization.inviteUser()`
- **`fern org member list <org>`** — lists members (userId, name, email) via `venus.organization.get()`
- **`fern org member remove <user-id> <org>`** — removes a user via `venus.organization.removeUser()`
- Wired both `member` and `token` command groups into the existing `org` command group
- All 6 commands reject organization-scoped tokens with a helpful message, consistent with existing `org create` and `org list`
- `member list` outputs `userId` so users can discover the ID needed for `member remove`
- Token and member commands resolve org name → `auth0Id` via `venus.organization.get()` before calling downstream endpoints
- **`--json` flag** on all 6 commands outputs structured JSON to `stdout` (human-readable output goes to `stderr`), following the pattern from `fern auth status --json`

All commands follow existing cli-v2 patterns (class-based with `handle()`, yargs builder, `_visit()` error handling, `withSpinner`, `Icons`/`Colors`).

## Updates Since Last Revision
- **Added `--json` output support to all 6 org sub-commands.** Each command accepts `--json` and outputs structured JSON to `stdout.info` while suppressing human-readable `stderr` output:
  - `member invite --json` → `{ success, email, org }`
  - `member remove --json` → `{ success, userId, org }`
  - `member list --json` → `[{ userId, displayName, email }]`
  - `token create --json` → `{ tokenId, token }`
  - `token list --json` → `[{ tokenId, status, createdTime, description }]`
  - `token revoke --json` → `{ success, tokenId }`
- **41 unit tests across 6 test files** (up from 31) — added JSON output tests for each command
- Resolved TS compilation errors (non-null assertion lint violations) and biome lint issues

## Human Review Checklist
> These items are worth extra scrutiny:

1. **JSON output formats**: Each command defines its own JSON shape (see list above). Verify these are the fields consumers would expect — particularly `member list` using `email` (mapped from `emailAddress`) and `token list` using `status` (mapped from `status.type`).
2. **Org ID semantics**: Member and token commands now resolve the user-supplied org name to `auth0Id` via `venus.organization.get()`. Verify this two-step lookup is correct — especially that `auth0Id` is the right field to pass to `inviteUser`/`removeUser`/`apiKeys.*`.
3. **Error union variant names**: The `_visit()` handlers assume specific variant names (e.g. `tokenNotFoundError`, `userIdDoesNotExistError`, `organizationNotFoundError`). If the SDK's actual error union has different names, these handlers would silently fall through to `_other`. Worth verifying against the SDK types.
4. **No `versions.yml` entry**: May need a new CLI version entry for this feature addition.
5. **`assertNever` in token list**: The `ListTokensCommand` uses `assertNever(meta.status)` in the status switch — verify this import exists and handles the exhaustive check correctly.

## Testing
- [x] Biome lint/format passes (`pnpm run check`)
- [x] TypeScript compilation passes (`tsc`)
- [x] 41 unit tests (6 files, all passing) with mocked `createVenusService` — covering success paths, `--json` output, org-token rejection, and all error variants
- [ ] Manual testing against live Venus API

Link to Devin session: https://app.devin.ai/sessions/88362feffe364fa6b4b4f82a847a97b7