### PR TITLE
chore(generator-cli): upgrade @fern-api/replay to 0.10.4 (pinned), bump python SDK to 5.3.12

### DIFF
--- a/generators/python/sdk/versions.yml
+++ b/generators/python/sdk/versions.yml
@@ -1,5 +1,13 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 # For unreleased changes, use unreleased.yml
+- version: 5.3.12
+  changelogEntry:
+    - summary: |
+        Bump generator-cli to 0.9.7 which upgrades @fern-api/replay to 0.10.4.
+      type: chore
+  createdAt: "2026-04-12"
+  irVersion: 65
+
 - version: 5.3.11
   changelogEntry:
     - summary: |

--- a/packages/generator-cli/package.json
+++ b/packages/generator-cli/package.json
@@ -24,7 +24,7 @@
   "files": ["bin", "dist", "lib"],
   "dependencies": {
     "@fern-api/core-utils": "workspace:*",
-    "@fern-api/replay": "0.10.3",
+    "@fern-api/replay": "0.10.4",
     "@octokit/rest": "catalog:",
     "es-toolkit": "catalog:",
     "tmp-promise": "catalog:"

--- a/packages/generator-cli/versions.yml
+++ b/packages/generator-cli/versions.yml
@@ -1,6 +1,13 @@
 # yaml-language-server: $schema=../../versions-yml.schema.json
 - changelogEntry:
     - summary: |
+        Upgrade @fern-api/replay to 0.10.4 (pinned).
+      type: chore
+  createdAt: "2026-04-12"
+  version: 0.9.7
+
+- changelogEntry:
+    - summary: |
         Upgrade @fern-api/replay to 0.10.3 (pinned).
       type: chore
   createdAt: "2026-04-10"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7814,8 +7814,8 @@ importers:
         specifier: workspace:*
         version: link:../commons/core-utils
       '@fern-api/replay':
-        specifier: 0.10.3
-        version: 0.10.3
+        specifier: 0.10.4
+        version: 0.10.4
       '@octokit/rest':
         specifier: 'catalog:'
         version: 22.0.1
@@ -9337,8 +9337,8 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
-  '@fern-api/replay@0.10.3':
-    resolution: {integrity: sha512-iR+AwoO6EK+kx/MeO1mudSOXVgFTweME2pAjKFioByiVkTR8ukBIPNOGPCIbjnrvQvVrBXJoglMR13fihTaTfA==}
+  '@fern-api/replay@0.10.4':
+    resolution: {integrity: sha512-j/stjn9QMrFPnuLy0KNCwb4rM8ruq7nPtem1ZD5d8E+T7q+yxx1R3QsIaKZcKwFp/LFoyf8PPLhOAa6H8il8WQ==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -16373,7 +16373,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@fern-api/replay@0.10.3':
+  '@fern-api/replay@0.10.4':
     dependencies:
       minimatch: 10.2.5
       node-diff3: 3.2.0


### PR DESCRIPTION
## Description

Upgrades `@fern-api/replay` to `0.10.4` (pinned) in generator-cli and bumps the Python SDK generator version to track the change.

A companion PR in fern-api/fiddle updates the Dockerfile to use the new generator-cli version (`0.9.7`) once it's published to npm.

## Changes Made

- Updated `@fern-api/replay` dependency from `0.10.3` → `0.10.4` (exact pin, no caret) in `packages/generator-cli/package.json`
- Added generator-cli `0.9.7` version entry in `packages/generator-cli/versions.yml`
- Added Python SDK `5.3.12` version entry in `generators/python/sdk/versions.yml` referencing generator-cli 0.9.7
- Updated `pnpm-lock.yaml`

## Human Review Checklist
- [ ] Verify `@fern-api/replay@0.10.4` is published on npm
- [ ] Confirm version numbers are sequential (generator-cli 0.9.7 after 0.9.6, Python SDK 5.3.12 after 5.3.11)
- [ ] Confirm replay is pinned (no `^` caret) — intentional to avoid uncontrolled upgrades

## Testing

- [ ] Unit tests added/updated — N/A, version bump only
- [x] CI validation

Link to Devin session: https://app.devin.ai/sessions/97bbc3e45f7e47bea6541c0503d031c1
Requested by: @tstanmay13