### PR TITLE
feat(cli): enable broken link checking by default in fern check

### DIFF
--- a/packages/cli/cli/changes/unreleased/enable-broken-links-check-by-default.yml
+++ b/packages/cli/cli/changes/unreleased/enable-broken-links-check-by-default.yml
@@ -1,0 +1,4 @@
+- summary: |
+    `fern check` now validates broken links (including Card component hrefs) by default as warnings.
+    Previously, broken link checking required the `--broken-links` flag.
+  type: feat

--- a/packages/cli/cli/src/commands/validate/validateDocsWorkspaceAndLogIssues.ts
+++ b/packages/cli/cli/src/commands/validate/validateDocsWorkspaceAndLogIssues.ts
@@ -45,10 +45,11 @@ export async function collectDocsWorkspaceViolations({
     );
     const elapsedMillis = performance.now() - startTime;
 
-    // Downgrade broken-link violations to warnings unless errorOnBrokenLinks is set,
-    // so that `fern check` reports them as warnings by default.
+    // Downgrade broken-link violations to warnings unless the user has explicitly
+    // configured severity via --error-on-broken-links or docs.yml check.rules.brokenLinks.
+    const userConfiguredBrokenLinkSeverity = workspace.config.check?.rules?.brokenLinks != null;
     const violations = rawViolations.map((v) => {
-        if (v.name === "valid-markdown-links" && !errorOnBrokenLinks) {
+        if (v.name === "valid-markdown-links" && !errorOnBrokenLinks && !userConfiguredBrokenLinkSeverity) {
             return { ...v, severity: "warning" as const };
         }
         return v;

--- a/packages/cli/cli/src/commands/validate/validateDocsWorkspaceAndLogIssues.ts
+++ b/packages/cli/cli/src/commands/validate/validateDocsWorkspaceAndLogIssues.ts
@@ -17,6 +17,7 @@ export async function collectDocsWorkspaceViolations({
     apiWorkspaces,
     ossWorkspaces,
     context,
+    brokenLinks,
     errorOnBrokenLinks,
     excludeRules
 }: {
@@ -24,6 +25,7 @@ export async function collectDocsWorkspaceViolations({
     apiWorkspaces: AbstractAPIWorkspace<unknown>[];
     ossWorkspaces: OSSWorkspace[];
     context: TaskContext;
+    brokenLinks?: boolean;
     errorOnBrokenLinks?: boolean;
     excludeRules?: string[];
 }): Promise<CollectedDocsViolations> {
@@ -46,10 +48,15 @@ export async function collectDocsWorkspaceViolations({
     const elapsedMillis = performance.now() - startTime;
 
     // Downgrade broken-link violations to warnings unless the user has explicitly
-    // configured severity via --error-on-broken-links or docs.yml check.rules.brokenLinks.
+    // configured severity via --broken-links, --error-on-broken-links, or docs.yml check.rules.brokenLinks.
     const userConfiguredBrokenLinkSeverity = workspace.config.check?.rules?.brokenLinks != null;
     const violations = rawViolations.map((v) => {
-        if (v.name === "valid-markdown-links" && !errorOnBrokenLinks && !userConfiguredBrokenLinkSeverity) {
+        if (
+            v.name === "valid-markdown-links" &&
+            !brokenLinks &&
+            !errorOnBrokenLinks &&
+            !userConfiguredBrokenLinkSeverity
+        ) {
             return { ...v, severity: "warning" as const };
         }
         return v;

--- a/packages/cli/cli/src/commands/validate/validateDocsWorkspaceAndLogIssues.ts
+++ b/packages/cli/cli/src/commands/validate/validateDocsWorkspaceAndLogIssues.ts
@@ -35,7 +35,7 @@ export async function collectDocsWorkspaceViolations({
     }
 
     const startTime = performance.now();
-    const violations = await validateDocsWorkspace(
+    const rawViolations = await validateDocsWorkspace(
         workspace,
         context,
         apiWorkspaces,
@@ -44,6 +44,15 @@ export async function collectDocsWorkspaceViolations({
         excludeRules
     );
     const elapsedMillis = performance.now() - startTime;
+
+    // Downgrade broken-link violations to warnings unless errorOnBrokenLinks is set,
+    // so that `fern check` reports them as warnings by default.
+    const violations = rawViolations.map((v) => {
+        if (v.name === "valid-markdown-links" && !errorOnBrokenLinks) {
+            return { ...v, severity: "warning" as const };
+        }
+        return v;
+    });
 
     let hasErrors = violations.some((v) => v.severity === "fatal" || v.severity === "error");
     if (errorOnBrokenLinks) {

--- a/packages/cli/cli/src/commands/validate/validateWorkspaces.ts
+++ b/packages/cli/cli/src/commands/validate/validateWorkspaces.ts
@@ -33,7 +33,7 @@ export async function validateWorkspaces({
     // Collect docs violations first (using runTaskForWorkspace to preserve [docs]: prefix for fatal errors)
     const docsWorkspace = project.docsWorkspaces;
     if (docsWorkspace != null) {
-        const excludeRules = brokenLinks || errorOnBrokenLinks ? [] : ["valid-markdown-links"];
+        const excludeRules: string[] = [];
         const ossWorkspaces = await filterOssWorkspaces(project);
 
         let collected: Awaited<ReturnType<typeof collectDocsWorkspaceViolations>> | undefined;

--- a/packages/cli/cli/src/commands/validate/validateWorkspaces.ts
+++ b/packages/cli/cli/src/commands/validate/validateWorkspaces.ts
@@ -43,6 +43,7 @@ export async function validateWorkspaces({
                 context,
                 apiWorkspaces: project.apiWorkspaces,
                 ossWorkspaces,
+                brokenLinks,
                 errorOnBrokenLinks,
                 excludeRules
             });

--- a/packages/cli/ete-tests/src/tests/broken-links/broken-links.test.ts
+++ b/packages/cli/ete-tests/src/tests/broken-links/broken-links.test.ts
@@ -75,6 +75,20 @@ describe("fern docs broken-links", () => {
         expect(stripAnsi(stdout)).toContain("All checks passed");
     }, 20_000);
 
+    it("broken Card component hrefs should be detected", async ({ signal }) => {
+        const { stdout } = await runFernCli(["docs", "broken-links"], {
+            cwd: join(fixturesDir, RelativeFilePath.of("card-href")),
+            reject: false,
+            signal
+        });
+        // Card components with href attributes pointing to non-existent pages should be flagged
+        expect(stripAnsi(stdout)).toContain("/does-not-exist");
+        expect(stripAnsi(stdout)).toContain("/plants/reference/missing");
+        // Valid Card hrefs should not be flagged
+        expect(stripAnsi(stdout)).not.toContain("/about");
+        expect(stripAnsi(stdout)).not.toContain("/api-reference/imdb/create-movie");
+    }, 20_000);
+
     it("broken links in sections with path property should be detected", async ({ signal }) => {
         const { stdout } = await runFernCli(["docs", "broken-links"], {
             cwd: join(fixturesDir, RelativeFilePath.of("section-with-path")),

--- a/packages/cli/ete-tests/src/tests/broken-links/fixtures/card-href/fern/about.mdx
+++ b/packages/cli/ete-tests/src/tests/broken-links/fixtures/card-href/fern/about.mdx
@@ -1,0 +1,3 @@
+# About
+
+This is a valid page.

--- a/packages/cli/ete-tests/src/tests/broken-links/fixtures/card-href/fern/definition/api.yml
+++ b/packages/cli/ete-tests/src/tests/broken-links/fixtures/card-href/fern/definition/api.yml
@@ -1,0 +1,27 @@
+imports:
+  commons: commons.yml
+name: my-api
+docs: foo bar baz
+auth: apiKey
+auth-schemes:
+  apiKey:
+    header: X_API_KEY
+    name: apiKey
+headers:
+  X-API-VERSION:
+    name: apiVersion
+    type: optional<string>
+error-discrimination:
+  strategy: property
+  property-name: error
+audiences:
+  - test
+errors:
+  - commons.BadRequestError
+default-environment: Production
+environments:
+  Production: https://buildwithfern.com
+  Staging: https://staging.buildwithfern.com
+base-path: /test/{rootPathParam}
+path-parameters:
+  rootPathParam: string

--- a/packages/cli/ete-tests/src/tests/broken-links/fixtures/card-href/fern/definition/commons.yml
+++ b/packages/cli/ete-tests/src/tests/broken-links/fixtures/card-href/fern/definition/commons.yml
@@ -1,0 +1,12 @@
+types:
+  UndiscriminatedUnion:
+    discriminated: false
+    union:
+      - string
+      - list<string>
+      - integer
+      - list<list<integer>>
+
+errors:
+  BadRequestError:
+    status-code: 400

--- a/packages/cli/ete-tests/src/tests/broken-links/fixtures/card-href/fern/definition/director.yml
+++ b/packages/cli/ete-tests/src/tests/broken-links/fixtures/card-href/fern/definition/director.yml
@@ -1,0 +1,18 @@
+docs: These are docs about directors.
+
+types:
+  Director:
+    properties:
+      name: string
+      age: Age
+    examples:
+      - name: GeorgeExample
+        value:
+          name: George the Director
+          age: $Age.Example1
+  Age:
+    type: integer
+    examples:
+      - name: Example1
+        value: 20
+  LiteralString: literal<"hello">

--- a/packages/cli/ete-tests/src/tests/broken-links/fixtures/card-href/fern/definition/imdb.yml
+++ b/packages/cli/ete-tests/src/tests/broken-links/fixtures/card-href/fern/definition/imdb.yml
@@ -1,0 +1,147 @@
+imports:
+  director: director.yml
+types:
+  CurrencyAmount:
+    type: string
+    examples:
+      - value: \$4.50
+  MovieId:
+    type: string
+    examples:
+      - value: id1
+      - value: id2
+  ActorId: string
+  Movie:
+    properties:
+      id: MovieId
+      title: string
+      rating: double
+    examples:
+      - value:
+          id: my-movie-id
+          title: Goodwill Hunting
+          rating: 14.5
+  CreateMovieRequest:
+    properties:
+      title: string
+      ratings: list<double>
+    examples:
+      - name: Example1
+        value:
+          title: Winnie the Pooh
+          ratings: [1, 2, 3]
+  DirectorWrapper:
+    properties:
+      director: director.Director
+    examples:
+      - value:
+          director: $director.Director.GeorgeExample
+  EmptyObject:
+    properties: {}
+  Person:
+    union:
+      actor: ActorId
+      director: director.Director
+      producer: EmptyObject
+      cinematographer:
+        docs: i am docs
+        type: EmptyObject
+    examples:
+      - name: PersonExample1
+        docs: this is a person example
+        value:
+          type: actor
+          value: Matt Damon
+      - value:
+          type: director
+          name: George the Directory
+          age: 100
+      - value:
+          type: producer
+  RecursiveType:
+    extends: CreateMovieRequest
+    properties:
+      selfReferencing: list<RecursiveType>
+    examples:
+      - value:
+          title: The Godfather
+          ratings: [10, 5, 9]
+          selfReferencing:
+            - title: The Godfather II
+              ratings: [10, 11]
+              selfReferencing: []
+            - title: The Godfather III
+              ratings: []
+              selfReferencing: []
+      - value:
+          title: Goodfellas
+          ratings: [1, 2, 3]
+          selfReferencing: []
+errors:
+  NotFoundError:
+    status-code: 404
+    type: string
+service:
+  auth: false
+  base-path: /movies
+  endpoints:
+    createMovie:
+      auth: true
+      method: POST
+      path: ""
+      request: CreateMovieRequest
+      response: MovieId
+      audiences:
+        - test
+      examples:
+        - path-parameters:
+            rootPathParam: root
+          request:
+            title: Shrek
+            ratings: [10, 10, 10, 10]
+          response:
+            body: shrek-123
+        - path-parameters:
+            rootPathParam: root
+          request: $CreateMovieRequest.Example1
+          response:
+            body: shrek-123
+    getMovie:
+      method: GET
+      display-name: "Get Movie by Id"
+      path: /{movieId}
+      path-parameters:
+        movieId: MovieId
+      request:
+        name: GetMovieRequest
+        query-parameters:
+          movieName:
+            type: string
+            allow-multiple: true
+      response: Movie
+      errors:
+        - NotFoundError
+      examples:
+        - path-parameters:
+            rootPathParam: root
+            movieId: id-123
+          query-parameters:
+            movieName: hello
+          response:
+            body:
+              id: id-123
+              title: Shrek
+              rating: 10
+        - path-parameters:
+            rootPathParam: root
+            movieId: id-123
+          query-parameters:
+            movieName: hello
+          response:
+            error: NotFoundError
+            body: id-123
+    delete:
+      method: DELETE
+      path: /{movieId}
+      path-parameters:
+        movieId: MovieId

--- a/packages/cli/ete-tests/src/tests/broken-links/fixtures/card-href/fern/docs.yml
+++ b/packages/cli/ete-tests/src/tests/broken-links/fixtures/card-href/fern/docs.yml
@@ -1,0 +1,9 @@
+instances:
+  - url: ferndevtest.docs.dev.buildwithfern.com
+
+navigation:
+  - page: Plants
+    path: plants.mdx
+  - page: About
+    path: about.mdx
+  - api: API Reference

--- a/packages/cli/ete-tests/src/tests/broken-links/fixtures/card-href/fern/fern.config.json
+++ b/packages/cli/ete-tests/src/tests/broken-links/fixtures/card-href/fern/fern.config.json
@@ -1,0 +1,4 @@
+{
+  "version": "*",
+  "organization": "fern"
+}

--- a/packages/cli/ete-tests/src/tests/broken-links/fixtures/card-href/fern/generators.yml
+++ b/packages/cli/ete-tests/src/tests/broken-links/fixtures/card-href/fern/generators.yml
@@ -1,0 +1,4 @@
+default-group: public
+groups:
+  public:
+    generators: []

--- a/packages/cli/ete-tests/src/tests/broken-links/fixtures/card-href/fern/plants.mdx
+++ b/packages/cli/ete-tests/src/tests/broken-links/fixtures/card-href/fern/plants.mdx
@@ -1,0 +1,26 @@
+# Plants
+
+## Valid Card Links
+
+<Card
+  title="About"
+  href="/about"
+/>
+
+<Card
+  title="API Reference"
+  href="/api-reference/imdb/create-movie"
+/>
+
+## Broken Card Links
+
+<Card
+  title="Nonexistent Page"
+  href="/does-not-exist"
+/>
+
+<Card
+  title="Also Broken"
+  icon="brands fa-leaf"
+  href="/plants/reference/missing"
+/>

--- a/packages/cli/yaml/docs-validator/src/rules/valid-markdown-link/valid-markdown-link.ts
+++ b/packages/cli/yaml/docs-validator/src/rules/valid-markdown-link/valid-markdown-link.ts
@@ -19,7 +19,7 @@ const NOOP_CONTEXT = createMockTaskContext({ logger: createLogger(noop) });
 
 export const ValidMarkdownLinks: Rule = {
     name: "valid-markdown-links",
-    create: async ({ workspace, apiWorkspaces, ossWorkspaces }) => {
+    create: async ({ workspace, apiWorkspaces, ossWorkspaces, logger }) => {
         const instanceUrls = getInstanceUrls(workspace);
 
         const url = instanceUrls[0] ?? "http://localhost";
@@ -37,10 +37,17 @@ export const ValidMarkdownLinks: Rule = {
             targetAudiences: undefined // not applicable for validation
         });
 
-        const resolvedDocsDefinition = await docsDefinitionResolver.resolve();
+        let resolvedDocsDefinition;
+        try {
+            resolvedDocsDefinition = await docsDefinitionResolver.resolve();
+        } catch (err) {
+            // Docs without navigation/versions can't be resolved; skip link checking
+            logger.debug(`Skipping broken-link validation: ${err}`);
+            return {};
+        }
 
         if (!resolvedDocsDefinition.config.root) {
-            throw new Error("Root node not found");
+            return {};
         }
 
         // TODO: this is a bit of a hack to get the navigation tree. We should probably just use the navigation tree


### PR DESCRIPTION
## Description

`fern check` now runs the `valid-markdown-links` rule by default, so broken links (including `<Card>` component `href` attributes in MDX) are caught without requiring the `--broken-links` flag. Violations are reported as **warnings** by default; the existing `--error-on-broken-links` flag still promotes them to errors.

Severity is preserved (not downgraded to warning) when any of the following is true:
- `--broken-links` flag is passed (backward compat for the deprecated flag)
- `--error-on-broken-links` flag is passed
- `check.rules.broken-links` is explicitly set in `docs.yml`

The `fern docs broken-links` command is unaffected — it continues to report broken links as errors.

## Changes Made

- **`validateWorkspaces.ts`**: Removed the conditional exclusion of the `valid-markdown-links` rule — it now always runs during `fern check`. Passes `brokenLinks` through to `collectDocsWorkspaceViolations`.
- **`validateDocsWorkspaceAndLogIssues.ts`**: Added post-processing in `collectDocsWorkspaceViolations` to downgrade `valid-markdown-links` violations to `"warning"` severity unless the user has explicitly configured severity via `--broken-links`, `--error-on-broken-links`, or `docs.yml` `check.rules.brokenLinks`.
- **`valid-markdown-link.ts`**: Wrapped `docsDefinitionResolver.resolve()` in a try-catch so docs workspaces without navigation/versions gracefully skip link checking instead of throwing a fatal error. Also changed `throw new Error("Root node not found")` to `return {}`.
- **New test fixture** (`card-href`): MDX page with `<Card>` components using both valid and broken `href` values, plus a test asserting broken hrefs are detected and valid ones are not flagged.
- **Changelog entry** added.

## Human Review Checklist

1. **Broad try-catch**: The catch in `valid-markdown-link.ts` swallows all errors from `docsDefinitionResolver.resolve()`, not just the "no navigation" case. This could silently suppress real resolution errors. Consider whether a more targeted check (e.g. inspecting the error message) is warranted.
2. **Severity downgrade logic** (`validateDocsWorkspaceAndLogIssues.ts:50-63`): The three-way guard (`!brokenLinks && !errorOnBrokenLinks && !userConfiguredBrokenLinkSeverity`) controls when violations are downgraded. Verify that `workspace.config.check?.rules?.brokenLinks` correctly reflects the parsed `docs.yml` value — any non-null value (including `"warn"`) will skip the downgrade.
3. **Other code paths**: `devDocsWorkspace.ts` and `generateDocsWorkspace.ts` have their own `getExcludeRules(brokenLinks, strictBrokenLinks)` gating — this PR intentionally only changes the `fern check` path. Confirm that's the desired scope.
4. **No ETE test for severity downgrade**: The new test exercises `fern docs broken-links` (Card href detection). There is no direct ETE test verifying `fern check` reports these as warnings by default or respects `docs.yml` severity overrides.

## Testing

- [x] ETE test added for Card component broken link detection
- [x] `pnpm run check` and `pnpm format` pass locally
- [x] Verified `fern check` against fixtures with and without navigation
- [x] CI passing (31/31 checks green)

Link to Devin session: https://app.devin.ai/sessions/bdc2b81bb4d3473ea0b0a1c158234982
Requested by: @paarthfern
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/14959" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
