### PR TITLE
fix(ts-sdk): apply license config to publish output mode in package.json

### DIFF
--- a/generators/typescript-v2/browser-compatible-base/src/utils/constructNpmPackage.ts
+++ b/generators/typescript-v2/browser-compatible-base/src/utils/constructNpmPackage.ts
@@ -48,7 +48,7 @@ export function constructNpmPackage({
                     registryUrl: outputMode.registriesV2.npm.registryUrl,
                     token: outputMode.registriesV2.npm.token
                 },
-                license: undefined,
+                license: licenseFromLicenseConfig(generatorConfig.license),
                 repoUrl: undefined
             };
         case "github":
@@ -63,13 +63,7 @@ export function constructNpmPackage({
                 private: isPackagePrivate,
                 publishInfo: undefined,
                 repoUrl: getRepoUrlFromUrl(outputMode.repoUrl),
-                license: generatorConfig.license?._visit({
-                    basic: (basic) => basic.id,
-                    custom: (custom) => `See ${custom.filename}`,
-                    _other: () => {
-                        return undefined;
-                    }
-                })
+                license: licenseFromLicenseConfig(generatorConfig.license)
             };
         default:
             throw new Error(`Encountered unknown output mode: ${outputMode}`);

--- a/generators/typescript/sdk/versions.yml
+++ b/generators/typescript/sdk/versions.yml
@@ -1,4 +1,15 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 3.63.4
+  changelogEntry:
+    - summary: |
+        Fix `license` field missing from generated `package.json` when using
+        the `publish` output mode. The license configuration was only applied
+        for `github` output mode; it is now applied consistently across all
+        output modes via the shared `licenseFromLicenseConfig` helper.
+      type: fix
+  createdAt: "2026-04-10"
+  irVersion: 66
+
 - version: 3.63.3
   changelogEntry:
     - summary: |


### PR DESCRIPTION
## Description

Fixes the `license` field being missing from generated `package.json` when using the `publish` output mode. The license configuration from `generators.yml` was only applied for the `github` output mode; the `publish` case hardcoded `license: undefined`.

## Changes Made

- **`constructNpmPackage.ts`**: Use `licenseFromLicenseConfig(generatorConfig.license)` in the `"publish"` output mode case instead of hardcoding `undefined`
- **`constructNpmPackage.ts`**: Refactor the `"github"` case to also use the shared `licenseFromLicenseConfig` helper instead of an inline `_visit` call (same behavior, reduces duplication)
- Added `versions.yml` entry for 3.63.4

## Review Checklist

- [ ] Verify `licenseFromLicenseConfig` (lines 113-119 of the file) handles the same `basic`/`custom`/`_other` cases as the removed inline `_visit` in the `github` branch
- [ ] Confirm no behavioral change to the `downloadFiles` case (returns `undefined` early, untouched)

## Testing

- [ ] Manual testing completed — lint passes (`pnpm run check`)
- No unit tests added; this is a one-line plumbing fix using an existing helper that was already tested via the `constructNpmPackageFromArgs` path

Link to Devin session: https://app.devin.ai/sessions/0c24018e60484ac0b7cead2b0c91d1fc
Requested by: @Ryan-Amirthan