### PR TITLE
fix(python): bump generated pytest to ^9.0.3 to fix CVE-2025-71176

### DIFF
--- a/generators/python/sdk/changes/unreleased/fix-pytest-cve-2025-71176.yml
+++ b/generators/python/sdk/changes/unreleased/fix-pytest-cve-2025-71176.yml
@@ -1,0 +1,9 @@
+# yaml-language-server: $schema=../../../../../fern-changes-yml.schema.json
+
+- summary: |
+    Bump generated pytest dev dependency from ^7.4.0 / ^8.2.0 to ^9.0.3 to fix
+    CVE-2025-71176 (insecure temporary directories). pytest-asyncio is bumped to
+    ^1.3.0 for compatibility. Both are gated behind a `python = ">=3.10"` marker
+    when the project supports Python < 3.10. The default CI Python version is
+    raised from 3.9 to 3.10 accordingly.
+  type: fix

--- a/generators/python/src/fern_python/codegen/pyproject_toml.py
+++ b/generators/python/src/fern_python/codegen/pyproject_toml.py
@@ -226,23 +226,23 @@ packages = [
             if self.enable_wire_tests:
                 wire_test_deps = 'requests = "^2.31.0"\ntypes-requests = "^2.31.0"\n'
 
-            # pytest-asyncio ^1.0.0 fixes Python 3.14+ deprecation warnings but
-            # requires pytest >= 8.2 and Python >= 3.9.  Fall back to the older
-            # pair when the project still supports Python 3.8.
-            #
-            # Extract the minimum minor version from the constraint string
-            # (e.g. "^3.8" -> 8, "^3.8.1" -> 8, "^3.10" -> 10, ">=3.9" -> 9).
+            # pytest >= 9.0.3 fixes CVE-2025-71176 (insecure /tmp/pytest-of-{user}
+            # temporary directories).  pytest 9.x requires Python >= 3.10, so when
+            # the project still supports older Pythons we gate the dev-only test
+            # tooling behind a version marker.
             min_minor = 0
             match = re.search(r"(\d+)\.(\d+)", self.python_version)
             if match:
                 min_minor = int(match.group(2))
 
-            if min_minor >= 9:
-                pytest_version = "^8.2.0"
-                pytest_asyncio_version = "^1.0.0"
+            if min_minor >= 10:
+                pytest_dep = '"^9.0.3"'
+                pytest_asyncio_dep = '"^1.3.0"'
+                pytest_xdist_dep = '"^3.6.1"'
             else:
-                pytest_version = "^7.4.0"
-                pytest_asyncio_version = "^0.23.5"
+                pytest_dep = '{version = "^9.0.3", python = ">=3.10"}'
+                pytest_asyncio_dep = '{version = "^1.3.0", python = ">=3.10"}'
+                pytest_xdist_dep = '{version = "^3.6.1", python = ">=3.10"}'
 
             return f"""
 [tool.poetry.dependencies]
@@ -250,9 +250,9 @@ python = "{self.python_version}"
 {deps}
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "{pytest_version}"
-pytest-asyncio = "{pytest_asyncio_version}"
-pytest-xdist = "^3.6.1"
+pytest = {pytest_dep}
+pytest-asyncio = {pytest_asyncio_dep}
+pytest-xdist = {pytest_xdist_dep}
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"
 {wire_test_deps}{dev_deps}"""

--- a/generators/python/src/fern_python/version/ci_python_version.py
+++ b/generators/python/src/fern_python/version/ci_python_version.py
@@ -21,7 +21,7 @@ class GithubCIPythonVersionResolver:
         PythonVersion.PY3_14,
     }
 
-    DEFAULT_VERSION: ClassVar[PythonVersion] = PythonVersion.PY3_9
+    DEFAULT_VERSION: ClassVar[PythonVersion] = PythonVersion.PY3_10
 
     @staticmethod
     def resolve(python_version_constraint: str) -> PythonVersion:

--- a/seed/python-sdk/accept-header/poetry.lock
+++ b/seed/python-sdk/accept-header/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "73db04dccdc2f6e569f03c5b71b81dedb41fd67af4d88c28ae7c40465edecf3a"

--- a/seed/python-sdk/accept-header/pyproject.toml
+++ b/seed/python-sdk/accept-header/pyproject.toml
@@ -51,8 +51,8 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
-pytest-asyncio = "^1.0.0"
+pytest = "^9.0.3"
+pytest-asyncio = "^1.3.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/alias-extends/no-custom-config/poetry.lock
+++ b/seed/python-sdk/alias-extends/no-custom-config/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "73db04dccdc2f6e569f03c5b71b81dedb41fd67af4d88c28ae7c40465edecf3a"

--- a/seed/python-sdk/alias-extends/no-custom-config/pyproject.toml
+++ b/seed/python-sdk/alias-extends/no-custom-config/pyproject.toml
@@ -51,8 +51,8 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
-pytest-asyncio = "^1.0.0"
+pytest = "^9.0.3"
+pytest-asyncio = "^1.3.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/alias-extends/no-inheritance-for-extended-models/poetry.lock
+++ b/seed/python-sdk/alias-extends/no-inheritance-for-extended-models/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "73db04dccdc2f6e569f03c5b71b81dedb41fd67af4d88c28ae7c40465edecf3a"

--- a/seed/python-sdk/alias-extends/no-inheritance-for-extended-models/pyproject.toml
+++ b/seed/python-sdk/alias-extends/no-inheritance-for-extended-models/pyproject.toml
@@ -51,8 +51,8 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
-pytest-asyncio = "^1.0.0"
+pytest = "^9.0.3"
+pytest-asyncio = "^1.3.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/alias/poetry.lock
+++ b/seed/python-sdk/alias/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "73db04dccdc2f6e569f03c5b71b81dedb41fd67af4d88c28ae7c40465edecf3a"

--- a/seed/python-sdk/alias/pyproject.toml
+++ b/seed/python-sdk/alias/pyproject.toml
@@ -51,8 +51,8 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
-pytest-asyncio = "^1.0.0"
+pytest = "^9.0.3"
+pytest-asyncio = "^1.3.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/any-auth/poetry.lock
+++ b/seed/python-sdk/any-auth/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "73db04dccdc2f6e569f03c5b71b81dedb41fd67af4d88c28ae7c40465edecf3a"

--- a/seed/python-sdk/any-auth/pyproject.toml
+++ b/seed/python-sdk/any-auth/pyproject.toml
@@ -51,8 +51,8 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
-pytest-asyncio = "^1.0.0"
+pytest = "^9.0.3"
+pytest-asyncio = "^1.3.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/api-wide-base-path/poetry.lock
+++ b/seed/python-sdk/api-wide-base-path/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "73db04dccdc2f6e569f03c5b71b81dedb41fd67af4d88c28ae7c40465edecf3a"

--- a/seed/python-sdk/api-wide-base-path/pyproject.toml
+++ b/seed/python-sdk/api-wide-base-path/pyproject.toml
@@ -51,8 +51,8 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
-pytest-asyncio = "^1.0.0"
+pytest = "^9.0.3"
+pytest-asyncio = "^1.3.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/audiences/poetry.lock
+++ b/seed/python-sdk/audiences/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "73db04dccdc2f6e569f03c5b71b81dedb41fd67af4d88c28ae7c40465edecf3a"

--- a/seed/python-sdk/audiences/pyproject.toml
+++ b/seed/python-sdk/audiences/pyproject.toml
@@ -51,8 +51,8 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
-pytest-asyncio = "^1.0.0"
+pytest = "^9.0.3"
+pytest-asyncio = "^1.3.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/basic-auth-environment-variables/poetry.lock
+++ b/seed/python-sdk/basic-auth-environment-variables/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "73db04dccdc2f6e569f03c5b71b81dedb41fd67af4d88c28ae7c40465edecf3a"

--- a/seed/python-sdk/basic-auth-environment-variables/pyproject.toml
+++ b/seed/python-sdk/basic-auth-environment-variables/pyproject.toml
@@ -51,8 +51,8 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
-pytest-asyncio = "^1.0.0"
+pytest = "^9.0.3"
+pytest-asyncio = "^1.3.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/basic-auth-pw-omitted/poetry.lock
+++ b/seed/python-sdk/basic-auth-pw-omitted/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "73db04dccdc2f6e569f03c5b71b81dedb41fd67af4d88c28ae7c40465edecf3a"

--- a/seed/python-sdk/basic-auth-pw-omitted/pyproject.toml
+++ b/seed/python-sdk/basic-auth-pw-omitted/pyproject.toml
@@ -51,8 +51,8 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
-pytest-asyncio = "^1.0.0"
+pytest = "^9.0.3"
+pytest-asyncio = "^1.3.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/basic-auth/poetry.lock
+++ b/seed/python-sdk/basic-auth/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "73db04dccdc2f6e569f03c5b71b81dedb41fd67af4d88c28ae7c40465edecf3a"

--- a/seed/python-sdk/basic-auth/pyproject.toml
+++ b/seed/python-sdk/basic-auth/pyproject.toml
@@ -51,8 +51,8 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
-pytest-asyncio = "^1.0.0"
+pytest = "^9.0.3"
+pytest-asyncio = "^1.3.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/bearer-token-environment-variable/poetry.lock
+++ b/seed/python-sdk/bearer-token-environment-variable/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "73db04dccdc2f6e569f03c5b71b81dedb41fd67af4d88c28ae7c40465edecf3a"

--- a/seed/python-sdk/bearer-token-environment-variable/pyproject.toml
+++ b/seed/python-sdk/bearer-token-environment-variable/pyproject.toml
@@ -51,8 +51,8 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
-pytest-asyncio = "^1.0.0"
+pytest = "^9.0.3"
+pytest-asyncio = "^1.3.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/bytes-download/poetry.lock
+++ b/seed/python-sdk/bytes-download/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "73db04dccdc2f6e569f03c5b71b81dedb41fd67af4d88c28ae7c40465edecf3a"

--- a/seed/python-sdk/bytes-download/pyproject.toml
+++ b/seed/python-sdk/bytes-download/pyproject.toml
@@ -51,8 +51,8 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
-pytest-asyncio = "^1.0.0"
+pytest = "^9.0.3"
+pytest-asyncio = "^1.3.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/bytes-upload/poetry.lock
+++ b/seed/python-sdk/bytes-upload/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "73db04dccdc2f6e569f03c5b71b81dedb41fd67af4d88c28ae7c40465edecf3a"

--- a/seed/python-sdk/bytes-upload/pyproject.toml
+++ b/seed/python-sdk/bytes-upload/pyproject.toml
@@ -51,8 +51,8 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
-pytest-asyncio = "^1.0.0"
+pytest = "^9.0.3"
+pytest-asyncio = "^1.3.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/circular-references-advanced/no-inheritance-for-extended-models/poetry.lock
+++ b/seed/python-sdk/circular-references-advanced/no-inheritance-for-extended-models/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "73db04dccdc2f6e569f03c5b71b81dedb41fd67af4d88c28ae7c40465edecf3a"

--- a/seed/python-sdk/circular-references-advanced/no-inheritance-for-extended-models/pyproject.toml
+++ b/seed/python-sdk/circular-references-advanced/no-inheritance-for-extended-models/pyproject.toml
@@ -51,8 +51,8 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
-pytest-asyncio = "^1.0.0"
+pytest = "^9.0.3"
+pytest-asyncio = "^1.3.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/circular-references-extends/no-custom-config/poetry.lock
+++ b/seed/python-sdk/circular-references-extends/no-custom-config/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "73db04dccdc2f6e569f03c5b71b81dedb41fd67af4d88c28ae7c40465edecf3a"

--- a/seed/python-sdk/circular-references-extends/no-custom-config/pyproject.toml
+++ b/seed/python-sdk/circular-references-extends/no-custom-config/pyproject.toml
@@ -51,8 +51,8 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
-pytest-asyncio = "^1.0.0"
+pytest = "^9.0.3"
+pytest-asyncio = "^1.3.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/circular-references/no-custom-config/poetry.lock
+++ b/seed/python-sdk/circular-references/no-custom-config/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "73db04dccdc2f6e569f03c5b71b81dedb41fd67af4d88c28ae7c40465edecf3a"

--- a/seed/python-sdk/circular-references/no-custom-config/pyproject.toml
+++ b/seed/python-sdk/circular-references/no-custom-config/pyproject.toml
@@ -51,8 +51,8 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
-pytest-asyncio = "^1.0.0"
+pytest = "^9.0.3"
+pytest-asyncio = "^1.3.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/circular-references/no-inheritance-for-extended-models/poetry.lock
+++ b/seed/python-sdk/circular-references/no-inheritance-for-extended-models/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "73db04dccdc2f6e569f03c5b71b81dedb41fd67af4d88c28ae7c40465edecf3a"

--- a/seed/python-sdk/circular-references/no-inheritance-for-extended-models/pyproject.toml
+++ b/seed/python-sdk/circular-references/no-inheritance-for-extended-models/pyproject.toml
@@ -51,8 +51,8 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
-pytest-asyncio = "^1.0.0"
+pytest = "^9.0.3"
+pytest-asyncio = "^1.3.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/client-side-params/poetry.lock
+++ b/seed/python-sdk/client-side-params/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "73db04dccdc2f6e569f03c5b71b81dedb41fd67af4d88c28ae7c40465edecf3a"

--- a/seed/python-sdk/client-side-params/pyproject.toml
+++ b/seed/python-sdk/client-side-params/pyproject.toml
@@ -51,8 +51,8 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
-pytest-asyncio = "^1.0.0"
+pytest = "^9.0.3"
+pytest-asyncio = "^1.3.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/content-type/poetry.lock
+++ b/seed/python-sdk/content-type/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "73db04dccdc2f6e569f03c5b71b81dedb41fd67af4d88c28ae7c40465edecf3a"

--- a/seed/python-sdk/content-type/pyproject.toml
+++ b/seed/python-sdk/content-type/pyproject.toml
@@ -51,8 +51,8 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
-pytest-asyncio = "^1.0.0"
+pytest = "^9.0.3"
+pytest-asyncio = "^1.3.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/cross-package-type-names/poetry.lock
+++ b/seed/python-sdk/cross-package-type-names/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "73db04dccdc2f6e569f03c5b71b81dedb41fd67af4d88c28ae7c40465edecf3a"

--- a/seed/python-sdk/cross-package-type-names/pyproject.toml
+++ b/seed/python-sdk/cross-package-type-names/pyproject.toml
@@ -51,8 +51,8 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
-pytest-asyncio = "^1.0.0"
+pytest = "^9.0.3"
+pytest-asyncio = "^1.3.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/dollar-string-examples/poetry.lock
+++ b/seed/python-sdk/dollar-string-examples/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "73db04dccdc2f6e569f03c5b71b81dedb41fd67af4d88c28ae7c40465edecf3a"

--- a/seed/python-sdk/dollar-string-examples/pyproject.toml
+++ b/seed/python-sdk/dollar-string-examples/pyproject.toml
@@ -51,8 +51,8 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
-pytest-asyncio = "^1.0.0"
+pytest = "^9.0.3"
+pytest-asyncio = "^1.3.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/empty-clients/poetry.lock
+++ b/seed/python-sdk/empty-clients/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "73db04dccdc2f6e569f03c5b71b81dedb41fd67af4d88c28ae7c40465edecf3a"

--- a/seed/python-sdk/empty-clients/pyproject.toml
+++ b/seed/python-sdk/empty-clients/pyproject.toml
@@ -51,8 +51,8 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
-pytest-asyncio = "^1.0.0"
+pytest = "^9.0.3"
+pytest-asyncio = "^1.3.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/endpoint-security-auth/poetry.lock
+++ b/seed/python-sdk/endpoint-security-auth/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "73db04dccdc2f6e569f03c5b71b81dedb41fd67af4d88c28ae7c40465edecf3a"

--- a/seed/python-sdk/endpoint-security-auth/pyproject.toml
+++ b/seed/python-sdk/endpoint-security-auth/pyproject.toml
@@ -51,8 +51,8 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
-pytest-asyncio = "^1.0.0"
+pytest = "^9.0.3"
+pytest-asyncio = "^1.3.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/enum/no-custom-config/poetry.lock
+++ b/seed/python-sdk/enum/no-custom-config/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "73db04dccdc2f6e569f03c5b71b81dedb41fd67af4d88c28ae7c40465edecf3a"

--- a/seed/python-sdk/enum/no-custom-config/pyproject.toml
+++ b/seed/python-sdk/enum/no-custom-config/pyproject.toml
@@ -51,8 +51,8 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
-pytest-asyncio = "^1.0.0"
+pytest = "^9.0.3"
+pytest-asyncio = "^1.3.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/enum/real-enum-forward-compat/poetry.lock
+++ b/seed/python-sdk/enum/real-enum-forward-compat/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "73db04dccdc2f6e569f03c5b71b81dedb41fd67af4d88c28ae7c40465edecf3a"

--- a/seed/python-sdk/enum/real-enum-forward-compat/pyproject.toml
+++ b/seed/python-sdk/enum/real-enum-forward-compat/pyproject.toml
@@ -51,8 +51,8 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
-pytest-asyncio = "^1.0.0"
+pytest = "^9.0.3"
+pytest-asyncio = "^1.3.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/enum/real-enum/poetry.lock
+++ b/seed/python-sdk/enum/real-enum/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "73db04dccdc2f6e569f03c5b71b81dedb41fd67af4d88c28ae7c40465edecf3a"

--- a/seed/python-sdk/enum/real-enum/pyproject.toml
+++ b/seed/python-sdk/enum/real-enum/pyproject.toml
@@ -51,8 +51,8 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
-pytest-asyncio = "^1.0.0"
+pytest = "^9.0.3"
+pytest-asyncio = "^1.3.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/enum/strenum/poetry.lock
+++ b/seed/python-sdk/enum/strenum/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "73db04dccdc2f6e569f03c5b71b81dedb41fd67af4d88c28ae7c40465edecf3a"

--- a/seed/python-sdk/enum/strenum/pyproject.toml
+++ b/seed/python-sdk/enum/strenum/pyproject.toml
@@ -51,8 +51,8 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
-pytest-asyncio = "^1.0.0"
+pytest = "^9.0.3"
+pytest-asyncio = "^1.3.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/error-property/poetry.lock
+++ b/seed/python-sdk/error-property/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "73db04dccdc2f6e569f03c5b71b81dedb41fd67af4d88c28ae7c40465edecf3a"

--- a/seed/python-sdk/error-property/pyproject.toml
+++ b/seed/python-sdk/error-property/pyproject.toml
@@ -51,8 +51,8 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
-pytest-asyncio = "^1.0.0"
+pytest = "^9.0.3"
+pytest-asyncio = "^1.3.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/errors/poetry.lock
+++ b/seed/python-sdk/errors/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "73db04dccdc2f6e569f03c5b71b81dedb41fd67af4d88c28ae7c40465edecf3a"

--- a/seed/python-sdk/errors/pyproject.toml
+++ b/seed/python-sdk/errors/pyproject.toml
@@ -51,8 +51,8 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
-pytest-asyncio = "^1.0.0"
+pytest = "^9.0.3"
+pytest-asyncio = "^1.3.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/examples/additional_init_exports_with_duplicates/poetry.lock
+++ b/seed/python-sdk/examples/additional_init_exports_with_duplicates/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "73db04dccdc2f6e569f03c5b71b81dedb41fd67af4d88c28ae7c40465edecf3a"

--- a/seed/python-sdk/examples/additional_init_exports_with_duplicates/pyproject.toml
+++ b/seed/python-sdk/examples/additional_init_exports_with_duplicates/pyproject.toml
@@ -51,8 +51,8 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
-pytest-asyncio = "^1.0.0"
+pytest = "^9.0.3"
+pytest-asyncio = "^1.3.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/examples/client-filename/poetry.lock
+++ b/seed/python-sdk/examples/client-filename/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "73db04dccdc2f6e569f03c5b71b81dedb41fd67af4d88c28ae7c40465edecf3a"

--- a/seed/python-sdk/examples/client-filename/pyproject.toml
+++ b/seed/python-sdk/examples/client-filename/pyproject.toml
@@ -51,8 +51,8 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
-pytest-asyncio = "^1.0.0"
+pytest = "^9.0.3"
+pytest-asyncio = "^1.3.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/examples/legacy-wire-tests/poetry.lock
+++ b/seed/python-sdk/examples/legacy-wire-tests/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "73db04dccdc2f6e569f03c5b71b81dedb41fd67af4d88c28ae7c40465edecf3a"

--- a/seed/python-sdk/examples/legacy-wire-tests/pyproject.toml
+++ b/seed/python-sdk/examples/legacy-wire-tests/pyproject.toml
@@ -51,8 +51,8 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
-pytest-asyncio = "^1.0.0"
+pytest = "^9.0.3"
+pytest-asyncio = "^1.3.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/examples/no-custom-config/poetry.lock
+++ b/seed/python-sdk/examples/no-custom-config/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "73db04dccdc2f6e569f03c5b71b81dedb41fd67af4d88c28ae7c40465edecf3a"

--- a/seed/python-sdk/examples/no-custom-config/pyproject.toml
+++ b/seed/python-sdk/examples/no-custom-config/pyproject.toml
@@ -51,8 +51,8 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
-pytest-asyncio = "^1.0.0"
+pytest = "^9.0.3"
+pytest-asyncio = "^1.3.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/examples/omit-fern-headers/poetry.lock
+++ b/seed/python-sdk/examples/omit-fern-headers/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "73db04dccdc2f6e569f03c5b71b81dedb41fd67af4d88c28ae7c40465edecf3a"

--- a/seed/python-sdk/examples/omit-fern-headers/pyproject.toml
+++ b/seed/python-sdk/examples/omit-fern-headers/pyproject.toml
@@ -51,8 +51,8 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
-pytest-asyncio = "^1.0.0"
+pytest = "^9.0.3"
+pytest-asyncio = "^1.3.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/examples/readme/poetry.lock
+++ b/seed/python-sdk/examples/readme/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "73db04dccdc2f6e569f03c5b71b81dedb41fd67af4d88c28ae7c40465edecf3a"

--- a/seed/python-sdk/examples/readme/pyproject.toml
+++ b/seed/python-sdk/examples/readme/pyproject.toml
@@ -51,8 +51,8 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
-pytest-asyncio = "^1.0.0"
+pytest = "^9.0.3"
+pytest-asyncio = "^1.3.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/exhaustive/additional_init_exports/poetry.lock
+++ b/seed/python-sdk/exhaustive/additional_init_exports/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "73db04dccdc2f6e569f03c5b71b81dedb41fd67af4d88c28ae7c40465edecf3a"

--- a/seed/python-sdk/exhaustive/additional_init_exports/pyproject.toml
+++ b/seed/python-sdk/exhaustive/additional_init_exports/pyproject.toml
@@ -51,8 +51,8 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
-pytest-asyncio = "^1.0.0"
+pytest = "^9.0.3"
+pytest-asyncio = "^1.3.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/exhaustive/aliases_with_validation/poetry.lock
+++ b/seed/python-sdk/exhaustive/aliases_with_validation/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "73db04dccdc2f6e569f03c5b71b81dedb41fd67af4d88c28ae7c40465edecf3a"

--- a/seed/python-sdk/exhaustive/aliases_with_validation/pyproject.toml
+++ b/seed/python-sdk/exhaustive/aliases_with_validation/pyproject.toml
@@ -51,8 +51,8 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
-pytest-asyncio = "^1.0.0"
+pytest = "^9.0.3"
+pytest-asyncio = "^1.3.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/exhaustive/aliases_without_validation/poetry.lock
+++ b/seed/python-sdk/exhaustive/aliases_without_validation/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "73db04dccdc2f6e569f03c5b71b81dedb41fd67af4d88c28ae7c40465edecf3a"

--- a/seed/python-sdk/exhaustive/aliases_without_validation/pyproject.toml
+++ b/seed/python-sdk/exhaustive/aliases_without_validation/pyproject.toml
@@ -51,8 +51,8 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
-pytest-asyncio = "^1.0.0"
+pytest = "^9.0.3"
+pytest-asyncio = "^1.3.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/exhaustive/custom-transport/poetry.lock
+++ b/seed/python-sdk/exhaustive/custom-transport/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "73db04dccdc2f6e569f03c5b71b81dedb41fd67af4d88c28ae7c40465edecf3a"

--- a/seed/python-sdk/exhaustive/custom-transport/pyproject.toml
+++ b/seed/python-sdk/exhaustive/custom-transport/pyproject.toml
@@ -51,8 +51,8 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
-pytest-asyncio = "^1.0.0"
+pytest = "^9.0.3"
+pytest-asyncio = "^1.3.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/exhaustive/datetime-milliseconds/poetry.lock
+++ b/seed/python-sdk/exhaustive/datetime-milliseconds/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "73db04dccdc2f6e569f03c5b71b81dedb41fd67af4d88c28ae7c40465edecf3a"

--- a/seed/python-sdk/exhaustive/datetime-milliseconds/pyproject.toml
+++ b/seed/python-sdk/exhaustive/datetime-milliseconds/pyproject.toml
@@ -51,8 +51,8 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
-pytest-asyncio = "^1.0.0"
+pytest = "^9.0.3"
+pytest-asyncio = "^1.3.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/exhaustive/deps_with_min_python_version/.github/workflows/ci.yml
+++ b/seed/python-sdk/exhaustive/deps_with_min_python_version/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Set up python
         uses: actions/setup-python@v4
         with:
-          python-version: "3.9"
+          python-version: "3.10"
       - name: Bootstrap poetry
         run: |
           curl -sSL https://install.python-poetry.org | python - -y --version 1.5.1
@@ -30,7 +30,7 @@ jobs:
       - name: Set up python
         uses: actions/setup-python@v4
         with:
-          python-version: "3.9"
+          python-version: "3.10"
       - name: Bootstrap poetry
         run: |
           curl -sSL https://install.python-poetry.org | python - -y --version 1.5.1
@@ -56,7 +56,7 @@ jobs:
       - name: Set up python
         uses: actions/setup-python@v4
         with:
-          python-version: "3.9"
+          python-version: "3.10"
       - name: Bootstrap poetry
         run: |
           curl -sSL https://install.python-poetry.org | python - -y --version 1.5.1

--- a/seed/python-sdk/exhaustive/deps_with_min_python_version/poetry.lock
+++ b/seed/python-sdk/exhaustive/deps_with_min_python_version/poetry.lock
@@ -204,6 +204,17 @@ tests = ["cloudpickle", "hypothesis", "mypy (>=1.11.1)", "pympler", "pytest (>=4
 tests-mypy = ["mypy (>=1.11.1)", "pytest-mypy-plugins"]
 
 [[package]]
+name = "backports-asyncio-runner"
+version = "1.2.0"
+description = "Backport of asyncio.Runner, a context manager that controls event loop life cycle."
+optional = false
+python-versions = "<3.11,>=3.8"
+files = [
+    {file = "backports_asyncio_runner-1.2.0-py3-none-any.whl", hash = "sha256:0da0a936a8aeb554eccb426dc55af3ba63bcdc69fa1a600b5bb305413a4477b5"},
+    {file = "backports_asyncio_runner-1.2.0.tar.gz", hash = "sha256:a5aa7b2b7d8f8bfcaa2b57313f70792df84e32a2a746f585213373f900b42162"},
+]
+
+[[package]]
 name = "boto3"
 version = "1.28.57"
 description = "The AWS SDK for Python"
@@ -752,13 +763,13 @@ all = ["flake8 (>=7.1.1)", "mypy (>=1.11.2)", "pytest (>=8.3.2)", "ruff (>=0.6.2
 
 [[package]]
 name = "iniconfig"
-version = "2.1.0"
+version = "2.3.0"
 description = "brain-dead simple config-ini parsing"
 optional = false
-python-versions = ">=3.8"
+python-versions = ">=3.10"
 files = [
-    {file = "iniconfig-2.1.0-py3-none-any.whl", hash = "sha256:9deba5723312380e77435581c6bf4935c94cbfab9b1ed33ef8d238ea168eb760"},
-    {file = "iniconfig-2.1.0.tar.gz", hash = "sha256:3abbd2e30b36733fee78f9c7f7308f2d0050e88f0087fd25c2645f63c773e1c7"},
+    {file = "iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12"},
+    {file = "iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730"},
 ]
 
 [[package]]
@@ -1380,18 +1391,18 @@ files = [
 
 [[package]]
 name = "pluggy"
-version = "1.5.0"
+version = "1.6.0"
 description = "plugin and hook calling mechanisms for python"
 optional = false
-python-versions = ">=3.8"
+python-versions = ">=3.9"
 files = [
-    {file = "pluggy-1.5.0-py3-none-any.whl", hash = "sha256:44e1ad92c8ca002de6377e165f3e0f1be63266ab4d554740532335b9d75ea669"},
-    {file = "pluggy-1.5.0.tar.gz", hash = "sha256:2cffa88e94fdc978c4c574f15f9e59b7f4201d439195c3715ca9e2486f1d0cf1"},
+    {file = "pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746"},
+    {file = "pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3"},
 ]
 
 [package.extras]
 dev = ["pre-commit", "tox"]
-testing = ["pytest", "pytest-benchmark"]
+testing = ["coverage", "pytest", "pytest-benchmark"]
 
 [[package]]
 name = "propcache"
@@ -1633,54 +1644,71 @@ files = [
 typing-extensions = ">=4.6.0,<4.7.0 || >4.7.0"
 
 [[package]]
+name = "pygments"
+version = "2.20.0"
+description = "Pygments is a syntax highlighting package written in Python."
+optional = false
+python-versions = ">=3.9"
+files = [
+    {file = "pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176"},
+    {file = "pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f"},
+]
+
+[package.extras]
+windows-terminal = ["colorama (>=0.4.6)"]
+
+[[package]]
 name = "pytest"
-version = "7.4.4"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.7"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-7.4.4-py3-none-any.whl", hash = "sha256:b090cdf5ed60bf4c45261be03239c2c1c22df034fbffe691abe93cd80cea01d8"},
-    {file = "pytest-7.4.4.tar.gz", hash = "sha256:2cf0005922c6ace4a3e2ec8b4080eb0d9753fdc93107415332f50ce9e7994280"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
-colorama = {version = "*", markers = "sys_platform == \"win32\""}
-exceptiongroup = {version = ">=1.0.0rc8", markers = "python_version < \"3.11\""}
-iniconfig = "*"
-packaging = "*"
-pluggy = ">=0.12,<2.0"
-tomli = {version = ">=1.0.0", markers = "python_version < \"3.11\""}
+colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
+exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
+iniconfig = ">=1.0.1"
+packaging = ">=22"
+pluggy = ">=1.5,<2"
+pygments = ">=2.7.2"
+tomli = {version = ">=1", markers = "python_version < \"3.11\""}
 
 [package.extras]
-testing = ["argcomplete", "attrs (>=19.2.0)", "hypothesis (>=3.56)", "mock", "nose", "pygments (>=2.7.2)", "requests", "setuptools", "xmlschema"]
+dev = ["argcomplete", "attrs (>=19.2)", "hypothesis (>=3.56)", "mock", "requests", "setuptools", "xmlschema"]
 
 [[package]]
 name = "pytest-asyncio"
-version = "0.23.8"
+version = "1.3.0"
 description = "Pytest support for asyncio"
 optional = false
-python-versions = ">=3.8"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest_asyncio-0.23.8-py3-none-any.whl", hash = "sha256:50265d892689a5faefb84df80819d1ecef566eb3549cf915dfb33569359d1ce2"},
-    {file = "pytest_asyncio-0.23.8.tar.gz", hash = "sha256:759b10b33a6dc61cce40a8bd5205e302978bbbcc00e279a8b61d9a6a3c82e4d3"},
+    {file = "pytest_asyncio-1.3.0-py3-none-any.whl", hash = "sha256:611e26147c7f77640e6d0a92a38ed17c3e9848063698d5c93d5aa7aa11cebff5"},
+    {file = "pytest_asyncio-1.3.0.tar.gz", hash = "sha256:d7f52f36d231b80ee124cd216ffb19369aa168fc10095013c6b014a34d3ee9e5"},
 ]
 
 [package.dependencies]
-pytest = ">=7.0.0,<9"
+backports-asyncio-runner = {version = ">=1.1,<2", markers = "python_version < \"3.11\""}
+pytest = ">=8.2,<10"
+typing-extensions = {version = ">=4.12", markers = "python_version < \"3.13\""}
 
 [package.extras]
-docs = ["sphinx (>=5.3)", "sphinx-rtd-theme (>=1.0)"]
+docs = ["sphinx (>=5.3)", "sphinx-rtd-theme (>=1)"]
 testing = ["coverage (>=6.2)", "hypothesis (>=5.7.1)"]
 
 [[package]]
 name = "pytest-xdist"
-version = "3.6.1"
+version = "3.8.0"
 description = "pytest xdist plugin for distributed testing, most importantly across multiple CPUs"
 optional = false
-python-versions = ">=3.8"
+python-versions = ">=3.9"
 files = [
-    {file = "pytest_xdist-3.6.1-py3-none-any.whl", hash = "sha256:9ed4adfb68a016610848639bb7e02c9352d5d9f03d04809919e2dafc3be4cca7"},
-    {file = "pytest_xdist-3.6.1.tar.gz", hash = "sha256:ead156a4db231eec769737f57668ef58a2084a34b2e55c4a8fa20d861107300d"},
+    {file = "pytest_xdist-3.8.0-py3-none-any.whl", hash = "sha256:202ca578cfeb7370784a8c33d6d05bc6e13b4f25b5053c30a152269fd10f0b88"},
+    {file = "pytest_xdist-3.8.0.tar.gz", hash = "sha256:7e578125ec9bc6050861aa93f2d59f1d8d085595d6551c2c90b6f4fad8d3a9f1"},
 ]
 
 [package.dependencies]
@@ -2436,4 +2464,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8.1"
-content-hash = "3cf71d51a0ef616f8a8ee546b9711bdddace72798594bca5a44b48e63c4f8c26"
+content-hash = "709e8a1fa97116d4d7c8b8406648466575ee048a1f45c04a18adf1d9d48eb207"

--- a/seed/python-sdk/exhaustive/deps_with_min_python_version/pyproject.toml
+++ b/seed/python-sdk/exhaustive/deps_with_min_python_version/pyproject.toml
@@ -53,9 +53,9 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
-pytest-xdist = "^3.6.1"
+pytest = {version = "^9.0.3", python = ">=3.10"}
+pytest-asyncio = {version = "^1.3.0", python = ">=3.10"}
+pytest-xdist = {version = "^3.6.1", python = ">=3.10"}
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"
 covcheck = { version = "^0.4.3", extras = ["toml"]}

--- a/seed/python-sdk/exhaustive/eager-imports/poetry.lock
+++ b/seed/python-sdk/exhaustive/eager-imports/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "73db04dccdc2f6e569f03c5b71b81dedb41fd67af4d88c28ae7c40465edecf3a"

--- a/seed/python-sdk/exhaustive/eager-imports/pyproject.toml
+++ b/seed/python-sdk/exhaustive/eager-imports/pyproject.toml
@@ -51,8 +51,8 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
-pytest-asyncio = "^1.0.0"
+pytest = "^9.0.3"
+pytest-asyncio = "^1.3.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/exhaustive/extra_dependencies/.github/workflows/ci.yml
+++ b/seed/python-sdk/exhaustive/extra_dependencies/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Set up python
         uses: actions/setup-python@v4
         with:
-          python-version: "3.9"
+          python-version: "3.10"
       - name: Bootstrap poetry
         run: |
           curl -sSL https://install.python-poetry.org | python - -y --version 1.5.1
@@ -30,7 +30,7 @@ jobs:
       - name: Set up python
         uses: actions/setup-python@v4
         with:
-          python-version: "3.9"
+          python-version: "3.10"
       - name: Bootstrap poetry
         run: |
           curl -sSL https://install.python-poetry.org | python - -y --version 1.5.1
@@ -56,7 +56,7 @@ jobs:
       - name: Set up python
         uses: actions/setup-python@v4
         with:
-          python-version: "3.9"
+          python-version: "3.10"
       - name: Bootstrap poetry
         run: |
           curl -sSL https://install.python-poetry.org | python - -y --version 1.5.1

--- a/seed/python-sdk/exhaustive/extra_dependencies/poetry.lock
+++ b/seed/python-sdk/exhaustive/extra_dependencies/poetry.lock
@@ -204,6 +204,17 @@ tests = ["cloudpickle", "hypothesis", "mypy (>=1.11.1)", "pympler", "pytest (>=4
 tests-mypy = ["mypy (>=1.11.1)", "pytest-mypy-plugins"]
 
 [[package]]
+name = "backports-asyncio-runner"
+version = "1.2.0"
+description = "Backport of asyncio.Runner, a context manager that controls event loop life cycle."
+optional = false
+python-versions = "<3.11,>=3.8"
+files = [
+    {file = "backports_asyncio_runner-1.2.0-py3-none-any.whl", hash = "sha256:0da0a936a8aeb554eccb426dc55af3ba63bcdc69fa1a600b5bb305413a4477b5"},
+    {file = "backports_asyncio_runner-1.2.0.tar.gz", hash = "sha256:a5aa7b2b7d8f8bfcaa2b57313f70792df84e32a2a746f585213373f900b42162"},
+]
+
+[[package]]
 name = "boto3"
 version = "1.28.57"
 description = "The AWS SDK for Python"
@@ -724,13 +735,13 @@ all = ["flake8 (>=7.1.1)", "mypy (>=1.11.2)", "pytest (>=8.3.2)", "ruff (>=0.6.2
 
 [[package]]
 name = "iniconfig"
-version = "2.1.0"
+version = "2.3.0"
 description = "brain-dead simple config-ini parsing"
 optional = false
-python-versions = ">=3.8"
+python-versions = ">=3.10"
 files = [
-    {file = "iniconfig-2.1.0-py3-none-any.whl", hash = "sha256:9deba5723312380e77435581c6bf4935c94cbfab9b1ed33ef8d238ea168eb760"},
-    {file = "iniconfig-2.1.0.tar.gz", hash = "sha256:3abbd2e30b36733fee78f9c7f7308f2d0050e88f0087fd25c2645f63c773e1c7"},
+    {file = "iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12"},
+    {file = "iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730"},
 ]
 
 [[package]]
@@ -1223,18 +1234,18 @@ files = [
 
 [[package]]
 name = "pluggy"
-version = "1.5.0"
+version = "1.6.0"
 description = "plugin and hook calling mechanisms for python"
 optional = false
-python-versions = ">=3.8"
+python-versions = ">=3.9"
 files = [
-    {file = "pluggy-1.5.0-py3-none-any.whl", hash = "sha256:44e1ad92c8ca002de6377e165f3e0f1be63266ab4d554740532335b9d75ea669"},
-    {file = "pluggy-1.5.0.tar.gz", hash = "sha256:2cffa88e94fdc978c4c574f15f9e59b7f4201d439195c3715ca9e2486f1d0cf1"},
+    {file = "pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746"},
+    {file = "pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3"},
 ]
 
 [package.extras]
 dev = ["pre-commit", "tox"]
-testing = ["pytest", "pytest-benchmark"]
+testing = ["coverage", "pytest", "pytest-benchmark"]
 
 [[package]]
 name = "propcache"
@@ -1476,54 +1487,71 @@ files = [
 typing-extensions = ">=4.6.0,<4.7.0 || >4.7.0"
 
 [[package]]
+name = "pygments"
+version = "2.20.0"
+description = "Pygments is a syntax highlighting package written in Python."
+optional = false
+python-versions = ">=3.9"
+files = [
+    {file = "pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176"},
+    {file = "pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f"},
+]
+
+[package.extras]
+windows-terminal = ["colorama (>=0.4.6)"]
+
+[[package]]
 name = "pytest"
-version = "7.4.4"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.7"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-7.4.4-py3-none-any.whl", hash = "sha256:b090cdf5ed60bf4c45261be03239c2c1c22df034fbffe691abe93cd80cea01d8"},
-    {file = "pytest-7.4.4.tar.gz", hash = "sha256:2cf0005922c6ace4a3e2ec8b4080eb0d9753fdc93107415332f50ce9e7994280"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
-colorama = {version = "*", markers = "sys_platform == \"win32\""}
-exceptiongroup = {version = ">=1.0.0rc8", markers = "python_version < \"3.11\""}
-iniconfig = "*"
-packaging = "*"
-pluggy = ">=0.12,<2.0"
-tomli = {version = ">=1.0.0", markers = "python_version < \"3.11\""}
+colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
+exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
+iniconfig = ">=1.0.1"
+packaging = ">=22"
+pluggy = ">=1.5,<2"
+pygments = ">=2.7.2"
+tomli = {version = ">=1", markers = "python_version < \"3.11\""}
 
 [package.extras]
-testing = ["argcomplete", "attrs (>=19.2.0)", "hypothesis (>=3.56)", "mock", "nose", "pygments (>=2.7.2)", "requests", "setuptools", "xmlschema"]
+dev = ["argcomplete", "attrs (>=19.2)", "hypothesis (>=3.56)", "mock", "requests", "setuptools", "xmlschema"]
 
 [[package]]
 name = "pytest-asyncio"
-version = "0.23.8"
+version = "1.3.0"
 description = "Pytest support for asyncio"
 optional = false
-python-versions = ">=3.8"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest_asyncio-0.23.8-py3-none-any.whl", hash = "sha256:50265d892689a5faefb84df80819d1ecef566eb3549cf915dfb33569359d1ce2"},
-    {file = "pytest_asyncio-0.23.8.tar.gz", hash = "sha256:759b10b33a6dc61cce40a8bd5205e302978bbbcc00e279a8b61d9a6a3c82e4d3"},
+    {file = "pytest_asyncio-1.3.0-py3-none-any.whl", hash = "sha256:611e26147c7f77640e6d0a92a38ed17c3e9848063698d5c93d5aa7aa11cebff5"},
+    {file = "pytest_asyncio-1.3.0.tar.gz", hash = "sha256:d7f52f36d231b80ee124cd216ffb19369aa168fc10095013c6b014a34d3ee9e5"},
 ]
 
 [package.dependencies]
-pytest = ">=7.0.0,<9"
+backports-asyncio-runner = {version = ">=1.1,<2", markers = "python_version < \"3.11\""}
+pytest = ">=8.2,<10"
+typing-extensions = {version = ">=4.12", markers = "python_version < \"3.13\""}
 
 [package.extras]
-docs = ["sphinx (>=5.3)", "sphinx-rtd-theme (>=1.0)"]
+docs = ["sphinx (>=5.3)", "sphinx-rtd-theme (>=1)"]
 testing = ["coverage (>=6.2)", "hypothesis (>=5.7.1)"]
 
 [[package]]
 name = "pytest-xdist"
-version = "3.6.1"
+version = "3.8.0"
 description = "pytest xdist plugin for distributed testing, most importantly across multiple CPUs"
 optional = false
-python-versions = ">=3.8"
+python-versions = ">=3.9"
 files = [
-    {file = "pytest_xdist-3.6.1-py3-none-any.whl", hash = "sha256:9ed4adfb68a016610848639bb7e02c9352d5d9f03d04809919e2dafc3be4cca7"},
-    {file = "pytest_xdist-3.6.1.tar.gz", hash = "sha256:ead156a4db231eec769737f57668ef58a2084a34b2e55c4a8fa20d861107300d"},
+    {file = "pytest_xdist-3.8.0-py3-none-any.whl", hash = "sha256:202ca578cfeb7370784a8c33d6d05bc6e13b4f25b5053c30a152269fd10f0b88"},
+    {file = "pytest_xdist-3.8.0.tar.gz", hash = "sha256:7e578125ec9bc6050861aa93f2d59f1d8d085595d6551c2c90b6f4fad8d3a9f1"},
 ]
 
 [package.dependencies]
@@ -2093,4 +2121,4 @@ telemetry = ["boto3", "langchain"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8.1"
-content-hash = "9cea6b9750b1ab129a1b19cf6e16641fad79666d1dacbc2e68192e4d225cb05e"
+content-hash = "ce4853a3e5a5e03287c0d790877f27668f7d8e4d411db4aee9609ec179a20771"

--- a/seed/python-sdk/exhaustive/extra_dependencies/pyproject.toml
+++ b/seed/python-sdk/exhaustive/extra_dependencies/pyproject.toml
@@ -54,9 +54,9 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
-pytest-xdist = "^3.6.1"
+pytest = {version = "^9.0.3", python = ">=3.10"}
+pytest-asyncio = {version = "^1.3.0", python = ">=3.10"}
+pytest-xdist = {version = "^3.6.1", python = ">=3.10"}
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"
 ruff = "==0.11.5"

--- a/seed/python-sdk/exhaustive/extra_dev_dependencies/poetry.lock
+++ b/seed/python-sdk/exhaustive/extra_dev_dependencies/poetry.lock
@@ -1255,20 +1255,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1680,4 +1680,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "cdde23ef42dd3499ec0bb7a747ed4029d24e426bfe00e6819f9b3712c56d4927"
+content-hash = "93c1b95775cf3e2bf1295ac758a61c69997355d8dc2e7b2cbd5f07f6d08f46c7"

--- a/seed/python-sdk/exhaustive/extra_dev_dependencies/pyproject.toml
+++ b/seed/python-sdk/exhaustive/extra_dev_dependencies/pyproject.toml
@@ -52,8 +52,8 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
-pytest-asyncio = "^1.0.0"
+pytest = "^9.0.3"
+pytest-asyncio = "^1.3.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/exhaustive/five-second-timeout/poetry.lock
+++ b/seed/python-sdk/exhaustive/five-second-timeout/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "73db04dccdc2f6e569f03c5b71b81dedb41fd67af4d88c28ae7c40465edecf3a"

--- a/seed/python-sdk/exhaustive/five-second-timeout/pyproject.toml
+++ b/seed/python-sdk/exhaustive/five-second-timeout/pyproject.toml
@@ -51,8 +51,8 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
-pytest-asyncio = "^1.0.0"
+pytest = "^9.0.3"
+pytest-asyncio = "^1.3.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/exhaustive/follow_redirects_by_default/poetry.lock
+++ b/seed/python-sdk/exhaustive/follow_redirects_by_default/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "73db04dccdc2f6e569f03c5b71b81dedb41fd67af4d88c28ae7c40465edecf3a"

--- a/seed/python-sdk/exhaustive/follow_redirects_by_default/pyproject.toml
+++ b/seed/python-sdk/exhaustive/follow_redirects_by_default/pyproject.toml
@@ -51,8 +51,8 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
-pytest-asyncio = "^1.0.0"
+pytest = "^9.0.3"
+pytest-asyncio = "^1.3.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/exhaustive/import-paths/poetry.lock
+++ b/seed/python-sdk/exhaustive/import-paths/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "73db04dccdc2f6e569f03c5b71b81dedb41fd67af4d88c28ae7c40465edecf3a"

--- a/seed/python-sdk/exhaustive/import-paths/pyproject.toml
+++ b/seed/python-sdk/exhaustive/import-paths/pyproject.toml
@@ -51,8 +51,8 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
-pytest-asyncio = "^1.0.0"
+pytest = "^9.0.3"
+pytest-asyncio = "^1.3.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/exhaustive/improved_imports/poetry.lock
+++ b/seed/python-sdk/exhaustive/improved_imports/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "73db04dccdc2f6e569f03c5b71b81dedb41fd67af4d88c28ae7c40465edecf3a"

--- a/seed/python-sdk/exhaustive/improved_imports/pyproject.toml
+++ b/seed/python-sdk/exhaustive/improved_imports/pyproject.toml
@@ -51,8 +51,8 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
-pytest-asyncio = "^1.0.0"
+pytest = "^9.0.3"
+pytest-asyncio = "^1.3.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/exhaustive/infinite-timeout/poetry.lock
+++ b/seed/python-sdk/exhaustive/infinite-timeout/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "73db04dccdc2f6e569f03c5b71b81dedb41fd67af4d88c28ae7c40465edecf3a"

--- a/seed/python-sdk/exhaustive/infinite-timeout/pyproject.toml
+++ b/seed/python-sdk/exhaustive/infinite-timeout/pyproject.toml
@@ -51,8 +51,8 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
-pytest-asyncio = "^1.0.0"
+pytest = "^9.0.3"
+pytest-asyncio = "^1.3.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/exhaustive/inline-path-params/poetry.lock
+++ b/seed/python-sdk/exhaustive/inline-path-params/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "73db04dccdc2f6e569f03c5b71b81dedb41fd67af4d88c28ae7c40465edecf3a"

--- a/seed/python-sdk/exhaustive/inline-path-params/pyproject.toml
+++ b/seed/python-sdk/exhaustive/inline-path-params/pyproject.toml
@@ -51,8 +51,8 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
-pytest-asyncio = "^1.0.0"
+pytest = "^9.0.3"
+pytest-asyncio = "^1.3.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/exhaustive/inline_request_params/poetry.lock
+++ b/seed/python-sdk/exhaustive/inline_request_params/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "73db04dccdc2f6e569f03c5b71b81dedb41fd67af4d88c28ae7c40465edecf3a"

--- a/seed/python-sdk/exhaustive/inline_request_params/pyproject.toml
+++ b/seed/python-sdk/exhaustive/inline_request_params/pyproject.toml
@@ -51,8 +51,8 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
-pytest-asyncio = "^1.0.0"
+pytest = "^9.0.3"
+pytest-asyncio = "^1.3.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/exhaustive/no-custom-config/poetry.lock
+++ b/seed/python-sdk/exhaustive/no-custom-config/poetry.lock
@@ -1206,20 +1206,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1611,4 +1611,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "7ac12b5d251e81a278fba2c051cbf4f768fb951f006f23ad0faedb1289539c1a"
+content-hash = "2bce94d2b349d050a23e91a08b482f35a7cbe67815d120d0c4cb5c8d1204a59b"

--- a/seed/python-sdk/exhaustive/no-custom-config/pyproject.toml
+++ b/seed/python-sdk/exhaustive/no-custom-config/pyproject.toml
@@ -51,8 +51,8 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
-pytest-asyncio = "^1.0.0"
+pytest = "^9.0.3"
+pytest-asyncio = "^1.3.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/exhaustive/package-path/poetry.lock
+++ b/seed/python-sdk/exhaustive/package-path/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "73db04dccdc2f6e569f03c5b71b81dedb41fd67af4d88c28ae7c40465edecf3a"

--- a/seed/python-sdk/exhaustive/package-path/pyproject.toml
+++ b/seed/python-sdk/exhaustive/package-path/pyproject.toml
@@ -51,8 +51,8 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
-pytest-asyncio = "^1.0.0"
+pytest = "^9.0.3"
+pytest-asyncio = "^1.3.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/exhaustive/pydantic-extra-fields/poetry.lock
+++ b/seed/python-sdk/exhaustive/pydantic-extra-fields/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "73db04dccdc2f6e569f03c5b71b81dedb41fd67af4d88c28ae7c40465edecf3a"

--- a/seed/python-sdk/exhaustive/pydantic-extra-fields/pyproject.toml
+++ b/seed/python-sdk/exhaustive/pydantic-extra-fields/pyproject.toml
@@ -51,8 +51,8 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
-pytest-asyncio = "^1.0.0"
+pytest = "^9.0.3"
+pytest-asyncio = "^1.3.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/exhaustive/pydantic-ignore-fields/poetry.lock
+++ b/seed/python-sdk/exhaustive/pydantic-ignore-fields/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "73db04dccdc2f6e569f03c5b71b81dedb41fd67af4d88c28ae7c40465edecf3a"

--- a/seed/python-sdk/exhaustive/pydantic-ignore-fields/pyproject.toml
+++ b/seed/python-sdk/exhaustive/pydantic-ignore-fields/pyproject.toml
@@ -51,8 +51,8 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
-pytest-asyncio = "^1.0.0"
+pytest = "^9.0.3"
+pytest-asyncio = "^1.3.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/exhaustive/pydantic-v1-with-utils/poetry.lock
+++ b/seed/python-sdk/exhaustive/pydantic-v1-with-utils/poetry.lock
@@ -1080,20 +1080,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1419,4 +1419,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "4a8254cfab519b5fdf33c2eb47ede9da99cfc1d411d88660cc116c13edbcddcc"
+content-hash = "a678a78e54bfd8062410e9fce5034188f4e65dba6647f9e43f75bfc935a756dc"

--- a/seed/python-sdk/exhaustive/pydantic-v1-with-utils/pyproject.toml
+++ b/seed/python-sdk/exhaustive/pydantic-v1-with-utils/pyproject.toml
@@ -51,8 +51,8 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
-pytest-asyncio = "^1.0.0"
+pytest = "^9.0.3"
+pytest-asyncio = "^1.3.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/exhaustive/pydantic-v1-wrapped/poetry.lock
+++ b/seed/python-sdk/exhaustive/pydantic-v1-wrapped/poetry.lock
@@ -1080,20 +1080,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1419,4 +1419,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "4a8254cfab519b5fdf33c2eb47ede9da99cfc1d411d88660cc116c13edbcddcc"
+content-hash = "a678a78e54bfd8062410e9fce5034188f4e65dba6647f9e43f75bfc935a756dc"

--- a/seed/python-sdk/exhaustive/pydantic-v1-wrapped/pyproject.toml
+++ b/seed/python-sdk/exhaustive/pydantic-v1-wrapped/pyproject.toml
@@ -51,8 +51,8 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
-pytest-asyncio = "^1.0.0"
+pytest = "^9.0.3"
+pytest-asyncio = "^1.3.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/exhaustive/pydantic-v1/poetry.lock
+++ b/seed/python-sdk/exhaustive/pydantic-v1/poetry.lock
@@ -1080,20 +1080,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1419,4 +1419,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "4a8254cfab519b5fdf33c2eb47ede9da99cfc1d411d88660cc116c13edbcddcc"
+content-hash = "a678a78e54bfd8062410e9fce5034188f4e65dba6647f9e43f75bfc935a756dc"

--- a/seed/python-sdk/exhaustive/pydantic-v1/pyproject.toml
+++ b/seed/python-sdk/exhaustive/pydantic-v1/pyproject.toml
@@ -51,8 +51,8 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
-pytest-asyncio = "^1.0.0"
+pytest = "^9.0.3"
+pytest-asyncio = "^1.3.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/exhaustive/pydantic-v2-wrapped/poetry.lock
+++ b/seed/python-sdk/exhaustive/pydantic-v2-wrapped/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c6bf0f1a4ea5cfca20a9bd8bf6d0af44697939804bef125015305f0f38d7395e"
+content-hash = "8f313ca36d634ff9ea05d62b53d944717b72f7bcd5408d4a0cd0715903f0f17f"

--- a/seed/python-sdk/exhaustive/pydantic-v2-wrapped/pyproject.toml
+++ b/seed/python-sdk/exhaustive/pydantic-v2-wrapped/pyproject.toml
@@ -51,8 +51,8 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
-pytest-asyncio = "^1.0.0"
+pytest = "^9.0.3"
+pytest-asyncio = "^1.3.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/exhaustive/pyproject_extras/.github/workflows/ci.yml
+++ b/seed/python-sdk/exhaustive/pyproject_extras/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Set up python
         uses: actions/setup-python@v4
         with:
-          python-version: "3.9"
+          python-version: "3.10"
       - name: Bootstrap poetry
         run: |
           curl -sSL https://install.python-poetry.org | python - -y --version 1.5.1
@@ -30,7 +30,7 @@ jobs:
       - name: Set up python
         uses: actions/setup-python@v4
         with:
-          python-version: "3.9"
+          python-version: "3.10"
       - name: Bootstrap poetry
         run: |
           curl -sSL https://install.python-poetry.org | python - -y --version 1.5.1
@@ -56,7 +56,7 @@ jobs:
       - name: Set up python
         uses: actions/setup-python@v4
         with:
-          python-version: "3.9"
+          python-version: "3.10"
       - name: Bootstrap poetry
         run: |
           curl -sSL https://install.python-poetry.org | python - -y --version 1.5.1

--- a/seed/python-sdk/exhaustive/pyproject_extras/poetry.lock
+++ b/seed/python-sdk/exhaustive/pyproject_extras/poetry.lock
@@ -204,6 +204,17 @@ tests = ["cloudpickle", "hypothesis", "mypy (>=1.11.1)", "pympler", "pytest (>=4
 tests-mypy = ["mypy (>=1.11.1)", "pytest-mypy-plugins"]
 
 [[package]]
+name = "backports-asyncio-runner"
+version = "1.2.0"
+description = "Backport of asyncio.Runner, a context manager that controls event loop life cycle."
+optional = false
+python-versions = "<3.11,>=3.8"
+files = [
+    {file = "backports_asyncio_runner-1.2.0-py3-none-any.whl", hash = "sha256:0da0a936a8aeb554eccb426dc55af3ba63bcdc69fa1a600b5bb305413a4477b5"},
+    {file = "backports_asyncio_runner-1.2.0.tar.gz", hash = "sha256:a5aa7b2b7d8f8bfcaa2b57313f70792df84e32a2a746f585213373f900b42162"},
+]
+
+[[package]]
 name = "certifi"
 version = "2026.2.25"
 description = "Python package for providing Mozilla's CA Bundle."
@@ -461,13 +472,13 @@ all = ["flake8 (>=7.1.1)", "mypy (>=1.11.2)", "pytest (>=8.3.2)", "ruff (>=0.6.2
 
 [[package]]
 name = "iniconfig"
-version = "2.1.0"
+version = "2.3.0"
 description = "brain-dead simple config-ini parsing"
 optional = false
-python-versions = ">=3.8"
+python-versions = ">=3.10"
 files = [
-    {file = "iniconfig-2.1.0-py3-none-any.whl", hash = "sha256:9deba5723312380e77435581c6bf4935c94cbfab9b1ed33ef8d238ea168eb760"},
-    {file = "iniconfig-2.1.0.tar.gz", hash = "sha256:3abbd2e30b36733fee78f9c7f7308f2d0050e88f0087fd25c2645f63c773e1c7"},
+    {file = "iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12"},
+    {file = "iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730"},
 ]
 
 [[package]]
@@ -651,18 +662,18 @@ files = [
 
 [[package]]
 name = "pluggy"
-version = "1.5.0"
+version = "1.6.0"
 description = "plugin and hook calling mechanisms for python"
 optional = false
-python-versions = ">=3.8"
+python-versions = ">=3.9"
 files = [
-    {file = "pluggy-1.5.0-py3-none-any.whl", hash = "sha256:44e1ad92c8ca002de6377e165f3e0f1be63266ab4d554740532335b9d75ea669"},
-    {file = "pluggy-1.5.0.tar.gz", hash = "sha256:2cffa88e94fdc978c4c574f15f9e59b7f4201d439195c3715ca9e2486f1d0cf1"},
+    {file = "pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746"},
+    {file = "pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3"},
 ]
 
 [package.extras]
 dev = ["pre-commit", "tox"]
-testing = ["pytest", "pytest-benchmark"]
+testing = ["coverage", "pytest", "pytest-benchmark"]
 
 [[package]]
 name = "propcache"
@@ -904,54 +915,71 @@ files = [
 typing-extensions = ">=4.6.0,<4.7.0 || >4.7.0"
 
 [[package]]
+name = "pygments"
+version = "2.20.0"
+description = "Pygments is a syntax highlighting package written in Python."
+optional = false
+python-versions = ">=3.9"
+files = [
+    {file = "pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176"},
+    {file = "pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f"},
+]
+
+[package.extras]
+windows-terminal = ["colorama (>=0.4.6)"]
+
+[[package]]
 name = "pytest"
-version = "7.4.4"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.7"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-7.4.4-py3-none-any.whl", hash = "sha256:b090cdf5ed60bf4c45261be03239c2c1c22df034fbffe691abe93cd80cea01d8"},
-    {file = "pytest-7.4.4.tar.gz", hash = "sha256:2cf0005922c6ace4a3e2ec8b4080eb0d9753fdc93107415332f50ce9e7994280"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
-colorama = {version = "*", markers = "sys_platform == \"win32\""}
-exceptiongroup = {version = ">=1.0.0rc8", markers = "python_version < \"3.11\""}
-iniconfig = "*"
-packaging = "*"
-pluggy = ">=0.12,<2.0"
-tomli = {version = ">=1.0.0", markers = "python_version < \"3.11\""}
+colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
+exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
+iniconfig = ">=1.0.1"
+packaging = ">=22"
+pluggy = ">=1.5,<2"
+pygments = ">=2.7.2"
+tomli = {version = ">=1", markers = "python_version < \"3.11\""}
 
 [package.extras]
-testing = ["argcomplete", "attrs (>=19.2.0)", "hypothesis (>=3.56)", "mock", "nose", "pygments (>=2.7.2)", "requests", "setuptools", "xmlschema"]
+dev = ["argcomplete", "attrs (>=19.2)", "hypothesis (>=3.56)", "mock", "requests", "setuptools", "xmlschema"]
 
 [[package]]
 name = "pytest-asyncio"
-version = "0.23.8"
+version = "1.3.0"
 description = "Pytest support for asyncio"
 optional = false
-python-versions = ">=3.8"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest_asyncio-0.23.8-py3-none-any.whl", hash = "sha256:50265d892689a5faefb84df80819d1ecef566eb3549cf915dfb33569359d1ce2"},
-    {file = "pytest_asyncio-0.23.8.tar.gz", hash = "sha256:759b10b33a6dc61cce40a8bd5205e302978bbbcc00e279a8b61d9a6a3c82e4d3"},
+    {file = "pytest_asyncio-1.3.0-py3-none-any.whl", hash = "sha256:611e26147c7f77640e6d0a92a38ed17c3e9848063698d5c93d5aa7aa11cebff5"},
+    {file = "pytest_asyncio-1.3.0.tar.gz", hash = "sha256:d7f52f36d231b80ee124cd216ffb19369aa168fc10095013c6b014a34d3ee9e5"},
 ]
 
 [package.dependencies]
-pytest = ">=7.0.0,<9"
+backports-asyncio-runner = {version = ">=1.1,<2", markers = "python_version < \"3.11\""}
+pytest = ">=8.2,<10"
+typing-extensions = {version = ">=4.12", markers = "python_version < \"3.13\""}
 
 [package.extras]
-docs = ["sphinx (>=5.3)", "sphinx-rtd-theme (>=1.0)"]
+docs = ["sphinx (>=5.3)", "sphinx-rtd-theme (>=1)"]
 testing = ["coverage (>=6.2)", "hypothesis (>=5.7.1)"]
 
 [[package]]
 name = "pytest-xdist"
-version = "3.6.1"
+version = "3.8.0"
 description = "pytest xdist plugin for distributed testing, most importantly across multiple CPUs"
 optional = false
-python-versions = ">=3.8"
+python-versions = ">=3.9"
 files = [
-    {file = "pytest_xdist-3.6.1-py3-none-any.whl", hash = "sha256:9ed4adfb68a016610848639bb7e02c9352d5d9f03d04809919e2dafc3be4cca7"},
-    {file = "pytest_xdist-3.6.1.tar.gz", hash = "sha256:ead156a4db231eec769737f57668ef58a2084a34b2e55c4a8fa20d861107300d"},
+    {file = "pytest_xdist-3.8.0-py3-none-any.whl", hash = "sha256:202ca578cfeb7370784a8c33d6d05bc6e13b4f25b5053c30a152269fd10f0b88"},
+    {file = "pytest_xdist-3.8.0.tar.gz", hash = "sha256:7e578125ec9bc6050861aa93f2d59f1d8d085595d6551c2c90b6f4fad8d3a9f1"},
 ]
 
 [package.dependencies]
@@ -1233,4 +1261,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8.1"
-content-hash = "5edf43e46f03c354d1cf3f7721a3c93b4ba57f6711a81342325a88ec02cea366"
+content-hash = "12fd8bdd1371fe06dcf535cb08549722a7a5b9278e4fc54eb3e6391e97c838be"

--- a/seed/python-sdk/exhaustive/pyproject_extras/pyproject.toml
+++ b/seed/python-sdk/exhaustive/pyproject_extras/pyproject.toml
@@ -52,9 +52,9 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^7.4.0"
-pytest-asyncio = "^0.23.5"
-pytest-xdist = "^3.6.1"
+pytest = {version = "^9.0.3", python = ">=3.10"}
+pytest-asyncio = {version = "^1.3.0", python = ">=3.10"}
+pytest-xdist = {version = "^3.6.1", python = ">=3.10"}
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"
 covcheck = { version = "^0.4.3", extras = ["toml"]}

--- a/seed/python-sdk/exhaustive/skip-pydantic-validation/poetry.lock
+++ b/seed/python-sdk/exhaustive/skip-pydantic-validation/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "73db04dccdc2f6e569f03c5b71b81dedb41fd67af4d88c28ae7c40465edecf3a"

--- a/seed/python-sdk/exhaustive/skip-pydantic-validation/pyproject.toml
+++ b/seed/python-sdk/exhaustive/skip-pydantic-validation/pyproject.toml
@@ -51,8 +51,8 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
-pytest-asyncio = "^1.0.0"
+pytest = "^9.0.3"
+pytest-asyncio = "^1.3.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/exhaustive/union-utils/poetry.lock
+++ b/seed/python-sdk/exhaustive/union-utils/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "73db04dccdc2f6e569f03c5b71b81dedb41fd67af4d88c28ae7c40465edecf3a"

--- a/seed/python-sdk/exhaustive/union-utils/pyproject.toml
+++ b/seed/python-sdk/exhaustive/union-utils/pyproject.toml
@@ -51,8 +51,8 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
-pytest-asyncio = "^1.0.0"
+pytest = "^9.0.3"
+pytest-asyncio = "^1.3.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/exhaustive/wire-tests-custom-client-name/poetry.lock
+++ b/seed/python-sdk/exhaustive/wire-tests-custom-client-name/poetry.lock
@@ -1206,20 +1206,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1611,4 +1611,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "7ac12b5d251e81a278fba2c051cbf4f768fb951f006f23ad0faedb1289539c1a"
+content-hash = "2bce94d2b349d050a23e91a08b482f35a7cbe67815d120d0c4cb5c8d1204a59b"

--- a/seed/python-sdk/exhaustive/wire-tests-custom-client-name/pyproject.toml
+++ b/seed/python-sdk/exhaustive/wire-tests-custom-client-name/pyproject.toml
@@ -51,8 +51,8 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
-pytest-asyncio = "^1.0.0"
+pytest = "^9.0.3"
+pytest-asyncio = "^1.3.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/extends/poetry.lock
+++ b/seed/python-sdk/extends/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "73db04dccdc2f6e569f03c5b71b81dedb41fd67af4d88c28ae7c40465edecf3a"

--- a/seed/python-sdk/extends/pyproject.toml
+++ b/seed/python-sdk/extends/pyproject.toml
@@ -51,8 +51,8 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
-pytest-asyncio = "^1.0.0"
+pytest = "^9.0.3"
+pytest-asyncio = "^1.3.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/extra-properties/poetry.lock
+++ b/seed/python-sdk/extra-properties/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "73db04dccdc2f6e569f03c5b71b81dedb41fd67af4d88c28ae7c40465edecf3a"

--- a/seed/python-sdk/extra-properties/pyproject.toml
+++ b/seed/python-sdk/extra-properties/pyproject.toml
@@ -51,8 +51,8 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
-pytest-asyncio = "^1.0.0"
+pytest = "^9.0.3"
+pytest-asyncio = "^1.3.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/file-download/default-chunk-size/poetry.lock
+++ b/seed/python-sdk/file-download/default-chunk-size/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "73db04dccdc2f6e569f03c5b71b81dedb41fd67af4d88c28ae7c40465edecf3a"

--- a/seed/python-sdk/file-download/default-chunk-size/pyproject.toml
+++ b/seed/python-sdk/file-download/default-chunk-size/pyproject.toml
@@ -51,8 +51,8 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
-pytest-asyncio = "^1.0.0"
+pytest = "^9.0.3"
+pytest-asyncio = "^1.3.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/file-download/no-custom-config/poetry.lock
+++ b/seed/python-sdk/file-download/no-custom-config/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "73db04dccdc2f6e569f03c5b71b81dedb41fd67af4d88c28ae7c40465edecf3a"

--- a/seed/python-sdk/file-download/no-custom-config/pyproject.toml
+++ b/seed/python-sdk/file-download/no-custom-config/pyproject.toml
@@ -51,8 +51,8 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
-pytest-asyncio = "^1.0.0"
+pytest = "^9.0.3"
+pytest-asyncio = "^1.3.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/file-upload-openapi/poetry.lock
+++ b/seed/python-sdk/file-upload-openapi/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "73db04dccdc2f6e569f03c5b71b81dedb41fd67af4d88c28ae7c40465edecf3a"

--- a/seed/python-sdk/file-upload-openapi/pyproject.toml
+++ b/seed/python-sdk/file-upload-openapi/pyproject.toml
@@ -51,8 +51,8 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
-pytest-asyncio = "^1.0.0"
+pytest = "^9.0.3"
+pytest-asyncio = "^1.3.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/file-upload/exclude_types_from_init_exports/poetry.lock
+++ b/seed/python-sdk/file-upload/exclude_types_from_init_exports/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "73db04dccdc2f6e569f03c5b71b81dedb41fd67af4d88c28ae7c40465edecf3a"

--- a/seed/python-sdk/file-upload/exclude_types_from_init_exports/pyproject.toml
+++ b/seed/python-sdk/file-upload/exclude_types_from_init_exports/pyproject.toml
@@ -51,8 +51,8 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
-pytest-asyncio = "^1.0.0"
+pytest = "^9.0.3"
+pytest-asyncio = "^1.3.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/file-upload/no-custom-config/poetry.lock
+++ b/seed/python-sdk/file-upload/no-custom-config/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "73db04dccdc2f6e569f03c5b71b81dedb41fd67af4d88c28ae7c40465edecf3a"

--- a/seed/python-sdk/file-upload/no-custom-config/pyproject.toml
+++ b/seed/python-sdk/file-upload/no-custom-config/pyproject.toml
@@ -51,8 +51,8 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
-pytest-asyncio = "^1.0.0"
+pytest = "^9.0.3"
+pytest-asyncio = "^1.3.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/file-upload/use_typeddict_requests/poetry.lock
+++ b/seed/python-sdk/file-upload/use_typeddict_requests/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "73db04dccdc2f6e569f03c5b71b81dedb41fd67af4d88c28ae7c40465edecf3a"

--- a/seed/python-sdk/file-upload/use_typeddict_requests/pyproject.toml
+++ b/seed/python-sdk/file-upload/use_typeddict_requests/pyproject.toml
@@ -51,8 +51,8 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
-pytest-asyncio = "^1.0.0"
+pytest = "^9.0.3"
+pytest-asyncio = "^1.3.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/folders/poetry.lock
+++ b/seed/python-sdk/folders/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "73db04dccdc2f6e569f03c5b71b81dedb41fd67af4d88c28ae7c40465edecf3a"

--- a/seed/python-sdk/folders/pyproject.toml
+++ b/seed/python-sdk/folders/pyproject.toml
@@ -51,8 +51,8 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
-pytest-asyncio = "^1.0.0"
+pytest = "^9.0.3"
+pytest-asyncio = "^1.3.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/header-auth-environment-variable/poetry.lock
+++ b/seed/python-sdk/header-auth-environment-variable/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "73db04dccdc2f6e569f03c5b71b81dedb41fd67af4d88c28ae7c40465edecf3a"

--- a/seed/python-sdk/header-auth-environment-variable/pyproject.toml
+++ b/seed/python-sdk/header-auth-environment-variable/pyproject.toml
@@ -51,8 +51,8 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
-pytest-asyncio = "^1.0.0"
+pytest = "^9.0.3"
+pytest-asyncio = "^1.3.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/header-auth/poetry.lock
+++ b/seed/python-sdk/header-auth/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "73db04dccdc2f6e569f03c5b71b81dedb41fd67af4d88c28ae7c40465edecf3a"

--- a/seed/python-sdk/header-auth/pyproject.toml
+++ b/seed/python-sdk/header-auth/pyproject.toml
@@ -51,8 +51,8 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
-pytest-asyncio = "^1.0.0"
+pytest = "^9.0.3"
+pytest-asyncio = "^1.3.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/http-head/poetry.lock
+++ b/seed/python-sdk/http-head/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "73db04dccdc2f6e569f03c5b71b81dedb41fd67af4d88c28ae7c40465edecf3a"

--- a/seed/python-sdk/http-head/pyproject.toml
+++ b/seed/python-sdk/http-head/pyproject.toml
@@ -51,8 +51,8 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
-pytest-asyncio = "^1.0.0"
+pytest = "^9.0.3"
+pytest-asyncio = "^1.3.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/idempotency-headers/poetry.lock
+++ b/seed/python-sdk/idempotency-headers/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "73db04dccdc2f6e569f03c5b71b81dedb41fd67af4d88c28ae7c40465edecf3a"

--- a/seed/python-sdk/idempotency-headers/pyproject.toml
+++ b/seed/python-sdk/idempotency-headers/pyproject.toml
@@ -51,8 +51,8 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
-pytest-asyncio = "^1.0.0"
+pytest = "^9.0.3"
+pytest-asyncio = "^1.3.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/imdb/poetry.lock
+++ b/seed/python-sdk/imdb/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "73db04dccdc2f6e569f03c5b71b81dedb41fd67af4d88c28ae7c40465edecf3a"

--- a/seed/python-sdk/imdb/pyproject.toml
+++ b/seed/python-sdk/imdb/pyproject.toml
@@ -51,8 +51,8 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
-pytest-asyncio = "^1.0.0"
+pytest = "^9.0.3"
+pytest-asyncio = "^1.3.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/inferred-auth-explicit/poetry.lock
+++ b/seed/python-sdk/inferred-auth-explicit/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "73db04dccdc2f6e569f03c5b71b81dedb41fd67af4d88c28ae7c40465edecf3a"

--- a/seed/python-sdk/inferred-auth-explicit/pyproject.toml
+++ b/seed/python-sdk/inferred-auth-explicit/pyproject.toml
@@ -51,8 +51,8 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
-pytest-asyncio = "^1.0.0"
+pytest = "^9.0.3"
+pytest-asyncio = "^1.3.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/inferred-auth-implicit-api-key/poetry.lock
+++ b/seed/python-sdk/inferred-auth-implicit-api-key/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "73db04dccdc2f6e569f03c5b71b81dedb41fd67af4d88c28ae7c40465edecf3a"

--- a/seed/python-sdk/inferred-auth-implicit-api-key/pyproject.toml
+++ b/seed/python-sdk/inferred-auth-implicit-api-key/pyproject.toml
@@ -51,8 +51,8 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
-pytest-asyncio = "^1.0.0"
+pytest = "^9.0.3"
+pytest-asyncio = "^1.3.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/inferred-auth-implicit-no-expiry/poetry.lock
+++ b/seed/python-sdk/inferred-auth-implicit-no-expiry/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "73db04dccdc2f6e569f03c5b71b81dedb41fd67af4d88c28ae7c40465edecf3a"

--- a/seed/python-sdk/inferred-auth-implicit-no-expiry/pyproject.toml
+++ b/seed/python-sdk/inferred-auth-implicit-no-expiry/pyproject.toml
@@ -51,8 +51,8 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
-pytest-asyncio = "^1.0.0"
+pytest = "^9.0.3"
+pytest-asyncio = "^1.3.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/inferred-auth-implicit-reference/poetry.lock
+++ b/seed/python-sdk/inferred-auth-implicit-reference/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "73db04dccdc2f6e569f03c5b71b81dedb41fd67af4d88c28ae7c40465edecf3a"

--- a/seed/python-sdk/inferred-auth-implicit-reference/pyproject.toml
+++ b/seed/python-sdk/inferred-auth-implicit-reference/pyproject.toml
@@ -51,8 +51,8 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
-pytest-asyncio = "^1.0.0"
+pytest = "^9.0.3"
+pytest-asyncio = "^1.3.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/inferred-auth-implicit/poetry.lock
+++ b/seed/python-sdk/inferred-auth-implicit/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "73db04dccdc2f6e569f03c5b71b81dedb41fd67af4d88c28ae7c40465edecf3a"

--- a/seed/python-sdk/inferred-auth-implicit/pyproject.toml
+++ b/seed/python-sdk/inferred-auth-implicit/pyproject.toml
@@ -51,8 +51,8 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
-pytest-asyncio = "^1.0.0"
+pytest = "^9.0.3"
+pytest-asyncio = "^1.3.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/license/poetry.lock
+++ b/seed/python-sdk/license/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "73db04dccdc2f6e569f03c5b71b81dedb41fd67af4d88c28ae7c40465edecf3a"

--- a/seed/python-sdk/license/pyproject.toml
+++ b/seed/python-sdk/license/pyproject.toml
@@ -51,8 +51,8 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
-pytest-asyncio = "^1.0.0"
+pytest = "^9.0.3"
+pytest-asyncio = "^1.3.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/literal/no-custom-config/poetry.lock
+++ b/seed/python-sdk/literal/no-custom-config/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "73db04dccdc2f6e569f03c5b71b81dedb41fd67af4d88c28ae7c40465edecf3a"

--- a/seed/python-sdk/literal/no-custom-config/pyproject.toml
+++ b/seed/python-sdk/literal/no-custom-config/pyproject.toml
@@ -51,8 +51,8 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
-pytest-asyncio = "^1.0.0"
+pytest = "^9.0.3"
+pytest-asyncio = "^1.3.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/literal/use_typeddict_requests/poetry.lock
+++ b/seed/python-sdk/literal/use_typeddict_requests/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "73db04dccdc2f6e569f03c5b71b81dedb41fd67af4d88c28ae7c40465edecf3a"

--- a/seed/python-sdk/literal/use_typeddict_requests/pyproject.toml
+++ b/seed/python-sdk/literal/use_typeddict_requests/pyproject.toml
@@ -51,8 +51,8 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
-pytest-asyncio = "^1.0.0"
+pytest = "^9.0.3"
+pytest-asyncio = "^1.3.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/literals-unions/poetry.lock
+++ b/seed/python-sdk/literals-unions/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "73db04dccdc2f6e569f03c5b71b81dedb41fd67af4d88c28ae7c40465edecf3a"

--- a/seed/python-sdk/literals-unions/pyproject.toml
+++ b/seed/python-sdk/literals-unions/pyproject.toml
@@ -51,8 +51,8 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
-pytest-asyncio = "^1.0.0"
+pytest = "^9.0.3"
+pytest-asyncio = "^1.3.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/mixed-case/poetry.lock
+++ b/seed/python-sdk/mixed-case/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "73db04dccdc2f6e569f03c5b71b81dedb41fd67af4d88c28ae7c40465edecf3a"

--- a/seed/python-sdk/mixed-case/pyproject.toml
+++ b/seed/python-sdk/mixed-case/pyproject.toml
@@ -51,8 +51,8 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
-pytest-asyncio = "^1.0.0"
+pytest = "^9.0.3"
+pytest-asyncio = "^1.3.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/mixed-file-directory/exclude_types_from_init_exports/poetry.lock
+++ b/seed/python-sdk/mixed-file-directory/exclude_types_from_init_exports/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "73db04dccdc2f6e569f03c5b71b81dedb41fd67af4d88c28ae7c40465edecf3a"

--- a/seed/python-sdk/mixed-file-directory/exclude_types_from_init_exports/pyproject.toml
+++ b/seed/python-sdk/mixed-file-directory/exclude_types_from_init_exports/pyproject.toml
@@ -51,8 +51,8 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
-pytest-asyncio = "^1.0.0"
+pytest = "^9.0.3"
+pytest-asyncio = "^1.3.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/mixed-file-directory/no-custom-config/poetry.lock
+++ b/seed/python-sdk/mixed-file-directory/no-custom-config/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "73db04dccdc2f6e569f03c5b71b81dedb41fd67af4d88c28ae7c40465edecf3a"

--- a/seed/python-sdk/mixed-file-directory/no-custom-config/pyproject.toml
+++ b/seed/python-sdk/mixed-file-directory/no-custom-config/pyproject.toml
@@ -51,8 +51,8 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
-pytest-asyncio = "^1.0.0"
+pytest = "^9.0.3"
+pytest-asyncio = "^1.3.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/multi-line-docs/poetry.lock
+++ b/seed/python-sdk/multi-line-docs/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "73db04dccdc2f6e569f03c5b71b81dedb41fd67af4d88c28ae7c40465edecf3a"

--- a/seed/python-sdk/multi-line-docs/pyproject.toml
+++ b/seed/python-sdk/multi-line-docs/pyproject.toml
@@ -51,8 +51,8 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
-pytest-asyncio = "^1.0.0"
+pytest = "^9.0.3"
+pytest-asyncio = "^1.3.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/multi-url-environment-no-default/poetry.lock
+++ b/seed/python-sdk/multi-url-environment-no-default/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "73db04dccdc2f6e569f03c5b71b81dedb41fd67af4d88c28ae7c40465edecf3a"

--- a/seed/python-sdk/multi-url-environment-no-default/pyproject.toml
+++ b/seed/python-sdk/multi-url-environment-no-default/pyproject.toml
@@ -51,8 +51,8 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
-pytest-asyncio = "^1.0.0"
+pytest = "^9.0.3"
+pytest-asyncio = "^1.3.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/multi-url-environment/poetry.lock
+++ b/seed/python-sdk/multi-url-environment/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "73db04dccdc2f6e569f03c5b71b81dedb41fd67af4d88c28ae7c40465edecf3a"

--- a/seed/python-sdk/multi-url-environment/pyproject.toml
+++ b/seed/python-sdk/multi-url-environment/pyproject.toml
@@ -51,8 +51,8 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
-pytest-asyncio = "^1.0.0"
+pytest = "^9.0.3"
+pytest-asyncio = "^1.3.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/multiple-request-bodies/poetry.lock
+++ b/seed/python-sdk/multiple-request-bodies/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "73db04dccdc2f6e569f03c5b71b81dedb41fd67af4d88c28ae7c40465edecf3a"

--- a/seed/python-sdk/multiple-request-bodies/pyproject.toml
+++ b/seed/python-sdk/multiple-request-bodies/pyproject.toml
@@ -51,8 +51,8 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
-pytest-asyncio = "^1.0.0"
+pytest = "^9.0.3"
+pytest-asyncio = "^1.3.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/no-content-response/poetry.lock
+++ b/seed/python-sdk/no-content-response/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "73db04dccdc2f6e569f03c5b71b81dedb41fd67af4d88c28ae7c40465edecf3a"

--- a/seed/python-sdk/no-content-response/pyproject.toml
+++ b/seed/python-sdk/no-content-response/pyproject.toml
@@ -51,8 +51,8 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
-pytest-asyncio = "^1.0.0"
+pytest = "^9.0.3"
+pytest-asyncio = "^1.3.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/no-environment/poetry.lock
+++ b/seed/python-sdk/no-environment/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "73db04dccdc2f6e569f03c5b71b81dedb41fd67af4d88c28ae7c40465edecf3a"

--- a/seed/python-sdk/no-environment/pyproject.toml
+++ b/seed/python-sdk/no-environment/pyproject.toml
@@ -51,8 +51,8 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
-pytest-asyncio = "^1.0.0"
+pytest = "^9.0.3"
+pytest-asyncio = "^1.3.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/no-retries/poetry.lock
+++ b/seed/python-sdk/no-retries/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "73db04dccdc2f6e569f03c5b71b81dedb41fd67af4d88c28ae7c40465edecf3a"

--- a/seed/python-sdk/no-retries/pyproject.toml
+++ b/seed/python-sdk/no-retries/pyproject.toml
@@ -51,8 +51,8 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
-pytest-asyncio = "^1.0.0"
+pytest = "^9.0.3"
+pytest-asyncio = "^1.3.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/null-type/poetry.lock
+++ b/seed/python-sdk/null-type/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "73db04dccdc2f6e569f03c5b71b81dedb41fd67af4d88c28ae7c40465edecf3a"

--- a/seed/python-sdk/null-type/pyproject.toml
+++ b/seed/python-sdk/null-type/pyproject.toml
@@ -51,8 +51,8 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
-pytest-asyncio = "^1.0.0"
+pytest = "^9.0.3"
+pytest-asyncio = "^1.3.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/nullable-allof-extends/poetry.lock
+++ b/seed/python-sdk/nullable-allof-extends/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "73db04dccdc2f6e569f03c5b71b81dedb41fd67af4d88c28ae7c40465edecf3a"

--- a/seed/python-sdk/nullable-allof-extends/pyproject.toml
+++ b/seed/python-sdk/nullable-allof-extends/pyproject.toml
@@ -51,8 +51,8 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
-pytest-asyncio = "^1.0.0"
+pytest = "^9.0.3"
+pytest-asyncio = "^1.3.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/nullable-optional/poetry.lock
+++ b/seed/python-sdk/nullable-optional/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "73db04dccdc2f6e569f03c5b71b81dedb41fd67af4d88c28ae7c40465edecf3a"

--- a/seed/python-sdk/nullable-optional/pyproject.toml
+++ b/seed/python-sdk/nullable-optional/pyproject.toml
@@ -51,8 +51,8 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
-pytest-asyncio = "^1.0.0"
+pytest = "^9.0.3"
+pytest-asyncio = "^1.3.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/nullable-request-body/poetry.lock
+++ b/seed/python-sdk/nullable-request-body/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "73db04dccdc2f6e569f03c5b71b81dedb41fd67af4d88c28ae7c40465edecf3a"

--- a/seed/python-sdk/nullable-request-body/pyproject.toml
+++ b/seed/python-sdk/nullable-request-body/pyproject.toml
@@ -51,8 +51,8 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
-pytest-asyncio = "^1.0.0"
+pytest = "^9.0.3"
+pytest-asyncio = "^1.3.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/nullable/no-custom-config/poetry.lock
+++ b/seed/python-sdk/nullable/no-custom-config/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "73db04dccdc2f6e569f03c5b71b81dedb41fd67af4d88c28ae7c40465edecf3a"

--- a/seed/python-sdk/nullable/no-custom-config/pyproject.toml
+++ b/seed/python-sdk/nullable/no-custom-config/pyproject.toml
@@ -51,8 +51,8 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
-pytest-asyncio = "^1.0.0"
+pytest = "^9.0.3"
+pytest-asyncio = "^1.3.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/nullable/use-typeddict-requests/poetry.lock
+++ b/seed/python-sdk/nullable/use-typeddict-requests/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "73db04dccdc2f6e569f03c5b71b81dedb41fd67af4d88c28ae7c40465edecf3a"

--- a/seed/python-sdk/nullable/use-typeddict-requests/pyproject.toml
+++ b/seed/python-sdk/nullable/use-typeddict-requests/pyproject.toml
@@ -51,8 +51,8 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
-pytest-asyncio = "^1.0.0"
+pytest = "^9.0.3"
+pytest-asyncio = "^1.3.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/oauth-client-credentials-custom/poetry.lock
+++ b/seed/python-sdk/oauth-client-credentials-custom/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "73db04dccdc2f6e569f03c5b71b81dedb41fd67af4d88c28ae7c40465edecf3a"

--- a/seed/python-sdk/oauth-client-credentials-custom/pyproject.toml
+++ b/seed/python-sdk/oauth-client-credentials-custom/pyproject.toml
@@ -51,8 +51,8 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
-pytest-asyncio = "^1.0.0"
+pytest = "^9.0.3"
+pytest-asyncio = "^1.3.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/oauth-client-credentials-default/poetry.lock
+++ b/seed/python-sdk/oauth-client-credentials-default/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "73db04dccdc2f6e569f03c5b71b81dedb41fd67af4d88c28ae7c40465edecf3a"

--- a/seed/python-sdk/oauth-client-credentials-default/pyproject.toml
+++ b/seed/python-sdk/oauth-client-credentials-default/pyproject.toml
@@ -51,8 +51,8 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
-pytest-asyncio = "^1.0.0"
+pytest = "^9.0.3"
+pytest-asyncio = "^1.3.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/oauth-client-credentials-environment-variables/poetry.lock
+++ b/seed/python-sdk/oauth-client-credentials-environment-variables/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "73db04dccdc2f6e569f03c5b71b81dedb41fd67af4d88c28ae7c40465edecf3a"

--- a/seed/python-sdk/oauth-client-credentials-environment-variables/pyproject.toml
+++ b/seed/python-sdk/oauth-client-credentials-environment-variables/pyproject.toml
@@ -51,8 +51,8 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
-pytest-asyncio = "^1.0.0"
+pytest = "^9.0.3"
+pytest-asyncio = "^1.3.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/oauth-client-credentials-mandatory-auth/no-custom-config/poetry.lock
+++ b/seed/python-sdk/oauth-client-credentials-mandatory-auth/no-custom-config/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "73db04dccdc2f6e569f03c5b71b81dedb41fd67af4d88c28ae7c40465edecf3a"

--- a/seed/python-sdk/oauth-client-credentials-mandatory-auth/no-custom-config/pyproject.toml
+++ b/seed/python-sdk/oauth-client-credentials-mandatory-auth/no-custom-config/pyproject.toml
@@ -51,8 +51,8 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
-pytest-asyncio = "^1.0.0"
+pytest = "^9.0.3"
+pytest-asyncio = "^1.3.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/oauth-client-credentials-nested-root/poetry.lock
+++ b/seed/python-sdk/oauth-client-credentials-nested-root/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "73db04dccdc2f6e569f03c5b71b81dedb41fd67af4d88c28ae7c40465edecf3a"

--- a/seed/python-sdk/oauth-client-credentials-nested-root/pyproject.toml
+++ b/seed/python-sdk/oauth-client-credentials-nested-root/pyproject.toml
@@ -51,8 +51,8 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
-pytest-asyncio = "^1.0.0"
+pytest = "^9.0.3"
+pytest-asyncio = "^1.3.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/oauth-client-credentials-openapi/poetry.lock
+++ b/seed/python-sdk/oauth-client-credentials-openapi/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "73db04dccdc2f6e569f03c5b71b81dedb41fd67af4d88c28ae7c40465edecf3a"

--- a/seed/python-sdk/oauth-client-credentials-openapi/pyproject.toml
+++ b/seed/python-sdk/oauth-client-credentials-openapi/pyproject.toml
@@ -51,8 +51,8 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
-pytest-asyncio = "^1.0.0"
+pytest = "^9.0.3"
+pytest-asyncio = "^1.3.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/oauth-client-credentials-reference/poetry.lock
+++ b/seed/python-sdk/oauth-client-credentials-reference/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "73db04dccdc2f6e569f03c5b71b81dedb41fd67af4d88c28ae7c40465edecf3a"

--- a/seed/python-sdk/oauth-client-credentials-reference/pyproject.toml
+++ b/seed/python-sdk/oauth-client-credentials-reference/pyproject.toml
@@ -51,8 +51,8 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
-pytest-asyncio = "^1.0.0"
+pytest = "^9.0.3"
+pytest-asyncio = "^1.3.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/oauth-client-credentials-with-variables/poetry.lock
+++ b/seed/python-sdk/oauth-client-credentials-with-variables/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "73db04dccdc2f6e569f03c5b71b81dedb41fd67af4d88c28ae7c40465edecf3a"

--- a/seed/python-sdk/oauth-client-credentials-with-variables/pyproject.toml
+++ b/seed/python-sdk/oauth-client-credentials-with-variables/pyproject.toml
@@ -51,8 +51,8 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
-pytest-asyncio = "^1.0.0"
+pytest = "^9.0.3"
+pytest-asyncio = "^1.3.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/oauth-client-credentials/poetry.lock
+++ b/seed/python-sdk/oauth-client-credentials/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "73db04dccdc2f6e569f03c5b71b81dedb41fd67af4d88c28ae7c40465edecf3a"

--- a/seed/python-sdk/oauth-client-credentials/pyproject.toml
+++ b/seed/python-sdk/oauth-client-credentials/pyproject.toml
@@ -51,8 +51,8 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
-pytest-asyncio = "^1.0.0"
+pytest = "^9.0.3"
+pytest-asyncio = "^1.3.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/object/poetry.lock
+++ b/seed/python-sdk/object/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "73db04dccdc2f6e569f03c5b71b81dedb41fd67af4d88c28ae7c40465edecf3a"

--- a/seed/python-sdk/object/pyproject.toml
+++ b/seed/python-sdk/object/pyproject.toml
@@ -51,8 +51,8 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
-pytest-asyncio = "^1.0.0"
+pytest = "^9.0.3"
+pytest-asyncio = "^1.3.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/objects-with-imports/poetry.lock
+++ b/seed/python-sdk/objects-with-imports/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "73db04dccdc2f6e569f03c5b71b81dedb41fd67af4d88c28ae7c40465edecf3a"

--- a/seed/python-sdk/objects-with-imports/pyproject.toml
+++ b/seed/python-sdk/objects-with-imports/pyproject.toml
@@ -51,8 +51,8 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
-pytest-asyncio = "^1.0.0"
+pytest = "^9.0.3"
+pytest-asyncio = "^1.3.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/optional/poetry.lock
+++ b/seed/python-sdk/optional/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "73db04dccdc2f6e569f03c5b71b81dedb41fd67af4d88c28ae7c40465edecf3a"

--- a/seed/python-sdk/optional/pyproject.toml
+++ b/seed/python-sdk/optional/pyproject.toml
@@ -51,8 +51,8 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
-pytest-asyncio = "^1.0.0"
+pytest = "^9.0.3"
+pytest-asyncio = "^1.3.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/package-yml/poetry.lock
+++ b/seed/python-sdk/package-yml/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "73db04dccdc2f6e569f03c5b71b81dedb41fd67af4d88c28ae7c40465edecf3a"

--- a/seed/python-sdk/package-yml/pyproject.toml
+++ b/seed/python-sdk/package-yml/pyproject.toml
@@ -51,8 +51,8 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
-pytest-asyncio = "^1.0.0"
+pytest = "^9.0.3"
+pytest-asyncio = "^1.3.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/pagination-custom/poetry.lock
+++ b/seed/python-sdk/pagination-custom/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "73db04dccdc2f6e569f03c5b71b81dedb41fd67af4d88c28ae7c40465edecf3a"

--- a/seed/python-sdk/pagination-custom/pyproject.toml
+++ b/seed/python-sdk/pagination-custom/pyproject.toml
@@ -51,8 +51,8 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
-pytest-asyncio = "^1.0.0"
+pytest = "^9.0.3"
+pytest-asyncio = "^1.3.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/pagination-uri-path/poetry.lock
+++ b/seed/python-sdk/pagination-uri-path/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "73db04dccdc2f6e569f03c5b71b81dedb41fd67af4d88c28ae7c40465edecf3a"

--- a/seed/python-sdk/pagination-uri-path/pyproject.toml
+++ b/seed/python-sdk/pagination-uri-path/pyproject.toml
@@ -51,8 +51,8 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
-pytest-asyncio = "^1.0.0"
+pytest = "^9.0.3"
+pytest-asyncio = "^1.3.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/pagination/no-custom-config/poetry.lock
+++ b/seed/python-sdk/pagination/no-custom-config/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "73db04dccdc2f6e569f03c5b71b81dedb41fd67af4d88c28ae7c40465edecf3a"

--- a/seed/python-sdk/pagination/no-custom-config/pyproject.toml
+++ b/seed/python-sdk/pagination/no-custom-config/pyproject.toml
@@ -51,8 +51,8 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
-pytest-asyncio = "^1.0.0"
+pytest = "^9.0.3"
+pytest-asyncio = "^1.3.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/pagination/no-inheritance-for-extended-models/poetry.lock
+++ b/seed/python-sdk/pagination/no-inheritance-for-extended-models/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "73db04dccdc2f6e569f03c5b71b81dedb41fd67af4d88c28ae7c40465edecf3a"

--- a/seed/python-sdk/pagination/no-inheritance-for-extended-models/pyproject.toml
+++ b/seed/python-sdk/pagination/no-inheritance-for-extended-models/pyproject.toml
@@ -51,8 +51,8 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
-pytest-asyncio = "^1.0.0"
+pytest = "^9.0.3"
+pytest-asyncio = "^1.3.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/pagination/page-index-semantics/poetry.lock
+++ b/seed/python-sdk/pagination/page-index-semantics/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "73db04dccdc2f6e569f03c5b71b81dedb41fd67af4d88c28ae7c40465edecf3a"

--- a/seed/python-sdk/pagination/page-index-semantics/pyproject.toml
+++ b/seed/python-sdk/pagination/page-index-semantics/pyproject.toml
@@ -51,8 +51,8 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
-pytest-asyncio = "^1.0.0"
+pytest = "^9.0.3"
+pytest-asyncio = "^1.3.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/path-parameters/poetry.lock
+++ b/seed/python-sdk/path-parameters/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "73db04dccdc2f6e569f03c5b71b81dedb41fd67af4d88c28ae7c40465edecf3a"

--- a/seed/python-sdk/path-parameters/pyproject.toml
+++ b/seed/python-sdk/path-parameters/pyproject.toml
@@ -51,8 +51,8 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
-pytest-asyncio = "^1.0.0"
+pytest = "^9.0.3"
+pytest-asyncio = "^1.3.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/plain-text/poetry.lock
+++ b/seed/python-sdk/plain-text/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "73db04dccdc2f6e569f03c5b71b81dedb41fd67af4d88c28ae7c40465edecf3a"

--- a/seed/python-sdk/plain-text/pyproject.toml
+++ b/seed/python-sdk/plain-text/pyproject.toml
@@ -51,8 +51,8 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
-pytest-asyncio = "^1.0.0"
+pytest = "^9.0.3"
+pytest-asyncio = "^1.3.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/property-access/poetry.lock
+++ b/seed/python-sdk/property-access/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "73db04dccdc2f6e569f03c5b71b81dedb41fd67af4d88c28ae7c40465edecf3a"

--- a/seed/python-sdk/property-access/pyproject.toml
+++ b/seed/python-sdk/property-access/pyproject.toml
@@ -51,8 +51,8 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
-pytest-asyncio = "^1.0.0"
+pytest = "^9.0.3"
+pytest-asyncio = "^1.3.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/public-object/poetry.lock
+++ b/seed/python-sdk/public-object/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "73db04dccdc2f6e569f03c5b71b81dedb41fd67af4d88c28ae7c40465edecf3a"

--- a/seed/python-sdk/public-object/pyproject.toml
+++ b/seed/python-sdk/public-object/pyproject.toml
@@ -51,8 +51,8 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
-pytest-asyncio = "^1.0.0"
+pytest = "^9.0.3"
+pytest-asyncio = "^1.3.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/python-backslash-escape/poetry.lock
+++ b/seed/python-sdk/python-backslash-escape/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "73db04dccdc2f6e569f03c5b71b81dedb41fd67af4d88c28ae7c40465edecf3a"

--- a/seed/python-sdk/python-backslash-escape/pyproject.toml
+++ b/seed/python-sdk/python-backslash-escape/pyproject.toml
@@ -51,8 +51,8 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
-pytest-asyncio = "^1.0.0"
+pytest = "^9.0.3"
+pytest-asyncio = "^1.3.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/python-mypy-exclude/no-custom-config/poetry.lock
+++ b/seed/python-sdk/python-mypy-exclude/no-custom-config/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "73db04dccdc2f6e569f03c5b71b81dedb41fd67af4d88c28ae7c40465edecf3a"

--- a/seed/python-sdk/python-mypy-exclude/no-custom-config/pyproject.toml
+++ b/seed/python-sdk/python-mypy-exclude/no-custom-config/pyproject.toml
@@ -51,8 +51,8 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
-pytest-asyncio = "^1.0.0"
+pytest = "^9.0.3"
+pytest-asyncio = "^1.3.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/python-mypy-exclude/with-mypy-exclude/poetry.lock
+++ b/seed/python-sdk/python-mypy-exclude/with-mypy-exclude/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "73db04dccdc2f6e569f03c5b71b81dedb41fd67af4d88c28ae7c40465edecf3a"

--- a/seed/python-sdk/python-mypy-exclude/with-mypy-exclude/pyproject.toml
+++ b/seed/python-sdk/python-mypy-exclude/with-mypy-exclude/pyproject.toml
@@ -51,8 +51,8 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
-pytest-asyncio = "^1.0.0"
+pytest = "^9.0.3"
+pytest-asyncio = "^1.3.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/python-positional-single-property/no-custom-config/poetry.lock
+++ b/seed/python-sdk/python-positional-single-property/no-custom-config/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "73db04dccdc2f6e569f03c5b71b81dedb41fd67af4d88c28ae7c40465edecf3a"

--- a/seed/python-sdk/python-positional-single-property/no-custom-config/pyproject.toml
+++ b/seed/python-sdk/python-positional-single-property/no-custom-config/pyproject.toml
@@ -51,8 +51,8 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
-pytest-asyncio = "^1.0.0"
+pytest = "^9.0.3"
+pytest-asyncio = "^1.3.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/python-positional-single-property/with-positional-constructors/poetry.lock
+++ b/seed/python-sdk/python-positional-single-property/with-positional-constructors/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "73db04dccdc2f6e569f03c5b71b81dedb41fd67af4d88c28ae7c40465edecf3a"

--- a/seed/python-sdk/python-positional-single-property/with-positional-constructors/pyproject.toml
+++ b/seed/python-sdk/python-positional-single-property/with-positional-constructors/pyproject.toml
@@ -51,8 +51,8 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
-pytest-asyncio = "^1.0.0"
+pytest = "^9.0.3"
+pytest-asyncio = "^1.3.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/python-streaming-parameter-openapi/with-wire-tests/poetry.lock
+++ b/seed/python-sdk/python-streaming-parameter-openapi/with-wire-tests/poetry.lock
@@ -1206,20 +1206,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1611,4 +1611,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "7ac12b5d251e81a278fba2c051cbf4f768fb951f006f23ad0faedb1289539c1a"
+content-hash = "2bce94d2b349d050a23e91a08b482f35a7cbe67815d120d0c4cb5c8d1204a59b"

--- a/seed/python-sdk/python-streaming-parameter-openapi/with-wire-tests/pyproject.toml
+++ b/seed/python-sdk/python-streaming-parameter-openapi/with-wire-tests/pyproject.toml
@@ -51,8 +51,8 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
-pytest-asyncio = "^1.0.0"
+pytest = "^9.0.3"
+pytest-asyncio = "^1.3.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/query-param-name-conflict/poetry.lock
+++ b/seed/python-sdk/query-param-name-conflict/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "73db04dccdc2f6e569f03c5b71b81dedb41fd67af4d88c28ae7c40465edecf3a"

--- a/seed/python-sdk/query-param-name-conflict/pyproject.toml
+++ b/seed/python-sdk/query-param-name-conflict/pyproject.toml
@@ -51,8 +51,8 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
-pytest-asyncio = "^1.0.0"
+pytest = "^9.0.3"
+pytest-asyncio = "^1.3.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/query-parameters-openapi-as-objects/no-custom-config/poetry.lock
+++ b/seed/python-sdk/query-parameters-openapi-as-objects/no-custom-config/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "73db04dccdc2f6e569f03c5b71b81dedb41fd67af4d88c28ae7c40465edecf3a"

--- a/seed/python-sdk/query-parameters-openapi-as-objects/no-custom-config/pyproject.toml
+++ b/seed/python-sdk/query-parameters-openapi-as-objects/no-custom-config/pyproject.toml
@@ -51,8 +51,8 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
-pytest-asyncio = "^1.0.0"
+pytest = "^9.0.3"
+pytest-asyncio = "^1.3.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/query-parameters-openapi/no-custom-config/poetry.lock
+++ b/seed/python-sdk/query-parameters-openapi/no-custom-config/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "73db04dccdc2f6e569f03c5b71b81dedb41fd67af4d88c28ae7c40465edecf3a"

--- a/seed/python-sdk/query-parameters-openapi/no-custom-config/pyproject.toml
+++ b/seed/python-sdk/query-parameters-openapi/no-custom-config/pyproject.toml
@@ -51,8 +51,8 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
-pytest-asyncio = "^1.0.0"
+pytest = "^9.0.3"
+pytest-asyncio = "^1.3.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/query-parameters/no-custom-config/poetry.lock
+++ b/seed/python-sdk/query-parameters/no-custom-config/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "73db04dccdc2f6e569f03c5b71b81dedb41fd67af4d88c28ae7c40465edecf3a"

--- a/seed/python-sdk/query-parameters/no-custom-config/pyproject.toml
+++ b/seed/python-sdk/query-parameters/no-custom-config/pyproject.toml
@@ -51,8 +51,8 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
-pytest-asyncio = "^1.0.0"
+pytest = "^9.0.3"
+pytest-asyncio = "^1.3.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/request-parameters/poetry.lock
+++ b/seed/python-sdk/request-parameters/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "73db04dccdc2f6e569f03c5b71b81dedb41fd67af4d88c28ae7c40465edecf3a"

--- a/seed/python-sdk/request-parameters/pyproject.toml
+++ b/seed/python-sdk/request-parameters/pyproject.toml
@@ -51,8 +51,8 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
-pytest-asyncio = "^1.0.0"
+pytest = "^9.0.3"
+pytest-asyncio = "^1.3.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/required-nullable/poetry.lock
+++ b/seed/python-sdk/required-nullable/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "73db04dccdc2f6e569f03c5b71b81dedb41fd67af4d88c28ae7c40465edecf3a"

--- a/seed/python-sdk/required-nullable/pyproject.toml
+++ b/seed/python-sdk/required-nullable/pyproject.toml
@@ -51,8 +51,8 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
-pytest-asyncio = "^1.0.0"
+pytest = "^9.0.3"
+pytest-asyncio = "^1.3.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/reserved-keywords/poetry.lock
+++ b/seed/python-sdk/reserved-keywords/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "73db04dccdc2f6e569f03c5b71b81dedb41fd67af4d88c28ae7c40465edecf3a"

--- a/seed/python-sdk/reserved-keywords/pyproject.toml
+++ b/seed/python-sdk/reserved-keywords/pyproject.toml
@@ -51,8 +51,8 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
-pytest-asyncio = "^1.0.0"
+pytest = "^9.0.3"
+pytest-asyncio = "^1.3.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/response-property/poetry.lock
+++ b/seed/python-sdk/response-property/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "73db04dccdc2f6e569f03c5b71b81dedb41fd67af4d88c28ae7c40465edecf3a"

--- a/seed/python-sdk/response-property/pyproject.toml
+++ b/seed/python-sdk/response-property/pyproject.toml
@@ -51,8 +51,8 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
-pytest-asyncio = "^1.0.0"
+pytest = "^9.0.3"
+pytest-asyncio = "^1.3.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/schemaless-request-body-examples/poetry.lock
+++ b/seed/python-sdk/schemaless-request-body-examples/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "73db04dccdc2f6e569f03c5b71b81dedb41fd67af4d88c28ae7c40465edecf3a"

--- a/seed/python-sdk/schemaless-request-body-examples/pyproject.toml
+++ b/seed/python-sdk/schemaless-request-body-examples/pyproject.toml
@@ -51,8 +51,8 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
-pytest-asyncio = "^1.0.0"
+pytest = "^9.0.3"
+pytest-asyncio = "^1.3.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/server-sent-event-examples/poetry.lock
+++ b/seed/python-sdk/server-sent-event-examples/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "73db04dccdc2f6e569f03c5b71b81dedb41fd67af4d88c28ae7c40465edecf3a"

--- a/seed/python-sdk/server-sent-event-examples/pyproject.toml
+++ b/seed/python-sdk/server-sent-event-examples/pyproject.toml
@@ -51,8 +51,8 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
-pytest-asyncio = "^1.0.0"
+pytest = "^9.0.3"
+pytest-asyncio = "^1.3.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/server-sent-events-openapi/with-wire-tests/poetry.lock
+++ b/seed/python-sdk/server-sent-events-openapi/with-wire-tests/poetry.lock
@@ -1206,20 +1206,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1611,4 +1611,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "7ac12b5d251e81a278fba2c051cbf4f768fb951f006f23ad0faedb1289539c1a"
+content-hash = "2bce94d2b349d050a23e91a08b482f35a7cbe67815d120d0c4cb5c8d1204a59b"

--- a/seed/python-sdk/server-sent-events-openapi/with-wire-tests/pyproject.toml
+++ b/seed/python-sdk/server-sent-events-openapi/with-wire-tests/pyproject.toml
@@ -51,8 +51,8 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
-pytest-asyncio = "^1.0.0"
+pytest = "^9.0.3"
+pytest-asyncio = "^1.3.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/server-sent-events/with-wire-tests/poetry.lock
+++ b/seed/python-sdk/server-sent-events/with-wire-tests/poetry.lock
@@ -1206,20 +1206,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1611,4 +1611,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "7ac12b5d251e81a278fba2c051cbf4f768fb951f006f23ad0faedb1289539c1a"
+content-hash = "2bce94d2b349d050a23e91a08b482f35a7cbe67815d120d0c4cb5c8d1204a59b"

--- a/seed/python-sdk/server-sent-events/with-wire-tests/pyproject.toml
+++ b/seed/python-sdk/server-sent-events/with-wire-tests/pyproject.toml
@@ -51,8 +51,8 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
-pytest-asyncio = "^1.0.0"
+pytest = "^9.0.3"
+pytest-asyncio = "^1.3.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/server-url-templating/no-custom-config/poetry.lock
+++ b/seed/python-sdk/server-url-templating/no-custom-config/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "73db04dccdc2f6e569f03c5b71b81dedb41fd67af4d88c28ae7c40465edecf3a"

--- a/seed/python-sdk/server-url-templating/no-custom-config/pyproject.toml
+++ b/seed/python-sdk/server-url-templating/no-custom-config/pyproject.toml
@@ -51,8 +51,8 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
-pytest-asyncio = "^1.0.0"
+pytest = "^9.0.3"
+pytest-asyncio = "^1.3.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/simple-api/poetry.lock
+++ b/seed/python-sdk/simple-api/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "73db04dccdc2f6e569f03c5b71b81dedb41fd67af4d88c28ae7c40465edecf3a"

--- a/seed/python-sdk/simple-api/pyproject.toml
+++ b/seed/python-sdk/simple-api/pyproject.toml
@@ -51,8 +51,8 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
-pytest-asyncio = "^1.0.0"
+pytest = "^9.0.3"
+pytest-asyncio = "^1.3.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/simple-fhir/no-inheritance-for-extended-models/poetry.lock
+++ b/seed/python-sdk/simple-fhir/no-inheritance-for-extended-models/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "73db04dccdc2f6e569f03c5b71b81dedb41fd67af4d88c28ae7c40465edecf3a"

--- a/seed/python-sdk/simple-fhir/no-inheritance-for-extended-models/pyproject.toml
+++ b/seed/python-sdk/simple-fhir/no-inheritance-for-extended-models/pyproject.toml
@@ -51,8 +51,8 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
-pytest-asyncio = "^1.0.0"
+pytest = "^9.0.3"
+pytest-asyncio = "^1.3.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/single-url-environment-default/poetry.lock
+++ b/seed/python-sdk/single-url-environment-default/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "73db04dccdc2f6e569f03c5b71b81dedb41fd67af4d88c28ae7c40465edecf3a"

--- a/seed/python-sdk/single-url-environment-default/pyproject.toml
+++ b/seed/python-sdk/single-url-environment-default/pyproject.toml
@@ -51,8 +51,8 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
-pytest-asyncio = "^1.0.0"
+pytest = "^9.0.3"
+pytest-asyncio = "^1.3.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/single-url-environment-no-default/poetry.lock
+++ b/seed/python-sdk/single-url-environment-no-default/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "73db04dccdc2f6e569f03c5b71b81dedb41fd67af4d88c28ae7c40465edecf3a"

--- a/seed/python-sdk/single-url-environment-no-default/pyproject.toml
+++ b/seed/python-sdk/single-url-environment-no-default/pyproject.toml
@@ -51,8 +51,8 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
-pytest-asyncio = "^1.0.0"
+pytest = "^9.0.3"
+pytest-asyncio = "^1.3.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/streaming-parameter/poetry.lock
+++ b/seed/python-sdk/streaming-parameter/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "73db04dccdc2f6e569f03c5b71b81dedb41fd67af4d88c28ae7c40465edecf3a"

--- a/seed/python-sdk/streaming-parameter/pyproject.toml
+++ b/seed/python-sdk/streaming-parameter/pyproject.toml
@@ -51,8 +51,8 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
-pytest-asyncio = "^1.0.0"
+pytest = "^9.0.3"
+pytest-asyncio = "^1.3.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/streaming/no-custom-config/poetry.lock
+++ b/seed/python-sdk/streaming/no-custom-config/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "73db04dccdc2f6e569f03c5b71b81dedb41fd67af4d88c28ae7c40465edecf3a"

--- a/seed/python-sdk/streaming/no-custom-config/pyproject.toml
+++ b/seed/python-sdk/streaming/no-custom-config/pyproject.toml
@@ -51,8 +51,8 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
-pytest-asyncio = "^1.0.0"
+pytest = "^9.0.3"
+pytest-asyncio = "^1.3.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/streaming/skip-pydantic-validation/poetry.lock
+++ b/seed/python-sdk/streaming/skip-pydantic-validation/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "73db04dccdc2f6e569f03c5b71b81dedb41fd67af4d88c28ae7c40465edecf3a"

--- a/seed/python-sdk/streaming/skip-pydantic-validation/pyproject.toml
+++ b/seed/python-sdk/streaming/skip-pydantic-validation/pyproject.toml
@@ -51,8 +51,8 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
-pytest-asyncio = "^1.0.0"
+pytest = "^9.0.3"
+pytest-asyncio = "^1.3.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/trace/poetry.lock
+++ b/seed/python-sdk/trace/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "73db04dccdc2f6e569f03c5b71b81dedb41fd67af4d88c28ae7c40465edecf3a"

--- a/seed/python-sdk/trace/pyproject.toml
+++ b/seed/python-sdk/trace/pyproject.toml
@@ -51,8 +51,8 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
-pytest-asyncio = "^1.0.0"
+pytest = "^9.0.3"
+pytest-asyncio = "^1.3.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/undiscriminated-union-with-response-property/poetry.lock
+++ b/seed/python-sdk/undiscriminated-union-with-response-property/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "73db04dccdc2f6e569f03c5b71b81dedb41fd67af4d88c28ae7c40465edecf3a"

--- a/seed/python-sdk/undiscriminated-union-with-response-property/pyproject.toml
+++ b/seed/python-sdk/undiscriminated-union-with-response-property/pyproject.toml
@@ -51,8 +51,8 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
-pytest-asyncio = "^1.0.0"
+pytest = "^9.0.3"
+pytest-asyncio = "^1.3.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/undiscriminated-unions/poetry.lock
+++ b/seed/python-sdk/undiscriminated-unions/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "73db04dccdc2f6e569f03c5b71b81dedb41fd67af4d88c28ae7c40465edecf3a"

--- a/seed/python-sdk/undiscriminated-unions/pyproject.toml
+++ b/seed/python-sdk/undiscriminated-unions/pyproject.toml
@@ -51,8 +51,8 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
-pytest-asyncio = "^1.0.0"
+pytest = "^9.0.3"
+pytest-asyncio = "^1.3.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/unions-with-local-date/poetry.lock
+++ b/seed/python-sdk/unions-with-local-date/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "73db04dccdc2f6e569f03c5b71b81dedb41fd67af4d88c28ae7c40465edecf3a"

--- a/seed/python-sdk/unions-with-local-date/pyproject.toml
+++ b/seed/python-sdk/unions-with-local-date/pyproject.toml
@@ -51,8 +51,8 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
-pytest-asyncio = "^1.0.0"
+pytest = "^9.0.3"
+pytest-asyncio = "^1.3.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/unions/no-custom-config/poetry.lock
+++ b/seed/python-sdk/unions/no-custom-config/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "73db04dccdc2f6e569f03c5b71b81dedb41fd67af4d88c28ae7c40465edecf3a"

--- a/seed/python-sdk/unions/no-custom-config/pyproject.toml
+++ b/seed/python-sdk/unions/no-custom-config/pyproject.toml
@@ -51,8 +51,8 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
-pytest-asyncio = "^1.0.0"
+pytest = "^9.0.3"
+pytest-asyncio = "^1.3.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/unions/union-naming-v1/poetry.lock
+++ b/seed/python-sdk/unions/union-naming-v1/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "73db04dccdc2f6e569f03c5b71b81dedb41fd67af4d88c28ae7c40465edecf3a"

--- a/seed/python-sdk/unions/union-naming-v1/pyproject.toml
+++ b/seed/python-sdk/unions/union-naming-v1/pyproject.toml
@@ -51,8 +51,8 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
-pytest-asyncio = "^1.0.0"
+pytest = "^9.0.3"
+pytest-asyncio = "^1.3.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/unions/union-utils/poetry.lock
+++ b/seed/python-sdk/unions/union-utils/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "73db04dccdc2f6e569f03c5b71b81dedb41fd67af4d88c28ae7c40465edecf3a"

--- a/seed/python-sdk/unions/union-utils/pyproject.toml
+++ b/seed/python-sdk/unions/union-utils/pyproject.toml
@@ -51,8 +51,8 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
-pytest-asyncio = "^1.0.0"
+pytest = "^9.0.3"
+pytest-asyncio = "^1.3.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/unknown/poetry.lock
+++ b/seed/python-sdk/unknown/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "73db04dccdc2f6e569f03c5b71b81dedb41fd67af4d88c28ae7c40465edecf3a"

--- a/seed/python-sdk/unknown/pyproject.toml
+++ b/seed/python-sdk/unknown/pyproject.toml
@@ -51,8 +51,8 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
-pytest-asyncio = "^1.0.0"
+pytest = "^9.0.3"
+pytest-asyncio = "^1.3.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/url-form-encoded/poetry.lock
+++ b/seed/python-sdk/url-form-encoded/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "73db04dccdc2f6e569f03c5b71b81dedb41fd67af4d88c28ae7c40465edecf3a"

--- a/seed/python-sdk/url-form-encoded/pyproject.toml
+++ b/seed/python-sdk/url-form-encoded/pyproject.toml
@@ -51,8 +51,8 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
-pytest-asyncio = "^1.0.0"
+pytest = "^9.0.3"
+pytest-asyncio = "^1.3.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/validation/no-custom-config/poetry.lock
+++ b/seed/python-sdk/validation/no-custom-config/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "73db04dccdc2f6e569f03c5b71b81dedb41fd67af4d88c28ae7c40465edecf3a"

--- a/seed/python-sdk/validation/no-custom-config/pyproject.toml
+++ b/seed/python-sdk/validation/no-custom-config/pyproject.toml
@@ -51,8 +51,8 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
-pytest-asyncio = "^1.0.0"
+pytest = "^9.0.3"
+pytest-asyncio = "^1.3.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/validation/with-defaults/poetry.lock
+++ b/seed/python-sdk/validation/with-defaults/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "73db04dccdc2f6e569f03c5b71b81dedb41fd67af4d88c28ae7c40465edecf3a"

--- a/seed/python-sdk/validation/with-defaults/pyproject.toml
+++ b/seed/python-sdk/validation/with-defaults/pyproject.toml
@@ -51,8 +51,8 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
-pytest-asyncio = "^1.0.0"
+pytest = "^9.0.3"
+pytest-asyncio = "^1.3.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/variables/poetry.lock
+++ b/seed/python-sdk/variables/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "73db04dccdc2f6e569f03c5b71b81dedb41fd67af4d88c28ae7c40465edecf3a"

--- a/seed/python-sdk/variables/pyproject.toml
+++ b/seed/python-sdk/variables/pyproject.toml
@@ -51,8 +51,8 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
-pytest-asyncio = "^1.0.0"
+pytest = "^9.0.3"
+pytest-asyncio = "^1.3.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/version-no-default/poetry.lock
+++ b/seed/python-sdk/version-no-default/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "73db04dccdc2f6e569f03c5b71b81dedb41fd67af4d88c28ae7c40465edecf3a"

--- a/seed/python-sdk/version-no-default/pyproject.toml
+++ b/seed/python-sdk/version-no-default/pyproject.toml
@@ -51,8 +51,8 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
-pytest-asyncio = "^1.0.0"
+pytest = "^9.0.3"
+pytest-asyncio = "^1.3.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/version/poetry.lock
+++ b/seed/python-sdk/version/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "73db04dccdc2f6e569f03c5b71b81dedb41fd67af4d88c28ae7c40465edecf3a"

--- a/seed/python-sdk/version/pyproject.toml
+++ b/seed/python-sdk/version/pyproject.toml
@@ -51,8 +51,8 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
-pytest-asyncio = "^1.0.0"
+pytest = "^9.0.3"
+pytest-asyncio = "^1.3.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/webhook-audience/poetry.lock
+++ b/seed/python-sdk/webhook-audience/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "73db04dccdc2f6e569f03c5b71b81dedb41fd67af4d88c28ae7c40465edecf3a"

--- a/seed/python-sdk/webhook-audience/pyproject.toml
+++ b/seed/python-sdk/webhook-audience/pyproject.toml
@@ -51,8 +51,8 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
-pytest-asyncio = "^1.0.0"
+pytest = "^9.0.3"
+pytest-asyncio = "^1.3.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/webhooks/poetry.lock
+++ b/seed/python-sdk/webhooks/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "73db04dccdc2f6e569f03c5b71b81dedb41fd67af4d88c28ae7c40465edecf3a"

--- a/seed/python-sdk/webhooks/pyproject.toml
+++ b/seed/python-sdk/webhooks/pyproject.toml
@@ -51,8 +51,8 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
-pytest-asyncio = "^1.0.0"
+pytest = "^9.0.3"
+pytest-asyncio = "^1.3.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/websocket-bearer-auth/poetry.lock
+++ b/seed/python-sdk/websocket-bearer-auth/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "73db04dccdc2f6e569f03c5b71b81dedb41fd67af4d88c28ae7c40465edecf3a"

--- a/seed/python-sdk/websocket-bearer-auth/pyproject.toml
+++ b/seed/python-sdk/websocket-bearer-auth/pyproject.toml
@@ -51,8 +51,8 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
-pytest-asyncio = "^1.0.0"
+pytest = "^9.0.3"
+pytest-asyncio = "^1.3.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/websocket-inferred-auth/poetry.lock
+++ b/seed/python-sdk/websocket-inferred-auth/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "73db04dccdc2f6e569f03c5b71b81dedb41fd67af4d88c28ae7c40465edecf3a"

--- a/seed/python-sdk/websocket-inferred-auth/pyproject.toml
+++ b/seed/python-sdk/websocket-inferred-auth/pyproject.toml
@@ -51,8 +51,8 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
-pytest-asyncio = "^1.0.0"
+pytest = "^9.0.3"
+pytest-asyncio = "^1.3.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/websocket-multi-url/poetry.lock
+++ b/seed/python-sdk/websocket-multi-url/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "73db04dccdc2f6e569f03c5b71b81dedb41fd67af4d88c28ae7c40465edecf3a"

--- a/seed/python-sdk/websocket-multi-url/pyproject.toml
+++ b/seed/python-sdk/websocket-multi-url/pyproject.toml
@@ -51,8 +51,8 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
-pytest-asyncio = "^1.0.0"
+pytest = "^9.0.3"
+pytest-asyncio = "^1.3.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/websocket/websocket-base/poetry.lock
+++ b/seed/python-sdk/websocket/websocket-base/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "73db04dccdc2f6e569f03c5b71b81dedb41fd67af4d88c28ae7c40465edecf3a"

--- a/seed/python-sdk/websocket/websocket-base/pyproject.toml
+++ b/seed/python-sdk/websocket/websocket-base/pyproject.toml
@@ -51,8 +51,8 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
-pytest-asyncio = "^1.0.0"
+pytest = "^9.0.3"
+pytest-asyncio = "^1.3.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/websocket/websocket-with_generated_clients-skip_validation/poetry.lock
+++ b/seed/python-sdk/websocket/websocket-with_generated_clients-skip_validation/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1491,4 +1491,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "9815ecd03f1237ca99fb206d32d23b5885ad0150e8339bb54d3faff4f804b4f7"
+content-hash = "3d46f595401befcd8c599fd94adbdc5608c565d9700a26d739b329ea01f7355c"

--- a/seed/python-sdk/websocket/websocket-with_generated_clients-skip_validation/pyproject.toml
+++ b/seed/python-sdk/websocket/websocket-with_generated_clients-skip_validation/pyproject.toml
@@ -52,8 +52,8 @@ websockets = ">=12.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
-pytest-asyncio = "^1.0.0"
+pytest = "^9.0.3"
+pytest-asyncio = "^1.3.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/websocket/websocket-with_generated_clients/poetry.lock
+++ b/seed/python-sdk/websocket/websocket-with_generated_clients/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1491,4 +1491,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "9815ecd03f1237ca99fb206d32d23b5885ad0150e8339bb54d3faff4f804b4f7"
+content-hash = "3d46f595401befcd8c599fd94adbdc5608c565d9700a26d739b329ea01f7355c"

--- a/seed/python-sdk/websocket/websocket-with_generated_clients/pyproject.toml
+++ b/seed/python-sdk/websocket/websocket-with_generated_clients/pyproject.toml
@@ -52,8 +52,8 @@ websockets = ">=12.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
-pytest-asyncio = "^1.0.0"
+pytest = "^9.0.3"
+pytest-asyncio = "^1.3.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"

--- a/seed/python-sdk/x-fern-default/poetry.lock
+++ b/seed/python-sdk/x-fern-default/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "73db04dccdc2f6e569f03c5b71b81dedb41fd67af4d88c28ae7c40465edecf3a"

--- a/seed/python-sdk/x-fern-default/pyproject.toml
+++ b/seed/python-sdk/x-fern-default/pyproject.toml
@@ -51,8 +51,8 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
-pytest-asyncio = "^1.0.0"
+pytest = "^9.0.3"
+pytest-asyncio = "^1.3.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"
 types-python-dateutil = "^2.9.0.20240316"


### PR DESCRIPTION
## Description

Refs CVE-2025-71176 — pytest < 9.0.3 creates insecure temporary directories under `/tmp/pytest-of-{user}` that are world-readable, allowing local attackers to access test artifacts (CVSS 6.8, Moderate).

This updates the Python SDK **generator** so all newly generated SDKs emit the patched pytest version.

## Changes Made

- **`generators/python/src/fern_python/codegen/pyproject_toml.py`** — Bump generated dev dependencies:
  - `pytest`: `^7.4.0` / `^8.2.0` → `^9.0.3`
  - `pytest-asyncio`: `^0.23.5` / `^1.0.0` → `^1.3.0`
  - For projects with `min_python < 3.10`: all three test deps (`pytest`, `pytest-asyncio`, `pytest-xdist`) are gated behind a `python = ">=3.10"` version marker, since pytest 9.x dropped support for Python < 3.10.
- **`generators/python/src/fern_python/version/ci_python_version.py`** — Default CI Python version raised from `3.9` → `3.10` (dev dependencies now require it).
- **`generators/python/sdk/changes/unreleased/fix-pytest-cve-2025-71176.yml`** — Changelog entry.
- **`seed/python-sdk/...`** — All 173 seed fixtures regenerated (349 files: `pyproject.toml` + `poetry.lock` updates).

## ⚠️ Key review points

1. **Projects targeting Python < 3.10 will have no test dependencies on those interpreters.** pytest, pytest-asyncio, and pytest-xdist are all gated behind `python = ">=3.10"`. This means `poetry install` on Python 3.8/3.9 won't install test tooling. This is a trade-off to keep the generated SDK installable on older Pythons while still fixing the CVE. Confirm this is acceptable.
2. **Default CI Python bumped 3.9 → 3.10.** Any newly generated SDK that doesn't explicitly configure a Python version will now run CI on 3.10 instead of 3.9. Existing SDKs are unaffected until re-generated.
3. **Seed diff is mechanical but large** (349 files). All 173 seed test cases pass. Spot-check a standard fixture (`accept-header/pyproject.toml`) and a min-version fixture (`exhaustive/deps_with_min_python_version/pyproject.toml`) for the two code paths.

## Testing

- [x] `pnpm seed:local test --generator python-sdk` — 173/173 passed
- [x] Pre-commit hooks pass (ruff, ruff-format, trailing whitespace, etc.)
- [ ] Unit tests added/updated — no new unit tests (generator logic change is covered by seed snapshot tests)

Link to Devin session: https://app.devin.ai/sessions/3aa818521890471b8add3851a21600b9
Requested by: @davidkonigsberg