### PR TITLE
fix(go): remove unused wiremock/containerd deps from default go.mod imports

### DIFF
--- a/.github/workflows/test-remote-vs-local-generation-parity.yml
+++ b/.github/workflows/test-remote-vs-local-generation-parity.yml
@@ -55,11 +55,8 @@ jobs:
               "Publish TypeScript SDK Generator")
                 echo 'generators=["ts-sdk"]' >> $GITHUB_OUTPUT
                 ;;
-              # NOTE: go-sdk is temporarily disabled because the go-v2 subprocess
-              # crashes during generation (unhandled execa error in go mod tidy).
-              # Re-enable once the go-sdk generator ships the fix for this issue.
               "Publish Go SDK Generator")
-                echo 'generators=[]' >> $GITHUB_OUTPUT
+                echo 'generators=["go-sdk"]' >> $GITHUB_OUTPUT
                 ;;
               "Publish Java SDK Generator")
                 echo 'generators=["java-sdk"]' >> $GITHUB_OUTPUT
@@ -74,10 +71,7 @@ jobs:
             esac
           else
             # For push and workflow_dispatch, test all generators
-            # NOTE: go-sdk is temporarily disabled because the go-v2 subprocess
-            # crashes during generation (unhandled execa error in go mod tidy).
-            # Re-enable once the go-sdk generator ships the fix for this issue.
-            echo 'generators=["ts-sdk", "java-sdk", "python-sdk"]' >> $GITHUB_OUTPUT
+            echo 'generators=["ts-sdk", "java-sdk", "go-sdk", "python-sdk"]' >> $GITHUB_OUTPUT
           fi
 
   compile-and-build:

--- a/.github/workflows/test-remote-vs-local-generation-parity.yml
+++ b/.github/workflows/test-remote-vs-local-generation-parity.yml
@@ -55,8 +55,11 @@ jobs:
               "Publish TypeScript SDK Generator")
                 echo 'generators=["ts-sdk"]' >> $GITHUB_OUTPUT
                 ;;
+              # NOTE: go-sdk is temporarily disabled because the go-v2 subprocess
+              # crashes during generation (unhandled execa error in go mod tidy).
+              # Re-enable once the go-sdk generator ships the fix for this issue.
               "Publish Go SDK Generator")
-                echo 'generators=["go-sdk"]' >> $GITHUB_OUTPUT
+                echo 'generators=[]' >> $GITHUB_OUTPUT
                 ;;
               "Publish Java SDK Generator")
                 echo 'generators=["java-sdk"]' >> $GITHUB_OUTPUT
@@ -71,7 +74,10 @@ jobs:
             esac
           else
             # For push and workflow_dispatch, test all generators
-            echo 'generators=["ts-sdk", "java-sdk", "go-sdk", "python-sdk"]' >> $GITHUB_OUTPUT
+            # NOTE: go-sdk is temporarily disabled because the go-v2 subprocess
+            # crashes during generation (unhandled execa error in go mod tidy).
+            # Re-enable once the go-sdk generator ships the fix for this issue.
+            echo 'generators=["ts-sdk", "java-sdk", "python-sdk"]' >> $GITHUB_OUTPUT
           fi
 
   compile-and-build:

--- a/generators/go-v2/base/src/module/ModuleConfig.ts
+++ b/generators/go-v2/base/src/module/ModuleConfig.ts
@@ -7,13 +7,17 @@ export namespace ModuleConfig {
         imports: {
             "github.com/google/uuid": "v1.4.0",
             "github.com/stretchr/testify": "v1.7.0",
-            "gopkg.in/yaml.v3": "v3.0.1",
-            // must pin wiremock dependencies to versions that still support go 1.23
-            "github.com/wiremock/wiremock-testcontainers-go": "v1.0.0-alpha-9",
-            "github.com/wiremock/go-wiremock": "v1.14.0",
-            // must pin go-wiremock indirect dependencies to later fixed versions
-            "github.com/containerd/containerd": "v1.7.27"
+            "gopkg.in/yaml.v3": "v3.0.1"
         }
+    };
+
+    // Wiremock dependencies pinned to versions that still support go 1.23.
+    // Only include these in go.mod when wire test Go files that import them are generated.
+    export const WIREMOCK_IMPORTS: Record<string, string> = {
+        "github.com/wiremock/wiremock-testcontainers-go": "v1.0.0-alpha-9",
+        "github.com/wiremock/go-wiremock": "v1.14.0",
+        // must pin go-wiremock indirect dependencies to later fixed versions
+        "github.com/containerd/containerd": "v1.7.27"
     };
 }
 

--- a/generators/go-v2/base/src/project/GoProject.ts
+++ b/generators/go-v2/base/src/project/GoProject.ts
@@ -222,10 +222,17 @@ export class GoProject extends AbstractProject<AbstractGoGeneratorContext<BaseGo
     }
 
     private async runGoModTidy(): Promise<void> {
-        await loggingExeca(this.context.logger, "go", ["mod", "tidy"], {
-            doNotPipeOutput: true,
-            cwd: this.absolutePathToOutputDirectory
-        });
+        try {
+            await loggingExeca(this.context.logger, "go", ["mod", "tidy"], {
+                doNotPipeOutput: true,
+                cwd: this.absolutePathToOutputDirectory
+            });
+        } catch (error) {
+            this.context.logger.warn(
+                `Failed to tidy Go modules with 'go mod tidy': ${extractErrorMessage(error)}. ` +
+                    "The generated files have been written but the go.mod may contain unused dependencies."
+            );
+        }
     }
 
     private async writeLicenseFile(): Promise<void> {

--- a/generators/go/sdk/changes/unreleased/fix-go-mod-tidy-error-handling.yml
+++ b/generators/go/sdk/changes/unreleased/fix-go-mod-tidy-error-handling.yml
@@ -1,5 +1,7 @@
 - summary: |
-    Add error handling for 'go mod tidy' in the go-v2 generator to prevent
-    crashes when module tidying fails. The generator now logs a warning and
-    continues instead of crashing with an unhandled execa error.
+    Remove unused wiremock and containerd dependencies from the default go.mod
+    imports. These packages were never imported by generated Go code, but
+    go mod tidy had to download hundreds of transitive dependencies to discover
+    they were unused, causing failures in CI environments. Also add error
+    handling for go mod tidy to prevent crashes if module tidying fails.
   type: fix

--- a/generators/go/sdk/changes/unreleased/fix-go-mod-tidy-error-handling.yml
+++ b/generators/go/sdk/changes/unreleased/fix-go-mod-tidy-error-handling.yml
@@ -1,0 +1,5 @@
+- summary: |
+    Add error handling for 'go mod tidy' in the go-v2 generator to prevent
+    crashes when module tidying fails. The generator now logs a warning and
+    continues instead of crashing with an unhandled execa error.
+  type: fix


### PR DESCRIPTION
## Description

The `test-remote-vs-local-generation-parity` CI workflow has been consistently failing due to the `go-sdk` generator crashing during both local (Docker) and remote (Fiddle) generation.

**Root cause:** The go-v2 generator included `wiremock-testcontainers-go`, `go-wiremock`, and `containerd` dependencies in every generated `go.mod` via `ModuleConfig.DEFAULT.imports`. However, **no generated Go source files ever import these packages** — wire tests use raw HTTP calls to WireMock's admin API, not the Go wiremock client libraries. This forced `go mod tidy` to download hundreds of transitive dependencies (especially from `containerd`) just to discover they were unused and remove them. In CI environments, this download frequently failed, and the go-v2 generator had no error handling around `go mod tidy`, causing the entire generator process to crash with an unhandled execa error.

## Changes Made

1. **Remove unused deps from default go.mod** (`ModuleConfig.ts`):
   - Moved `wiremock-testcontainers-go`, `go-wiremock`, and `containerd` out of `ModuleConfig.DEFAULT.imports`
   - Preserved them in a separate `WIREMOCK_IMPORTS` constant for future use when wire test Go files that actually import these packages are generated

2. **Add error handling for go mod tidy** (`GoProject.ts`):
   - Wrapped `runGoModTidy()` in try-catch, matching the existing pattern used for `go fmt` in the same file
   - On failure, logs a warning and continues instead of crashing

3. **Changelog**: Added unreleased changelog entry for the go-sdk fix.

## Review Checklist
- [ ] Confirm that no generated Go source files import `wiremock-testcontainers-go`, `go-wiremock`, or `containerd` (investigation found zero imports across all generated `.go` files and `.go_` templates)
- [ ] Verify that swallowing `go mod tidy` failures as a warning is acceptable — the Go v1 binary already runs `go mod tidy` before go-v2, so the go.mod should already be largely valid

> **Note:** These generator changes won't take effect in the `test-remote-vs-local-generation-parity` CI until a new go-sdk Docker image is published containing this fix.

## Testing
- [x] Lint passes (`pnpm run check`)
- [x] Verified no seed test snapshots contain wiremock/containerd in `go.mod` files
- [x] Confirmed generated Go wire test files use HTTP (not Go wiremock library imports)

Link to Devin session: https://app.devin.ai/sessions/e64fe98c5d5e4b0196b9ce289221221e
Requested by: @davidkonigsberg