### PR TITLE
fix(ci): restore concurrent test execution to improve ETE test performance

### DIFF
--- a/packages/cli/ete-tests/src/tests/generate/fernignore.test.ts
+++ b/packages/cli/ete-tests/src/tests/generate/fernignore.test.ts
@@ -28,7 +28,7 @@ Practice schema-first API design with Fern
 
 describe("fern generate --local", () => {
     // eslint-disable-next-line jest/expect-expect
-    it("Keep files listed in .fernignore from unmodified", async ({ signal }) => {
+    it.concurrent("Keep files listed in .fernignore from unmodified", async ({ signal }) => {
         const pathOfDirectory = await init({ signal });
         await runFernCli(["generate", "--local", "--keepDocker"], { cwd: pathOfDirectory, signal });
 
@@ -55,7 +55,7 @@ describe("fern generate --local", () => {
     }, 360_000);
 
     // eslint-disable-next-line jest/expect-expect
-    it("Prevent initial generation of files listed in .fernignore", async ({ signal }) => {
+    it.concurrent("Prevent initial generation of files listed in .fernignore", async ({ signal }) => {
         const pathOfDirectory = await init({ signal });
 
         // Create output directory with .fernignore BEFORE first generation

--- a/packages/cli/ete-tests/src/tests/generate/generate-with-settings.test.ts
+++ b/packages/cli/ete-tests/src/tests/generate/generate-with-settings.test.ts
@@ -5,7 +5,7 @@ import tmp from "tmp-promise";
 import { runFernCli } from "../../utils/runFernCli.js";
 
 describe("fern generate with settings", () => {
-    it("single api", async ({ expect, signal }) => {
+    it.concurrent("single api", async ({ expect, signal }) => {
         const fixturesDir = join(AbsoluteFilePath.of(__dirname), RelativeFilePath.of("fixtures/api-settings"));
 
         const tmpDir = await tmp.dir();
@@ -20,7 +20,7 @@ describe("fern generate with settings", () => {
         ).toMatchSnapshot();
     }, 180_000);
 
-    it("dependencies-based api", async ({ expect, signal }) => {
+    it.concurrent("dependencies-based api", async ({ expect, signal }) => {
         const fixturesDir = join(AbsoluteFilePath.of(__dirname), RelativeFilePath.of("fixtures/api-settings-unioned"));
         const tmpDir = await tmp.dir();
         const directory = AbsoluteFilePath.of(tmpDir.path);

--- a/packages/cli/ete-tests/src/tests/generate/generate.test.ts
+++ b/packages/cli/ete-tests/src/tests/generate/generate.test.ts
@@ -8,7 +8,7 @@ import { init } from "../init/init.js";
 const fixturesDir = join(AbsoluteFilePath.of(__dirname), RelativeFilePath.of("fixtures"));
 
 describe("fern generate", () => {
-    it("default api (fern init)", async ({ signal }) => {
+    it.concurrent("default api (fern init)", async ({ signal }) => {
         const pathOfDirectory = await init({ signal });
 
         await runFernCli(["generate", "--local", "--keepDocker"], {
@@ -19,7 +19,7 @@ describe("fern generate", () => {
         expect(await doesPathExist(join(pathOfDirectory, RelativeFilePath.of("sdks/typescript")))).toBe(true);
     }, 180_000);
 
-    it("ir contains fdr definitionid", async ({ signal }) => {
+    it.concurrent("ir contains fdr definitionid", async ({ signal }) => {
         if (globalThis.process.env.FERN_ORG_TOKEN_DEV == null) {
             throw new Error("FERN_ORG_TOKEN_DEV is not set");
         }
@@ -68,7 +68,7 @@ describe("fern generate", () => {
         ).toMatchSnapshot();
     }, 180_000);
 
-    it("generate docs with no auth requires login", async ({ signal }) => {
+    it.concurrent("generate docs with no auth requires login", async ({ signal }) => {
         const { stdout, stderr } = await runFernCli(["generate", "--docs", "--no-prompt"], {
             cwd: join(fixturesDir, RelativeFilePath.of("docs")),
             reject: false,
@@ -84,7 +84,7 @@ describe("fern generate", () => {
         );
     }, 180_000);
 
-    it("generate docs with FDR origin override and token succeeds", async ({ signal }) => {
+    it.concurrent("generate docs with FDR origin override and token succeeds", async ({ signal }) => {
         const { stdout } = await runFernCli(["generate", "--docs", "--no-prompt"], {
             cwd: join(fixturesDir, RelativeFilePath.of("docs")),
             reject: false,
@@ -98,7 +98,7 @@ describe("fern generate", () => {
         expect(stdout).toContain("ferndevtest.docs.dev.buildwithfern.com Started.");
     }, 180_000);
 
-    it("generate docs with no docs.yml file fails", async ({ signal }) => {
+    it.concurrent("generate docs with no docs.yml file fails", async ({ signal }) => {
         const { stdout } = await runFernCli(["generate", "--docs"], {
             cwd: join(fixturesDir, RelativeFilePath.of("basic")),
             reject: false,
@@ -107,7 +107,7 @@ describe("fern generate", () => {
         expect(stdout).toContain("No docs.yml file found. Please make sure your project has one.");
     }, 180_000);
 
-    it("lists available groups when no group specified", async ({ signal }) => {
+    it.concurrent("lists available groups when no group specified", async ({ signal }) => {
         const { stdout, failed } = await runFernCli(["generate", "--local"], {
             cwd: join(fixturesDir, RelativeFilePath.of("no-default-group")),
             reject: false,

--- a/packages/cli/ete-tests/src/tests/upgrade-generator/upgrade-generator.test.ts
+++ b/packages/cli/ete-tests/src/tests/upgrade-generator/upgrade-generator.test.ts
@@ -10,7 +10,7 @@ import { runFernCli } from "../../utils/runFernCli.js";
 const FIXTURES_DIR = path.join(__dirname, "fixtures");
 
 describe("fern generator upgrade", () => {
-    it("fern generator upgrade", async ({ signal }) => {
+    it.concurrent("fern generator upgrade", async ({ signal }) => {
         // Create tmpdir and copy contents
         const tmpDir = await tmp.dir();
         const directory = AbsoluteFilePath.of(tmpDir.path);
@@ -38,7 +38,7 @@ describe("fern generator upgrade", () => {
         expect(JSON.parse((await readFile(outputFile)).toString()).version).not.toEqual("2.0.0");
     }, 180_000);
 
-    it("fern generator upgrade with filters", async ({ signal }) => {
+    it.concurrent("fern generator upgrade with filters", async ({ signal }) => {
         // Create tmpdir and copy contents
         const tmpDir = await tmp.dir();
         const directory = AbsoluteFilePath.of(tmpDir.path);
@@ -93,7 +93,7 @@ describe("fern generator upgrade", () => {
         ).toMatchSnapshot();
     }, 180_000);
 
-    it("fern generator upgrade majors", async ({ signal }) => {
+    it.concurrent("fern generator upgrade majors", async ({ signal }) => {
         // Create tmpdir and copy contents
         const tmpDir = await tmp.dir();
         const directory = AbsoluteFilePath.of(tmpDir.path);
@@ -183,7 +183,9 @@ describe("fern generator upgrade", () => {
         ).toMatchSnapshot();
     }, 180_000);
 
-    it("fern generator upgrade --skip-autorelease-disabled skips autorelease false generators", async ({ signal }) => {
+    it.concurrent("fern generator upgrade --skip-autorelease-disabled skips autorelease false generators", async ({
+        signal
+    }) => {
         const tmpDir = await tmp.dir();
         const directory = AbsoluteFilePath.of(tmpDir.path);
 
@@ -242,7 +244,9 @@ describe("fern generator upgrade", () => {
         expect(JSON.parse((await readFile(outputFileJava)).toString()).version).not.toEqual("0.0.1");
     }, 180_000);
 
-    it("fern generator upgrade without --skip-autorelease-disabled upgrades all generators", async ({ signal }) => {
+    it.concurrent("fern generator upgrade without --skip-autorelease-disabled upgrades all generators", async ({
+        signal
+    }) => {
         const tmpDir = await tmp.dir();
         const directory = AbsoluteFilePath.of(tmpDir.path);
 
@@ -272,7 +276,7 @@ describe("fern generator upgrade", () => {
         expect(JSON.parse((await readFile(outputFile)).toString()).version).not.toEqual("2.0.0");
     }, 180_000);
 
-    it("fern generator upgrade shows major version message", async ({ signal }) => {
+    it.concurrent("fern generator upgrade shows major version message", async ({ signal }) => {
         const tmpDir = await tmp.dir();
         const directory = AbsoluteFilePath.of(tmpDir.path);
 

--- a/packages/cli/ete-tests/vitest.config.ts
+++ b/packages/cli/ete-tests/vitest.config.ts
@@ -4,16 +4,14 @@ export default defineConfig(
     mergeConfig(defaultConfig, {
         test: {
             // ETE tests spawn heavy child processes (Node CLI, Docker containers).
-            // Running too many test files in parallel causes resource contention
-            // and widespread timeouts on CI runners.
-            fileParallelism: false,
-            maxConcurrency: 3,
+            // Limit parallelism to avoid resource contention on CI runners.
+            maxConcurrency: 5,
             poolOptions: {
                 threads: {
-                    maxThreads: 2
+                    maxThreads: 3
                 },
                 forks: {
-                    maxForks: 2
+                    maxForks: 3
                 }
             }
         }


### PR DESCRIPTION
## Description

Restores test parallelism that was progressively eliminated by #14356, #14601, and #14673 to fix flakiness. Those changes fixed timeouts but increased ETE wall-clock time from **~2.6 min to ~12.2 min** (~4.7x slower).

This PR re-enables both within-file concurrency (`it.concurrent()`) and cross-file parallelism, with conservative limits to avoid the original Docker container contention.

## Changes Made

- Restored `it.concurrent()` in 16 test definitions across 4 files:
  - `generate.test.ts` (6 tests)
  - `fernignore.test.ts` (2 tests)
  - `generate-with-settings.test.ts` (2 tests)
  - `upgrade-generator.test.ts` (6 tests)
- Updated `vitest.config.ts`:
  - Removed `fileParallelism: false` (re-enables cross-file parallelism)
  - Increased `maxConcurrency` from 3 → 5
  - Increased `maxThreads` from 2 → 3, `maxForks` from 2 → 3

## Testing

- [x] CI `test-ete` job passes
- [ ] Monitor ETE test stability post-merge for timeout regressions

## ⚠️ Review Checklist

- **Flakiness risk**: Removing `fileParallelism: false` is the most aggressive change — this was added in #14601 specifically because cross-file parallelism caused Docker container contention and widespread timeouts. A single green CI run does not guarantee this won't regress intermittently. Watch for flaky failures post-merge.
- Verify the `test-ete` job duration on this PR — expect it to drop significantly from the current ~12 min baseline.
- If timeouts resurface, consider re-adding `fileParallelism: false` while keeping `it.concurrent()` (which alone saved ~60s).

Link to Devin session: https://app.devin.ai/sessions/42d9339d9a7c463ca38d8c2bce17a878
Requested by: @Swimburger
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/14885" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
