### PR TITLE
fix(python): quote createdAt date in versions.yml

### DIFF
--- a/generators/python/sdk/versions.yml
+++ b/generators/python/sdk/versions.yml
@@ -19,7 +19,7 @@
 
         remain at the top of the file.
       type: fix
-  createdAt: 2026-04-13
+  createdAt: "2026-04-13"
   irVersion: 65
 # For unreleased changes, use unreleased.yml
 - version: 5.3.12


### PR DESCRIPTION
## Description

Fixes 3 CI failures on the `chore(python): release 5.3.13` commit (`dd45318`) by quoting the `createdAt` date value in the Python SDK's `versions.yml`.

## Changes Made

- Quote `createdAt: 2026-04-13` → `createdAt: "2026-04-13"` in `generators/python/sdk/versions.yml`

## Context

The `release.ts` script uses the `yaml` npm package (YAML 1.2) to serialize the new version entry. It outputs `createdAt: 2026-04-13` as a bare scalar, which is valid in YAML 1.2. However, the downstream consumers (`convertVersionsFileToReleases.ts`, changelog validation) use `js-yaml`, which defaults to YAML 1.1 — where bare date-like values are automatically parsed as `Date` objects. The Zod schema then rejects the `Date` with `createdAt: Expected string. Received object.`

All other entries in `versions.yml` have quoted dates (e.g., `createdAt: "2026-04-12"`).

**Note:** The underlying issue in `release.ts` (which doesn't force-quote date-like strings) is not addressed in this PR.

## Human Review Checklist
- [ ] Confirm this unblocks the 3 failing CI jobs (Validate Changelog, Publish Python SDK Generator, Write Changelogs to Docs)
- [ ] Consider tracking the `release.ts` root cause fix separately to prevent recurrence

## Testing

- No code changes; this is a YAML data fix
- CI validation will confirm the fix works

Link to Devin session: https://app.devin.ai/sessions/88a2b8cd56d74d668f21b4e8b0552a16
Requested by: @Swimburger
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/14962" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
