### PR TITLE
feat(cli-v2): support `--output` with GitHub PR URLs in `fern generate`

### DIFF
--- a/packages/cli/cli-v2/package.json
+++ b/packages/cli/cli-v2/package.json
@@ -80,6 +80,7 @@
     "@fern-api/yaml-loader": "workspace:*",
     "@fern-fern/fiddle-sdk": "catalog:",
     "@fern-fern/generators-sdk": "catalog:",
+    "@octokit/rest": "catalog:",
     "@sentry/node": "^10.45.0",
     "@types/inquirer": "catalog:",
     "@types/is-ci": "catalog:",

--- a/packages/cli/cli-v2/src/commands/sdk/generate/command.ts
+++ b/packages/cli/cli-v2/src/commands/sdk/generate/command.ts
@@ -125,16 +125,13 @@ export class GenerateCommand {
             groupName: args.target != null ? undefined : (args.group ?? workspaceWithOverrides.sdks?.defaultGroup)
         });
 
-        // When --output is a PR URL, force local generation since it produces a self-hosted git output.
-        const forceLocal = args.output != null && isGithubPrUrl(args.output);
-
         this.validateArgs({
             workspace: workspaceWithOverrides,
-            args: { ...args, local: args.local || forceLocal },
+            args,
             targets
         });
 
-        await this.runGeneration({ context, workspace: workspaceWithOverrides, targets, args, forceLocal });
+        await this.runGeneration({ context, workspace: workspaceWithOverrides, targets, args });
     }
 
     private async handleWithFlags(context: Context, args: GenerateCommand.Args): Promise<void> {
@@ -183,21 +180,19 @@ export class GenerateCommand {
         });
 
         const targets = workspace.sdks?.targets ?? [];
-        await this.runGeneration({ context, workspace, targets, args, forceLocal: true });
+        await this.runGeneration({ context, workspace, targets, args });
     }
 
     private async runGeneration({
         context,
         workspace,
         targets,
-        args,
-        forceLocal
+        args
     }: {
         context: Context;
         workspace: Workspace;
         targets: Target[];
         args: GenerateCommand.Args;
-        forceLocal: boolean;
     }): Promise<void> {
         if (workspace.sdks == null) {
             throw new Error("No SDKs configured");
@@ -247,7 +242,7 @@ export class GenerateCommand {
             cliVersion: workspace.cliVersion
         });
 
-        const isLocal = forceLocal || args.local;
+        const isLocal = args.local;
 
         const token = this.isTokenRequired({ targets, args: { ...args, local: isLocal } })
             ? await context.getTokenOrPrompt()
@@ -450,6 +445,14 @@ export class GenerateCommand {
      */
     private async parseTargetOutput(args: GenerateCommand.Args): Promise<schemas.OutputObjectSchema> {
         if (args.output != null && isGithubPrUrl(args.output)) {
+            if (!args.local) {
+                throw new CliError({
+                    message:
+                        `Remote generation is not supported with a GitHub PR URL for --output.\n\n` +
+                        `  Use --local to generate locally:\n` +
+                        `    fern generate --local --output ${args.output}`
+                });
+            }
             const token = process.env.GITHUB_TOKEN ?? process.env.GIT_TOKEN;
             if (token == null) {
                 throw new CliError({

--- a/packages/cli/cli-v2/src/commands/sdk/generate/command.ts
+++ b/packages/cli/cli-v2/src/commands/sdk/generate/command.ts
@@ -26,7 +26,8 @@ import type { TaskStageLabels } from "../../../ui/TaskStageLabels.js";
 import type { Workspace } from "../../../workspace/Workspace.js";
 import { WorkspaceBuilder } from "../../../workspace/WorkspaceBuilder.js";
 import { command } from "../../_internal/command.js";
-import { isGitUrl } from "../utils/gitUrl.js";
+import { isGithubPrUrl, isGitUrl, parseGithubPrUrl } from "../utils/gitUrl.js";
+import { resolveGithubPrBranch } from "../utils/resolveGithubPrBranch.js";
 
 export declare namespace GenerateCommand {
     export interface Args extends GlobalArgs {
@@ -118,15 +119,22 @@ export class GenerateCommand {
             };
         }
 
-        const targets = this.getTargets({
+        const targets = await this.getTargets({
             workspace: workspaceWithOverrides,
             args,
             groupName: args.target != null ? undefined : (args.group ?? workspaceWithOverrides.sdks?.defaultGroup)
         });
 
-        this.validateArgs({ workspace: workspaceWithOverrides, args, targets });
+        // When --output is a PR URL, force local generation since it produces a self-hosted git output.
+        const forceLocal = args.output != null && isGithubPrUrl(args.output);
 
-        await this.runGeneration({ context, workspace: workspaceWithOverrides, targets, args, forceLocal: false });
+        this.validateArgs({
+            workspace: workspaceWithOverrides,
+            args: { ...args, local: args.local || forceLocal },
+            targets
+        });
+
+        await this.runGeneration({ context, workspace: workspaceWithOverrides, targets, args, forceLocal });
     }
 
     private async handleWithFlags(context: Context, args: GenerateCommand.Args): Promise<void> {
@@ -170,7 +178,7 @@ export class GenerateCommand {
             org,
             lang: this.resolveLanguage(target),
             resolvedSpec,
-            output: this.parseTargetOutput({ ...args, output }),
+            output: await this.parseTargetOutput({ ...args, output }),
             targetVersion: args["target-version"]
         });
 
@@ -430,11 +438,37 @@ export class GenerateCommand {
     /**
      * Parses the --output argument into an OutputSchema.
      *
+     * - GitHub PR URLs (e.g. https://github.com/owner/repo/pull/123)
+     *   resolve the PR's head branch and produce a push-mode git output.
      * - Git URLs (ending in .git, or starting with https://github.com/, https://gitlab.com/, git@)
      *   produce a self-hosted git output with token from GITHUB_TOKEN or GIT_TOKEN env vars.
      * - Anything else is treated as a local path.
      */
-    private parseTargetOutput(args: GenerateCommand.Args): schemas.OutputObjectSchema {
+    private async parseTargetOutput(args: GenerateCommand.Args): Promise<schemas.OutputObjectSchema> {
+        if (args.output != null && isGithubPrUrl(args.output)) {
+            const token = process.env.GITHUB_TOKEN ?? process.env.GIT_TOKEN;
+            if (token == null) {
+                throw new CliError({
+                    message:
+                        `A git token is required when --output is a GitHub PR URL.\n\n` +
+                        `  Set GITHUB_TOKEN or GIT_TOKEN:\n` +
+                        `    export GITHUB_TOKEN=ghp_xxx\n\n` +
+                        `  Or use a local path:\n` +
+                        `    --output ./my-sdk`
+                });
+            }
+            const prInfo = parseGithubPrUrl(args.output);
+            const { branch, uri } = await resolveGithubPrBranch(prInfo, token);
+            return {
+                git: {
+                    uri,
+                    token,
+                    mode: "push",
+                    branch
+                }
+            };
+        }
+
         if (args.output != null && isGitUrl(args.output)) {
             if (!args.local) {
                 throw new CliError({
@@ -466,7 +500,7 @@ export class GenerateCommand {
         return { path: args.output };
     }
 
-    private getTargets({
+    private async getTargets({
         workspace,
         args,
         groupName
@@ -474,7 +508,7 @@ export class GenerateCommand {
         workspace: Workspace;
         args: GenerateCommand.Args;
         groupName: string | undefined;
-    }): Target[] {
+    }): Promise<Target[]> {
         let matched = workspace.sdks != null ? this.filterTargetsByGroup(workspace.sdks.targets, groupName) : [];
         if (args.target != null) {
             matched = matched.filter((t) => t.name === args.target);
@@ -488,10 +522,11 @@ export class GenerateCommand {
             }
             throw new Error("No targets configured in fern.yml");
         }
+        const resolvedOutput = args.output != null ? await this.parseTargetOutput(args) : undefined;
         return matched.map((target) => ({
             ...target,
             version: args["target-version"] ?? target.version,
-            output: args.output != null ? this.parseTargetOutput(args) : target.output
+            output: resolvedOutput ?? target.output
         }));
     }
 
@@ -655,7 +690,8 @@ export function addGenerateCommand(cli: Argv<GlobalArgs>): void {
                 })
                 .option("output", {
                     type: "string",
-                    description: "Output path or git URL (required with --api; requires --preview in workspace mode)"
+                    description:
+                        "Output path, git URL, or GitHub PR URL (e.g. https://github.com/owner/repo/pull/123 to push to the PR's branch)"
                 })
                 .option("output-version", {
                     type: "string",

--- a/packages/cli/cli-v2/src/commands/sdk/generate/command.ts
+++ b/packages/cli/cli-v2/src/commands/sdk/generate/command.ts
@@ -275,12 +275,16 @@ export class GenerateCommand {
             });
         }
 
+        // When --output is a git/PR URL, it's not a local path — skip directory checks.
+        const isRemoteOutput = args.output != null && (isGithubPrUrl(args.output) || isGitUrl(args.output));
+
         // Check output directories before starting the task UI.
         for (const target of targets) {
-            const outputPath =
-                args.output != null
-                    ? resolve(context.cwd, args.output)
-                    : context.resolveOutputFilePath(target.output.path);
+            const outputPath = isRemoteOutput
+                ? undefined
+                : args.output != null
+                  ? resolve(context.cwd, args.output)
+                  : context.resolveOutputFilePath(target.output.path);
 
             if (outputPath != null) {
                 const { shouldProceed } = await this.checkOutputDirectory({ context, args, outputPath });
@@ -338,7 +342,7 @@ export class GenerateCommand {
                     containerEngine: args["container-engine"] ?? "docker",
                     keepContainer: args["keep-container"],
                     preview: args.preview,
-                    outputPath: args.output != null ? resolve(context.cwd, args.output) : undefined,
+                    outputPath: !isRemoteOutput && args.output != null ? resolve(context.cwd, args.output) : undefined,
                     token,
                     version: args["output-version"],
                     fernignorePath: args.fernignore,

--- a/packages/cli/cli-v2/src/commands/sdk/generate/command.ts
+++ b/packages/cli/cli-v2/src/commands/sdk/generate/command.ts
@@ -180,7 +180,9 @@ export class GenerateCommand {
         });
 
         const targets = workspace.sdks?.targets ?? [];
-        await this.runGeneration({ context, workspace, targets, args });
+        // No-config mode always runs locally — override args.local so that
+        // runGeneration (and its isLocal / isTokenRequired checks) behave correctly.
+        await this.runGeneration({ context, workspace, targets, args: { ...args, local: true } });
     }
 
     private async runGeneration({

--- a/packages/cli/cli-v2/src/commands/sdk/generate/parseOutputArg.ts
+++ b/packages/cli/cli-v2/src/commands/sdk/generate/parseOutputArg.ts
@@ -12,8 +12,18 @@ import { resolveGithubPrBranch } from "../utils/resolveGithubPrBranch.js";
  *   produce a self-hosted git output with token from GITHUB_TOKEN or GIT_TOKEN env vars.
  * - Anything else is treated as a local path.
  */
-export async function parseOutputArg(outputArg: string): Promise<schemas.OutputObjectSchema> {
+export async function parseOutputArg(
+    outputArg: string,
+    { local }: { local: boolean }
+): Promise<schemas.OutputObjectSchema> {
     if (isGithubPrUrl(outputArg)) {
+        if (!local) {
+            throw new Error(
+                `Remote generation is not supported with a GitHub PR URL for --output.\n\n` +
+                    `  Use --local to generate locally:\n` +
+                    `    fern generate --local --output ${outputArg}`
+            );
+        }
         const token = process.env.GITHUB_TOKEN ?? process.env.GIT_TOKEN;
         if (token == null) {
             throw new Error(

--- a/packages/cli/cli-v2/src/commands/sdk/generate/parseOutputArg.ts
+++ b/packages/cli/cli-v2/src/commands/sdk/generate/parseOutputArg.ts
@@ -1,15 +1,41 @@
 import type { schemas } from "@fern-api/config";
 
-import { isGitUrl } from "../utils/gitUrl.js";
+import { isGithubPrUrl, isGitUrl, parseGithubPrUrl } from "../utils/gitUrl.js";
+import { resolveGithubPrBranch } from "../utils/resolveGithubPrBranch.js";
 
 /**
  * Parses the --output argument into an OutputSchema.
  *
+ * - GitHub PR URLs (e.g. https://github.com/owner/repo/pull/123)
+ *   resolve the PR's head branch and produce a push-mode git output.
  * - Git URLs (ending in .git, or starting with https://github.com/, https://gitlab.com/, git@)
  *   produce a self-hosted git output with token from GITHUB_TOKEN or GIT_TOKEN env vars.
  * - Anything else is treated as a local path.
  */
-export function parseOutputArg(outputArg: string): schemas.OutputObjectSchema {
+export async function parseOutputArg(outputArg: string): Promise<schemas.OutputObjectSchema> {
+    if (isGithubPrUrl(outputArg)) {
+        const token = process.env.GITHUB_TOKEN ?? process.env.GIT_TOKEN;
+        if (token == null) {
+            throw new Error(
+                `A git token is required when --output is a GitHub PR URL.\n\n` +
+                    `  Set GITHUB_TOKEN or GIT_TOKEN:\n` +
+                    `    export GITHUB_TOKEN=ghp_xxx\n\n` +
+                    `  Or use a local path:\n` +
+                    `    --output ./my-sdk`
+            );
+        }
+        const prInfo = parseGithubPrUrl(outputArg);
+        const { branch, uri } = await resolveGithubPrBranch(prInfo, token);
+        return {
+            git: {
+                uri,
+                token,
+                mode: "push",
+                branch
+            }
+        };
+    }
+
     if (isGitUrl(outputArg)) {
         const token = process.env.GITHUB_TOKEN ?? process.env.GIT_TOKEN;
         if (token == null) {

--- a/packages/cli/cli-v2/src/commands/sdk/generate/parseOutputArg.ts
+++ b/packages/cli/cli-v2/src/commands/sdk/generate/parseOutputArg.ts
@@ -47,6 +47,13 @@ export async function parseOutputArg(
     }
 
     if (isGitUrl(outputArg)) {
+        if (!local) {
+            throw new Error(
+                `Remote generation is not supported with a git URL for --output.\n\n` +
+                    `  Use --local to generate locally:\n` +
+                    `    fern generate --local --output ${outputArg}`
+            );
+        }
         const token = process.env.GITHUB_TOKEN ?? process.env.GIT_TOKEN;
         if (token == null) {
             throw new Error(

--- a/packages/cli/cli-v2/src/commands/sdk/utils/gitUrl.ts
+++ b/packages/cli/cli-v2/src/commands/sdk/utils/gitUrl.ts
@@ -1,10 +1,48 @@
 /**
+ * Returns true if the given value looks like a GitHub pull request URL.
+ *
+ * Matches URLs like `https://github.com/owner/repo/pull/123`.
+ */
+export function isGithubPrUrl(value: string): boolean {
+    return /^https:\/\/github\.com\/[^/]+\/[^/]+\/pull\/\d+/.test(value);
+}
+
+export interface GithubPrUrlInfo {
+    owner: string;
+    repo: string;
+    prNumber: number;
+}
+
+/**
+ * Parses a GitHub pull request URL into its components.
+ *
+ * @param url A URL like `https://github.com/owner/repo/pull/123`
+ */
+export function parseGithubPrUrl(url: string): GithubPrUrlInfo {
+    const match = url.match(/^https:\/\/github\.com\/([^/]+)\/([^/]+)\/pull\/(\d+)/);
+    if (match == null || match[1] == null || match[2] == null || match[3] == null) {
+        throw new Error(`Invalid GitHub PR URL: ${url}`);
+    }
+    return {
+        owner: match[1],
+        repo: match[2],
+        prNumber: parseInt(match[3], 10)
+    };
+}
+
+/**
  * Returns true if the given value looks like a git URL.
  *
  * Matches URLs ending in `.git`, or starting with `https://github.com/`,
  * `https://gitlab.com/`, or `git@`.
+ *
+ * Note: GitHub PR URLs (e.g. `https://github.com/owner/repo/pull/123`)
+ * are excluded — use `isGithubPrUrl` for those.
  */
 export function isGitUrl(value: string): boolean {
+    if (isGithubPrUrl(value)) {
+        return false;
+    }
     return (
         value.endsWith(".git") ||
         value.startsWith("https://github.com/") ||

--- a/packages/cli/cli-v2/src/commands/sdk/utils/resolveGithubPrBranch.ts
+++ b/packages/cli/cli-v2/src/commands/sdk/utils/resolveGithubPrBranch.ts
@@ -1,3 +1,5 @@
+import { Octokit } from "@octokit/rest";
+
 import type { GithubPrUrlInfo } from "./gitUrl.js";
 
 interface GithubPrBranchInfo {
@@ -8,33 +10,20 @@ interface GithubPrBranchInfo {
 }
 
 /**
- * Fetches the head branch name of a GitHub pull request.
+ * Fetches the head branch name and repository of a GitHub pull request.
  *
- * Uses the GitHub REST API. Requires a token with read access to the repository.
+ * Uses the Octokit REST client. Requires a token with read access to the repository.
  */
 export async function resolveGithubPrBranch(pr: GithubPrUrlInfo, token: string): Promise<GithubPrBranchInfo> {
-    const url = `https://api.github.com/repos/${pr.owner}/${pr.repo}/pulls/${pr.prNumber}`;
-    const response = await fetch(url, {
-        headers: {
-            Authorization: `Bearer ${token}`,
-            Accept: "application/vnd.github.v3+json",
-            "User-Agent": "fern-cli"
-        }
+    const octokit = new Octokit({ auth: token });
+    const { data } = await octokit.pulls.get({
+        owner: pr.owner,
+        repo: pr.repo,
+        pull_number: pr.prNumber
     });
 
-    if (!response.ok) {
-        const body = await response.text().catch(() => "");
-        throw new Error(
-            `Failed to fetch PR #${pr.prNumber} from ${pr.owner}/${pr.repo}: ${response.status} ${response.statusText}${body ? `\n${body}` : ""}`
-        );
-    }
-
-    const data = (await response.json()) as { head?: { ref?: string; repo?: { full_name?: string } } };
-    const branch = data.head?.ref;
-    if (branch == null) {
-        throw new Error(`Could not determine head branch for PR #${pr.prNumber}`);
-    }
-    const headRepoFullName = data.head?.repo?.full_name;
+    const branch = data.head.ref;
+    const headRepoFullName = data.head.repo?.full_name;
     if (headRepoFullName == null) {
         throw new Error(`Could not determine head repository for PR #${pr.prNumber}`);
     }

--- a/packages/cli/cli-v2/src/commands/sdk/utils/resolveGithubPrBranch.ts
+++ b/packages/cli/cli-v2/src/commands/sdk/utils/resolveGithubPrBranch.ts
@@ -5,7 +5,7 @@ import type { GithubPrUrlInfo } from "./gitUrl.js";
 interface GithubPrBranchInfo {
     /** The head branch of the PR (e.g. "my-feature-branch") */
     branch: string;
-    /** The repository URI as "owner/repo" */
+    /** The full repository URL (e.g. "https://github.com/owner/repo") */
     uri: string;
 }
 
@@ -38,6 +38,6 @@ export async function resolveGithubPrBranch(pr: GithubPrUrlInfo, token: string):
 
     return {
         branch,
-        uri: headRepoFullName
+        uri: `https://github.com/${headRepoFullName}`
     };
 }

--- a/packages/cli/cli-v2/src/commands/sdk/utils/resolveGithubPrBranch.ts
+++ b/packages/cli/cli-v2/src/commands/sdk/utils/resolveGithubPrBranch.ts
@@ -1,0 +1,42 @@
+import type { GithubPrUrlInfo } from "./gitUrl.js";
+
+interface GithubPrBranchInfo {
+    /** The head branch of the PR (e.g. "my-feature-branch") */
+    branch: string;
+    /** The repository URI as "owner/repo" */
+    uri: string;
+}
+
+/**
+ * Fetches the head branch name of a GitHub pull request.
+ *
+ * Uses the GitHub REST API. Requires a token with read access to the repository.
+ */
+export async function resolveGithubPrBranch(pr: GithubPrUrlInfo, token: string): Promise<GithubPrBranchInfo> {
+    const url = `https://api.github.com/repos/${pr.owner}/${pr.repo}/pulls/${pr.prNumber}`;
+    const response = await fetch(url, {
+        headers: {
+            Authorization: `Bearer ${token}`,
+            Accept: "application/vnd.github.v3+json",
+            "User-Agent": "fern-cli"
+        }
+    });
+
+    if (!response.ok) {
+        const body = await response.text().catch(() => "");
+        throw new Error(
+            `Failed to fetch PR #${pr.prNumber} from ${pr.owner}/${pr.repo}: ${response.status} ${response.statusText}${body ? `\n${body}` : ""}`
+        );
+    }
+
+    const data = (await response.json()) as { head?: { ref?: string } };
+    const branch = data.head?.ref;
+    if (branch == null) {
+        throw new Error(`Could not determine head branch for PR #${pr.prNumber}`);
+    }
+
+    return {
+        branch,
+        uri: `${pr.owner}/${pr.repo}`
+    };
+}

--- a/packages/cli/cli-v2/src/commands/sdk/utils/resolveGithubPrBranch.ts
+++ b/packages/cli/cli-v2/src/commands/sdk/utils/resolveGithubPrBranch.ts
@@ -29,7 +29,7 @@ export async function resolveGithubPrBranch(pr: GithubPrUrlInfo, token: string):
     }
 
     const baseRepo = `${pr.owner}/${pr.repo}`;
-    if (headRepoFullName !== baseRepo) {
+    if (headRepoFullName.toLowerCase() !== baseRepo.toLowerCase()) {
         throw new Error(
             `PR #${pr.prNumber} is from a fork (${headRepoFullName}). ` +
                 `Pushing to fork-based PRs is not supported — the head branch must be on ${baseRepo}.`

--- a/packages/cli/cli-v2/src/commands/sdk/utils/resolveGithubPrBranch.ts
+++ b/packages/cli/cli-v2/src/commands/sdk/utils/resolveGithubPrBranch.ts
@@ -28,6 +28,14 @@ export async function resolveGithubPrBranch(pr: GithubPrUrlInfo, token: string):
         throw new Error(`Could not determine head repository for PR #${pr.prNumber}`);
     }
 
+    const baseRepo = `${pr.owner}/${pr.repo}`;
+    if (headRepoFullName !== baseRepo) {
+        throw new Error(
+            `PR #${pr.prNumber} is from a fork (${headRepoFullName}). ` +
+                `Pushing to fork-based PRs is not supported — the head branch must be on ${baseRepo}.`
+        );
+    }
+
     return {
         branch,
         uri: headRepoFullName

--- a/packages/cli/cli-v2/src/commands/sdk/utils/resolveGithubPrBranch.ts
+++ b/packages/cli/cli-v2/src/commands/sdk/utils/resolveGithubPrBranch.ts
@@ -29,14 +29,18 @@ export async function resolveGithubPrBranch(pr: GithubPrUrlInfo, token: string):
         );
     }
 
-    const data = (await response.json()) as { head?: { ref?: string } };
+    const data = (await response.json()) as { head?: { ref?: string; repo?: { full_name?: string } } };
     const branch = data.head?.ref;
     if (branch == null) {
         throw new Error(`Could not determine head branch for PR #${pr.prNumber}`);
     }
+    const headRepoFullName = data.head?.repo?.full_name;
+    if (headRepoFullName == null) {
+        throw new Error(`Could not determine head repository for PR #${pr.prNumber}`);
+    }
 
     return {
         branch,
-        uri: `${pr.owner}/${pr.repo}`
+        uri: headRepoFullName
     };
 }

--- a/packages/cli/cli/changes/unreleased/add-output-pr-url.yml
+++ b/packages/cli/cli/changes/unreleased/add-output-pr-url.yml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=../../../../../fern-changes-yml.schema.json
+
+- summary: |
+    Support GitHub PR URLs in `--output` flag for `fern generate`. When a PR URL
+    like `https://github.com/owner/repo/pull/123` is provided, the CLI resolves
+    the PR's head branch and pushes generated code directly to it.
+  type: feat

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4829,6 +4829,9 @@ importers:
       '@fern-fern/generators-sdk':
         specifier: 'catalog:'
         version: 0.114.0-5745f9e74
+      '@octokit/rest':
+        specifier: 'catalog:'
+        version: 22.0.1
       '@sentry/node':
         specifier: ^10.45.0
         version: 10.47.0


### PR DESCRIPTION
## Description

Refs internal Slack discussion (Niels)

Allows `fern generate --local --output https://github.com/owner/repo/pull/123` to resolve the PR's head branch and push generated code directly to it, updating the existing PR instead of creating a new one. This eliminates the manual workflow of editing `generators.yml` to set `mode: push` and `branch: <pr-branch>` when iterating on a PR.

The `--local` flag is required when using a PR URL for `--output` — remote generation is not supported for this flow. Fork-based PRs are explicitly rejected to prevent accidentally pushing generated code to an unintended repository.

## Changes Made

- **`gitUrl.ts`**: Added `isGithubPrUrl()` and `parseGithubPrUrl()` helpers; modified `isGitUrl()` to exclude PR URLs (both start with `https://github.com/`)
- **`resolveGithubPrBranch.ts`** (new): Fetches the PR's head branch and head repository via `@octokit/rest` using `GITHUB_TOKEN`/`GIT_TOKEN`. Rejects fork-based PRs by comparing `head.repo.full_name` against the base repo (case-insensitive). Returns the full GitHub URL (e.g. `https://github.com/owner/repo`) for `uri`.
- **`command.ts`**:
  - Made `parseTargetOutput()` and `getTargets()` async to support the GitHub API call
  - When a PR URL is detected, validates `--local` is set (throws a clear error otherwise), then resolves to `{ mode: "push", branch, uri }` output config
  - Hoisted `parseTargetOutput` call out of `.map()` in `getTargets()` to avoid redundant API calls
  - Added `isRemoteOutput` guard so git/PR URLs are not resolved as filesystem paths in `checkOutputDirectory` or `pipeline.run`
  - Removed `forceLocal` parameter from `runGeneration` — `isLocal` now uses `args.local` directly
  - No-config mode (`handleWithFlags`) overrides `args.local` to `true` via spread to preserve its always-local behavior
- **`parseOutputArg.ts`**: Same PR URL handling for the no-config (flags-only) code path; now accepts a `{ local }` option to enforce the `--local` requirement for both PR URLs and git URLs (consistent with `parseTargetOutput`)
- **`package.json`**: Added `@octokit/rest` (catalog) as a devDependency
- Updated `--output` CLI help text to mention PR URL support
- Added changelog entry

## Human Review Checklist

- [x] ~~Fork-PR rejection is case-sensitive~~ — Fixed: now uses `.toLowerCase()` on both sides
- [x] ~~`forceLocal` propagation~~ — Removed: `forceLocal` no longer exists; `--local` is required explicitly
- [x] ~~No-config mode regression~~ — Fixed: `handleWithFlags` passes `{ ...args, local: true }` to restore always-local behavior
- [x] ~~`parseOutputArg` missing `--local` check for git URLs~~ — Fixed: now checks `!local` for both PR URLs and git URLs
- [ ] **Duplicated PR URL logic**: `parseTargetOutput` in `command.ts` and `parseOutputArg` in `parseOutputArg.ts` both contain the same PR URL resolution logic. `parseOutputArg.ts` does not appear to be imported anywhere — confirm whether it's actively used or could be consolidated
- [ ] **`outputPath: undefined`**: When `isRemoteOutput` is true, `pipeline.run` receives `outputPath: undefined`. Verify this doesn't cause issues downstream — the git output config on `target.output.git` should be the primary output mechanism in this case
- [ ] **No-config mode `args.local` override**: `handleWithFlags` spreads `{ ...args, local: true }` — any downstream code reading `args.local` will see `true` even though the user didn't pass `--local`. Verify this doesn't cause unintended side effects (e.g. in logging or error messages)
- [ ] No retry/rate-limit handling on the Octokit API call — acceptable for v1?

## Testing
- [ ] Unit tests added/updated
- [x] Lint passes (`pnpm run check`)
- [ ] Manual testing completed — needs a real PR URL + `GITHUB_TOKEN` to verify end-to-end

Link to Devin session: https://app.devin.ai/sessions/9ec43fea26df4a57b4357ec778c86d8a
Requested by: @Swimburger
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/14901" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
