### PR TITLE
fix(cli): handle pnpm 10+ ERR_PNPM_TRUST_DOWNGRADE in docs preview

### DIFF
--- a/packages/cli/cli/changes/unreleased/fix-pnpm-trust-downgrade.yml
+++ b/packages/cli/cli/changes/unreleased/fix-pnpm-trust-downgrade.yml
@@ -1,0 +1,8 @@
+# yaml-language-server: $schema=../../../../../fern-changes-yml.schema.json
+
+- summary: |
+    Fix `fern docs dev` failing on Windows with pnpm 10+ `ERR_PNPM_TRUST_DOWNGRADE` error.
+    Strip inherited pnpm supply-chain security env vars before running `pnpm install`
+    in the standalone bundle folder, and retry after removing `trustPolicy` from the
+    workspace config if the error persists.
+  type: fix

--- a/packages/cli/docs-preview/src/downloadLocalDocsBundle.ts
+++ b/packages/cli/docs-preview/src/downloadLocalDocsBundle.ts
@@ -447,7 +447,7 @@ export async function downloadBundle({
                         );
                         if (pnpmWorkspaceExists) {
                             const content = (await readFile(pnpmWorkspacePath)).toString();
-                            const updatedContent = content.replace(/^trustPolicy:.*$/gm, "");
+                            const updatedContent = content.replace(/^trustPolicy:.*$(?:\n(?=[ \t]).*$)*/gm, "");
                             await writeFile(pnpmWorkspacePath, updatedContent);
                         }
                         try {

--- a/packages/cli/docs-preview/src/downloadLocalDocsBundle.ts
+++ b/packages/cli/docs-preview/src/downloadLocalDocsBundle.ts
@@ -29,6 +29,7 @@ const NPMRC_NAME = ".npmrc";
 const PNPMFILE_CJS_NAME = ".pnpmfile.cjs";
 const PNPM_WORKSPACE_YAML_NAME = "pnpm-workspace.yaml";
 const COREPACK_MISSING_KEYID_ERROR_MESSAGE = 'Cannot find matching keyid: {"signatures":';
+const PNPM_TRUST_DOWNGRADE_ERROR_MESSAGE = "ERR_PNPM_TRUST_DOWNGRADE";
 
 export function getLocalStorageFolder(): AbsoluteFilePath {
     return join(AbsoluteFilePath.of(homedir()), RelativeFilePath.of(LOCAL_STORAGE_FOLDER));
@@ -105,6 +106,26 @@ const PNPMFILE_CJS_CONTENTS = `module.exports = {
 `;
 
 const NPMRC_CONTENTS = "@fern-fern:registry=https://npm.buildwithfern.com\n";
+
+/**
+ * Returns a copy of process.env with pnpm supply-chain security env vars removed.
+ * pnpm 10+ propagates workspace settings (e.g. trustPolicy) as npm_config_*
+ * env vars to child processes. These can cause ERR_PNPM_TRUST_DOWNGRADE failures
+ * when running pnpm install in the standalone preview bundle folder.
+ */
+function getCleanPnpmEnv(): NodeJS.ProcessEnv {
+    const env = { ...process.env };
+    const supplyChainKeys = [
+        "npm_config_trust_policy",
+        "npm_config_strict_dep_builds",
+        "npm_config_minimum_release_age",
+        "npm_config_block_exotic_subdeps"
+    ];
+    for (const key of supplyChainKeys) {
+        delete env[key];
+    }
+    return env;
+}
 
 export async function downloadBundle({
     bucketUrl,
@@ -313,7 +334,9 @@ export async function downloadBundle({
                 logger.debug("Installing esbuild");
                 await loggingExeca(logger, "pnpm", ["i", "esbuild"], {
                     cwd: absolutePathToBundleFolder,
-                    doNotPipeOutput: true
+                    doNotPipeOutput: true,
+                    env: getCleanPnpmEnv(),
+                    extendEnv: false
                 });
             } catch (error) {
                 if (error instanceof Error) {
@@ -335,7 +358,9 @@ export async function downloadBundle({
                             logger.debug("Installing esbuild after upgrading corepack");
                             await loggingExeca(logger, "pnpm", ["i", "esbuild"], {
                                 cwd: absolutePathToBundleFolder,
-                                doNotPipeOutput: true
+                                doNotPipeOutput: true,
+                                env: getCleanPnpmEnv(),
+                                extendEnv: false
                             });
                         } catch (installError) {
                             throw contactFernSupportError(
@@ -404,10 +429,42 @@ export async function downloadBundle({
                     logger.debug("Running pnpm install within standalone");
                     await loggingExeca(logger, "pnpm", ["install"], {
                         cwd: absPathToStandalone,
-                        doNotPipeOutput: true
+                        doNotPipeOutput: true,
+                        env: getCleanPnpmEnv(),
+                        extendEnv: false
                     });
                 } catch (error) {
-                    throw contactFernSupportError(`Failed to install required package due to error: ${error}`);
+                    // pnpm 10+ trust policy can block installs when a package loses
+                    // provenance attestation between versions (e.g. undici-types).
+                    // If detected, strip trustPolicy from the workspace yaml and retry.
+                    if (
+                        error instanceof Error &&
+                        typeof error.message === "string" &&
+                        error.message.includes(PNPM_TRUST_DOWNGRADE_ERROR_MESSAGE)
+                    ) {
+                        logger.debug(
+                            "Detected pnpm trust policy error. Removing trustPolicy from workspace config and retrying"
+                        );
+                        if (pnpmWorkspaceExists) {
+                            const content = (await readFile(pnpmWorkspacePath)).toString();
+                            const updatedContent = content.replace(/^trustPolicy:.*$/gm, "");
+                            await writeFile(pnpmWorkspacePath, updatedContent);
+                        }
+                        try {
+                            await loggingExeca(logger, "pnpm", ["install"], {
+                                cwd: absPathToStandalone,
+                                doNotPipeOutput: true,
+                                env: getCleanPnpmEnv(),
+                                extendEnv: false
+                            });
+                        } catch (retryError) {
+                            throw contactFernSupportError(
+                                `Failed to install required package due to error: ${retryError}`
+                            );
+                        }
+                    } else {
+                        throw contactFernSupportError(`Failed to install required package due to error: ${error}`);
+                    }
                 }
             }
         }


### PR DESCRIPTION
## Description

Fixes `fern docs dev` failing on Windows 11 with pnpm 10+ when `trustPolicy: no-downgrade` is configured. The error occurs because pnpm propagates supply-chain security settings as `npm_config_*` env vars to child processes, causing `pnpm install` in the standalone preview bundle to fail with `ERR_PNPM_TRUST_DOWNGRADE` for packages like `undici-types@6.21.0` that have lost provenance attestation between versions.

## Changes Made

- Added `getCleanPnpmEnv()` helper that strips pnpm supply-chain security env vars (`npm_config_trust_policy`, `npm_config_strict_dep_builds`, `npm_config_minimum_release_age`, `npm_config_block_exotic_subdeps`) before running pnpm commands in the preview bundle folder
- Applied clean env with `extendEnv: false` to all three `pnpm` calls in `downloadLocalDocsBundle.ts` (two `pnpm i esbuild` calls and one `pnpm install`)
- Added specific `ERR_PNPM_TRUST_DOWNGRADE` error detection in the Windows `pnpm install` catch block — when detected, strips `trustPolicy` from the standalone `pnpm-workspace.yaml` and retries
- Added unreleased changelog entry

## Testing

- [x] Manual code review of all pnpm invocation paths
- [x] Verified lint passes (`pnpm run check`)
- [ ] Unit tests — no existing tests for this module; the fix is in error handling paths that require Windows + pnpm 10+ to reproduce

Link to Devin session: https://app.devin.ai/sessions/1be76045381f46ec95ceb354512677b1
Requested by: @cdonel707
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/14965" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
