### PR TITLE
fix(cli): validate broken links in folder-based navigation items

### DIFF
--- a/packages/cli/cli/changes/unreleased/enable-broken-links-by-default.yml
+++ b/packages/cli/cli/changes/unreleased/enable-broken-links-by-default.yml
@@ -1,9 +1,8 @@
 # yaml-language-server: $schema=../../../../../fern-changes-yml.schema.json
 
 - summary: |
-    Enable broken link validation by default in `fern check`. Previously, the
-    `valid-markdown-links` rule was excluded unless `--broken-links` or
-    `--strict-broken-links` was passed. Now broken links (including href
-    attributes on Card components) are always checked. Severity can still be
-    controlled via `check.rules.broken-links` in docs.yml.
-  type: feat
+    Improve broken link validation resilience: gracefully handle docs workspaces
+    that lack navigation or versions instead of throwing, and add debug logging
+    when the check is skipped. Also adds Card and CardGroup href coverage to
+    broken-links test fixtures.
+  type: fix

--- a/packages/cli/cli/changes/unreleased/enable-broken-links-by-default.yml
+++ b/packages/cli/cli/changes/unreleased/enable-broken-links-by-default.yml
@@ -1,8 +1,8 @@
 # yaml-language-server: $schema=../../../../../fern-changes-yml.schema.json
 
 - summary: |
-    Improve broken link validation resilience: gracefully handle docs workspaces
-    that lack navigation or versions instead of throwing, and add debug logging
-    when the check is skipped. Also adds Card and CardGroup href coverage to
-    broken-links test fixtures.
+    Fix broken link validation for folder-based navigation: pages inside `folder`
+    navigation items were not being visited by the AST validator, so broken links
+    in those files (including Card href attributes) were silently missed. Also
+    improves resilience by gracefully handling docs workspaces that lack navigation.
   type: fix

--- a/packages/cli/cli/changes/unreleased/enable-broken-links-by-default.yml
+++ b/packages/cli/cli/changes/unreleased/enable-broken-links-by-default.yml
@@ -1,0 +1,9 @@
+# yaml-language-server: $schema=../../../../../fern-changes-yml.schema.json
+
+- summary: |
+    Enable broken link validation by default in `fern check`. Previously, the
+    `valid-markdown-links` rule was excluded unless `--broken-links` or
+    `--strict-broken-links` was passed. Now broken links (including href
+    attributes on Card components) are always checked. Severity can still be
+    controlled via `check.rules.broken-links` in docs.yml.
+  type: feat

--- a/packages/cli/cli/src/commands/validate/validateWorkspaces.ts
+++ b/packages/cli/cli/src/commands/validate/validateWorkspaces.ts
@@ -33,7 +33,10 @@ export async function validateWorkspaces({
     // Collect docs violations first (using runTaskForWorkspace to preserve [docs]: prefix for fatal errors)
     const docsWorkspace = project.docsWorkspaces;
     if (docsWorkspace != null) {
-        const excludeRules = brokenLinks || errorOnBrokenLinks ? [] : ["valid-markdown-links"];
+        // Always include valid-markdown-links so fern check catches broken links (including in Cards).
+        // The deprecated --broken-links / --strict-broken-links flags are now effectively no-ops for
+        // rule inclusion; severity can still be controlled via docs.yml check.rules.broken-links.
+        const excludeRules: string[] = [];
         const ossWorkspaces = await filterOssWorkspaces(project);
 
         let collected: Awaited<ReturnType<typeof collectDocsWorkspaceViolations>> | undefined;

--- a/packages/cli/cli/src/commands/validate/validateWorkspaces.ts
+++ b/packages/cli/cli/src/commands/validate/validateWorkspaces.ts
@@ -33,10 +33,7 @@ export async function validateWorkspaces({
     // Collect docs violations first (using runTaskForWorkspace to preserve [docs]: prefix for fatal errors)
     const docsWorkspace = project.docsWorkspaces;
     if (docsWorkspace != null) {
-        // Always include valid-markdown-links so fern check catches broken links (including in Cards).
-        // The deprecated --broken-links / --strict-broken-links flags are now effectively no-ops for
-        // rule inclusion; severity can still be controlled via docs.yml check.rules.broken-links.
-        const excludeRules: string[] = [];
+        const excludeRules = brokenLinks || errorOnBrokenLinks ? [] : ["valid-markdown-links"];
         const ossWorkspaces = await filterOssWorkspaces(project);
 
         let collected: Awaited<ReturnType<typeof collectDocsWorkspaceViolations>> | undefined;

--- a/packages/cli/ete-tests/src/tests/broken-links/__snapshots__/broken-links.test.ts.snap
+++ b/packages/cli/ete-tests/src/tests/broken-links/__snapshots__/broken-links.test.ts.snap
@@ -16,6 +16,10 @@ exports[`fern docs broken-links > simple broken links 1`] = `
        	fix here: foo.md:11:21
        [error] broken link to /bar/baz.md
        	fix here: foo.md:12:21
+       [error] broken link to /nonexistent/card-page
+       	fix here: foo.md:32:1
+       [error] broken link to /bad/group-link
+       	fix here: foo.md:40:3
        
 [docs]:bar.mdx
        [error] broken link to ../hello (resolved path: section/hello)
@@ -23,5 +27,5 @@ exports[`fern docs broken-links > simple broken links 1`] = `
        [error] broken link to ../hello.md (resolved path: section/hello.md)
        	fix here: bar.mdx:7:30
        
-[docs]:Found 4 errors and 0 warnings in"
+[docs]:Found 6 errors and 0 warnings in"
 `;

--- a/packages/cli/ete-tests/src/tests/broken-links/fixtures/simple/fern/foo.md
+++ b/packages/cli/ete-tests/src/tests/broken-links/fixtures/simple/fern/foo.md
@@ -22,3 +22,22 @@
 ## Special Files
 
 1. link to llms.txt file [llms.txt](/llms.txt)
+
+## Card Links
+
+<Card title="Valid Card" href="/api-reference/imdb/create-movie">
+  This card links to a valid page
+</Card>
+
+<Card title="Broken Card" href="/nonexistent/card-page">
+  This card links to a broken page
+</Card>
+
+<CardGroup cols={2}>
+  <Card title="Valid Group Card" href="/section/bar">
+    Valid link in card group
+  </Card>
+  <Card title="Broken Group Card" href="/bad/group-link">
+    Broken link in card group
+  </Card>
+</CardGroup>

--- a/packages/cli/yaml/docs-validator/src/docsAst/visitNavigationAst.ts
+++ b/packages/cli/yaml/docs-validator/src/docsAst/visitNavigationAst.ts
@@ -5,6 +5,7 @@ import { NodePath } from "@fern-api/fern-definition-schema";
 import { AbsoluteFilePath, dirname, doesPathExist, relative, resolve } from "@fern-api/fs-utils";
 import { TaskContext } from "@fern-api/task-context";
 import { AbstractAPIWorkspace } from "@fern-api/workspace-loader";
+import path from "path";
 import { readdir, readFile, stat } from "fs/promises";
 import { asyncPool } from "../utils/asyncPool.js";
 import { DocsConfigFileAstVisitor } from "./DocsConfigFileAstVisitor.js";
@@ -177,7 +178,11 @@ async function visitNavigationItem({
             }
         },
         orphaned: noop,
-        availability: noop
+        availability: noop,
+        folder: noop,
+        titleSource: noop,
+        collapsible: noop,
+        collapsedByDefault: noop
     });
 
     const markdownPath = getNavigationItemMarkdownPath(navigationItem);
@@ -248,6 +253,49 @@ async function visitNavigationItem({
                 },
                 [...nodePath, "api"]
             );
+        }
+    }
+
+    if (navigationItemIsFolder(navigationItem)) {
+        const folderDir = resolve(dirname(absoluteFilepathToConfiguration), navigationItem.folder);
+
+        if (await doesPathExist(folderDir)) {
+            const markdownFiles = await collectMarkdownFiles(folderDir);
+            context.logger.debug(`Processing ${markdownFiles.length} markdown files in folder: ${navigationItem.folder}`);
+
+            await asyncPool(VALIDATION_CONCURRENCY, markdownFiles, async (absoluteFilepath) => {
+                const content = (await readFile(absoluteFilepath, "utf8")).toString();
+                const title = path.basename(absoluteFilepath, path.extname(absoluteFilepath));
+
+                await visitor.markdownPage?.(
+                    {
+                        title,
+                        content,
+                        absoluteFilepath
+                    },
+                    [...nodePath, "folder", path.relative(folderDir, absoluteFilepath)]
+                );
+
+                try {
+                    const { filepaths } = parseImagePaths(content, {
+                        absolutePathToFernFolder,
+                        absolutePathToMarkdownFile: absoluteFilepath
+                    });
+
+                    for (const filepath of filepaths) {
+                        await visitor.filepath?.(
+                            {
+                                absoluteFilepath: filepath,
+                                value: relative(absolutePathToFernFolder, filepath),
+                                willBeUploaded: true
+                            },
+                            [...nodePath, "folder", path.relative(folderDir, absoluteFilepath)]
+                        );
+                    }
+                } catch (err) {
+                    context.logger.trace(`Failed to parse image paths in ${absoluteFilepath}: ${err}`);
+                }
+            });
         }
     }
 
@@ -323,6 +371,28 @@ function getNavigationItemTitle(item: docsYml.RawSchemas.NavigationItem): string
         return item.section;
     }
     return "Unknown";
+}
+
+function navigationItemIsFolder(
+    item: docsYml.RawSchemas.NavigationItem
+): item is docsYml.RawSchemas.FolderConfiguration {
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+    return (item as docsYml.RawSchemas.FolderConfiguration)?.folder != null;
+}
+
+async function collectMarkdownFiles(dirPath: AbsoluteFilePath): Promise<AbsoluteFilePath[]> {
+    const results: AbsoluteFilePath[] = [];
+    const entries = await readdir(dirPath, { withFileTypes: true });
+    for (const entry of entries) {
+        const fullPath = resolve(dirPath, entry.name);
+        if (entry.isDirectory()) {
+            const nested = await collectMarkdownFiles(fullPath);
+            results.push(...nested);
+        } else if (entry.name.endsWith(".md") || entry.name.endsWith(".mdx")) {
+            results.push(fullPath);
+        }
+    }
+    return results;
 }
 
 function navigationItemIsApi(

--- a/packages/cli/yaml/docs-validator/src/docsAst/visitNavigationAst.ts
+++ b/packages/cli/yaml/docs-validator/src/docsAst/visitNavigationAst.ts
@@ -5,8 +5,8 @@ import { NodePath } from "@fern-api/fern-definition-schema";
 import { AbsoluteFilePath, dirname, doesPathExist, relative, resolve } from "@fern-api/fs-utils";
 import { TaskContext } from "@fern-api/task-context";
 import { AbstractAPIWorkspace } from "@fern-api/workspace-loader";
-import path from "path";
 import { readdir, readFile, stat } from "fs/promises";
+import path from "path";
 import { asyncPool } from "../utils/asyncPool.js";
 import { DocsConfigFileAstVisitor } from "./DocsConfigFileAstVisitor.js";
 import { visitFilepath } from "./visitFilepath.js";
@@ -261,7 +261,9 @@ async function visitNavigationItem({
 
         if (await doesPathExist(folderDir)) {
             const markdownFiles = await collectMarkdownFiles(folderDir);
-            context.logger.debug(`Processing ${markdownFiles.length} markdown files in folder: ${navigationItem.folder}`);
+            context.logger.debug(
+                `Processing ${markdownFiles.length} markdown files in folder: ${navigationItem.folder}`
+            );
 
             await asyncPool(VALIDATION_CONCURRENCY, markdownFiles, async (absoluteFilepath) => {
                 const content = (await readFile(absoluteFilepath, "utf8")).toString();

--- a/packages/cli/yaml/docs-validator/src/rules/valid-markdown-link/valid-markdown-link.ts
+++ b/packages/cli/yaml/docs-validator/src/rules/valid-markdown-link/valid-markdown-link.ts
@@ -100,6 +100,9 @@ export const ValidMarkdownLinks: Rule = {
             visitableSlugs.add(pageWithBasePath);
         }
 
+        logger.debug(`[valid-markdown-links] Collected ${visitableSlugs.size} visitable slugs`);
+        logger.debug(`[valid-markdown-links] Collected ${absoluteFilePathsToSlugs.size} file-to-slug mappings`);
+
         return {
             markdownPage: async ({ content, absoluteFilepath }) => {
                 const slugs = absoluteFilePathsToSlugs.get(absoluteFilepath);
@@ -107,6 +110,7 @@ export const ValidMarkdownLinks: Rule = {
                 // if this happens, this probably means that the current file is omitted from the docs navigation
                 // most likely due to a slug collision. This should be handled in a different rule.
                 if (!slugs || slugs.length === 0) {
+                    logger.debug(`[valid-markdown-links] Skipping ${absoluteFilepath} — no slugs found`);
                     return [];
                 }
 
@@ -122,6 +126,10 @@ export const ValidMarkdownLinks: Rule = {
                     absoluteFilepath,
                     instanceUrls
                 });
+
+                logger.debug(
+                    `[valid-markdown-links] ${absoluteFilepath}: ${pathnamesToCheck.length} pathnames to check, ${violations.length} parse violations`
+                );
 
                 const pathToCheckViolations = await Promise.all(
                     pathnamesToCheck.map(async (pathnameToCheck) => {

--- a/packages/cli/yaml/docs-validator/src/rules/valid-markdown-link/valid-markdown-link.ts
+++ b/packages/cli/yaml/docs-validator/src/rules/valid-markdown-link/valid-markdown-link.ts
@@ -37,10 +37,17 @@ export const ValidMarkdownLinks: Rule = {
             targetAudiences: undefined // not applicable for validation
         });
 
-        const resolvedDocsDefinition = await docsDefinitionResolver.resolve();
+        let resolvedDocsDefinition;
+        try {
+            resolvedDocsDefinition = await docsDefinitionResolver.resolve();
+        } catch {
+            // Docs workspace may lack navigation/versions (e.g. minimal docs.yml).
+            // Nothing to validate in that case, so return an empty visitor.
+            return {};
+        }
 
         if (!resolvedDocsDefinition.config.root) {
-            throw new Error("Root node not found");
+            return {};
         }
 
         // TODO: this is a bit of a hack to get the navigation tree. We should probably just use the navigation tree

--- a/packages/cli/yaml/docs-validator/src/rules/valid-markdown-link/valid-markdown-link.ts
+++ b/packages/cli/yaml/docs-validator/src/rules/valid-markdown-link/valid-markdown-link.ts
@@ -19,7 +19,7 @@ const NOOP_CONTEXT = createMockTaskContext({ logger: createLogger(noop) });
 
 export const ValidMarkdownLinks: Rule = {
     name: "valid-markdown-links",
-    create: async ({ workspace, apiWorkspaces, ossWorkspaces }) => {
+    create: async ({ workspace, apiWorkspaces, ossWorkspaces, logger }) => {
         const instanceUrls = getInstanceUrls(workspace);
 
         const url = instanceUrls[0] ?? "http://localhost";
@@ -40,9 +40,10 @@ export const ValidMarkdownLinks: Rule = {
         let resolvedDocsDefinition;
         try {
             resolvedDocsDefinition = await docsDefinitionResolver.resolve();
-        } catch {
+        } catch (error) {
             // Docs workspace may lack navigation/versions (e.g. minimal docs.yml).
             // Nothing to validate in that case, so return an empty visitor.
+            logger.debug(`Skipping broken link validation: docs definition could not be resolved. ${error}`);
             return {};
         }
 

--- a/packages/cli/yaml/docs-validator/src/validateDocsWorkspace.ts
+++ b/packages/cli/yaml/docs-validator/src/validateDocsWorkspace.ts
@@ -108,12 +108,10 @@ export async function runRulesOnDocsWorkspace({
 
     const ruleCreationStart = performance.now();
     const allRulesWithVisitors = await Promise.all(
-        rules.map(
-            async (rule): Promise<RuleWithVisitor> => {
-                const visitor = await rule.create({ workspace, apiWorkspaces, ossWorkspaces, logger: context.logger });
-                return { ruleName: rule.name, visitor };
-            }
-        )
+        rules.map(async (rule): Promise<RuleWithVisitor> => {
+            const visitor = await rule.create({ workspace, apiWorkspaces, ossWorkspaces, logger: context.logger });
+            return { ruleName: rule.name, visitor };
+        })
     );
     const ruleCreationTime = performance.now() - ruleCreationStart;
     context.logger.debug(`Created ${rules.length} rule visitors in ${ruleCreationTime.toFixed(0)}ms`);

--- a/packages/cli/yaml/docs-validator/src/validateDocsWorkspace.ts
+++ b/packages/cli/yaml/docs-validator/src/validateDocsWorkspace.ts
@@ -93,8 +93,9 @@ export async function runRulesOnDocsWorkspace({
     const rules = [...selectedRules];
     const severityOverrides = buildSeverityOverrides(workspace.config.check);
     const validMarkdownLinksOverride = severityOverrides.get(ValidMarkdownLinks.name);
-    // Safety net: ensure valid-markdown-links is always present when docs.yml
-    // configures check.rules.broken-links, even if a caller excludes it.
+    // Some CLI paths still exclude `valid-markdown-links` unless broken-link checking is enabled.
+    // Include it here when docs.yml configures `check.rules.broken-links` so that config takes effect
+    // until those CLI args are removed.
     if (validMarkdownLinksOverride != null && rules.find((r) => r.name === ValidMarkdownLinks.name) == null) {
         rules.push(ValidMarkdownLinks);
     }

--- a/packages/cli/yaml/docs-validator/src/validateDocsWorkspace.ts
+++ b/packages/cli/yaml/docs-validator/src/validateDocsWorkspace.ts
@@ -109,10 +109,10 @@ export async function runRulesOnDocsWorkspace({
     const ruleCreationStart = performance.now();
     const allRulesWithVisitors = await Promise.all(
         rules.map(
-            async (rule): Promise<RuleWithVisitor> => ({
-                ruleName: rule.name,
-                visitor: await rule.create({ workspace, apiWorkspaces, ossWorkspaces, logger: context.logger })
-            })
+            async (rule): Promise<RuleWithVisitor> => {
+                const visitor = await rule.create({ workspace, apiWorkspaces, ossWorkspaces, logger: context.logger });
+                return { ruleName: rule.name, visitor };
+            }
         )
     );
     const ruleCreationTime = performance.now() - ruleCreationStart;

--- a/packages/cli/yaml/docs-validator/src/validateDocsWorkspace.ts
+++ b/packages/cli/yaml/docs-validator/src/validateDocsWorkspace.ts
@@ -93,9 +93,8 @@ export async function runRulesOnDocsWorkspace({
     const rules = [...selectedRules];
     const severityOverrides = buildSeverityOverrides(workspace.config.check);
     const validMarkdownLinksOverride = severityOverrides.get(ValidMarkdownLinks.name);
-    // Some CLI paths still exclude `valid-markdown-links` unless broken-link checking is enabled.
-    // Include it here when docs.yml configures `check.rules.broken-links` so that config takes effect
-    // until those CLI args are removed.
+    // Safety net: ensure valid-markdown-links is always present when docs.yml
+    // configures check.rules.broken-links, even if a caller excludes it.
     if (validMarkdownLinksOverride != null && rules.find((r) => r.name === ValidMarkdownLinks.name) == null) {
         rules.push(ValidMarkdownLinks);
     }


### PR DESCRIPTION
## Description

Fixes broken link validation for docs that use `folder` navigation items (e.g., `- folder: ../pages/latest/guides/core`). Previously, `fern check --broken-links` and `fern docs broken-links` silently skipped all pages inside folder-based navigation, so broken links (including `<Card>` href attributes) in those files were never caught.

## Changes Made

- **Add folder navigation handling to AST visitor** (`visitNavigationAst.ts`): When a navigation item has a `folder` property, recursively collect all `.md`/`.mdx` files in that directory and visit each one with the `markdownPage` callback — matching the existing behavior for `page`, `contents`, and `changelog` items.
- **Graceful error handling** (`valid-markdown-link.ts`): When the docs definition resolver fails (e.g., minimal `docs.yml` without navigation), catch the error, log at debug level, and return an empty visitor instead of crashing.
- **Add Card/CardGroup test coverage**: Added `<Card>` and `<CardGroup>` components with broken `href` attributes to the existing broken-links E2E fixture.
- **Updated changelog** describing the fix.

## Root Cause

The `visitNavigationItem` function in `visitNavigationAst.ts` uses `visitObjectAsync` to traverse navigation item properties. It had handlers for `page`, `contents`, `path`, `api`, `changelog`, etc. — but NOT for `folder`. When a product config used folder-based navigation (common in versioned docs), the `folder` property was silently ignored by `visitObjectAsync`, so none of the markdown files in those directories were ever visited by the broken link validator.

## Testing

- [x] Unit tests pass (71/71 in docs-validator)
- [x] E2E broken-links tests pass (7/7) — including new Card/CardGroup cases
- [x] Manual testing against [signalwire/docs](https://github.com/signalwire/docs) repo:
  - Broke a Card href in `fern/products/browser-sdk/pages/latest/guides/core/overview.mdx`
  - Ran `fern check --broken-links` → correctly detected the broken link
  - Ran `fern docs broken-links` → correctly detected the broken link
- [x] `--broken-links` remains opt-in (not enabled by default)

Link to Devin session: https://app.devin.ai/sessions/105c82120c8d42d3b7e811a922f4976e
Requested by: @fern-support
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/14942" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
