### PR TITLE
fix(ci): replace PR_BOT_GH_PAT with FERN_GITHUB_TOKEN in CI workflows

### DIFF
--- a/.github/workflows/fix-lint.yml
+++ b/.github/workflows/fix-lint.yml
@@ -66,7 +66,7 @@ jobs:
         if: steps.cpr.outputs.pull-request-operation == 'created'
         uses: ./.github/actions/auto-approve
         with:
-          approver-gh-token: ${{ secrets.PR_BOT_GH_PAT }}
+          approver-gh-token: ${{ secrets.FERN_GITHUB_TOKEN }}
           pull-request-number: ${{ steps.cpr.outputs.pull-request-number }}
           enforced-checks: lint
           enforce-checks: "true"

--- a/.github/workflows/security-scanning-and-remediation.yml
+++ b/.github/workflows/security-scanning-and-remediation.yml
@@ -51,7 +51,7 @@ jobs:
         id: fetch-alerts
         uses: actions/github-script@v8
         with:
-          github-token: ${{ secrets.PR_BOT_GH_PAT }}
+          github-token: ${{ secrets.FERN_GITHUB_TOKEN }}
           script: |
             const owner = context.repo.owner;
             const repo = context.repo.repo;

--- a/.github/workflows/update-seed.yml
+++ b/.github/workflows/update-seed.yml
@@ -1145,5 +1145,5 @@ jobs:
         if: steps.cpr.outputs.pull-request-operation == 'created'
         uses: ./.github/actions/auto-approve
         with:
-          approver-gh-token: ${{ secrets.PR_BOT_GH_PAT }}
+          approver-gh-token: ${{ secrets.FERN_GITHUB_TOKEN }}
           pull-request-number: ${{ steps.cpr.outputs.pull-request-number }}

--- a/.github/workflows/write-changelogs-to-docs.yml
+++ b/.github/workflows/write-changelogs-to-docs.yml
@@ -99,5 +99,5 @@ jobs:
       - name: Approve PR
         if: steps.cpr.outputs.pull-request-number
         env:
-          GH_TOKEN: ${{ secrets.PR_BOT_GH_PAT }}
+          GH_TOKEN: ${{ secrets.FERN_GITHUB_TOKEN }}
         run: gh pr review ${{ steps.cpr.outputs.pull-request-number }} --repo fern-api/docs --approve


### PR DESCRIPTION
## Description

Replaces all references to `PR_BOT_GH_PAT` with `FERN_GITHUB_TOKEN` across four CI workflow files. The `PR_BOT_GH_PAT` token only has `repo` scope, which is insufficient for the Dependabot alerts API (returns 404 without `security_events` scope). `FERN_GITHUB_TOKEN` already works correctly in `fern-api/fern-autopilot`'s identical security scanning workflow and has the required scopes.

This is part of an org-wide migration away from `PR_BOT_GH_PAT` — matching PRs are being opened in `fern-api/fern-platform` and `fern-api/docs`.

## Changes Made

- `security-scanning-and-remediation.yml`: Switched `github-token` for Dependabot alert fetching
- `fix-lint.yml`: Switched `approver-gh-token` for auto-approve action
- `update-seed.yml`: Switched `approver-gh-token` for auto-approve action
- `write-changelogs-to-docs.yml`: Switched `GH_TOKEN` env var used by `gh pr review`

## Testing

- [ ] Cannot be tested locally — requires workflow execution post-merge

## Human Review Checklist

- [ ] Verify `FERN_GITHUB_TOKEN` is configured as a repo secret in `fern-api/fern` (Settings → Secrets → Actions)
- [ ] Verify `FERN_GITHUB_TOKEN` has both `security_events` scope (for Dependabot alerts) and sufficient permissions to approve PRs (for the auto-approve and `gh pr review` steps)

Link to Devin session: https://app.devin.ai/sessions/facba5dbb3fb4869a94c949db5085817
Requested by: @davidkonigsberg