### PR TITLE
chore(generator-cli): upgrade @fern-api/replay to 0.10.3 (pinned), bump python SDK to 5.3.10

### DIFF
--- a/generators/python/sdk/versions.yml
+++ b/generators/python/sdk/versions.yml
@@ -1,5 +1,13 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 # For unreleased changes, use unreleased.yml
+- version: 5.3.10
+  changelogEntry:
+    - summary: |
+        Bump generator-cli to 0.9.6 which upgrades @fern-api/replay to 0.10.3.
+      type: chore
+  createdAt: "2026-04-10"
+  irVersion: 65
+
 - version: 5.3.9
   changelogEntry:
     - summary: |

--- a/packages/generator-cli/package.json
+++ b/packages/generator-cli/package.json
@@ -24,7 +24,7 @@
   "files": ["bin", "dist", "lib"],
   "dependencies": {
     "@fern-api/core-utils": "workspace:*",
-    "@fern-api/replay": "0.10.2",
+    "@fern-api/replay": "0.10.3",
     "@octokit/rest": "catalog:",
     "es-toolkit": "catalog:",
     "tmp-promise": "catalog:"

--- a/packages/generator-cli/versions.yml
+++ b/packages/generator-cli/versions.yml
@@ -1,6 +1,13 @@
 # yaml-language-server: $schema=../../versions-yml.schema.json
 - changelogEntry:
     - summary: |
+        Upgrade @fern-api/replay to 0.10.3 (pinned).
+      type: chore
+  createdAt: "2026-04-10"
+  version: 0.9.6
+
+- changelogEntry:
+    - summary: |
         Upgrade @fern-api/replay to 0.10.2 (pinned).
       type: chore
   createdAt: "2026-04-10"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7816,8 +7816,8 @@ importers:
         specifier: workspace:*
         version: link:../commons/core-utils
       '@fern-api/replay':
-        specifier: 0.10.2
-        version: 0.10.2
+        specifier: 0.10.3
+        version: 0.10.3
       '@octokit/rest':
         specifier: 'catalog:'
         version: 22.0.1
@@ -9339,8 +9339,8 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
-  '@fern-api/replay@0.10.2':
-    resolution: {integrity: sha512-lUkmqtHqQw5H6Zm6efC+qYcOAVJ+XbeVs+BR/X1Ug39DjupaIjxUT3ADBks0A/2wtWQmkxb1ZSEUdc+J4kBT1g==}
+  '@fern-api/replay@0.10.3':
+    resolution: {integrity: sha512-iR+AwoO6EK+kx/MeO1mudSOXVgFTweME2pAjKFioByiVkTR8ukBIPNOGPCIbjnrvQvVrBXJoglMR13fihTaTfA==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -9382,12 +9382,12 @@ packages:
     resolution: {integrity: sha512-uo1+fMnJOw5ApWVmKzb5wcLggjS4te3N8QorMClttA6DcBpgn0x1HbSl823oSyFvdqNV9U7GjmeQ+kzX1lWJUg==}
     engines: {node: '>=18.0.0'}
 
-  '@fern-fern/ir-sdk@66.1.0':
-    resolution: {integrity: sha512-Gq/sxhxFtXIFnsDorSnmkBO9QTAgrM51GDuxx4uGXyUARwoKhGOhSx+AM+6kMVVUHcUHoZ8FDG7sGIOOryDjvQ==}
-    engines: {node: '>=18.0.0'}
-
   '@fern-fern/ir-sdk@66.0.0-alpha.1':
     resolution: {integrity: sha512-scSdUIo0E30ES3Jvx6ox7kby7ZB8jAVDB/52a4TaHquQOMJqrR626NtKHVSfKRCZ7Ut0AjeJ9TR4RRN3zoy6og==}
+    engines: {node: '>=18.0.0'}
+
+  '@fern-fern/ir-sdk@66.1.0':
+    resolution: {integrity: sha512-Gq/sxhxFtXIFnsDorSnmkBO9QTAgrM51GDuxx4uGXyUARwoKhGOhSx+AM+6kMVVUHcUHoZ8FDG7sGIOOryDjvQ==}
     engines: {node: '>=18.0.0'}
 
   '@fern-fern/ir-v53-sdk@1.0.1':
@@ -9413,9 +9413,6 @@ packages:
   '@fern-fern/ir-v58-sdk@1.0.1':
     resolution: {integrity: sha512-U2U1OwrFyviyaTDzRloDzgBw7Ko6TrbqQZqZfavDBl1Y1S20Q1QfZLqJfJcMhYQcntRbXKJeReNjYsSJFaBGsQ==}
     engines: {node: '>=18.0.0'}
-
-  '@fern-fern/ir-v59-sdk@0.0.8':
-    resolution: {integrity: sha512-rPk7crlijG0PvgYZ7g2y5EdhSMMohjGJGfGKo0g5BzdBnA4KqD/LHdful62aHuibYFdORjtGy6GHu1nEH5SD3Q==}
 
   '@fern-fern/ir-v59-sdk@1.0.1':
     resolution: {integrity: sha512-8qEWF6LW+Hr4Ssk8CjnyKcPNnEAKWQYid0sSLHhpsytCHuoywmId3i8/UsCkj2PCYqd+L2zX1xOQ+nATTVxeAQ==}
@@ -16378,7 +16375,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@fern-api/replay@0.10.2':
+  '@fern-api/replay@0.10.3':
     dependencies:
       minimatch: 10.2.5
       node-diff3: 3.2.0
@@ -16482,9 +16479,9 @@ snapshots:
 
   '@fern-fern/ir-sdk@66.0.0': {}
 
-  '@fern-fern/ir-sdk@66.1.0': {}
-
   '@fern-fern/ir-sdk@66.0.0-alpha.1': {}
+
+  '@fern-fern/ir-sdk@66.1.0': {}
 
   '@fern-fern/ir-v53-sdk@1.0.1': {}
 
@@ -16497,16 +16494,6 @@ snapshots:
   '@fern-fern/ir-v57-sdk@1.0.1': {}
 
   '@fern-fern/ir-v58-sdk@1.0.1': {}
-
-  '@fern-fern/ir-v59-sdk@0.0.8':
-    dependencies:
-      form-data: 4.0.5
-      formdata-node: 6.0.3
-      node-fetch: 2.7.0
-      qs: 6.15.0
-      readable-stream: 4.7.0
-    transitivePeerDependencies:
-      - encoding
 
   '@fern-fern/ir-v59-sdk@1.0.1': {}
 


### PR DESCRIPTION
## Description

Upgrades `@fern-api/replay` to `0.10.3` (pinned) in generator-cli and bumps the Python SDK generator version to track the change.

A companion PR in fern-api/fiddle updates the Dockerfile to use the new generator-cli version (`0.9.6`) once it's published to npm.

## Changes Made

- Updated `@fern-api/replay` dependency from `0.10.2` → `0.10.3` (exact pin) in `packages/generator-cli/package.json`
- Added generator-cli `0.9.6` version entry in `packages/generator-cli/versions.yml`
- Added Python SDK `5.3.10` version entry in `generators/python/sdk/versions.yml` referencing generator-cli 0.9.6
- Updated `pnpm-lock.yaml`

## Review Notes

- The lockfile diff includes some entry reordering and the removal of `@fern-fern/ir-v59-sdk@0.0.8` — these are pnpm lockfile reorganization artifacts from running `pnpm install`, not intentional changes.

## Testing

- [ ] Unit tests added/updated — N/A, version bump only
- [x] CI validation

Link to Devin session: https://app.devin.ai/sessions/97bbc3e45f7e47bea6541c0503d031c1
Requested by: @tstanmay13