### PR TITLE
chore(ci): pre-pull all pinned Docker images used by ETE tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -237,8 +237,14 @@ jobs:
         run: |
           # Pull images in parallel to warm the Docker cache before tests run.
           # This prevents Docker pull time from eating into individual test timeouts.
+          #
+          # v1 fixture images (packages/cli/ete-tests/src/tests/generate/fixtures/):
           docker pull fernapi/fern-pydantic-model:1.11.2 &
           docker pull fernapi/fern-typescript-sdk:2.3.2 &
+          docker pull fernapi/fern-typescript-sdk:3.60.9 &
+          # v2 fixture images (packages/cli/ete-tests/src/tests/v2/fixtures/):
+          docker pull fernapi/fern-python-sdk:4.50.1 &
+          docker pull fernapi/fern-go-sdk:1.30.0 &
           wait
 
       - name: Run ETE tests


### PR DESCRIPTION
## Description

Refs: #14708

Follow-up to #14708 which added Docker image pre-pulling but only included 2 of the 5 pinned images. This adds the remaining 3.

## Changes Made

- Added pre-pull for `fernapi/fern-typescript-sdk:3.60.9` (used by `custom-registry.test.ts`)
- Added pre-pull for `fernapi/fern-python-sdk:4.50.1` (used by v2 generate tests via `petstore/fern.yml` and `fern-definition/fern.yml`)
- Added pre-pull for `fernapi/fern-go-sdk:1.30.0` (used by v2 generate tests via same fixtures)
- Added comments grouping images by v1 vs v2 fixture origin for maintainability

## Human Review Checklist

- [ ] Verify pinned versions match fixture files: `packages/cli/ete-tests/src/tests/generate/custom-registry.test.ts` (line 8), `packages/cli/ete-tests/src/tests/v2/fixtures/petstore/fern.yml`, `packages/cli/ete-tests/src/tests/v2/fixtures/fern-definition/fern.yml`

## Testing

- [ ] CI-only change — validated by observing ETE test pass rates

Link to Devin session: https://app.devin.ai/sessions/34df4d3148454716979a8cddd3f62b6e
Requested by: @davidkonigsberg