### PR TITLE
feat(cli): support custom `llms.txt` and `llms-full.txt` files in `docs.yml`

### DIFF
--- a/docs-yml.schema.json
+++ b/docs-yml.schema.json
@@ -4396,6 +4396,26 @@
               "type": "null"
             }
           ]
+        },
+        "llms-txt": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "llms-full-txt": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
         }
       },
       "additionalProperties": false

--- a/fern/apis/docs-yml/definition/docs.yml
+++ b/fern/apis/docs-yml/definition/docs.yml
@@ -163,6 +163,16 @@ types:
           in llms.txt. Defaults to "description". If the preferred field is not present
           in a page's frontmatter, falls back to other fields (description, subtitle,
           og:description, headline, excerpt).
+      llms-txt:
+        type: optional<string>
+        docs: |
+          Relative filepath to a custom `llms.txt` file that Fern should host at `/llms.txt`,
+          overriding the auto-generated version. The file should follow the llmstxt.org specification.
+      llms-full-txt:
+        type: optional<string>
+        docs: |
+          Relative filepath to a custom `llms-full.txt` file that Fern should host at `/llms-full.txt`,
+          overriding the auto-generated version. The file should contain the full concatenated documentation content.
 
   CheckRuleSeverity:
     enum:

--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -1,4 +1,15 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+
+- version: 4.67.0
+  changelogEntry:
+    - summary: |
+        Add `agents.llms-txt` and `agents.llms-full-txt` to `docs.yml` so customers can upload
+        custom `llms.txt` and `llms-full.txt` files that override the auto-generated versions
+        on their docs sites.
+      type: feat
+  createdAt: "2026-04-10"
+  irVersion: 66
+
 - version: 4.66.1
   changelogEntry:
     - summary: |

--- a/packages/cli/configuration-loader/src/docs-yml/parseDocsConfiguration.ts
+++ b/packages/cli/configuration-loader/src/docs-yml/parseDocsConfiguration.ts
@@ -137,15 +137,28 @@ export async function parseDocsConfiguration({
         context
     });
 
-    const [navigation, pages, typography, css, js, metadata, context7File] = await Promise.all([
-        convertedNavigationPromise,
-        pagesPromise,
-        typographyPromise,
-        cssPromise,
-        jsPromise,
-        metadataPromise,
-        context7FilePromise
-    ]);
+    const llmsTxtFilePromise = parseTextFile({
+        rawPath: agents?.llmsTxt,
+        absoluteFilepathToDocsConfig
+    });
+
+    const llmsFullTxtFilePromise = parseTextFile({
+        rawPath: agents?.llmsFullTxt,
+        absoluteFilepathToDocsConfig
+    });
+
+    const [navigation, pages, typography, css, js, metadata, context7File, llmsTxtFile, llmsFullTxtFile] =
+        await Promise.all([
+            convertedNavigationPromise,
+            pagesPromise,
+            typographyPromise,
+            cssPromise,
+            jsPromise,
+            metadataPromise,
+            context7FilePromise,
+            llmsTxtFilePromise,
+            llmsFullTxtFilePromise
+        ]);
 
     // Validate incompatible tabs configuration: sidebar placement + center alignment
     const resolvedTheme = convertThemeConfig(rawDocsConfiguration.theme);
@@ -196,6 +209,8 @@ export async function parseDocsConfiguration({
         layout: convertLayoutConfig(layout, tabsObj?.alignment, tabsObj?.placement),
         settings: convertSettingsConfig(rawDocsConfiguration.settings),
         context7File,
+        llmsTxtFile,
+        llmsFullTxtFile,
         theme: resolvedTheme,
         analyticsConfig: {
             ...rawDocsConfiguration.analytics,
@@ -462,6 +477,23 @@ function convertSettingsConfig(
         disableExplorerProxy: settings.disableExplorerProxy ?? false,
         disableAnalytics: settings.disableAnalytics ?? false
     };
+}
+
+async function parseTextFile({
+    rawPath,
+    absoluteFilepathToDocsConfig
+}: {
+    rawPath: string | undefined;
+    absoluteFilepathToDocsConfig: AbsoluteFilePath;
+}): Promise<AbsoluteFilePath | undefined> {
+    if (rawPath == null) {
+        return undefined;
+    }
+
+    const absolutePath = resolveFilepath(rawPath, absoluteFilepathToDocsConfig);
+    await readFile(absolutePath, "utf8");
+
+    return absolutePath;
 }
 
 async function parseContext7File({

--- a/packages/cli/configuration/src/docs-yml/DocsYmlSchemas.ts
+++ b/packages/cli/configuration/src/docs-yml/DocsYmlSchemas.ts
@@ -240,7 +240,9 @@ export const PageDescriptionSource = z.enum(["description", "subtitle"]);
 
 export const AgentsConfig = z.object({
     "page-directive": z.string().optional(),
-    "page-description-source": PageDescriptionSource.optional()
+    "page-description-source": PageDescriptionSource.optional(),
+    "llms-txt": z.string().optional(),
+    "llms-full-txt": z.string().optional()
 });
 
 export const AIChatConfig = z.object({

--- a/packages/cli/configuration/src/docs-yml/ParsedDocsConfiguration.ts
+++ b/packages/cli/configuration/src/docs-yml/ParsedDocsConfiguration.ts
@@ -71,6 +71,8 @@ export interface ParsedDocsConfiguration {
     layout: CjsFdrSdk.docs.v1.commons.DocsLayoutConfig | undefined;
     settings: CjsFdrSdk.docs.v1.commons.DocsSettingsConfig | undefined;
     context7File: AbsoluteFilePath | undefined;
+    llmsTxtFile: AbsoluteFilePath | undefined;
+    llmsFullTxtFile: AbsoluteFilePath | undefined;
     languages: Language[] | undefined;
     defaultLanguage: CjsFdrSdk.docs.v1.commons.ProgrammingLanguage | undefined;
     analyticsConfig: CjsFdrSdk.docs.v1.commons.AnalyticsConfig | undefined;

--- a/packages/cli/configuration/src/docs-yml/schemas/sdk/api/resources/docs/types/AgentsConfig.ts
+++ b/packages/cli/configuration/src/docs-yml/schemas/sdk/api/resources/docs/types/AgentsConfig.ts
@@ -12,4 +12,14 @@ export interface AgentsConfig {
      * og:description, headline, excerpt).
      */
     pageDescriptionSource?: FernDocsConfig.PageDescriptionSource;
+    /**
+     * Relative filepath to a custom `llms.txt` file that Fern should host at `/llms.txt`,
+     * overriding the auto-generated version. The file should follow the llmstxt.org specification.
+     */
+    llmsTxt?: string;
+    /**
+     * Relative filepath to a custom `llms-full.txt` file that Fern should host at `/llms-full.txt`,
+     * overriding the auto-generated version. The file should contain the full concatenated documentation content.
+     */
+    llmsFullTxt?: string;
 }

--- a/packages/cli/configuration/src/docs-yml/schemas/sdk/serialization/resources/docs/types/AgentsConfig.ts
+++ b/packages/cli/configuration/src/docs-yml/schemas/sdk/serialization/resources/docs/types/AgentsConfig.ts
@@ -9,11 +9,15 @@ export const AgentsConfig: core.serialization.ObjectSchema<serializers.AgentsCon
     core.serialization.object({
         pageDirective: core.serialization.property("page-directive", core.serialization.string().optional()),
         pageDescriptionSource: core.serialization.property("page-description-source", PageDescriptionSource.optional()),
+        llmsTxt: core.serialization.property("llms-txt", core.serialization.string().optional()),
+        llmsFullTxt: core.serialization.property("llms-full-txt", core.serialization.string().optional()),
     });
 
 export declare namespace AgentsConfig {
     export interface Raw {
         "page-directive"?: string | null;
         "page-description-source"?: PageDescriptionSource.Raw | null;
+        "llms-txt"?: string | null;
+        "llms-full-txt"?: string | null;
     }
 }

--- a/packages/cli/docs-resolver/src/DocsDefinitionResolver.ts
+++ b/packages/cli/docs-resolver/src/DocsDefinitionResolver.ts
@@ -813,7 +813,16 @@ export class DocsDefinitionResolver {
             css: this.parsedDocsConfig.css,
             js: this.convertJavascriptConfiguration(),
             // @ts-expect-error - Remove this when the fdr-sdk upgraded to the latest version
-            agents: this.parsedDocsConfig.agents,
+            agents:
+                this.parsedDocsConfig.agents != null ||
+                this.parsedDocsConfig.llmsTxtFile != null ||
+                this.parsedDocsConfig.llmsFullTxtFile != null
+                    ? {
+                          ...this.parsedDocsConfig.agents,
+                          llmsTxt: this.getFileId(this.parsedDocsConfig.llmsTxtFile),
+                          llmsFullTxt: this.getFileId(this.parsedDocsConfig.llmsFullTxtFile)
+                      }
+                    : undefined,
             metadata: this.convertMetadata(),
             redirects: this.parsedDocsConfig.redirects,
             integrations,

--- a/packages/cli/docs-resolver/src/utils/getImageFilepathsToUpload.ts
+++ b/packages/cli/docs-resolver/src/utils/getImageFilepathsToUpload.ts
@@ -157,6 +157,14 @@ export async function collectFilesFromDocsConfig({
         filepaths.add(parsedDocsConfig.context7File);
     }
 
+    if (parsedDocsConfig.llmsTxtFile != null) {
+        filepaths.add(parsedDocsConfig.llmsTxtFile);
+    }
+
+    if (parsedDocsConfig.llmsFullTxtFile != null) {
+        filepaths.add(parsedDocsConfig.llmsFullTxtFile);
+    }
+
     /* custom page action icons */
     if (parsedDocsConfig.pageActions?.options?.custom != null) {
         await Promise.all(

--- a/packages/cli/workspace/loader/src/docs-yml.schema.json
+++ b/packages/cli/workspace/loader/src/docs-yml.schema.json
@@ -4396,6 +4396,26 @@
               "type": "null"
             }
           ]
+        },
+        "llms-txt": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "llms-full-txt": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
         }
       },
       "additionalProperties": false

--- a/packages/cli/yaml/docs-validator/src/docsAst/visitDocsConfigFileYamlAst.ts
+++ b/packages/cli/yaml/docs-validator/src/docsAst/visitDocsConfigFileYamlAst.ts
@@ -200,7 +200,26 @@ export async function visitDocsConfigFileYamlAst({
         },
         landingPage: noop,
         layout: noop,
-        agents: noop,
+        agents: async (agents) => {
+            if (agents?.llmsTxt != null) {
+                await visitFilepath({
+                    absoluteFilepathToConfiguration,
+                    rawUnresolvedFilepath: agents.llmsTxt,
+                    visitor,
+                    nodePath: ["agents", "llms-txt"],
+                    willBeUploaded: true
+                });
+            }
+            if (agents?.llmsFullTxt != null) {
+                await visitFilepath({
+                    absoluteFilepathToConfiguration,
+                    rawUnresolvedFilepath: agents.llmsFullTxt,
+                    visitor,
+                    nodePath: ["agents", "llms-full-txt"],
+                    willBeUploaded: true
+                });
+            }
+        },
         settings: noop,
         logo: async () => {
             if (contents.logo?.dark != null) {


### PR DESCRIPTION
## Description
Linear ticket: Closes [FER-9736](https://linear.app/buildwithfern/issue/FER-9736/add-support-for-custom-llmstxt-and-llms-fulltxt)
<!-- Use "Closes" to automatically close the ticket when PR merges, or "Refs" to link without closing -->
<!-- Provide a clear and concise description of the changes made in this PR -->
Adds support for custom `llms.txt` and `llms-full.txt` files in `docs.yml` under the `agents` key. Fern already auto-generates these files for all docs sites, but some customers want to provide their own. When configured, the CLI validates the file exists, uploads it as an asset, and publishes its file ID in the docs config. The companion fern-platform PR handles serving the custom file at the docs site, falling back to auto-generation when not configured.

## Changes Made
<!-- List the main changes and updates implemented in this PR -->
- Added `llms-txt` and `llms-full-txt` optional string fields to `AgentsConfig` in the API definition (`fern/apis/docs-yml/definition/docs.yml`)
- Updated JSON schemas (`docs-yml.schema.json` and workspace loader copy)
- Added fields to the Zod schema in `DocsYmlSchemas.ts`
- Updated generated SDK API type and serialization for `AgentsConfig`
- Added `llmsTxtFile` and `llmsFullTxtFile` to `ParsedDocsConfiguration`
- Added `parseTextFile` helper in `parseDocsConfiguration.ts` to resolve and validate the file path
- Added both files to the upload set in `getImageFilepathsToUpload.ts`
- Updated AST visitor in `visitDocsConfigFileYamlAst.ts` to visit both file paths with `willBeUploaded: true`
- Published file IDs via `DocsDefinitionResolver.ts` in the agents config

## Testing
<!-- Describe how you tested these changes -->
- [ ] Unit tests added/updated
- [x] Manual testing completed
