### PR TITLE
fix(ci): use literal block scalar in release script YAML output

### DIFF
--- a/generators/python/sdk/versions.yml
+++ b/generators/python/sdk/versions.yml
@@ -1,25 +1,15 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 - version: 5.3.13
   changelogEntry:
-    - summary: >
-        Fix `NameError` when a type uses `extends` to inherit from a base type
-        in a different
-
-        file and that base type is part of a circular reference cycle. The
-        generator was
-
-        incorrectly deferring the base class import to the bottom of the file
-        via ghost
-
-        references, but Python requires base class imports before the class
-        definition.
-
-        Ghost references for extended (base class) types are now skipped so
-        their imports
-
+    - summary: |
+        Fix `NameError` when a type uses `extends` to inherit from a base type in a different
+        file and that base type is part of a circular reference cycle. The generator was
+        incorrectly deferring the base class import to the bottom of the file via ghost
+        references, but Python requires base class imports before the class definition.
+        Ghost references for extended (base class) types are now skipped so their imports
         remain at the top of the file.
       type: fix
-  createdAt: 2026-04-13
+  createdAt: "2026-04-13"
   irVersion: 65
 # For unreleased changes, use unreleased.yml
 - version: 5.3.12

--- a/scripts/release.ts
+++ b/scripts/release.ts
@@ -229,9 +229,13 @@ function updateVersionsFile(
         irVersion
     };
 
-    // Use yaml.stringify() for the new entry
-    // Note: We wrap in array to get the "- version:" format, then add extra newline
-    const newEntryYaml = stringifyYaml([newVersionEntry]);
+    // Use yaml.stringify() for the new entry with literal block style (|) for multi-line summaries.
+    // Without blockQuote: "literal", the yaml library defaults to folded style (>) which
+    // re-wraps lines and inserts blank lines, breaking the formatting of versions.yml.
+    const rawYaml = stringifyYaml([newVersionEntry], { blockQuote: "literal", lineWidth: 120 });
+
+    // Quote the createdAt date string to match existing versions.yml style (e.g., "2026-04-13")
+    const newEntryYaml = rawYaml.replace(/createdAt: (\d{4}-\d{2}-\d{2})/, 'createdAt: "$1"');
 
     // Find where to insert (after the yaml-language-server comment if present)
     const lines = existingContent.split("\n");


### PR DESCRIPTION
## Description
Fixes malformatted changelog entry in `versions.yml` caused by the release script (`scripts/release.ts`) using the YAML library's default folded scalar style (`>`) instead of literal block scalar style (`|`).

Triggered by: https://github.com/fern-api/fern/actions/runs/24349690599

## Changes Made
- **`scripts/release.ts`**: Pass `{ blockQuote: "literal", lineWidth: 120 }` to `yaml.stringify()` so multi-line summary strings use `|` (literal block) instead of `>` (folded). The folded style was re-wrapping lines and inserting blank lines between them. Also quote the `createdAt` date string to match existing `versions.yml` convention.
- **`generators/python/sdk/versions.yml`**: Fix the malformatted 5.3.13 entry that was generated with the old (broken) behavior — convert from `>` to `|` block scalar and quote `createdAt`.

## Testing
- Verified the fix locally by running `yaml.stringify()` with the new options against both multi-line and single-line summaries
- Confirmed `pnpm format` passes cleanly

Link to Devin session: https://app.devin.ai/sessions/47fe5fcce94a4dfb9f79571b0b5f5fb8
Requested by: @aditya-arolkar-swe