### PR TITLE
fix(docs): use frontmatter title as fallback for sidebar title

### DIFF
--- a/packages/cli/cli/changes/unreleased/frontmatter-title-sidebar-fallback.yml
+++ b/packages/cli/cli/changes/unreleased/frontmatter-title-sidebar-fallback.yml
@@ -1,0 +1,7 @@
+- summary: |
+    Use frontmatter `title` as fallback for sidebar title when `sidebar-title` is not set.
+    Previously, pages using directory-based navigation would derive sidebar titles from
+    filenames using title-casing, which clobbered acronyms (e.g., "Port LLDP Info" became
+    "Port Lldp Info"). Now the frontmatter `title` is used as an intermediate fallback
+    before the filename-derived title.
+  type: fix

--- a/packages/cli/docs-preview/src/previewDocs.ts
+++ b/packages/cli/docs-preview/src/previewDocs.ts
@@ -32,6 +32,7 @@ import { v4 as uuidv4 } from "uuid";
 
 const frontmatterPositionCache = new Map<string, number | undefined>();
 const frontmatterSidebarTitleCache = new Map<string, string | undefined>();
+const frontmatterTitleCache = new Map<string, string | undefined>();
 const frontmatterSlugCache = new Map<string, string | undefined>();
 
 /**
@@ -75,6 +76,31 @@ function extractFrontmatterSidebarTitle(markdown: string): string | undefined {
 
         if (typeof sidebarTitle === "string") {
             return sidebarTitle;
+        }
+
+        return undefined;
+    } catch {
+        return undefined;
+    }
+}
+
+/**
+ * Extracts the title field from markdown frontmatter.
+ * Returns the string value if present, undefined otherwise.
+ * Used as a fallback for sidebar title when sidebar-title is not set.
+ */
+function extractFrontmatterTitle(markdown: string): string | undefined {
+    try {
+        const { data } = grayMatter(markdown);
+
+        if (data.title == null) {
+            return undefined;
+        }
+
+        const title = data.title;
+
+        if (typeof title === "string" && title.trim().length > 0) {
+            return title.trim();
         }
 
         return undefined;
@@ -165,6 +191,12 @@ export async function getPreviewDocsDefinition({
                 navAffectingChange = true;
             }
 
+            const currentTitle = extractFrontmatterTitle(markdown);
+            const cachedTitle = frontmatterTitleCache.get(absoluteFilePath);
+            if (cachedTitle !== currentTitle) {
+                navAffectingChange = true;
+            }
+
             const currentSlug = extractFrontmatterSlug(markdown);
             const cachedSlug = frontmatterSlugCache.get(absoluteFilePath);
             if (cachedSlug !== currentSlug) {
@@ -173,6 +205,7 @@ export async function getPreviewDocsDefinition({
 
             frontmatterPositionCache.set(absoluteFilePath, currentPosition);
             frontmatterSidebarTitleCache.set(absoluteFilePath, currentSidebarTitle);
+            frontmatterTitleCache.set(absoluteFilePath, currentTitle);
             frontmatterSlugCache.set(absoluteFilePath, currentSlug);
 
             if (isNewFile) {
@@ -293,15 +326,18 @@ export async function getPreviewDocsDefinition({
 
     frontmatterPositionCache.clear();
     frontmatterSidebarTitleCache.clear();
+    frontmatterTitleCache.clear();
     frontmatterSlugCache.clear();
     for (const [pageId, page] of Object.entries(dbDocsDefinition.pages)) {
         if (page.rawMarkdown != null) {
             const absolutePath = AbsoluteFilePath.of(`${docsWorkspace.absoluteFilePath}/${pageId.replace("api/", "")}`);
             const position = extractFrontmatterPosition(page.rawMarkdown);
             const sidebarTitle = extractFrontmatterSidebarTitle(page.rawMarkdown);
+            const title = extractFrontmatterTitle(page.rawMarkdown);
             const slug = extractFrontmatterSlug(page.rawMarkdown);
             frontmatterPositionCache.set(absolutePath, position);
             frontmatterSidebarTitleCache.set(absolutePath, sidebarTitle);
+            frontmatterTitleCache.set(absolutePath, title);
             frontmatterSlugCache.set(absolutePath, slug);
         }
     }

--- a/packages/cli/docs-resolver/src/DocsDefinitionResolver.ts
+++ b/packages/cli/docs-resolver/src/DocsDefinitionResolver.ts
@@ -258,6 +258,7 @@ export class DocsDefinitionResolver {
     private collectedFileIds = new Map<AbsoluteFilePath, string>();
     private markdownFilesToFullSlugs: Map<AbsoluteFilePath, string> = new Map();
     private markdownFilesToSidebarTitle: Map<AbsoluteFilePath, string> = new Map();
+    private markdownFilesToFrontmatterTitle: Map<AbsoluteFilePath, string> = new Map();
     private markdownFilesToNoIndex: Map<AbsoluteFilePath, boolean> = new Map();
     private markdownFilesToTags: Map<AbsoluteFilePath, string[]> = new Map();
     private markdownFilesToAvailability: Map<AbsoluteFilePath, docsYml.RawSchemas.Availability> = new Map();
@@ -651,6 +652,12 @@ export class DocsDefinitionResolver {
             const sidebarTitle = frontmatter.data["sidebar-title"];
             if (typeof sidebarTitle === "string" && sidebarTitle.trim().length > 0) {
                 this.markdownFilesToSidebarTitle.set(absolutePath, sidebarTitle.trim());
+            }
+
+            // Extract title (used as fallback for sidebar title when sidebar-title is not set)
+            const frontmatterTitle = frontmatter.data.title;
+            if (typeof frontmatterTitle === "string" && frontmatterTitle.trim().length > 0) {
+                this.markdownFilesToFrontmatterTitle.set(absolutePath, frontmatterTitle.trim());
             }
 
             // Extract noindex
@@ -1853,7 +1860,10 @@ export class DocsDefinitionResolver {
             id,
             type: "page",
             slug: slug.get(),
-            title: this.markdownFilesToSidebarTitle.get(item.absolutePath) ?? item.title,
+            title:
+                this.markdownFilesToSidebarTitle.get(item.absolutePath) ??
+                this.markdownFilesToFrontmatterTitle.get(item.absolutePath) ??
+                item.title,
             icon: this.resolveIconFileId(item.icon),
             hidden: hideChildren || item.hidden,
             viewers: item.viewers,
@@ -1932,7 +1942,9 @@ export class DocsDefinitionResolver {
             slug: slug.get(),
             title:
                 item.overviewAbsolutePath != null
-                    ? (this.markdownFilesToSidebarTitle.get(item.overviewAbsolutePath) ?? item.title)
+                    ? (this.markdownFilesToSidebarTitle.get(item.overviewAbsolutePath) ??
+                      this.markdownFilesToFrontmatterTitle.get(item.overviewAbsolutePath) ??
+                      item.title)
                     : item.title,
             icon: this.resolveIconFileId(item.icon),
             collapsed: item.collapsed,

--- a/packages/cli/docs-resolver/src/__test__/fixtures/sidebar-title/fern/docs.yml
+++ b/packages/cli/docs-resolver/src/__test__/fixtures/sidebar-title/fern/docs.yml
@@ -5,6 +5,8 @@ navigation:
     path: ./page-with-sidebar-title.mdx
   - page: Page Without Override
     path: ./page-without-override.mdx
+  - page: Filename Derived Title
+    path: ./page-with-frontmatter-title.mdx
   - section: Original Section Title
     path: ./section-overview.mdx
     contents:

--- a/packages/cli/docs-resolver/src/__test__/fixtures/sidebar-title/fern/page-with-frontmatter-title.mdx
+++ b/packages/cli/docs-resolver/src/__test__/fixtures/sidebar-title/fern/page-with-frontmatter-title.mdx
@@ -1,0 +1,7 @@
+---
+title: Port LLDP Info
+---
+
+# Port LLDP Info
+
+This page has a frontmatter title with acronyms but no sidebar-title, so the sidebar should use the frontmatter title.

--- a/packages/cli/docs-resolver/src/__test__/sidebar-title.test.ts
+++ b/packages/cli/docs-resolver/src/__test__/sidebar-title.test.ts
@@ -58,6 +58,14 @@ describe("sidebar-title frontmatter override", () => {
         const sectionOverview = await readFile(resolve(fixtureDir, "section-overview.mdx"), "utf-8");
         const frontmatter3 = matter(sectionOverview);
         expect(frontmatter3.data["sidebar-title"]).toBe("Custom Section Title");
+
+        const pageWithFrontmatterTitle = await readFile(
+            resolve(fixtureDir, "page-with-frontmatter-title.mdx"),
+            "utf-8"
+        );
+        const frontmatter4 = matter(pageWithFrontmatterTitle);
+        expect(frontmatter4.data["sidebar-title"]).toBeUndefined();
+        expect(frontmatter4.data.title).toBe("Port LLDP Info");
     });
 
     it("should load docs workspace with sidebar-title pages", async () => {
@@ -106,9 +114,23 @@ describe("sidebar-title frontmatter override", () => {
         // This should use the sidebar-title frontmatter override, not the original title
         expect(nestedPage?.title).toBe("Custom Nested Title");
 
+        // Find the page with frontmatter title but no sidebar-title
+        const frontmatterTitlePage = pageNodes.find((node) => node.pageId.includes("page-with-frontmatter-title.mdx"));
+        expect(frontmatterTitlePage).toBeDefined();
+        // This should use the frontmatter title as fallback, not the docs.yml config title
+        expect(frontmatterTitlePage?.title).toBe("Port LLDP Info");
+
+        // Find the page without any frontmatter override
+        const noOverridePage = pageNodes.find((node) => node.pageId.includes("page-without-override.mdx"));
+        expect(noOverridePage).toBeDefined();
+        // This should use the docs.yml config title since there's no frontmatter title or sidebar-title
+        expect(noOverridePage?.title).toBe("Page Without Override");
+
         // This test verifies that:
         // 1. The docs resolver correctly processes sidebar-title frontmatter
         // 2. The resolved page node uses the custom sidebar title instead of the original title
         // 3. The sidebar-title override functionality works after docs definition resolution
+        // 4. Frontmatter title is used as fallback when sidebar-title is not set
+        // 5. Acronyms in frontmatter titles are preserved (e.g., "LLDP" stays uppercase)
     });
 });


### PR DESCRIPTION
## Description

Fixes an issue where page titles in the left nav get Title Cased, clobbering acronyms (e.g., `Port LLDP Info` becomes `Port Lldp Info`). When pages use directory-based navigation and derive sidebar titles from filenames, the `nameToTitle()` function applies basic title-casing that doesn't preserve acronyms.

Previously, the only way to fix this was to add a `sidebar-title` frontmatter field duplicating the `title`. Now the frontmatter `title` is used as an intermediate fallback before the filename-derived title.

**Fallback chain for sidebar titles:**
1. `sidebar-title` from frontmatter (explicit sidebar override)
2. `title` from frontmatter (preserves original casing including acronyms)
3. Config title from `docs.yml` or filename-derived title

## Changes Made
- **DocsDefinitionResolver.ts**: Added `markdownFilesToFrontmatterTitle` map, extract frontmatter `title` in `extractAllFrontmatterData()`, and use it as fallback in `toPageNode()` and `toSectionNode()`
- **previewDocs.ts**: Added `extractFrontmatterTitle()` function and `frontmatterTitleCache` to track frontmatter title changes during `fern docs dev` preview, triggering nav rebuild when title changes
- **sidebar-title.test.ts**: Added test cases verifying frontmatter title fallback preserves acronyms
- **Test fixtures**: Added `page-with-frontmatter-title.mdx` fixture with `title: Port LLDP Info` (no `sidebar-title`)
- [x] Updated README.md generator (if applicable) — N/A

## Testing
- [x] Unit tests added/updated — extended sidebar-title test suite with frontmatter title fallback cases
- [x] Manual testing completed — all 44 tests in docs-resolver pass, lint checks pass

Link to Devin session: https://app.devin.ai/sessions/5ffc4fa60c6048adacde61b35b7ad4bd
Requested by: @aditya-arolkar-swe