### PR TITLE
feat: support `--output` with GitHub PR URLs in `fern generate`

### DIFF
--- a/packages/cli/cli-v2/src/commands/sdk/generate/command.ts
+++ b/packages/cli/cli-v2/src/commands/sdk/generate/command.ts
@@ -26,7 +26,8 @@ import type { TaskStageLabels } from "../../../ui/TaskStageLabels.js";
 import type { Workspace } from "../../../workspace/Workspace.js";
 import { WorkspaceBuilder } from "../../../workspace/WorkspaceBuilder.js";
 import { command } from "../../_internal/command.js";
-import { isGitUrl } from "../utils/gitUrl.js";
+import { isGithubPrUrl, isGitUrl, parseGithubPrUrl } from "../utils/gitUrl.js";
+import { resolveGithubPrBranch } from "../utils/resolveGithubPrBranch.js";
 
 export declare namespace GenerateCommand {
     export interface Args extends GlobalArgs {
@@ -118,15 +119,22 @@ export class GenerateCommand {
             };
         }
 
-        const targets = this.getTargets({
+        const targets = await this.getTargets({
             workspace: workspaceWithOverrides,
             args,
             groupName: args.target != null ? undefined : (args.group ?? workspaceWithOverrides.sdks?.defaultGroup)
         });
 
-        this.validateArgs({ workspace: workspaceWithOverrides, args, targets });
+        // When --output is a PR URL, force local generation since it produces a self-hosted git output.
+        const forceLocal = args.output != null && isGithubPrUrl(args.output);
 
-        await this.runGeneration({ context, workspace: workspaceWithOverrides, targets, args, forceLocal: false });
+        this.validateArgs({
+            workspace: workspaceWithOverrides,
+            args: { ...args, local: args.local || forceLocal },
+            targets
+        });
+
+        await this.runGeneration({ context, workspace: workspaceWithOverrides, targets, args, forceLocal });
     }
 
     private async handleWithFlags(context: Context, args: GenerateCommand.Args): Promise<void> {
@@ -170,7 +178,7 @@ export class GenerateCommand {
             org,
             lang: this.resolveLanguage(target),
             resolvedSpec,
-            output: this.parseTargetOutput({ ...args, output }),
+            output: await this.parseTargetOutput({ ...args, output }),
             targetVersion: args["target-version"]
         });
 
@@ -430,11 +438,37 @@ export class GenerateCommand {
     /**
      * Parses the --output argument into an OutputSchema.
      *
+     * - GitHub PR URLs (e.g. https://github.com/owner/repo/pull/123)
+     *   resolve the PR's head branch and produce a push-mode git output.
      * - Git URLs (ending in .git, or starting with https://github.com/, https://gitlab.com/, git@)
      *   produce a self-hosted git output with token from GITHUB_TOKEN or GIT_TOKEN env vars.
      * - Anything else is treated as a local path.
      */
-    private parseTargetOutput(args: GenerateCommand.Args): schemas.OutputObjectSchema {
+    private async parseTargetOutput(args: GenerateCommand.Args): Promise<schemas.OutputObjectSchema> {
+        if (args.output != null && isGithubPrUrl(args.output)) {
+            const token = process.env.GITHUB_TOKEN ?? process.env.GIT_TOKEN;
+            if (token == null) {
+                throw new CliError({
+                    message:
+                        `A git token is required when --output is a GitHub PR URL.\n\n` +
+                        `  Set GITHUB_TOKEN or GIT_TOKEN:\n` +
+                        `    export GITHUB_TOKEN=ghp_xxx\n\n` +
+                        `  Or use a local path:\n` +
+                        `    --output ./my-sdk`
+                });
+            }
+            const prInfo = parseGithubPrUrl(args.output);
+            const { branch, uri } = await resolveGithubPrBranch(prInfo, token);
+            return {
+                git: {
+                    uri,
+                    token,
+                    mode: "push",
+                    branch
+                }
+            };
+        }
+
         if (args.output != null && isGitUrl(args.output)) {
             if (!args.local) {
                 throw new CliError({
@@ -466,7 +500,7 @@ export class GenerateCommand {
         return { path: args.output };
     }
 
-    private getTargets({
+    private async getTargets({
         workspace,
         args,
         groupName
@@ -474,7 +508,7 @@ export class GenerateCommand {
         workspace: Workspace;
         args: GenerateCommand.Args;
         groupName: string | undefined;
-    }): Target[] {
+    }): Promise<Target[]> {
         let matched = workspace.sdks != null ? this.filterTargetsByGroup(workspace.sdks.targets, groupName) : [];
         if (args.target != null) {
             matched = matched.filter((t) => t.name === args.target);
@@ -488,10 +522,11 @@ export class GenerateCommand {
             }
             throw new Error("No targets configured in fern.yml");
         }
+        const resolvedOutput = args.output != null ? await this.parseTargetOutput(args) : undefined;
         return matched.map((target) => ({
             ...target,
             version: args["target-version"] ?? target.version,
-            output: args.output != null ? this.parseTargetOutput(args) : target.output
+            output: resolvedOutput ?? target.output
         }));
     }
 
@@ -655,7 +690,8 @@ export function addGenerateCommand(cli: Argv<GlobalArgs>): void {
                 })
                 .option("output", {
                     type: "string",
-                    description: "Output path or git URL (required with --api; requires --preview in workspace mode)"
+                    description:
+                        "Output path, git URL, or GitHub PR URL (e.g. https://github.com/owner/repo/pull/123 to push to the PR's branch)"
                 })
                 .option("output-version", {
                     type: "string",

--- a/packages/cli/cli-v2/src/commands/sdk/generate/parseOutputArg.ts
+++ b/packages/cli/cli-v2/src/commands/sdk/generate/parseOutputArg.ts
@@ -1,15 +1,41 @@
 import type { schemas } from "@fern-api/config";
 
-import { isGitUrl } from "../utils/gitUrl.js";
+import { isGithubPrUrl, isGitUrl, parseGithubPrUrl } from "../utils/gitUrl.js";
+import { resolveGithubPrBranch } from "../utils/resolveGithubPrBranch.js";
 
 /**
  * Parses the --output argument into an OutputSchema.
  *
+ * - GitHub PR URLs (e.g. https://github.com/owner/repo/pull/123)
+ *   resolve the PR's head branch and produce a push-mode git output.
  * - Git URLs (ending in .git, or starting with https://github.com/, https://gitlab.com/, git@)
  *   produce a self-hosted git output with token from GITHUB_TOKEN or GIT_TOKEN env vars.
  * - Anything else is treated as a local path.
  */
-export function parseOutputArg(outputArg: string): schemas.OutputObjectSchema {
+export async function parseOutputArg(outputArg: string): Promise<schemas.OutputObjectSchema> {
+    if (isGithubPrUrl(outputArg)) {
+        const token = process.env.GITHUB_TOKEN ?? process.env.GIT_TOKEN;
+        if (token == null) {
+            throw new Error(
+                `A git token is required when --output is a GitHub PR URL.\n\n` +
+                    `  Set GITHUB_TOKEN or GIT_TOKEN:\n` +
+                    `    export GITHUB_TOKEN=ghp_xxx\n\n` +
+                    `  Or use a local path:\n` +
+                    `    --output ./my-sdk`
+            );
+        }
+        const prInfo = parseGithubPrUrl(outputArg);
+        const { branch, uri } = await resolveGithubPrBranch(prInfo, token);
+        return {
+            git: {
+                uri,
+                token,
+                mode: "push",
+                branch
+            }
+        };
+    }
+
     if (isGitUrl(outputArg)) {
         const token = process.env.GITHUB_TOKEN ?? process.env.GIT_TOKEN;
         if (token == null) {

--- a/packages/cli/cli-v2/src/commands/sdk/utils/gitUrl.ts
+++ b/packages/cli/cli-v2/src/commands/sdk/utils/gitUrl.ts
@@ -1,10 +1,48 @@
 /**
+ * Returns true if the given value looks like a GitHub pull request URL.
+ *
+ * Matches URLs like `https://github.com/owner/repo/pull/123`.
+ */
+export function isGithubPrUrl(value: string): boolean {
+    return /^https:\/\/github\.com\/[^/]+\/[^/]+\/pull\/\d+/.test(value);
+}
+
+export interface GithubPrUrlInfo {
+    owner: string;
+    repo: string;
+    prNumber: number;
+}
+
+/**
+ * Parses a GitHub pull request URL into its components.
+ *
+ * @param url A URL like `https://github.com/owner/repo/pull/123`
+ */
+export function parseGithubPrUrl(url: string): GithubPrUrlInfo {
+    const match = url.match(/^https:\/\/github\.com\/([^/]+)\/([^/]+)\/pull\/(\d+)/);
+    if (match == null || match[1] == null || match[2] == null || match[3] == null) {
+        throw new Error(`Invalid GitHub PR URL: ${url}`);
+    }
+    return {
+        owner: match[1],
+        repo: match[2],
+        prNumber: parseInt(match[3], 10)
+    };
+}
+
+/**
  * Returns true if the given value looks like a git URL.
  *
  * Matches URLs ending in `.git`, or starting with `https://github.com/`,
  * `https://gitlab.com/`, or `git@`.
+ *
+ * Note: GitHub PR URLs (e.g. `https://github.com/owner/repo/pull/123`)
+ * are excluded — use `isGithubPrUrl` for those.
  */
 export function isGitUrl(value: string): boolean {
+    if (isGithubPrUrl(value)) {
+        return false;
+    }
     return (
         value.endsWith(".git") ||
         value.startsWith("https://github.com/") ||

--- a/packages/cli/cli-v2/src/commands/sdk/utils/resolveGithubPrBranch.ts
+++ b/packages/cli/cli-v2/src/commands/sdk/utils/resolveGithubPrBranch.ts
@@ -1,0 +1,42 @@
+import type { GithubPrUrlInfo } from "./gitUrl.js";
+
+interface GithubPrBranchInfo {
+    /** The head branch of the PR (e.g. "my-feature-branch") */
+    branch: string;
+    /** The repository URI as "owner/repo" */
+    uri: string;
+}
+
+/**
+ * Fetches the head branch name of a GitHub pull request.
+ *
+ * Uses the GitHub REST API. Requires a token with read access to the repository.
+ */
+export async function resolveGithubPrBranch(pr: GithubPrUrlInfo, token: string): Promise<GithubPrBranchInfo> {
+    const url = `https://api.github.com/repos/${pr.owner}/${pr.repo}/pulls/${pr.prNumber}`;
+    const response = await fetch(url, {
+        headers: {
+            Authorization: `Bearer ${token}`,
+            Accept: "application/vnd.github.v3+json",
+            "User-Agent": "fern-cli"
+        }
+    });
+
+    if (!response.ok) {
+        const body = await response.text().catch(() => "");
+        throw new Error(
+            `Failed to fetch PR #${pr.prNumber} from ${pr.owner}/${pr.repo}: ${response.status} ${response.statusText}${body ? `\n${body}` : ""}`
+        );
+    }
+
+    const data = (await response.json()) as { head?: { ref?: string } };
+    const branch = data.head?.ref;
+    if (branch == null) {
+        throw new Error(`Could not determine head branch for PR #${pr.prNumber}`);
+    }
+
+    return {
+        branch,
+        uri: `${pr.owner}/${pr.repo}`
+    };
+}

--- a/packages/cli/cli/changes/unreleased/add-output-pr-url.yml
+++ b/packages/cli/cli/changes/unreleased/add-output-pr-url.yml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=../../../../../fern-changes-yml.schema.json
+
+- summary: |
+    Support GitHub PR URLs in `--output` flag for `fern generate`. When a PR URL
+    like `https://github.com/owner/repo/pull/123` is provided, the CLI resolves
+    the PR's head branch and pushes generated code directly to it.
+  type: feat


### PR DESCRIPTION
## Description

Refs internal Slack discussion (Niels)

Adds support for passing a GitHub PR URL directly to `--output` in `fern generate`, e.g.:
```
fern generate --api unioned --group csharp-sdk --output https://github.com/HumeAI/hume-dotnet-sdk/pull/55
```

When a PR URL is detected, the CLI resolves the PR's head branch via the GitHub API and pushes generated code directly to it (mode: `push`), updating the existing PR instead of creating a new one. This eliminates the manual workflow of editing `generators.yml` to set `mode: push` and `branch: <pr-branch>` when iterating on a PR.

## Changes Made

- **`gitUrl.ts`**: Added `isGithubPrUrl()` and `parseGithubPrUrl()` helpers. Modified `isGitUrl()` to exclude PR URLs (since both start with `https://github.com/`)
- **`resolveGithubPrBranch.ts`** (new): Fetches the PR's head branch name via the GitHub REST API using `fetch()` and `GITHUB_TOKEN`/`GIT_TOKEN`
- **`command.ts`**: 
  - Made `parseTargetOutput()` and `getTargets()` async to support the GitHub API call
  - Added PR URL detection that resolves to `{ mode: "push", branch, uri }` output config
  - When `--output` is a PR URL in workspace mode, forces local generation (same behavior as git URL output)
  - Hoisted `parseTargetOutput` call out of the `.map()` in `getTargets()` so it's only called once (avoids redundant API calls)
- **`parseOutputArg.ts`**: Same PR URL handling for the no-config (flags-only) code path
- Updated `--output` CLI description to mention PR URL support
- Added changelog entry

## Important Review Points

1. **`parseOutputArg.ts` may be unused** — grep shows no imports of this file. The changes are consistent but may be dead code worth confirming
2. **No cross-fork PR handling** — if a PR's head branch is on a fork (different owner/repo than the base), the resolved `uri` will be `owner/repo` of the *base* repo, but the branch lives on the fork. This could be an issue for external contributor PRs
3. **`forceLocal` propagation** — in `handleWithWorkspace`, `validateArgs` receives overridden `args.local` but `runGeneration` receives original `args` + separate `forceLocal` param. Verify `runGeneration` respects the `forceLocal` parameter independently
4. **No retry/rate-limit handling** on the GitHub API call in `resolveGithubPrBranch`

## Testing
- [ ] Unit tests added/updated
- [x] Lint passes (`pnpm run check`)
- [ ] Manual testing completed — needs a real PR URL + `GITHUB_TOKEN` to verify end-to-end

Link to Devin session: https://app.devin.ai/sessions/9ec43fea26df4a57b4357ec778c86d8a
Requested by: @Swimburger
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/14900" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
