### PR TITLE
chore(deps): remove redundant pnpm overrides and vite minimumReleaseAgeExclude

### DIFF
--- a/package.json
+++ b/package.json
@@ -155,15 +155,10 @@
       "qs": "6.15.0",
       "url-join": "^4.0.1",
       "@fern-api/fdr-sdk": "0.145.12-b50d999d1",
-      "es-toolkit": "^1.45.1",
-      "ts-essentials": "^10.1.1",
       "form-data": "^4.0.4",
       "@fern-api/ui-core-utils": "0.145.12-b50d999d1",
       "vite": "^7.3.2",
-      "yauzl": "^3.2.1",
-      "brace-expansion": ">=5.0.5",
-      "path-to-regexp@~0.1.12": "0.1.13",
-      "defu": ">=6.1.5"
+      "yauzl": "^3.2.1"
     }
   },
   "dependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -291,6 +291,9 @@ catalogs:
     domhandler:
       specifier: ^5.0.3
       version: 5.0.3
+    es-toolkit:
+      specifier: ^1.45.1
+      version: 1.45.1
     esbuild:
       specifier: ^0.27.3
       version: 0.27.7
@@ -589,15 +592,10 @@ overrides:
   qs: 6.15.0
   url-join: ^4.0.1
   '@fern-api/fdr-sdk': 0.145.12-b50d999d1
-  es-toolkit: ^1.45.1
-  ts-essentials: ^10.1.1
   form-data: ^4.0.4
   '@fern-api/ui-core-utils': 0.145.12-b50d999d1
   vite: ^7.3.2
   yauzl: ^3.2.1
-  brace-expansion: '>=5.0.5'
-  path-to-regexp@~0.1.12: 0.1.13
-  defu: '>=6.1.5'
 
 importers:
 
@@ -7822,7 +7820,7 @@ importers:
         specifier: 'catalog:'
         version: 22.0.1
       es-toolkit:
-        specifier: ^1.45.1
+        specifier: 'catalog:'
         version: 1.45.1
       tmp-promise:
         specifier: 'catalog:'

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -28,7 +28,6 @@ minimumReleaseAge: 1440
 minimumReleaseAgeExclude:
   - "@fern-api/*"
   - "@fern-fern/*"
-  - "vite"
 
 # Prevent trust level downgrades (e.g. a previously trusted-publisher package
 # losing its attestation). Catches compromised maintainer accounts.


### PR DESCRIPTION
## Description

Removes 5 pnpm overrides that are redundant (all transitive consumers already resolve to the same version without the override) and removes `vite` from `minimumReleaseAgeExclude` since the pinned version is well past the 1-day window.

## Changes Made

**Removed overrides (no version changes result):**
- `es-toolkit: ^1.45.1` — only consumer (`@fern-api/generator-cli@0.9.4`) already requests `^1.45.1`
- `ts-essentials: ^10.1.1` — consumers request `^10.0.x`, latest in range is already 10.1.1
- `brace-expansion: >=5.0.5` — redundant given the `minimatch: >=10.2.3` override, which forces minimatch 10.x that already depends on `brace-expansion: ^5.0.5`
- `path-to-regexp@~0.1.12: 0.1.13` — 0.1.13 is the latest version in the `~0.1.12` range (express's range), so pnpm resolves to it naturally
- `defu: >=6.1.5` — tsdown requests `^6.1.4`, latest is 6.1.7 which exceeds the override floor

**Removed `minimumReleaseAgeExclude` entry:**
- `vite` — pinned to `^7.3.2` (latest 7.x), well past the 1-day release age window; vite has moved to 8.x so new 7.x releases are unlikely

**Kept overrides** (still necessary): `ajv`, `node-fetch>whatwg-url`, `minimatch`, `qs`, `url-join`, `@fern-api/fdr-sdk`, `form-data`, `@fern-api/ui-core-utils`, `vite`, `yauzl` — all of these prevent actual version downgrades or pin intentional versions.

## Review Checklist
- [ ] Confirm resolved versions are unchanged after override removal (lockfile diff is minimal: `+3 -3` packages, same versions)
- [ ] Verify removing `vite` from `minimumReleaseAgeExclude` is acceptable (if a hypothetical 7.3.3 were published, it would be blocked for 1 day by the release age policy)

## Testing
- [x] `pnpm install` succeeds, lockfile diff is clean
- [x] `pnpm check` (biome) passes
- [x] Verified via `pnpm why` that all five packages resolve to identical versions after override removal

Link to Devin session: https://app.devin.ai/sessions/33d79163a67b494e82f67b5ec6eef2a2
Requested by: @davidkonigsberg