### PR TITLE
fix(csharp): add domain-specific event properties to websocket client interface

### DIFF
--- a/generators/csharp/codegen/src/ast/types/Field.ts
+++ b/generators/csharp/codegen/src/ast/types/Field.ts
@@ -76,6 +76,8 @@ export declare namespace Field {
         interfaceReference?: ClassReference;
         /* If true, the field is overridden */
         override?: boolean;
+        /* If true, use expression-bodied property syntax (=> initializer). If false, use auto-property with initializer (= initializer). Defaults to true for backward compatibility when get is set and no init/set. */
+        useExpressionBody?: boolean;
 
         /* If specified, use the accessor methods for the field implementation */
         accessors?: Accessors;
@@ -121,6 +123,7 @@ export class Field extends MemberNode {
         remove?: (writer: Writer) => void;
     };
     private readonly override?: boolean;
+    private readonly useExpressionBody?: boolean;
     private readonly isEvent_: boolean;
     constructor(
         {
@@ -144,6 +147,7 @@ export class Field extends MemberNode {
             interfaceReference,
             accessors,
             override,
+            useExpressionBody,
             isEvent,
             origin,
             enclosingType
@@ -185,6 +189,7 @@ export class Field extends MemberNode {
         this.interfaceReference = interfaceReference;
         this.accessors = accessors;
         this.override = override ?? false;
+        this.useExpressionBody = useExpressionBody;
         this.isEvent_ = isEvent ?? false;
         if (this.jsonPropertyName != null) {
             this.annotations = [
@@ -294,9 +299,10 @@ export class Field extends MemberNode {
             return;
         }
 
-        // TODO: refactor useExpressionBodiedPropertySyntax to be an argument that defaults to false
-        // expression body will run the code every time, which is not the intended/expected behavior of initializer
-        const useExpressionBodiedPropertySyntax = this.get && !this.init && !this.set && this.initializer != null;
+        const useExpressionBodiedPropertySyntax =
+            this.useExpressionBody !== undefined
+                ? this.useExpressionBody
+                : this.get && !this.init && !this.set && this.initializer != null;
         if ((this.get || this.init || this.set) && !useExpressionBodiedPropertySyntax) {
             writer.write(" { ");
             if (this.get) {

--- a/generators/csharp/sdk/src/websocket/WebsocketClientGenerator.ts
+++ b/generators/csharp/sdk/src/websocket/WebsocketClientGenerator.ts
@@ -1098,7 +1098,7 @@ export class WebSocketClientGenerator extends WithGeneration {
             cls.addField({
                 origin: cls.explicit(`${each.name}`),
                 get: true,
-                set: ast.Access.Private,
+                useExpressionBody: false,
                 initializer: this.csharp.codeblock((writer) => writer.write(`new()`)),
                 access: ast.Access.Public,
                 doc: this.csharp.xmlDocBlockOf({
@@ -1111,7 +1111,7 @@ export class WebSocketClientGenerator extends WithGeneration {
         cls.addField({
             origin: cls.explicit("UnknownMessage"),
             get: true,
-            set: ast.Access.Private,
+            useExpressionBody: false,
             initializer: this.csharp.codeblock((writer) => writer.write(`new()`)),
             access: ast.Access.Public,
             doc: this.csharp.xmlDocBlockOf({

--- a/generators/csharp/sdk/src/websocket/WebsocketClientGenerator.ts
+++ b/generators/csharp/sdk/src/websocket/WebsocketClientGenerator.ts
@@ -1386,8 +1386,11 @@ export class WebSocketClientGenerator extends WithGeneration {
 
         // Domain-specific events (server-to-client messages)
         for (const each of this.events) {
+            if (each.name == null) {
+                continue;
+            }
             interface_.addField({
-                name: each.name ?? "",
+                name: each.name,
                 enclosingType: interface_,
                 access: ast.Access.Public,
                 get: true,

--- a/generators/csharp/sdk/src/websocket/WebsocketClientGenerator.ts
+++ b/generators/csharp/sdk/src/websocket/WebsocketClientGenerator.ts
@@ -1384,6 +1384,26 @@ export class WebSocketClientGenerator extends WithGeneration {
             type: this.Types.WebSocketEvent(this.Types.ReconnectionInfo)
         });
 
+        // Domain-specific events (server-to-client messages)
+        for (const each of this.events) {
+            interface_.addField({
+                name: each.name ?? "",
+                enclosingType: interface_,
+                access: ast.Access.Public,
+                get: true,
+                type: each.eventType
+            });
+        }
+
+        // UnknownMessage event
+        interface_.addField({
+            name: "UnknownMessage",
+            enclosingType: interface_,
+            access: ast.Access.Public,
+            get: true,
+            type: this.Types.WebSocketEvent(this.System.Text.Json.JsonElement)
+        });
+
         // Status property
         interface_.addField({
             name: "Status",

--- a/generators/csharp/sdk/src/websocket/WebsocketClientGenerator.ts
+++ b/generators/csharp/sdk/src/websocket/WebsocketClientGenerator.ts
@@ -1097,7 +1097,8 @@ export class WebSocketClientGenerator extends WithGeneration {
         for (const each of this.events) {
             cls.addField({
                 origin: cls.explicit(`${each.name}`),
-                readonly: true,
+                get: true,
+                set: ast.Access.Private,
                 initializer: this.csharp.codeblock((writer) => writer.write(`new()`)),
                 access: ast.Access.Public,
                 doc: this.csharp.xmlDocBlockOf({
@@ -1109,7 +1110,8 @@ export class WebSocketClientGenerator extends WithGeneration {
 
         cls.addField({
             origin: cls.explicit("UnknownMessage"),
-            readonly: true,
+            get: true,
+            set: ast.Access.Private,
             initializer: this.csharp.codeblock((writer) => writer.write(`new()`)),
             access: ast.Access.Public,
             doc: this.csharp.xmlDocBlockOf({

--- a/generators/csharp/sdk/versions.yml
+++ b/generators/csharp/sdk/versions.yml
@@ -1,4 +1,15 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 2.59.6
+  changelogEntry:
+    - summary: |
+        Add domain-specific event properties (e.g. AssistantMessage, ChatMetadata,
+        AudioOutput) and UnknownMessage to the generated WebSocket client interface.
+        Previously, these events were only available on the concrete class, forcing
+        consumers to downcast from the interface type to access them.
+      type: fix
+  createdAt: "2026-04-10"
+  irVersion: 66
+
 - version: 2.59.5
   changelogEntry:
     - summary: |

--- a/seed/csharp-sdk/websocket-multi-url/no-custom-config/src/SeedWebsocketMultiUrl/Realtime/IRealtimeApi.cs
+++ b/seed/csharp-sdk/websocket-multi-url/no-custom-config/src/SeedWebsocketMultiUrl/Realtime/IRealtimeApi.cs
@@ -1,3 +1,4 @@
+using global::System.Text.Json;
 using SeedWebsocketMultiUrl.Core.WebSockets;
 
 namespace SeedWebsocketMultiUrl;
@@ -8,6 +9,8 @@ public partial interface IRealtimeApi : IAsyncDisposable, IDisposable
     public Event<Closed> Closed { get; }
     public Event<Exception> ExceptionOccurred { get; }
     public Event<ReconnectionInfo> Reconnecting { get; }
+    public Event<ReceiveEvent> ReceiveEvent { get; }
+    public Event<JsonElement> UnknownMessage { get; }
     public ConnectionStatus Status { get; }
     Task ConnectAsync(CancellationToken cancellationToken = default);
 

--- a/seed/csharp-sdk/websocket-multi-url/no-custom-config/src/SeedWebsocketMultiUrl/Realtime/RealtimeApi.cs
+++ b/seed/csharp-sdk/websocket-multi-url/no-custom-config/src/SeedWebsocketMultiUrl/Realtime/RealtimeApi.cs
@@ -76,13 +76,13 @@ public partial class RealtimeApi
     /// Event handler for ReceiveEvent.
     /// Use ReceiveEvent.Subscribe(...) to receive messages.
     /// </summary>
-    public Event<ReceiveEvent> ReceiveEvent { get; private set; } = new();
+    public Event<ReceiveEvent> ReceiveEvent { get; } = new();
 
     /// <summary>
     /// Event handler for unknown/unrecognized message types.
     /// Use UnknownMessage.Subscribe(...) to handle messages from newer server versions.
     /// </summary>
-    public Event<JsonElement> UnknownMessage { get; private set; } = new();
+    public Event<JsonElement> UnknownMessage { get; } = new();
 
     /// <summary>
     /// Disposes of event subscriptions

--- a/seed/csharp-sdk/websocket-multi-url/no-custom-config/src/SeedWebsocketMultiUrl/Realtime/RealtimeApi.cs
+++ b/seed/csharp-sdk/websocket-multi-url/no-custom-config/src/SeedWebsocketMultiUrl/Realtime/RealtimeApi.cs
@@ -26,18 +26,6 @@ public partial class RealtimeApi
     }
 
     /// <summary>
-    /// Event handler for ReceiveEvent.
-    /// Use ReceiveEvent.Subscribe(...) to receive messages.
-    /// </summary>
-    public readonly Event<ReceiveEvent> ReceiveEvent = new();
-
-    /// <summary>
-    /// Event handler for unknown/unrecognized message types.
-    /// Use UnknownMessage.Subscribe(...) to handle messages from newer server versions.
-    /// </summary>
-    public readonly Event<JsonElement> UnknownMessage = new();
-
-    /// <summary>
     /// Constructor with options
     /// </summary>
     public RealtimeApi(RealtimeApi.Options options)
@@ -83,6 +71,18 @@ public partial class RealtimeApi
     /// Event raised when the WebSocket connection is re-established after a disconnect.
     /// </summary>
     public Event<ReconnectionInfo> Reconnecting => _client.Reconnecting;
+
+    /// <summary>
+    /// Event handler for ReceiveEvent.
+    /// Use ReceiveEvent.Subscribe(...) to receive messages.
+    /// </summary>
+    public Event<ReceiveEvent> ReceiveEvent { get; private set; } = new();
+
+    /// <summary>
+    /// Event handler for unknown/unrecognized message types.
+    /// Use UnknownMessage.Subscribe(...) to handle messages from newer server versions.
+    /// </summary>
+    public Event<JsonElement> UnknownMessage { get; private set; } = new();
 
     /// <summary>
     /// Disposes of event subscriptions

--- a/seed/csharp-sdk/websocket/with-websockets/src/SeedWebsocket/Empty/EmptyRealtime/EmptyRealtimeApi.cs
+++ b/seed/csharp-sdk/websocket/with-websockets/src/SeedWebsocket/Empty/EmptyRealtime/EmptyRealtimeApi.cs
@@ -75,7 +75,7 @@ public partial class EmptyRealtimeApi
     /// Event handler for unknown/unrecognized message types.
     /// Use UnknownMessage.Subscribe(...) to handle messages from newer server versions.
     /// </summary>
-    public Event<JsonElement> UnknownMessage { get; private set; } = new();
+    public Event<JsonElement> UnknownMessage { get; } = new();
 
     /// <summary>
     /// Disposes of event subscriptions

--- a/seed/csharp-sdk/websocket/with-websockets/src/SeedWebsocket/Empty/EmptyRealtime/EmptyRealtimeApi.cs
+++ b/seed/csharp-sdk/websocket/with-websockets/src/SeedWebsocket/Empty/EmptyRealtime/EmptyRealtimeApi.cs
@@ -25,12 +25,6 @@ public partial class EmptyRealtimeApi
     }
 
     /// <summary>
-    /// Event handler for unknown/unrecognized message types.
-    /// Use UnknownMessage.Subscribe(...) to handle messages from newer server versions.
-    /// </summary>
-    public readonly Event<JsonElement> UnknownMessage = new();
-
-    /// <summary>
     /// Default constructor
     /// </summary>
     public EmptyRealtimeApi() { }
@@ -76,6 +70,12 @@ public partial class EmptyRealtimeApi
     /// Event raised when the WebSocket connection is re-established after a disconnect.
     /// </summary>
     public Event<ReconnectionInfo> Reconnecting => _client.Reconnecting;
+
+    /// <summary>
+    /// Event handler for unknown/unrecognized message types.
+    /// Use UnknownMessage.Subscribe(...) to handle messages from newer server versions.
+    /// </summary>
+    public Event<JsonElement> UnknownMessage { get; private set; } = new();
 
     /// <summary>
     /// Disposes of event subscriptions

--- a/seed/csharp-sdk/websocket/with-websockets/src/SeedWebsocket/Empty/EmptyRealtime/IEmptyRealtimeApi.cs
+++ b/seed/csharp-sdk/websocket/with-websockets/src/SeedWebsocket/Empty/EmptyRealtime/IEmptyRealtimeApi.cs
@@ -1,3 +1,4 @@
+using global::System.Text.Json;
 using SeedWebsocket.Core.WebSockets;
 
 namespace SeedWebsocket.Empty;
@@ -8,6 +9,7 @@ public partial interface IEmptyRealtimeApi : IAsyncDisposable, IDisposable
     public Event<Closed> Closed { get; }
     public Event<Exception> ExceptionOccurred { get; }
     public Event<ReconnectionInfo> Reconnecting { get; }
+    public Event<JsonElement> UnknownMessage { get; }
     public ConnectionStatus Status { get; }
     Task ConnectAsync(CancellationToken cancellationToken = default);
 

--- a/seed/csharp-sdk/websocket/with-websockets/src/SeedWebsocket/Realtime/IRealtimeApi.cs
+++ b/seed/csharp-sdk/websocket/with-websockets/src/SeedWebsocket/Realtime/IRealtimeApi.cs
@@ -1,3 +1,4 @@
+using global::System.Text.Json;
 using SeedWebsocket.Core.WebSockets;
 
 namespace SeedWebsocket;
@@ -8,6 +9,14 @@ public partial interface IRealtimeApi : IAsyncDisposable, IDisposable
     public Event<Closed> Closed { get; }
     public Event<Exception> ExceptionOccurred { get; }
     public Event<ReconnectionInfo> Reconnecting { get; }
+    public Event<ReceiveEvent> ReceiveEvent { get; }
+    public Event<ReceiveSnakeCase> ReceiveSnakeCase { get; }
+    public Event<ReceiveEvent2> ReceiveEvent2 { get; }
+    public Event<ReceiveEvent3> ReceiveEvent3 { get; }
+    public Event<TranscriptEvent> TranscriptEvent { get; }
+    public Event<FlushedEvent> FlushedEvent { get; }
+    public Event<ErrorEvent> ErrorEvent { get; }
+    public Event<JsonElement> UnknownMessage { get; }
     public ConnectionStatus Status { get; }
     Task ConnectAsync(CancellationToken cancellationToken = default);
 

--- a/seed/csharp-sdk/websocket/with-websockets/src/SeedWebsocket/Realtime/RealtimeApi.cs
+++ b/seed/csharp-sdk/websocket/with-websockets/src/SeedWebsocket/Realtime/RealtimeApi.cs
@@ -78,49 +78,49 @@ public partial class RealtimeApi
     /// Event handler for ReceiveEvent.
     /// Use ReceiveEvent.Subscribe(...) to receive messages.
     /// </summary>
-    public Event<ReceiveEvent> ReceiveEvent { get; private set; } = new();
+    public Event<ReceiveEvent> ReceiveEvent { get; } = new();
 
     /// <summary>
     /// Event handler for ReceiveSnakeCase.
     /// Use ReceiveSnakeCase.Subscribe(...) to receive messages.
     /// </summary>
-    public Event<ReceiveSnakeCase> ReceiveSnakeCase { get; private set; } = new();
+    public Event<ReceiveSnakeCase> ReceiveSnakeCase { get; } = new();
 
     /// <summary>
     /// Event handler for ReceiveEvent2.
     /// Use ReceiveEvent2.Subscribe(...) to receive messages.
     /// </summary>
-    public Event<ReceiveEvent2> ReceiveEvent2 { get; private set; } = new();
+    public Event<ReceiveEvent2> ReceiveEvent2 { get; } = new();
 
     /// <summary>
     /// Event handler for ReceiveEvent3.
     /// Use ReceiveEvent3.Subscribe(...) to receive messages.
     /// </summary>
-    public Event<ReceiveEvent3> ReceiveEvent3 { get; private set; } = new();
+    public Event<ReceiveEvent3> ReceiveEvent3 { get; } = new();
 
     /// <summary>
     /// Event handler for TranscriptEvent.
     /// Use TranscriptEvent.Subscribe(...) to receive messages.
     /// </summary>
-    public Event<TranscriptEvent> TranscriptEvent { get; private set; } = new();
+    public Event<TranscriptEvent> TranscriptEvent { get; } = new();
 
     /// <summary>
     /// Event handler for FlushedEvent.
     /// Use FlushedEvent.Subscribe(...) to receive messages.
     /// </summary>
-    public Event<FlushedEvent> FlushedEvent { get; private set; } = new();
+    public Event<FlushedEvent> FlushedEvent { get; } = new();
 
     /// <summary>
     /// Event handler for ErrorEvent.
     /// Use ErrorEvent.Subscribe(...) to receive messages.
     /// </summary>
-    public Event<ErrorEvent> ErrorEvent { get; private set; } = new();
+    public Event<ErrorEvent> ErrorEvent { get; } = new();
 
     /// <summary>
     /// Event handler for unknown/unrecognized message types.
     /// Use UnknownMessage.Subscribe(...) to handle messages from newer server versions.
     /// </summary>
-    public Event<JsonElement> UnknownMessage { get; private set; } = new();
+    public Event<JsonElement> UnknownMessage { get; } = new();
 
     /// <summary>
     /// Disposes of event subscriptions

--- a/seed/csharp-sdk/websocket/with-websockets/src/SeedWebsocket/Realtime/RealtimeApi.cs
+++ b/seed/csharp-sdk/websocket/with-websockets/src/SeedWebsocket/Realtime/RealtimeApi.cs
@@ -26,54 +26,6 @@ public partial class RealtimeApi
     }
 
     /// <summary>
-    /// Event handler for ReceiveEvent.
-    /// Use ReceiveEvent.Subscribe(...) to receive messages.
-    /// </summary>
-    public readonly Event<ReceiveEvent> ReceiveEvent = new();
-
-    /// <summary>
-    /// Event handler for ReceiveSnakeCase.
-    /// Use ReceiveSnakeCase.Subscribe(...) to receive messages.
-    /// </summary>
-    public readonly Event<ReceiveSnakeCase> ReceiveSnakeCase = new();
-
-    /// <summary>
-    /// Event handler for ReceiveEvent2.
-    /// Use ReceiveEvent2.Subscribe(...) to receive messages.
-    /// </summary>
-    public readonly Event<ReceiveEvent2> ReceiveEvent2 = new();
-
-    /// <summary>
-    /// Event handler for ReceiveEvent3.
-    /// Use ReceiveEvent3.Subscribe(...) to receive messages.
-    /// </summary>
-    public readonly Event<ReceiveEvent3> ReceiveEvent3 = new();
-
-    /// <summary>
-    /// Event handler for TranscriptEvent.
-    /// Use TranscriptEvent.Subscribe(...) to receive messages.
-    /// </summary>
-    public readonly Event<TranscriptEvent> TranscriptEvent = new();
-
-    /// <summary>
-    /// Event handler for FlushedEvent.
-    /// Use FlushedEvent.Subscribe(...) to receive messages.
-    /// </summary>
-    public readonly Event<FlushedEvent> FlushedEvent = new();
-
-    /// <summary>
-    /// Event handler for ErrorEvent.
-    /// Use ErrorEvent.Subscribe(...) to receive messages.
-    /// </summary>
-    public readonly Event<ErrorEvent> ErrorEvent = new();
-
-    /// <summary>
-    /// Event handler for unknown/unrecognized message types.
-    /// Use UnknownMessage.Subscribe(...) to handle messages from newer server versions.
-    /// </summary>
-    public readonly Event<JsonElement> UnknownMessage = new();
-
-    /// <summary>
     /// Constructor with options
     /// </summary>
     public RealtimeApi(RealtimeApi.Options options)
@@ -121,6 +73,54 @@ public partial class RealtimeApi
     /// Event raised when the WebSocket connection is re-established after a disconnect.
     /// </summary>
     public Event<ReconnectionInfo> Reconnecting => _client.Reconnecting;
+
+    /// <summary>
+    /// Event handler for ReceiveEvent.
+    /// Use ReceiveEvent.Subscribe(...) to receive messages.
+    /// </summary>
+    public Event<ReceiveEvent> ReceiveEvent { get; private set; } = new();
+
+    /// <summary>
+    /// Event handler for ReceiveSnakeCase.
+    /// Use ReceiveSnakeCase.Subscribe(...) to receive messages.
+    /// </summary>
+    public Event<ReceiveSnakeCase> ReceiveSnakeCase { get; private set; } = new();
+
+    /// <summary>
+    /// Event handler for ReceiveEvent2.
+    /// Use ReceiveEvent2.Subscribe(...) to receive messages.
+    /// </summary>
+    public Event<ReceiveEvent2> ReceiveEvent2 { get; private set; } = new();
+
+    /// <summary>
+    /// Event handler for ReceiveEvent3.
+    /// Use ReceiveEvent3.Subscribe(...) to receive messages.
+    /// </summary>
+    public Event<ReceiveEvent3> ReceiveEvent3 { get; private set; } = new();
+
+    /// <summary>
+    /// Event handler for TranscriptEvent.
+    /// Use TranscriptEvent.Subscribe(...) to receive messages.
+    /// </summary>
+    public Event<TranscriptEvent> TranscriptEvent { get; private set; } = new();
+
+    /// <summary>
+    /// Event handler for FlushedEvent.
+    /// Use FlushedEvent.Subscribe(...) to receive messages.
+    /// </summary>
+    public Event<FlushedEvent> FlushedEvent { get; private set; } = new();
+
+    /// <summary>
+    /// Event handler for ErrorEvent.
+    /// Use ErrorEvent.Subscribe(...) to receive messages.
+    /// </summary>
+    public Event<ErrorEvent> ErrorEvent { get; private set; } = new();
+
+    /// <summary>
+    /// Event handler for unknown/unrecognized message types.
+    /// Use UnknownMessage.Subscribe(...) to handle messages from newer server versions.
+    /// </summary>
+    public Event<JsonElement> UnknownMessage { get; private set; } = new();
 
     /// <summary>
     /// Disposes of event subscriptions


### PR DESCRIPTION
## Description

The generated WebSocket client interface (e.g. `IChatApi`) was missing domain-specific event properties. Only the 4 infrastructure events (`Connected`, `Closed`, `ExceptionOccurred`, `Reconnecting`) were declared on the interface, while domain events (e.g. `AssistantMessage`, `ChatMetadata`, `AudioOutput`) were only added to the concrete class by `createEventFields()`. This forced consumers to downcast from the interface type to access domain events.

## Changes Made

- In `createWebsocketInterface()`, iterate over `this.events` and add each as a get-only property on the interface, plus `UnknownMessage` (mirroring what `createEventFields()` does for the class)
- Skip events with `undefined` names to avoid a runtime crash in the `Field` constructor (empty string is falsy, so `name || fail(...)` would throw)
- Changed `createEventFields()` to emit `{ get; } = new()` **get-only auto-properties** instead of `public readonly ... = new()` **fields** on the concrete class — C# fields do not satisfy `{ get; }` interface properties, so this change is required for the class to implement the updated interface
- Added `useExpressionBody` option to `Field.ts` AST to allow opting out of expression-bodied property syntax (`=> initializer`) in favor of auto-property with initializer (`{ get; } = initializer`). This addresses a pre-existing TODO in the codegen. Default behavior is preserved for all existing callers.
- Regenerated seed snapshots for all websocket fixtures
- Version bump to 2.59.6

## Testing

- [x] Seed tests regenerated and passing for all websocket fixtures (`websocket`, `websocket-multi-url`, `websocket-bearer-auth`, `websocket-inferred-auth`)
- [ ] Manual testing completed (regenerate Hume C# SDK and confirm `IChatApi.cs` includes domain event properties and compiles)

## Human Review Checklist

- **`{ get; } = new()` compilation**: Seed tests ran with `--skip-scripts` (generation only, no `dotnet build`). Confirm the generated code compiles — specifically that `public Event<X> Foo { get; } = new();` on the class satisfies `Event<X> Foo { get; }` on the interface. This is valid C# 6+ but hasn't been build-verified in this PR.
- **`useExpressionBody` backward compatibility**: The new `Field.Args.useExpressionBody` flag defaults to `undefined`, preserving the original heuristic (`get && !init && !set && initializer != null` → expression-bodied). Only `createEventFields()` passes `useExpressionBody: false`. Note that `Field.ts` is in the shared `csharp-codegen` package, so confirm existing expression-bodied properties (e.g. `Status => _client.Status`, `Connected => _client.Connected`) are unaffected.
- **Null-name events**: Events with `undefined` names are skipped on the interface but still added to the concrete class via `createEventFields` (which uses origin-based naming). Extra members on the class are fine in C#, but worth confirming this divergence can't occur in practice.

Link to Devin session: https://app.devin.ai/sessions/79705951291841d88b07ea544e9ee42f
Requested by: @Swimburger
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/14888" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
