### PR TITLE
feat(internal): add GeneratorError taxonomy for sdk runtimes

### DIFF
--- a/generators/base/src/AbstractGeneratorCli.ts
+++ b/generators/base/src/AbstractGeneratorCli.ts
@@ -9,6 +9,7 @@ import {
 import { assertNever } from "@fern-api/core-utils";
 import { RelativeFilePath } from "@fern-api/fs-utils";
 import { readFile } from "fs/promises";
+import { GeneratorError, resolveErrorCode, shouldReportToSentry } from "./GeneratorError.js";
 import { SentryClient } from "./telemetry/SentryClient.js";
 
 export declare namespace AbstractGeneratorCli {
@@ -80,12 +81,16 @@ export abstract class AbstractGeneratorCli<
                 FernGeneratorExec.GeneratorUpdate.exitStatusUpdate(FernGeneratorExec.ExitStatusUpdate.successful({}))
             );
         } catch (e) {
-            await sentryClient?.captureException(e);
+            const errorCode = resolveErrorCode(e);
+            if (shouldReportToSentry(e)) {
+                await sentryClient?.captureException(e);
+            }
             if (generatorNotificationService != null) {
+                const exitMessage = e instanceof Error ? e.message : "Encountered error";
                 await generatorNotificationService.sendUpdate(
                     FernGeneratorExec.GeneratorUpdate.exitStatusUpdate(
                         FernGeneratorExec.ExitStatusUpdate.error({
-                            message: e instanceof Error ? e.message : "Encountered error"
+                            message: exitMessage
                         })
                     )
                 );
@@ -154,7 +159,7 @@ export abstract class AbstractGeneratorCli<
 async function getGeneratorConfig(): Promise<FernGeneratorExec.GeneratorConfig> {
     const pathToConfig = process.argv[process.argv.length - 1];
     if (pathToConfig == null) {
-        throw new Error("No argument for config filepath was provided.");
+        throw GeneratorError.environmentError("No argument for config filepath was provided.");
     }
     const rawConfig = await readFile(pathToConfig);
     console.log(`Reading ${pathToConfig}`);
@@ -164,7 +169,7 @@ async function getGeneratorConfig(): Promise<FernGeneratorExec.GeneratorConfig> 
         unrecognizedObjectKeys: "passthrough"
     });
     if (!validatedConfig.ok) {
-        throw new Error(
+        throw GeneratorError.validationError(
             `The generator config failed to pass validation. ${validatedConfig.errors.map((e) => (typeof e === "object" ? JSON.stringify(e) : String(e))).join(", ")}`
         );
     }

--- a/generators/base/src/GeneratorError.ts
+++ b/generators/base/src/GeneratorError.ts
@@ -1,0 +1,95 @@
+export declare namespace GeneratorError {
+    /**
+     * Error codes used by generator runtimes to distinguish user-facing errors
+     * from internal Fern bugs.
+     */
+    export type Code =
+        | "INTERNAL_ERROR"
+        | "RESOLUTION_ERROR"
+        | "IR_CONVERSION_ERROR"
+        | "CONTAINER_ERROR"
+        | "VERSION_ERROR"
+        | "PARSE_ERROR"
+        | "ENVIRONMENT_ERROR"
+        | "REFERENCE_ERROR"
+        | "VALIDATION_ERROR"
+        | "NETWORK_ERROR"
+        | "AUTH_ERROR"
+        | "CONFIG_ERROR";
+}
+
+const SENTRY_REPORTABLE_CODES: ReadonlySet<GeneratorError.Code> = new Set<GeneratorError.Code>([
+    "INTERNAL_ERROR",
+    "RESOLUTION_ERROR",
+    "IR_CONVERSION_ERROR",
+    "CONTAINER_ERROR",
+    "VERSION_ERROR"
+]);
+
+export class GeneratorError extends Error {
+    public readonly code: GeneratorError.Code;
+
+    constructor({ message, code }: { message: string; code: GeneratorError.Code }) {
+        super(message);
+        this.code = code;
+    }
+
+    public static internalError(message: string): GeneratorError {
+        return new GeneratorError({ message, code: "INTERNAL_ERROR" });
+    }
+
+    public static resolutionError(message: string): GeneratorError {
+        return new GeneratorError({ message, code: "RESOLUTION_ERROR" });
+    }
+
+    public static irConversionError(message: string): GeneratorError {
+        return new GeneratorError({ message, code: "IR_CONVERSION_ERROR" });
+    }
+
+    public static containerError(message: string): GeneratorError {
+        return new GeneratorError({ message, code: "CONTAINER_ERROR" });
+    }
+
+    public static versionError(message: string): GeneratorError {
+        return new GeneratorError({ message, code: "VERSION_ERROR" });
+    }
+
+    public static parseError(message: string): GeneratorError {
+        return new GeneratorError({ message, code: "PARSE_ERROR" });
+    }
+
+    public static environmentError(message: string): GeneratorError {
+        return new GeneratorError({ message, code: "ENVIRONMENT_ERROR" });
+    }
+
+    public static referenceError(message: string): GeneratorError {
+        return new GeneratorError({ message, code: "REFERENCE_ERROR" });
+    }
+
+    public static validationError(message: string): GeneratorError {
+        return new GeneratorError({ message, code: "VALIDATION_ERROR" });
+    }
+
+    public static networkError(message: string): GeneratorError {
+        return new GeneratorError({ message, code: "NETWORK_ERROR" });
+    }
+
+    public static authError(message: string): GeneratorError {
+        return new GeneratorError({ message, code: "AUTH_ERROR" });
+    }
+
+    public static configError(message: string): GeneratorError {
+        return new GeneratorError({ message, code: "CONFIG_ERROR" });
+    }
+}
+
+export function resolveErrorCode(error: unknown): GeneratorError.Code {
+    if (error instanceof GeneratorError) {
+        return error.code;
+    }
+    return "INTERNAL_ERROR";
+}
+
+export function shouldReportToSentry(error: unknown): boolean {
+    return SENTRY_REPORTABLE_CODES.has(resolveErrorCode(error));
+}

--- a/generators/base/src/SourceFetcher.ts
+++ b/generators/base/src/SourceFetcher.ts
@@ -5,6 +5,7 @@ import { createWriteStream } from "fs";
 import { mkdir, readdir } from "fs/promises";
 import { pipeline } from "stream";
 import { promisify } from "util";
+import { GeneratorError } from "./GeneratorError.js";
 
 const LOCAL_FILE_SCHEME = "file:///";
 const PROTOBUF_ZIP_FILENAME = "proto.zip";
@@ -136,7 +137,9 @@ export class SourceFetcher {
         this.context.logger.debug(`Downloading ${downloadURL} to ${destinationPath}`);
         const response = await fetch(downloadURL);
         if (!response.ok) {
-            throw new Error(`Failed to download source. Status: ${response.status}, ${response.statusText}`);
+            throw GeneratorError.networkError(
+                `Failed to download source. Status: ${response.status}, ${response.statusText}`
+            );
         }
         const fileStream = createWriteStream(destinationPath);
 

--- a/generators/base/src/__test__/GeneratorError.test.ts
+++ b/generators/base/src/__test__/GeneratorError.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+import { GeneratorError, resolveErrorCode, shouldReportToSentry } from "../GeneratorError.js";
+
+describe("GeneratorError", () => {
+    it("defaults unknown errors to INTERNAL_ERROR", () => {
+        expect(resolveErrorCode(new Error("boom"))).toBe("INTERNAL_ERROR");
+    });
+
+    it("does not report user-facing config errors to sentry", () => {
+        expect(shouldReportToSentry(GeneratorError.configError("bad config"))).toBe(false);
+    });
+
+    it("reports internal errors to sentry", () => {
+        expect(shouldReportToSentry(GeneratorError.internalError("bug"))).toBe(true);
+    });
+});

--- a/generators/base/src/__test__/SentryClient.test.ts
+++ b/generators/base/src/__test__/SentryClient.test.ts
@@ -18,6 +18,7 @@ vi.mock("@sentry/node", () => ({
     setTag: mockSentrySetTag
 }));
 
+import { GeneratorError } from "../GeneratorError.js";
 import { SentryClient } from "../telemetry/SentryClient.js";
 
 const DEFAULT_ARGS = {
@@ -127,5 +128,16 @@ describe("SentryClient (base-generator)", () => {
                 release: "unknown-generator:unknown-version"
             })
         );
+    });
+
+    it("sets the provided error_code tag when capturing exception", async () => {
+        const client = new SentryClient({ release: "generator@1.2.3" });
+
+        await client.captureException(new GeneratorError({ message: "bad config", code: "CONFIG_ERROR" }), {
+            errorCode: "CONFIG_ERROR"
+        });
+
+        expect(mockSentrySetTag).toHaveBeenCalledWith("error_code", "CONFIG_ERROR");
+        expect(mockSentryCaptureException).toHaveBeenCalledOnce();
     });
 });

--- a/generators/base/src/index.ts
+++ b/generators/base/src/index.ts
@@ -1,5 +1,6 @@
 export * from "./AbstractGeneratorAgent.js";
 export * from "./AbstractGeneratorCli.js";
+export * from "./GeneratorError.js";
 export * from "./browserCompatibleExports.js";
 export * from "./project/index.js";
 export * from "./readme/index.js";

--- a/generators/base/src/readme/AbstractReadmeSnippetBuilder.ts
+++ b/generators/base/src/readme/AbstractReadmeSnippetBuilder.ts
@@ -1,5 +1,6 @@
 import { FernGeneratorExec } from "@fern-api/browser-compatible-base-generator";
 import { camelCase } from "lodash-es";
+import { GeneratorError } from "../GeneratorError.js";
 
 export abstract class AbstractReadmeSnippetBuilder {
     private endpointSnippets: FernGeneratorExec.Endpoint[];
@@ -18,12 +19,14 @@ export abstract class AbstractReadmeSnippetBuilder {
         if (defaultEndpoint == null) {
             const firstEndpoint = this.endpointSnippets[0];
             if (firstEndpoint == null) {
-                throw new Error("Internal error; no endpoint snippets were provided");
+                throw GeneratorError.internalError("Internal error; no endpoint snippets were provided");
             }
             defaultEndpoint = firstEndpoint;
         }
         if (defaultEndpoint.id.identifierOverride == null) {
-            throw new Error("Internal error; all endpoints must define an endpoint id to generate README.md");
+            throw GeneratorError.internalError(
+                "Internal error; all endpoints must define an endpoint id to generate README.md"
+            );
         }
         return defaultEndpoint.id.identifierOverride;
     }

--- a/generators/base/src/telemetry/SentryClient.ts
+++ b/generators/base/src/telemetry/SentryClient.ts
@@ -1,4 +1,5 @@
 import * as Sentry from "@sentry/node";
+import { resolveErrorCode } from "../GeneratorError.js";
 
 export class SentryClient {
     private readonly sentry: Sentry.NodeClient | undefined;
@@ -37,11 +38,12 @@ export class SentryClient {
         }
     }
 
-    public async captureException(error: unknown): Promise<void> {
+    public async captureException(error: unknown, { errorCode }: { errorCode?: string } = {}): Promise<void> {
         if (this.sentry == null) {
             return;
         }
         try {
+            Sentry.setTag("error_code", errorCode ?? resolveErrorCode(error));
             this.sentry.captureException(error);
         } catch {
             // no-op

--- a/generators/base/src/utils/GitHubConfig.ts
+++ b/generators/base/src/utils/GitHubConfig.ts
@@ -1,5 +1,6 @@
 import { isNonNullish } from "@fern-api/core-utils";
 import { Logger } from "@fern-api/logger";
+import { GeneratorError } from "../GeneratorError.js";
 
 /**
  * The configuration used to interact with a GitHub repository.
@@ -30,17 +31,17 @@ export function resolveGitHubConfig({
 }): ResolvedGithubConfig {
     if (rawGithubConfig.type == null) {
         logger.error("Publishing config is missing");
-        throw new Error("Publishing config is required for GitHub actions");
+        throw GeneratorError.configError("Publishing config is required for GitHub actions");
     }
 
     if (rawGithubConfig.type !== "github") {
         logger.error(`Publishing type ${rawGithubConfig.type} is not supported`);
-        throw new Error("Only GitHub publishing is supported");
+        throw GeneratorError.configError("Only GitHub publishing is supported");
     }
 
     if (!(isNonNullish(rawGithubConfig.uri) && isNonNullish(rawGithubConfig.token))) {
         logger.error("GitHub URI or token is missing in publishing config");
-        throw new Error("GitHub URI and token are required in publishing config");
+        throw GeneratorError.configError("GitHub URI and token are required in publishing config");
     }
 
     return {

--- a/generators/base/src/utils/parseGeneratorConfig.ts
+++ b/generators/base/src/utils/parseGeneratorConfig.ts
@@ -1,5 +1,6 @@
 import { FernGeneratorExec, GeneratorExecParsing } from "@fern-api/browser-compatible-base-generator";
 import { readFile } from "fs/promises";
+import { GeneratorError } from "../GeneratorError.js";
 
 export async function parseGeneratorConfig(pathToConfig: string): Promise<FernGeneratorExec.GeneratorConfig> {
     const configStr = await readFile(pathToConfig);
@@ -13,7 +14,7 @@ export async function parseGeneratorConfig(pathToConfig: string): Promise<FernGe
     if (!parsedConfig.ok) {
         // biome-ignore lint/suspicious/noConsole: allow console
         console.log(`Failed to parse ${pathToConfig}`);
-        throw new Error("Failed to parse the generator configuration");
+        throw GeneratorError.parseError("Failed to parse the generator configuration");
     }
 
     return parsedConfig.value;

--- a/generators/base/src/utils/parseIR.ts
+++ b/generators/base/src/utils/parseIR.ts
@@ -1,5 +1,6 @@
 import { AbsoluteFilePath, streamObjectFromFile } from "@fern-api/fs-utils";
 import { readFile, stat } from "fs/promises";
+import { GeneratorError } from "../GeneratorError.js";
 
 export declare namespace parseIR {
     export interface Args<IntermediateRepresentation> {
@@ -99,7 +100,7 @@ export async function parseIR<IR>({ absolutePathToIR, parse }: parseIR.Args<IR>)
     if (!parsedIR.ok) {
         // biome-ignore lint/suspicious/noConsole: allow console
         console.log(`Failed to parse ${absolutePathToIR}`);
-        throw new Error(`Failed to parse IR: ${JSON.stringify(parsedIR.errors, null, 4)}`);
+        throw GeneratorError.parseError(`Failed to parse IR: ${JSON.stringify(parsedIR.errors, null, 4)}`);
     }
 
     return parsedIR.value;

--- a/generators/typescript/utils/abstract-generator-cli/src/AbstractGeneratorCli.ts
+++ b/generators/typescript/utils/abstract-generator-cli/src/AbstractGeneratorCli.ts
@@ -1,10 +1,13 @@
 import {
     FernGeneratorExec,
+    GeneratorError,
     GeneratorNotificationService,
     NopGeneratorNotificationService,
     parseGeneratorConfig,
     parseIR,
-    SentryClient
+    resolveErrorCode,
+    SentryClient,
+    shouldReportToSentry
 } from "@fern-api/base-generator";
 import { assertNever } from "@fern-api/core-utils";
 import { AbsoluteFilePath, join, RelativeFilePath } from "@fern-api/fs-utils";
@@ -49,7 +52,7 @@ export abstract class AbstractGeneratorCli<CustomConfig> {
     public async runCli(options?: AbstractGeneratorCli.Options): Promise<void> {
         const pathToConfig = process.argv[process.argv.length - 1];
         if (pathToConfig == null) {
-            throw new Error("No argument for config filepath.");
+            throw GeneratorError.environmentError("No argument for config filepath.");
         }
         await this.run(pathToConfig, options);
     }
@@ -131,7 +134,7 @@ export abstract class AbstractGeneratorCli<CustomConfig> {
             });
             logger.debug(`[TIMING] code generation took ${Date.now() - codeGenStartTime}ms`);
             if (!generatorContext.didSucceed()) {
-                throw new Error("Failed to generate TypeScript project.");
+                throw GeneratorError.internalError("Failed to generate TypeScript project.");
             }
 
             const destinationPath = join(
@@ -266,7 +269,7 @@ export abstract class AbstractGeneratorCli<CustomConfig> {
                     });
                 },
                 _other: ({ type }) => {
-                    throw new Error(`${type} mode is not implemented`);
+                    throw GeneratorError.internalError(`${type} mode is not implemented`);
                 }
             });
 
@@ -280,7 +283,10 @@ export abstract class AbstractGeneratorCli<CustomConfig> {
             // biome-ignore lint/suspicious/noConsole: allow console
             console.log("Sent success event to coordinator");
         } catch (e) {
-            await sentryClient?.captureException(e);
+            const errorCode = resolveErrorCode(e);
+            if (shouldReportToSentry(e)) {
+                await sentryClient?.captureException(e, { errorCode });
+            }
             await generatorNotificationService?.sendUpdate(
                 FernGeneratorExec.GeneratorUpdate.exitStatusUpdate(
                     FernGeneratorExec.ExitStatusUpdate.error({


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description
Follow-up stacked PR that introduces structured generator runtime error codes and Sentry routing rules.

## Changes Made
- Added `GeneratorError` taxonomy in `@fern-api/base-generator`:
  - codes aligned with CLI error taxonomy spirit (`INTERNAL_ERROR`, `PARSE_ERROR`, `CONFIG_ERROR`, etc.)
  - `resolveErrorCode(error)` fallback to `INTERNAL_ERROR` for unknown errors
  - `shouldReportToSentry(error)` that reports only internal/bug-class codes
- Updated `generators/base/src/AbstractGeneratorCli.ts` to:
  - route Sentry capture through `shouldReportToSentry`
  - preserve existing coordinator failure signaling
  - map generator config argument/validation failures to user-facing `GeneratorError` codes
- Updated `generators/typescript/utils/abstract-generator-cli/src/AbstractGeneratorCli.ts` similarly:
  - uses `resolveErrorCode` + `shouldReportToSentry`
  - captures only reportable errors in Sentry
- Updated `SentryClient` to tag `error_code` on captured exceptions
- Migrated key runtime plain `Error` throw sites to typed `GeneratorError`:
  - generator config parse/validation
  - IR parse failures
  - GitHub publishing config errors
  - source download HTTP failures
  - README snippet internal invariants
- Exported `GeneratorError` from base generator index
- Added/updated tests:
  - `GeneratorError.test.ts` for defaulting + routing behavior
  - `SentryClient.test.ts` verifies `error_code` tag behavior
- [ ] Updated README.md generator (if applicable)

## Testing
- [x] Unit tests added/updated
- [x] Manual testing completed

Commands run:
- `pnpm --filter @fern-api/base-generator compile`
- `pnpm --filter @fern-typescript/abstract-generator-cli compile`
- `pnpm --filter @fern-api/base-generator test`
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://buildwithfern.slack.com/archives/D0AK8NXJXE3/p1773158738046919?thread_ts=1773158738.046919&cid=D0AK8NXJXE3)

<div><a href="https://cursor.com/agents/bc-2419d262-7918-5b4f-8ee6-d008e222d3e6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2419d262-7918-5b4f-8ee6-d008e222d3e6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

