### PR TITLE
feat(openapi): switch to output OAS 3.1.0, release v0.5.0

### DIFF
--- a/generators/openapi/CHANGELOG.md
+++ b/generators/openapi/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
-## [1.0.0] - 2026-04-14
+## [0.5.0] - 2026-04-14
 
 - Break: The generator now emits OpenAPI 3.1.0 specifications (previously 3.0.1).
   - Nullability: `nullable: true` is no longer emitted. Optional/nullable primitives

--- a/generators/openapi/CHANGELOG.md
+++ b/generators/openapi/CHANGELOG.md
@@ -7,6 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## [1.0.0] - 2026-04-14
+
+- Break: The generator now emits OpenAPI 3.1.0 specifications (previously 3.0.1).
+  - Nullability: `nullable: true` is no longer emitted. Optional/nullable primitives
+    now emit `type: [T, "null"]`, and nullable references emit
+    `anyOf: [{$ref: ...}, {type: "null"}]`. This fixes the silent no-op where
+    `$ref` + sibling `nullable` previously had no effect.
+  - Examples: Parameters no longer emit both `example` and `examples` on the same
+    object (they are mutually exclusive in OAS 3.0 and 3.1). `examples` is
+    preferred when present.
+  - `info.version` now defaults to a non-empty string (`"0.0.0"`) rather than the
+    empty string, which is invalid per the OAS spec.
+  - `exclusiveMinimum`/`exclusiveMaximum` now emit as numbers (JSON Schema 2020-12)
+    instead of the OAS 3.0 boolean format.
+  - Single-element enums and union discriminant properties now use `const` instead of
+    `enum: [singleValue]`.
+  - Redundant `additionalProperties: true` removed (defaults to true in 3.1).
+  - Schema property examples use the 3.1 `examples` array instead of the deprecated
+    singular `example` keyword.
+  - Response descriptions now have meaningful defaults instead of empty strings.
+
 ## [0.0.31] - 2024-03-22
 
 - Fix: Update open api generator to v2 urls.

--- a/generators/openapi/README.md
+++ b/generators/openapi/README.md
@@ -22,7 +22,7 @@ This repository contains the source for the [Fern](https://www.buildwithfern.com
 
 - `fernapi/fern-openapi`
 
-The generator is written in TypeScript and produces an OpenAPI `3.0.0` specification. If you have a need for Fern to generate a more recent specification version, let us know in [this issue](https://github.com/fern-api/fern-openapi/issues/65).
+The generator is written in TypeScript and produces an OpenAPI `3.1.0` specification. If you have a need for Fern to generate a more recent specification version, let us know in [this issue](https://github.com/fern-api/fern-openapi/issues/65).
 
 Fern handles transforming a Fern specification into Fern _intermediate representation_. IR is a normalized, Fern-specific definition of an API containing its endpoints, models, errors, authentication scheme, version, and more. Then the OpenAPI generator takes over and turns the IR into a production-ready OpenAPI specification.
 

--- a/generators/openapi/src/__test__/nullability.test.ts
+++ b/generators/openapi/src/__test__/nullability.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+
+import { makeNullable } from "../converters/typeConverter.js";
+
+describe("makeNullable", () => {
+    it("wraps a $ref in anyOf with a null-typed branch", () => {
+        expect(makeNullable({ $ref: "#/components/schemas/Foo" })).toEqual({
+            anyOf: [{ $ref: "#/components/schemas/Foo" }, { type: "null" }]
+        });
+    });
+
+    it("converts a single-string type into a [type, 'null'] array", () => {
+        expect(makeNullable({ type: "string" })).toEqual({ type: ["string", "null"] });
+    });
+
+    it("preserves other schema fields when making a primitive nullable", () => {
+        expect(makeNullable({ type: "string", format: "uuid", description: "An id" })).toEqual({
+            type: ["string", "null"],
+            format: "uuid",
+            description: "An id"
+        });
+    });
+
+    it("appends 'null' to an existing type array when not already present", () => {
+        // The `type` array case isn't representable in OpenAPIV3's TS types, so we build the
+        // input loosely and trust `makeNullable`'s runtime handling.
+        const input = { type: ["string", "integer"] } as unknown as Parameters<typeof makeNullable>[0];
+        expect(makeNullable(input)).toEqual({ type: ["string", "integer", "null"] });
+    });
+
+    it("is a no-op when 'null' is already in the type array", () => {
+        const input = { type: ["string", "null"] } as unknown as Parameters<typeof makeNullable>[0];
+        expect(makeNullable(input)).toEqual({ type: ["string", "null"] });
+    });
+
+    it("leaves an empty schema untouched (unconstrained schema already admits null)", () => {
+        expect(makeNullable({})).toEqual({});
+    });
+});

--- a/generators/openapi/src/convertToOpenApi.ts
+++ b/generators/openapi/src/convertToOpenApi.ts
@@ -1,6 +1,6 @@
 import { CaseConverter, getOriginalName } from "@fern-api/base-generator";
 import { FernIr } from "@fern-fern/ir-sdk";
-import { OpenAPIV3 } from "openapi-types";
+import { OpenAPIV3, OpenAPIV3_1 } from "openapi-types";
 
 import { convertServices } from "./converters/servicesConverter.js";
 import { convertType } from "./converters/typeConverter.js";
@@ -16,7 +16,7 @@ export function convertToOpenApi({
     apiName: string;
     ir: FernIr.IntermediateRepresentation;
     mode: Mode;
-}): OpenAPIV3.Document | undefined {
+}): OpenAPIV3_1.Document | undefined {
     const caseConverter = new CaseConverter({
         generationLanguage: undefined,
         keywords: undefined,
@@ -64,14 +64,21 @@ export function convertToOpenApi({
 
     const info: OpenAPIV3.InfoObject = {
         title: ir.apiDisplayName ?? apiName,
-        version: ""
+        // OAS requires info.version to be a non-empty string. Fern IR's `apiVersion` is a
+        // header-based versioning scheme, not a document version, so fall back to "0.0.0".
+        // Users can override via `customOverrides` in their generator config.
+        version: "0.0.0"
     };
     if (ir.apiDocs != null) {
         info.description = ir.apiDocs;
     }
 
+    // We assemble the document using OAS 3.0 TypeScript shapes (from openapi-types) because
+    // v12 of that package has structurally-broken 3.1 types. At runtime we emit valid OAS
+    // 3.1 JSON (schemas include `type: [..., "null"]` and `const`; `nullable` is absent),
+    // and we narrow the public return type to `OpenAPIV3_1.Document` at the boundary.
     const openAPISpec: OpenAPIV3.Document = {
-        openapi: "3.0.1",
+        openapi: "3.1.0",
         info,
         paths,
         components: {
@@ -92,7 +99,7 @@ export function convertToOpenApi({
         });
     }
 
-    return openAPISpec;
+    return openAPISpec as unknown as OpenAPIV3_1.Document;
 }
 
 export function getDeclaredTypeNameKey(declaredTypeName: FernIr.DeclaredTypeName): string {

--- a/generators/openapi/src/converters/convertObject.ts
+++ b/generators/openapi/src/converters/convertObject.ts
@@ -27,22 +27,24 @@ export function convertObject({
     properties.forEach((objectProperty) => {
         const convertedObjectProperty = convertTypeReference(objectProperty.valueType);
 
-        let example: unknown = undefined;
+        // OAS 3.1 (JSON Schema 2020-12) deprecates the singular `example` keyword on schemas
+        // in favour of `examples` (an array of example values).
+        let examples: unknown[] | undefined = undefined;
         if (objectProperty.example != null && objectProperty.valueType.type === "primitive") {
-            example = objectProperty.example.value.jsonExample;
+            examples = [objectProperty.example.value.jsonExample];
         } else if (
             objectProperty.example != null &&
             objectProperty.valueType.type === "container" &&
             objectProperty.valueType.container.type === "list" &&
             objectProperty.valueType.container.list.type === "primitive"
         ) {
-            example = objectProperty.example.value.jsonExample;
+            examples = [objectProperty.example.value.jsonExample];
         }
 
         const propertySchema: Record<string, unknown> = {
             ...convertedObjectProperty,
             description: objectProperty.docs ?? undefined,
-            example
+            examples
         };
 
         if (objectProperty.availability != null) {

--- a/generators/openapi/src/converters/servicesConverter.ts
+++ b/generators/openapi/src/converters/servicesConverter.ts
@@ -391,14 +391,14 @@ function convertResponse({
         }
 
         responseByStatusCode[String(httpResponse.statusCode ?? 200)] = {
-            description: httpResponse.body.value.docs ?? "",
+            description: httpResponse.body.value.docs || "Success",
             content: {
                 "application/json": convertedResponse
             }
         };
     } else {
         responseByStatusCode["204"] = {
-            description: ""
+            description: "No content"
         };
     }
 
@@ -412,7 +412,7 @@ function convertResponse({
                     );
                 }
                 const responseForStatusCode: OpenAPIV3.ResponseObject = {
-                    description: responseError.docs ?? ""
+                    description: responseError.docs || getOriginalName(responseError.error.name)
                 };
                 if (errorDeclaration.type != null) {
                     const convertedResponse: OpenAPIV3.MediaTypeObject = {
@@ -492,7 +492,7 @@ function convertResponse({
                 }
 
                 responseByStatusCode[statusCode] = {
-                    description: "",
+                    description: errorInfos.map((e) => getOriginalName(e.responseError.error.name)).join(", "),
                     content: {
                         "application/json": convertedResponse
                     }
@@ -608,32 +608,13 @@ function convertPathParameter({
         schema: convertTypeReference(pathParameter.valueType)
     };
 
-    const openapiExamples: OpenAPIV3.ParameterObject["examples"] = {};
-    for (const example of examples) {
-        const pathParameterExample = [
+    applyParameterExamples(convertedParameter, examples, (example) => {
+        return [
             ...example.rootPathParameters,
             ...example.servicePathParameters,
             ...example.endpointPathParameters
         ].find((param) => getOriginalName(param.name) === getOriginalName(pathParameter.name));
-        if (pathParameterExample != null) {
-            if (example.name && getOriginalName(example.name) !== "") {
-                openapiExamples[getOriginalName(example.name)] = {
-                    value: pathParameterExample.value.jsonExample
-                };
-            } else {
-                openapiExamples[`Example${size(openapiExamples) + 1}`] = {
-                    value: pathParameterExample.value.jsonExample
-                };
-            }
-
-            if (convertedParameter.example == null) {
-                convertedParameter.example = pathParameterExample.value.jsonExample;
-            }
-        }
-    }
-    if (size(openapiExamples) > 0) {
-        convertedParameter.examples = openapiExamples;
-    }
+    });
 
     return convertedParameter;
 }
@@ -664,30 +645,9 @@ function convertQueryParameter({
         }
     }
 
-    const openapiExamples: OpenAPIV3.ParameterObject["examples"] = {};
-    for (const example of examples) {
-        const queryParameterExample = example.queryParameters.find(
-            (param) => getWireValue(param.name) === getWireValue(queryParameter.name)
-        );
-        if (queryParameterExample != null) {
-            if (example.name && getOriginalName(example.name) !== "") {
-                openapiExamples[getOriginalName(example.name)] = {
-                    value: queryParameterExample.value.jsonExample
-                };
-            } else {
-                openapiExamples[`Example${size(openapiExamples) + 1}`] = {
-                    value: queryParameterExample.value.jsonExample
-                };
-            }
-
-            if (convertedParameter.example == null) {
-                convertedParameter.example = queryParameterExample.value.jsonExample;
-            }
-        }
-    }
-    if (size(openapiExamples) > 0) {
-        convertedParameter.examples = openapiExamples;
-    }
+    applyParameterExamples(convertedParameter, examples, (example) => {
+        return example.queryParameters.find((param) => getWireValue(param.name) === getWireValue(queryParameter.name));
+    });
 
     return convertedParameter;
 }
@@ -716,30 +676,11 @@ function convertHeader({
         }
     }
 
-    const openapiExamples: OpenAPIV3.ParameterObject["examples"] = {};
-    for (const example of examples) {
-        const headerExample = [...example.serviceHeaders, ...example.endpointHeaders].find(
+    applyParameterExamples(convertedParameter, examples, (example) => {
+        return [...example.serviceHeaders, ...example.endpointHeaders].find(
             (headerFromExample) => getWireValue(headerFromExample.name) === getWireValue(httpHeader.name)
         );
-        if (headerExample != null) {
-            if (example.name && getOriginalName(example.name) !== "") {
-                openapiExamples[getOriginalName(example.name)] = {
-                    value: headerExample.value.jsonExample
-                };
-            } else {
-                openapiExamples[`Example${size(openapiExamples) + 1}`] = {
-                    value: headerExample.value.jsonExample
-                };
-            }
-
-            if (convertedParameter.example == null) {
-                convertedParameter.example = headerExample.value.jsonExample;
-            }
-        }
-    }
-    if (size(openapiExamples) > 0) {
-        convertedParameter.examples = openapiExamples;
-    }
+    });
 
     return convertedParameter;
 }
@@ -750,6 +691,37 @@ function convertHttpPathToString(httpPath: FernIr.HttpPath): string {
         endpointPath += `{${httpPathPart.pathParameter}}${httpPathPart.tail}`;
     }
     return endpointPath;
+}
+
+/**
+ * Collects examples for a parameter and sets either `example` or `examples` (never both)
+ * on the parameter object. OAS 3.0/3.1 require these to be mutually exclusive.
+ */
+function applyParameterExamples(
+    parameter: OpenAPIV3.ParameterObject,
+    examples: FernIr.ExampleEndpointCall[],
+    selector: (example: FernIr.ExampleEndpointCall) => { value: { jsonExample: unknown } } | undefined
+): void {
+    const openapiExamples: OpenAPIV3.ParameterObject["examples"] = {};
+    let firstJsonExample: unknown = undefined;
+    for (const example of examples) {
+        const match = selector(example);
+        if (match != null) {
+            const key =
+                example.name && getOriginalName(example.name) !== ""
+                    ? getOriginalName(example.name)
+                    : `Example${size(openapiExamples) + 1}`;
+            openapiExamples[key] = { value: match.value.jsonExample };
+            if (firstJsonExample === undefined) {
+                firstJsonExample = match.value.jsonExample;
+            }
+        }
+    }
+    if (size(openapiExamples) > 0) {
+        parameter.examples = openapiExamples;
+    } else if (firstJsonExample !== undefined) {
+        parameter.example = firstJsonExample;
+    }
 }
 
 function isTypeReferenceRequired({

--- a/generators/openapi/src/converters/typeConverter.ts
+++ b/generators/openapi/src/converters/typeConverter.ts
@@ -115,11 +115,13 @@ export function convertEnum({
     enumTypeDeclaration: FernIr.EnumTypeDeclaration;
     docs: string | undefined;
 }): OpenAPIV3.SchemaObject {
+    const values = enumTypeDeclaration.values.map((enumValue) => getWireValue(enumValue.name));
+    if (values.length === 1) {
+        return { type: "string", const: values[0], description: docs } as unknown as OpenAPIV3.SchemaObject;
+    }
     return {
         type: "string",
-        enum: enumTypeDeclaration.values.map((enumValue) => {
-            return getWireValue(enumValue.name);
-        }),
+        enum: values,
         description: docs
     };
 }
@@ -135,8 +137,8 @@ export function convertUnion({
         const discriminantProperty: OpenAPIV3.BaseSchemaObject["properties"] = {
             [getWireValue(unionTypeDeclaration.discriminant)]: {
                 type: "string",
-                enum: [getWireValue(singleUnionType.discriminantValue)]
-            }
+                const: getWireValue(singleUnionType.discriminantValue)
+            } as unknown as OpenAPIV3.SchemaObject
         };
         return FernIr.SingleUnionTypeProperties._visit<OpenAPIV3.SchemaObject>(singleUnionType.shape, {
             noProperties: () => ({
@@ -422,21 +424,64 @@ function applyNumericValidation(
     if (rules == null) {
         return;
     }
+    // OAS 3.1 (JSON Schema 2020-12): `exclusiveMinimum`/`exclusiveMaximum` are numbers
+    // (the bound itself), not booleans. When the IR says "exclusive", we promote the value
+    // to `exclusiveMinimum`/`exclusiveMaximum` and omit `minimum`/`maximum`.
     if (rules.min != null) {
-        schema.minimum = rules.min;
+        if (rules.exclusiveMin === true) {
+            (schema as Record<string, unknown>).exclusiveMinimum = rules.min;
+        } else {
+            schema.minimum = rules.min;
+        }
     }
     if (rules.max != null) {
-        schema.maximum = rules.max;
-    }
-    if (rules.exclusiveMin === true) {
-        schema.exclusiveMinimum = rules.exclusiveMin;
-    }
-    if (rules.exclusiveMax === true) {
-        schema.exclusiveMaximum = rules.exclusiveMax;
+        if (rules.exclusiveMax === true) {
+            (schema as Record<string, unknown>).exclusiveMaximum = rules.max;
+        } else {
+            schema.maximum = rules.max;
+        }
     }
     if (rules.multipleOf != null) {
         schema.multipleOf = rules.multipleOf;
     }
+}
+
+/**
+ * Wraps an OpenAPI schema so that `null` is a permitted value, using OpenAPI 3.1 / JSON
+ * Schema 2020-12 conventions. OpenAPI 3.1 removed the `nullable` keyword; null is now
+ * expressed either by including `"null"` in the `type` array or, for `$ref`s, by wrapping
+ * the reference in `anyOf`/`oneOf` alongside `{ "type": "null" }`.
+ *
+ * Cases:
+ *   - schema uses `$ref` → `{ anyOf: [schema, { type: "null" }] }`
+ *   - schema.type is a string → merge `"null"` into a `type` array
+ *   - schema.type is already an array → add `"null"` if missing
+ *   - schema has neither `type` nor `$ref` (e.g., IR `unknown`) → leave untouched;
+ *     a constraint-free schema already admits null.
+ */
+export function makeNullable(schema: OpenApiComponentSchema): OpenApiComponentSchema {
+    if (schemaIsReference(schema)) {
+        // OpenAPI 3.1: `$ref` alone cannot also be null, so wrap in `anyOf` with a null-typed branch.
+        return { anyOf: [schema, { type: "null" }] } as unknown as OpenApiComponentSchema;
+    }
+    // `OpenAPIV3.SchemaObject` in openapi-types v12 types `type` as a single string, but OAS 3.1
+    // allows `type` to be an array including "null". We read it at runtime regardless of the static type.
+    const existingType = (schema as { type?: string | string[] }).type;
+    if (existingType == null) {
+        // Unknown / unconstrained schemas already accept null in JSON Schema 2020-12.
+        return schema;
+    }
+    if (Array.isArray(existingType)) {
+        if (existingType.includes("null")) {
+            return schema;
+        }
+        return { ...schema, type: [...existingType, "null"] } as unknown as OpenApiComponentSchema;
+    }
+    return { ...schema, type: [existingType, "null"] } as unknown as OpenApiComponentSchema;
+}
+
+function schemaIsReference(schema: OpenApiComponentSchema): schema is OpenAPIV3.ReferenceObject {
+    return typeof (schema as OpenAPIV3.ReferenceObject).$ref === "string";
 }
 
 function convertContainerType(containerType: FernIr.ContainerType): OpenApiComponentSchema {
@@ -459,9 +504,10 @@ function convertContainerType(containerType: FernIr.ContainerType): OpenApiCompo
                 mapType.keyType.primitive.v1 === "STRING" &&
                 mapType.valueType.type === "unknown"
             ) {
+                // In OAS 3.1 (JSON Schema 2020-12) additionalProperties defaults to true,
+                // so an unconstrained map is simply `type: "object"`.
                 return {
-                    type: "object",
-                    additionalProperties: true
+                    type: "object"
                 };
             }
             return {
@@ -470,10 +516,7 @@ function convertContainerType(containerType: FernIr.ContainerType): OpenApiCompo
             };
         },
         optional: (optionalType) => {
-            return {
-                ...convertTypeReference(optionalType),
-                nullable: true
-            };
+            return makeNullable(convertTypeReference(optionalType));
         },
         literal: (literalType) => {
             return literalType._visit({
@@ -493,10 +536,7 @@ function convertContainerType(containerType: FernIr.ContainerType): OpenApiCompo
             });
         },
         nullable: (nullableType) => {
-            return {
-                ...convertTypeReference(nullableType),
-                nullable: true
-            };
+            return makeNullable(convertTypeReference(nullableType));
         },
         _other: () => {
             throw new Error("Encountered unknown containerType: " + containerType.type);

--- a/generators/openapi/versions.yml
+++ b/generators/openapi/versions.yml
@@ -1,4 +1,28 @@
 # yaml-language-server: $schema=../../fern-versions-yml.schema.json
+- version: 1.0.0
+  changelogEntry:
+    - summary: |
+        The generator now emits OpenAPI 3.1.0 specifications (previously 3.0.1). As part of this:
+          - `nullable: true` is no longer emitted. Optional/nullable types now use the OAS 3.1
+            idiom: `type: [T, "null"]` for primitives, and `anyOf: [$ref, {type: "null"}]` for
+            references. This fixes the silent no-op where `$ref` + sibling `nullable` did nothing.
+          - Parameters no longer emit both `example` and `examples` (they are mutually exclusive
+            in OAS 3.0 and 3.1). `examples` is preferred when present.
+          - `info.version` is populated with a non-empty default (`"0.0.0"`) instead of an empty
+            string, which violated the spec.
+          - `exclusiveMinimum`/`exclusiveMaximum` now emit as numbers (JSON Schema 2020-12)
+            instead of the 3.0-era boolean format.
+          - Single-element enums and union discriminant properties now use `const` instead of
+            `enum: [singleValue]`.
+          - Redundant `additionalProperties: true` is no longer emitted (defaults to true in 3.1).
+          - Schema property examples use the 3.1 `examples` array instead of the deprecated
+            singular `example` keyword.
+          - Response descriptions now have meaningful defaults instead of empty strings.
+        This is a breaking change for consumers relying on OAS 3.0 tooling.
+      type: feat
+  createdAt: "2026-04-13"
+  irVersion: 66
+
 - version: 0.4.0-rc.0
   changelogEntry:
     - summary: |

--- a/generators/openapi/versions.yml
+++ b/generators/openapi/versions.yml
@@ -1,5 +1,5 @@
 # yaml-language-server: $schema=../../fern-versions-yml.schema.json
-- version: 1.0.0
+- version: 0.5.0
   changelogEntry:
     - summary: |
         The generator now emits OpenAPI 3.1.0 specifications (previously 3.0.1). As part of this:

--- a/seed/openapi/accept-header/openapi.yml
+++ b/seed/openapi/accept-header/openapi.yml
@@ -1,7 +1,7 @@
-openapi: 3.0.1
+openapi: 3.1.0
 info:
   title: accept
-  version: ''
+  version: 0.0.0
 paths:
   /container/:
     delete:
@@ -11,9 +11,9 @@ paths:
       parameters: []
       responses:
         '204':
-          description: ''
+          description: No content
         '404':
-          description: ''
+          description: NotFoundError
           content:
             application/json:
               schema: {}

--- a/seed/openapi/alias-extends/openapi.yml
+++ b/seed/openapi/alias-extends/openapi.yml
@@ -1,7 +1,7 @@
-openapi: 3.0.1
+openapi: 3.1.0
 info:
   title: alias-extends
-  version: ''
+  version: 0.0.0
   description: A Test Definition for extending an alias
 paths:
   /extends/extended-inline-request-body:
@@ -12,7 +12,7 @@ paths:
       parameters: []
       responses:
         '204':
-          description: ''
+          description: No content
       requestBody:
         required: true
         content:
@@ -37,7 +37,8 @@ components:
       properties:
         parent:
           type: string
-          example: Property from the parent
+          examples:
+            - Property from the parent
       required:
         - parent
     Child:
@@ -46,7 +47,8 @@ components:
       properties:
         child:
           type: string
-          example: Property from the child
+          examples:
+            - Property from the child
       required:
         - child
       allOf:

--- a/seed/openapi/alias/openapi.yml
+++ b/seed/openapi/alias/openapi.yml
@@ -1,7 +1,7 @@
-openapi: 3.0.1
+openapi: 3.1.0
 info:
   title: alias
-  version: ''
+  version: 0.0.0
 paths:
   /{typeId}:
     get:
@@ -16,7 +16,7 @@ paths:
             $ref: '#/components/schemas/TypeId'
       responses:
         '204':
-          description: ''
+          description: No content
 components:
   schemas:
     TypeId:
@@ -32,7 +32,8 @@ components:
           $ref: '#/components/schemas/TypeId'
         name:
           type: string
-          example: foo
+          examples:
+            - foo
       required:
         - id
         - name

--- a/seed/openapi/any-auth/openapi.yml
+++ b/seed/openapi/any-auth/openapi.yml
@@ -1,7 +1,7 @@
-openapi: 3.0.1
+openapi: 3.1.0
 info:
   title: any-auth
-  version: ''
+  version: 0.0.0
 paths:
   /token:
     post:
@@ -11,7 +11,7 @@ paths:
       parameters: []
       responses:
         '200':
-          description: ''
+          description: Success
           content:
             application/json:
               schema:
@@ -46,7 +46,7 @@ paths:
       parameters: []
       responses:
         '200':
-          description: ''
+          description: Success
           content:
             application/json:
               schema:
@@ -67,7 +67,7 @@ paths:
       parameters: []
       responses:
         '200':
-          description: ''
+          description: Success
           content:
             application/json:
               schema:
@@ -92,8 +92,9 @@ components:
         expires_in:
           type: integer
         refresh_token:
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
       required:
         - access_token
         - expires_in

--- a/seed/openapi/api-wide-base-path/openapi.yml
+++ b/seed/openapi/api-wide-base-path/openapi.yml
@@ -1,7 +1,7 @@
-openapi: 3.0.1
+openapi: 3.1.0
 info:
   title: api-wide-base-path
-  version: ''
+  version: 0.0.0
 paths:
   /test/{pathParam}/{serviceParam}/{endpointParam}/{resourceParam}:
     post:
@@ -31,7 +31,7 @@ paths:
             type: string
       responses:
         '204':
-          description: ''
+          description: No content
 components:
   schemas: {}
   securitySchemes: {}

--- a/seed/openapi/audiences/openapi.yml
+++ b/seed/openapi/audiences/openapi.yml
@@ -1,7 +1,7 @@
-openapi: 3.0.1
+openapi: 3.1.0
 info:
   title: Audiences API
-  version: ''
+  version: 0.0.0
 paths:
   /:
     get:
@@ -25,7 +25,7 @@ paths:
               type: string
       responses:
         '200':
-          description: ''
+          description: Success
           content:
             application/json:
               schema:
@@ -42,7 +42,7 @@ paths:
             $ref: '#/components/schemas/OptionalString'
       responses:
         '200':
-          description: ''
+          description: Success
           content:
             application/json:
               schema:
@@ -55,11 +55,13 @@ paths:
               type: object
               properties:
                 publicProperty:
-                  type: string
-                  nullable: true
+                  type:
+                    - string
+                    - 'null'
                 privateProperty:
-                  type: integer
-                  nullable: true
+                  type:
+                    - integer
+                    - 'null'
   /partner-path:
     get:
       operationId: folderD_service_getDirectThread
@@ -68,7 +70,7 @@ paths:
       parameters: []
       responses:
         '200':
-          description: ''
+          description: Success
           content:
             application/json:
               schema:
@@ -83,15 +85,17 @@ components:
       type: object
       properties:
         foo:
-          $ref: '#/components/schemas/folder-bFoo'
-          nullable: true
+          anyOf:
+            - $ref: '#/components/schemas/folder-bFoo'
+            - type: 'null'
     folder-bFoo:
       title: folder-bFoo
       type: object
       properties:
         foo:
-          $ref: '#/components/schemas/folder-cFolderCFoo'
-          nullable: true
+          anyOf:
+            - $ref: '#/components/schemas/folder-cFolderCFoo'
+            - type: 'null'
     folder-cFolderCFoo:
       title: folder-cFolderCFoo
       type: object
@@ -119,15 +123,17 @@ components:
         - imported
     OptionalString:
       title: OptionalString
-      type: string
-      nullable: true
+      type:
+        - string
+        - 'null'
     FilteredType:
       title: FilteredType
       type: object
       properties:
         public_property:
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
         private_property:
           type: integer
       required:

--- a/seed/openapi/basic-auth-environment-variables/openapi.yml
+++ b/seed/openapi/basic-auth-environment-variables/openapi.yml
@@ -1,7 +1,7 @@
-openapi: 3.0.1
+openapi: 3.1.0
 info:
   title: basic-auth-environment-variables
-  version: ''
+  version: 0.0.0
 paths:
   /basic-auth:
     get:
@@ -12,13 +12,13 @@ paths:
       parameters: []
       responses:
         '200':
-          description: ''
+          description: Success
           content:
             application/json:
               schema:
                 type: boolean
         '401':
-          description: ''
+          description: UnauthorizedRequest
           content:
             application/json:
               schema:
@@ -33,15 +33,15 @@ paths:
       parameters: []
       responses:
         '200':
-          description: ''
+          description: Success
           content:
             application/json:
               schema:
                 type: boolean
         '400':
-          description: ''
+          description: BadRequest
         '401':
-          description: ''
+          description: UnauthorizedRequest
           content:
             application/json:
               schema:

--- a/seed/openapi/basic-auth-pw-omitted/openapi.yml
+++ b/seed/openapi/basic-auth-pw-omitted/openapi.yml
@@ -1,7 +1,7 @@
-openapi: 3.0.1
+openapi: 3.1.0
 info:
   title: basic-auth-pw-omitted
-  version: ''
+  version: 0.0.0
 paths:
   /basic-auth:
     get:
@@ -12,7 +12,7 @@ paths:
       parameters: []
       responses:
         '200':
-          description: ''
+          description: Success
           content:
             application/json:
               schema:
@@ -21,7 +21,7 @@ paths:
                 Example1:
                   value: true
         '401':
-          description: ''
+          description: UnauthorizedRequest
           content:
             application/json:
               schema:
@@ -36,7 +36,7 @@ paths:
       parameters: []
       responses:
         '200':
-          description: ''
+          description: Success
           content:
             application/json:
               schema:
@@ -45,9 +45,9 @@ paths:
                 Example1:
                   value: true
         '400':
-          description: ''
+          description: BadRequest
         '401':
-          description: ''
+          description: UnauthorizedRequest
           content:
             application/json:
               schema:

--- a/seed/openapi/basic-auth/openapi.yml
+++ b/seed/openapi/basic-auth/openapi.yml
@@ -1,7 +1,7 @@
-openapi: 3.0.1
+openapi: 3.1.0
 info:
   title: basic-auth
-  version: ''
+  version: 0.0.0
 paths:
   /basic-auth:
     get:
@@ -12,7 +12,7 @@ paths:
       parameters: []
       responses:
         '200':
-          description: ''
+          description: Success
           content:
             application/json:
               schema:
@@ -21,7 +21,7 @@ paths:
                 Example1:
                   value: true
         '401':
-          description: ''
+          description: UnauthorizedRequest
           content:
             application/json:
               schema:
@@ -36,7 +36,7 @@ paths:
       parameters: []
       responses:
         '200':
-          description: ''
+          description: Success
           content:
             application/json:
               schema:
@@ -45,9 +45,9 @@ paths:
                 Example1:
                   value: true
         '400':
-          description: ''
+          description: BadRequest
         '401':
-          description: ''
+          description: UnauthorizedRequest
           content:
             application/json:
               schema:

--- a/seed/openapi/bearer-token-environment-variable/openapi.yml
+++ b/seed/openapi/bearer-token-environment-variable/openapi.yml
@@ -1,7 +1,7 @@
-openapi: 3.0.1
+openapi: 3.1.0
 info:
   title: bearer-token-environment-variable
-  version: ''
+  version: 0.0.0
 paths:
   /apiKey:
     get:
@@ -12,7 +12,7 @@ paths:
       parameters: []
       responses:
         '200':
-          description: ''
+          description: Success
           content:
             application/json:
               schema:

--- a/seed/openapi/bytes-download/openapi.yml
+++ b/seed/openapi/bytes-download/openapi.yml
@@ -1,7 +1,7 @@
-openapi: 3.0.1
+openapi: 3.1.0
 info:
   title: bytes-download
-  version: ''
+  version: 0.0.0
 paths:
   /snippet:
     post:
@@ -11,7 +11,7 @@ paths:
       parameters: []
       responses:
         '204':
-          description: ''
+          description: No content
   /download-content/{id}:
     get:
       operationId: service_download
@@ -25,7 +25,7 @@ paths:
             type: string
       responses:
         '204':
-          description: ''
+          description: No content
 components:
   schemas: {}
   securitySchemes: {}

--- a/seed/openapi/circular-references-advanced/openapi.yml
+++ b/seed/openapi/circular-references-advanced/openapi.yml
@@ -1,7 +1,7 @@
-openapi: 3.0.1
+openapi: 3.1.0
 info:
   title: api
-  version: ''
+  version: 0.0.0
 paths: {}
 components:
   schemas:
@@ -10,8 +10,9 @@ components:
       type: object
       properties:
         a:
-          $ref: '#/components/schemas/A'
-          nullable: true
+          anyOf:
+            - $ref: '#/components/schemas/A'
+            - type: 'null'
     RootType:
       title: RootType
       type: object
@@ -112,8 +113,7 @@ components:
           properties:
             type:
               type: string
-              enum:
-                - list
+              const: list
             value:
               type: array
               items:
@@ -124,11 +124,11 @@ components:
           properties:
             type:
               type: string
-              enum:
-                - optional
+              const: optional
             value:
-              $ref: '#/components/schemas/FieldValue'
-              nullable: true
+              anyOf:
+                - $ref: '#/components/schemas/FieldValue'
+                - type: 'null'
           required:
             - type
     PrimitiveValue:
@@ -151,8 +151,7 @@ components:
           properties:
             type:
               type: string
-              enum:
-                - primitive_value
+              const: primitive_value
             value:
               $ref: '#/components/schemas/PrimitiveValue'
           required:
@@ -163,8 +162,7 @@ components:
               properties:
                 type:
                   type: string
-                  enum:
-                    - object_value
+                  const: object_value
             - $ref: '#/components/schemas/ObjectValue'
           required:
             - type
@@ -172,8 +170,7 @@ components:
           properties:
             type:
               type: string
-              enum:
-                - container_value
+              const: container_value
             value:
               $ref: '#/components/schemas/ContainerValue'
           required:

--- a/seed/openapi/circular-references-extends/openapi.yml
+++ b/seed/openapi/circular-references-extends/openapi.yml
@@ -1,7 +1,7 @@
-openapi: 3.0.1
+openapi: 3.1.0
 info:
   title: api
-  version: ''
+  version: 0.0.0
 paths: {}
 components:
   schemas:
@@ -10,8 +10,9 @@ components:
       type: object
       properties:
         child_ref:
-          $ref: '#/components/schemas/ChildType'
-          nullable: true
+          anyOf:
+            - $ref: '#/components/schemas/ChildType'
+            - type: 'null'
     ChildType:
       title: ChildType
       type: object

--- a/seed/openapi/circular-references/openapi.yml
+++ b/seed/openapi/circular-references/openapi.yml
@@ -1,7 +1,7 @@
-openapi: 3.0.1
+openapi: 3.1.0
 info:
   title: api
-  version: ''
+  version: 0.0.0
 paths: {}
 components:
   schemas:
@@ -10,8 +10,9 @@ components:
       type: object
       properties:
         a:
-          $ref: '#/components/schemas/A'
-          nullable: true
+          anyOf:
+            - $ref: '#/components/schemas/A'
+            - type: 'null'
     RootType:
       title: RootType
       type: object
@@ -54,8 +55,7 @@ components:
           properties:
             type:
               type: string
-              enum:
-                - primitive_value
+              const: primitive_value
             value:
               $ref: '#/components/schemas/PrimitiveValue'
           required:
@@ -66,8 +66,7 @@ components:
               properties:
                 type:
                   type: string
-                  enum:
-                    - object_value
+                  const: object_value
             - $ref: '#/components/schemas/ObjectValue'
           required:
             - type
@@ -75,8 +74,7 @@ components:
           properties:
             type:
               type: string
-              enum:
-                - container_value
+              const: container_value
             value:
               $ref: '#/components/schemas/ContainerValue'
           required:
@@ -88,8 +86,7 @@ components:
           properties:
             type:
               type: string
-              enum:
-                - list
+              const: list
             value:
               type: array
               items:
@@ -100,11 +97,11 @@ components:
           properties:
             type:
               type: string
-              enum:
-                - optional
+              const: optional
             value:
-              $ref: '#/components/schemas/FieldValue'
-              nullable: true
+              anyOf:
+                - $ref: '#/components/schemas/FieldValue'
+                - type: 'null'
           required:
             - type
     PrimitiveValue:
@@ -134,16 +131,21 @@ components:
       oneOf:
         - type: array
           items:
-            $ref: '#/components/schemas/JsonLikeWithNullAndUndefined'
-            nullable: true
+            anyOf:
+              - $ref: '#/components/schemas/JsonLikeWithNullAndUndefined'
+              - type: 'null'
         - type: object
           additionalProperties:
-            $ref: '#/components/schemas/JsonLikeWithNullAndUndefined'
-            nullable: true
-        - type: string
-          nullable: true
-        - type: integer
-          nullable: true
-        - type: boolean
-          nullable: true
+            anyOf:
+              - $ref: '#/components/schemas/JsonLikeWithNullAndUndefined'
+              - type: 'null'
+        - type:
+            - string
+            - 'null'
+        - type:
+            - integer
+            - 'null'
+        - type:
+            - boolean
+            - 'null'
   securitySchemes: {}

--- a/seed/openapi/client-side-params/openapi.yml
+++ b/seed/openapi/client-side-params/openapi.yml
@@ -1,7 +1,7 @@
-openapi: 3.0.1
+openapi: 3.1.0
 info:
   title: client-side-params
-  version: ''
+  version: 0.0.0
 paths:
   /api/resources:
     get:
@@ -45,18 +45,20 @@ paths:
           description: Comma-separated list of fields to include
           required: false
           schema:
-            type: string
-            nullable: true
+            type:
+              - string
+              - 'null'
         - name: search
           in: query
           description: Search query
           required: false
           schema:
-            type: string
-            nullable: true
+            type:
+              - string
+              - 'null'
       responses:
         '200':
-          description: ''
+          description: Success
           content:
             application/json:
               schema:
@@ -89,7 +91,7 @@ paths:
             type: string
       responses:
         '200':
-          description: ''
+          description: Success
           content:
             application/json:
               schema:
@@ -115,7 +117,7 @@ paths:
             type: integer
       responses:
         '200':
-          description: ''
+          description: Success
           content:
             application/json:
               schema:
@@ -128,13 +130,14 @@ paths:
               type: object
               properties:
                 query:
-                  type: string
-                  nullable: true
+                  type:
+                    - string
+                    - 'null'
                   description: Search query text
                 filters:
-                  type: object
-                  additionalProperties: true
-                  nullable: true
+                  type:
+                    - object
+                    - 'null'
   /api/users:
     get:
       description: List or search for users
@@ -147,15 +150,17 @@ paths:
           description: Page index of the results to return. First page is 0.
           required: false
           schema:
-            type: integer
-            nullable: true
+            type:
+              - integer
+              - 'null'
         - name: per_page
           in: query
           description: Number of results per page.
           required: false
           schema:
-            type: integer
-            nullable: true
+            type:
+              - integer
+              - 'null'
         - name: include_totals
           in: query
           description: >-
@@ -163,8 +168,9 @@ paths:
             (true) or as a direct array of results (false, default).
           required: false
           schema:
-            type: boolean
-            nullable: true
+            type:
+              - boolean
+              - 'null'
         - name: sort
           in: query
           description: >-
@@ -172,36 +178,41 @@ paths:
             -1 for descending.
           required: false
           schema:
-            type: string
-            nullable: true
+            type:
+              - string
+              - 'null'
         - name: connection
           in: query
           description: Connection filter
           required: false
           schema:
-            type: string
-            nullable: true
+            type:
+              - string
+              - 'null'
         - name: q
           in: query
           description: Query string following Lucene query string syntax
           required: false
           schema:
-            type: string
-            nullable: true
+            type:
+              - string
+              - 'null'
         - name: search_engine
           in: query
           description: Search engine version (v1, v2, or v3)
           required: false
           schema:
-            type: string
-            nullable: true
+            type:
+              - string
+              - 'null'
         - name: fields
           in: query
           description: Comma-separated list of fields to include or exclude
           required: false
           schema:
-            type: string
-            nullable: true
+            type:
+              - string
+              - 'null'
       responses:
         '200':
           description: >-
@@ -219,7 +230,7 @@ paths:
       parameters: []
       responses:
         '200':
-          description: ''
+          description: Success
           content:
             application/json:
               schema:
@@ -247,18 +258,20 @@ paths:
           description: Comma-separated list of fields to include or exclude
           required: false
           schema:
-            type: string
-            nullable: true
+            type:
+              - string
+              - 'null'
         - name: include_fields
           in: query
           description: true to include the fields specified, false to exclude them
           required: false
           schema:
-            type: boolean
-            nullable: true
+            type:
+              - boolean
+              - 'null'
       responses:
         '200':
-          description: ''
+          description: Success
           content:
             application/json:
               schema:
@@ -276,7 +289,7 @@ paths:
             type: string
       responses:
         '200':
-          description: ''
+          description: Success
           content:
             application/json:
               schema:
@@ -300,7 +313,7 @@ paths:
             type: string
       responses:
         '204':
-          description: ''
+          description: No content
   /api/connections:
     get:
       description: List all connections
@@ -313,25 +326,28 @@ paths:
           description: Filter by strategy type (e.g., auth0, google-oauth2, samlp)
           required: false
           schema:
-            type: string
-            nullable: true
+            type:
+              - string
+              - 'null'
         - name: name
           in: query
           description: Filter by connection name
           required: false
           schema:
-            type: string
-            nullable: true
+            type:
+              - string
+              - 'null'
         - name: fields
           in: query
           description: Comma-separated list of fields to include
           required: false
           schema:
-            type: string
-            nullable: true
+            type:
+              - string
+              - 'null'
       responses:
         '200':
-          description: ''
+          description: Success
           content:
             application/json:
               schema:
@@ -355,11 +371,12 @@ paths:
           description: Comma-separated list of fields to include
           required: false
           schema:
-            type: string
-            nullable: true
+            type:
+              - string
+              - 'null'
       responses:
         '200':
-          description: ''
+          description: Success
           content:
             application/json:
               schema:
@@ -376,50 +393,57 @@ paths:
           description: Comma-separated list of fields to include
           required: false
           schema:
-            type: string
-            nullable: true
+            type:
+              - string
+              - 'null'
         - name: include_fields
           in: query
           description: Whether specified fields are included or excluded
           required: false
           schema:
-            type: boolean
-            nullable: true
+            type:
+              - boolean
+              - 'null'
         - name: page
           in: query
           description: Page number (zero-based)
           required: false
           schema:
-            type: integer
-            nullable: true
+            type:
+              - integer
+              - 'null'
         - name: per_page
           in: query
           description: Number of results per page
           required: false
           schema:
-            type: integer
-            nullable: true
+            type:
+              - integer
+              - 'null'
         - name: include_totals
           in: query
           description: Include total count in response
           required: false
           schema:
-            type: boolean
-            nullable: true
+            type:
+              - boolean
+              - 'null'
         - name: is_global
           in: query
           description: Filter by global clients
           required: false
           schema:
-            type: boolean
-            nullable: true
+            type:
+              - boolean
+              - 'null'
         - name: is_first_party
           in: query
           description: Filter by first party clients
           required: false
           schema:
-            type: boolean
-            nullable: true
+            type:
+              - boolean
+              - 'null'
         - name: app_type
           in: query
           description: >-
@@ -427,13 +451,14 @@ paths:
             non_interactive)
           required: false
           schema:
-            type: array
+            type:
+              - array
+              - 'null'
             items:
               type: string
-            nullable: true
       responses:
         '200':
-          description: ''
+          description: Success
           content:
             application/json:
               schema:
@@ -455,18 +480,20 @@ paths:
           description: Comma-separated list of fields to include
           required: false
           schema:
-            type: string
-            nullable: true
+            type:
+              - string
+              - 'null'
         - name: include_fields
           in: query
           description: Whether specified fields are included or excluded
           required: false
           schema:
-            type: boolean
-            nullable: true
+            type:
+              - boolean
+              - 'null'
       responses:
         '200':
-          description: ''
+          description: Success
           content:
             application/json:
               schema:
@@ -482,8 +509,9 @@ components:
         name:
           type: string
         description:
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
         created_at:
           type: string
           format: date-time
@@ -491,9 +519,9 @@ components:
           type: string
           format: date-time
         metadata:
-          type: object
-          additionalProperties: true
-          nullable: true
+          type:
+            - object
+            - 'null'
       required:
         - id
         - name
@@ -508,11 +536,13 @@ components:
           items:
             $ref: '#/components/schemas/Resource'
         total:
-          type: integer
-          nullable: true
+          type:
+            - integer
+            - 'null'
         next_offset:
-          type: integer
-          nullable: true
+          type:
+            - integer
+            - 'null'
       required:
         - results
     User:
@@ -527,14 +557,17 @@ components:
         email_verified:
           type: boolean
         username:
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
         phone_number:
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
         phone_verified:
-          type: boolean
-          nullable: true
+          type:
+            - boolean
+            - 'null'
         created_at:
           type: string
           format: date-time
@@ -542,51 +575,62 @@ components:
           type: string
           format: date-time
         identities:
-          type: array
+          type:
+            - array
+            - 'null'
           items:
             $ref: '#/components/schemas/Identity'
-          nullable: true
         app_metadata:
-          type: object
-          additionalProperties: true
-          nullable: true
+          type:
+            - object
+            - 'null'
         user_metadata:
-          type: object
-          additionalProperties: true
-          nullable: true
+          type:
+            - object
+            - 'null'
         picture:
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
         name:
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
         nickname:
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
         multifactor:
-          type: array
+          type:
+            - array
+            - 'null'
           items:
             type: string
-          nullable: true
         last_ip:
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
         last_login:
-          type: string
+          type:
+            - string
+            - 'null'
           format: date-time
-          nullable: true
         logins_count:
-          type: integer
-          nullable: true
+          type:
+            - integer
+            - 'null'
         blocked:
-          type: boolean
-          nullable: true
+          type:
+            - boolean
+            - 'null'
         given_name:
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
         family_name:
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
       required:
         - user_id
         - email
@@ -606,11 +650,13 @@ components:
         is_social:
           type: boolean
         access_token:
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
         expires_in:
-          type: integer
-          nullable: true
+          type:
+            - integer
+            - 'null'
       required:
         - connection
         - user_id
@@ -632,8 +678,9 @@ components:
         length:
           type: integer
         total:
-          type: integer
-          nullable: true
+          type:
+            - integer
+            - 'null'
       required:
         - users
         - start
@@ -646,28 +693,33 @@ components:
         email:
           type: string
         email_verified:
-          type: boolean
-          nullable: true
+          type:
+            - boolean
+            - 'null'
         username:
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
         password:
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
         phone_number:
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
         phone_verified:
-          type: boolean
-          nullable: true
+          type:
+            - boolean
+            - 'null'
         user_metadata:
-          type: object
-          additionalProperties: true
-          nullable: true
+          type:
+            - object
+            - 'null'
         app_metadata:
-          type: object
-          additionalProperties: true
-          nullable: true
+          type:
+            - object
+            - 'null'
         connection:
           type: string
       required:
@@ -678,34 +730,41 @@ components:
       type: object
       properties:
         email:
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
         email_verified:
-          type: boolean
-          nullable: true
+          type:
+            - boolean
+            - 'null'
         username:
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
         phone_number:
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
         phone_verified:
-          type: boolean
-          nullable: true
+          type:
+            - boolean
+            - 'null'
         user_metadata:
-          type: object
-          additionalProperties: true
-          nullable: true
+          type:
+            - object
+            - 'null'
         app_metadata:
-          type: object
-          additionalProperties: true
-          nullable: true
+          type:
+            - object
+            - 'null'
         password:
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
         blocked:
-          type: boolean
-          nullable: true
+          type:
+            - boolean
+            - 'null'
     Connection:
       title: Connection
       type: object
@@ -718,8 +777,9 @@ components:
           type: string
           description: Connection name
         display_name:
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
           description: Display name for the connection
         strategy:
           type: string
@@ -727,30 +787,33 @@ components:
             The identity provider identifier (auth0, google-oauth2, facebook,
             etc.)
         options:
-          type: object
-          additionalProperties: true
-          nullable: true
+          type:
+            - object
+            - 'null'
           description: Connection-specific configuration options
         enabled_clients:
-          type: array
+          type:
+            - array
+            - 'null'
           items:
             type: string
-          nullable: true
           description: List of client IDs that can use this connection
         realms:
-          type: array
+          type:
+            - array
+            - 'null'
           items:
             type: string
-          nullable: true
           description: Applicable realms for enterprise connections
         is_domain_connection:
-          type: boolean
-          nullable: true
+          type:
+            - boolean
+            - 'null'
           description: Whether this is a domain connection
         metadata:
-          type: object
-          additionalProperties: true
-          nullable: true
+          type:
+            - object
+            - 'null'
           description: Additional metadata
       required:
         - id
@@ -765,135 +828,157 @@ components:
           type: string
           description: The unique client identifier
         tenant:
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
           description: The tenant name
         name:
           type: string
           description: Name of the client
         description:
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
           description: Free text description of the client
         global:
-          type: boolean
-          nullable: true
+          type:
+            - boolean
+            - 'null'
           description: Whether this is a global client
         client_secret:
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
           description: The client secret (only for non-public clients)
         app_type:
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
           description: The type of application (spa, native, regular_web, non_interactive)
         logo_uri:
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
           description: URL of the client logo
         is_first_party:
-          type: boolean
-          nullable: true
+          type:
+            - boolean
+            - 'null'
           description: Whether this client is a first party client
         oidc_conformant:
-          type: boolean
-          nullable: true
+          type:
+            - boolean
+            - 'null'
           description: Whether this client conforms to OIDC specifications
         callbacks:
-          type: array
+          type:
+            - array
+            - 'null'
           items:
             type: string
-          nullable: true
           description: Allowed callback URLs
         allowed_origins:
-          type: array
+          type:
+            - array
+            - 'null'
           items:
             type: string
-          nullable: true
           description: Allowed origins for CORS
         web_origins:
-          type: array
+          type:
+            - array
+            - 'null'
           items:
             type: string
-          nullable: true
           description: Allowed web origins for CORS
         grant_types:
-          type: array
+          type:
+            - array
+            - 'null'
           items:
             type: string
-          nullable: true
           description: Allowed grant types
         jwt_configuration:
-          type: object
-          additionalProperties: true
-          nullable: true
+          type:
+            - object
+            - 'null'
           description: JWT configuration for the client
         signing_keys:
-          type: array
+          type:
+            - array
+            - 'null'
           items:
             type: object
-            additionalProperties: true
-          nullable: true
           description: Client signing keys
         encryption_key:
-          type: object
-          additionalProperties: true
-          nullable: true
+          type:
+            - object
+            - 'null'
           description: Encryption key
         sso:
-          type: boolean
-          nullable: true
+          type:
+            - boolean
+            - 'null'
           description: Whether SSO is enabled
         sso_disabled:
-          type: boolean
-          nullable: true
+          type:
+            - boolean
+            - 'null'
           description: Whether SSO is disabled
         cross_origin_auth:
-          type: boolean
-          nullable: true
+          type:
+            - boolean
+            - 'null'
           description: Whether to use cross-origin authentication
         cross_origin_loc:
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
           description: URL for cross-origin authentication
         custom_login_page_on:
-          type: boolean
-          nullable: true
+          type:
+            - boolean
+            - 'null'
           description: Whether a custom login page is enabled
         custom_login_page:
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
           description: Custom login page URL
         custom_login_page_preview:
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
           description: Custom login page preview URL
         form_template:
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
           description: Form template for WS-Federation
         is_heroku_app:
-          type: boolean
-          nullable: true
+          type:
+            - boolean
+            - 'null'
           description: Whether this is a Heroku application
         addons:
-          type: object
-          additionalProperties: true
-          nullable: true
+          type:
+            - object
+            - 'null'
           description: Addons enabled for this client
         token_endpoint_auth_method:
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
           description: Requested authentication method for the token endpoint
         client_metadata:
-          type: object
-          additionalProperties: true
-          nullable: true
+          type:
+            - object
+            - 'null'
           description: Metadata associated with the client
         mobile:
-          type: object
-          additionalProperties: true
-          nullable: true
+          type:
+            - object
+            - 'null'
           description: Mobile app settings
       required:
         - client_id
@@ -913,8 +998,9 @@ components:
           type: integer
           description: Number of items returned
         total:
-          type: integer
-          nullable: true
+          type:
+            - integer
+            - 'null'
           description: Total number of items (when include_totals=true)
         clients:
           type: array

--- a/seed/openapi/content-type/openapi.yml
+++ b/seed/openapi/content-type/openapi.yml
@@ -1,7 +1,7 @@
-openapi: 3.0.1
+openapi: 3.1.0
 info:
   title: content-types
-  version: ''
+  version: 0.0.0
 paths:
   /:
     patch:
@@ -11,7 +11,7 @@ paths:
       parameters: []
       responses:
         '204':
-          description: ''
+          description: No content
       requestBody:
         required: true
         content:
@@ -20,11 +20,13 @@ paths:
               type: object
               properties:
                 application:
-                  type: string
-                  nullable: true
+                  type:
+                    - string
+                    - 'null'
                 require_auth:
-                  type: boolean
-                  nullable: true
+                  type:
+                    - boolean
+                    - 'null'
               required:
                 - application
                 - require_auth
@@ -46,7 +48,7 @@ paths:
             type: string
       responses:
         '204':
-          description: ''
+          description: No content
       requestBody:
         required: true
         content:
@@ -55,39 +57,47 @@ paths:
               type: object
               properties:
                 name:
-                  type: string
-                  nullable: true
+                  type:
+                    - string
+                    - 'null'
                 age:
-                  type: integer
-                  nullable: true
+                  type:
+                    - integer
+                    - 'null'
                 active:
-                  type: boolean
-                  nullable: true
+                  type:
+                    - boolean
+                    - 'null'
                 metadata:
-                  type: object
-                  additionalProperties: true
-                  nullable: true
+                  type:
+                    - object
+                    - 'null'
                 tags:
-                  type: array
+                  type:
+                    - array
+                    - 'null'
                   items:
                     type: string
-                  nullable: true
                 email:
-                  type: string
-                  nullable: true
+                  type:
+                    - string
+                    - 'null'
                 nickname:
-                  type: string
-                  nullable: true
+                  type:
+                    - string
+                    - 'null'
                 bio:
-                  type: string
-                  nullable: true
+                  type:
+                    - string
+                    - 'null'
                 profileImageUrl:
-                  type: string
-                  nullable: true
+                  type:
+                    - string
+                    - 'null'
                 settings:
-                  type: object
-                  additionalProperties: true
-                  nullable: true
+                  type:
+                    - object
+                    - 'null'
   /named-mixed/{id}:
     patch:
       description: >-
@@ -107,7 +117,7 @@ paths:
             type: string
       responses:
         '204':
-          description: ''
+          description: No content
       requestBody:
         required: true
         content:
@@ -116,14 +126,17 @@ paths:
               type: object
               properties:
                 appId:
-                  type: string
-                  nullable: true
+                  type:
+                    - string
+                    - 'null'
                 instructions:
-                  type: string
-                  nullable: true
+                  type:
+                    - string
+                    - 'null'
                 active:
-                  type: boolean
-                  nullable: true
+                  type:
+                    - boolean
+                    - 'null'
               required:
                 - instructions
                 - active
@@ -144,7 +157,7 @@ paths:
       parameters: []
       responses:
         '204':
-          description: ''
+          description: No content
       requestBody:
         required: true
         content:
@@ -155,17 +168,21 @@ paths:
                 requiredField:
                   type: string
                 optionalString:
-                  type: string
-                  nullable: true
+                  type:
+                    - string
+                    - 'null'
                 optionalInteger:
-                  type: integer
-                  nullable: true
+                  type:
+                    - integer
+                    - 'null'
                 optionalBoolean:
-                  type: boolean
-                  nullable: true
+                  type:
+                    - boolean
+                    - 'null'
                 nullableString:
-                  type: string
-                  nullable: true
+                  type:
+                    - string
+                    - 'null'
               required:
                 - requiredField
                 - nullableString
@@ -183,7 +200,7 @@ paths:
             type: string
       responses:
         '204':
-          description: ''
+          description: No content
       requestBody:
         required: true
         content:
@@ -192,11 +209,13 @@ paths:
               type: object
               properties:
                 field1:
-                  type: string
-                  nullable: true
+                  type:
+                    - string
+                    - 'null'
                 field2:
-                  type: integer
-                  nullable: true
+                  type:
+                    - integer
+                    - 'null'
 components:
   schemas: {}
   securitySchemes: {}

--- a/seed/openapi/dollar-string-examples/openapi.yml
+++ b/seed/openapi/dollar-string-examples/openapi.yml
@@ -1,7 +1,7 @@
-openapi: 3.0.1
+openapi: 3.1.0
 info:
   title: dollar-string-examples
-  version: ''
+  version: 0.0.0
 paths: {}
 components:
   schemas:
@@ -14,8 +14,9 @@ components:
         currency:
           type: string
         description:
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
       required:
         - amount
         - currency

--- a/seed/openapi/empty-clients/openapi.yml
+++ b/seed/openapi/empty-clients/openapi.yml
@@ -1,7 +1,7 @@
-openapi: 3.0.1
+openapi: 3.1.0
 info:
   title: empty-clients
-  version: ''
+  version: 0.0.0
 paths: {}
 components:
   schemas:
@@ -23,8 +23,9 @@ components:
         line1:
           type: string
         line2:
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
         city:
           type: string
         state:
@@ -58,8 +59,9 @@ components:
         line1:
           type: string
         line2:
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
         city:
           type: string
         state:

--- a/seed/openapi/enum/custom-overrides/openapi.yml
+++ b/seed/openapi/enum/custom-overrides/openapi.yml
@@ -1,7 +1,7 @@
-openapi: 3.0.1
+openapi: 3.1.0
 info:
   title: enum
-  version: ''
+  version: 0.0.0
 paths:
   /headers:
     post:
@@ -18,8 +18,9 @@ paths:
           in: header
           required: false
           schema:
-            $ref: '#/components/schemas/Operand'
-            nullable: true
+            anyOf:
+              - $ref: '#/components/schemas/Operand'
+              - type: 'null'
         - name: operandOrColor
           in: header
           required: true
@@ -29,11 +30,12 @@ paths:
           in: header
           required: false
           schema:
-            $ref: '#/components/schemas/ColorOrOperand'
-            nullable: true
+            anyOf:
+              - $ref: '#/components/schemas/ColorOrOperand'
+              - type: 'null'
       responses:
         '204':
-          description: ''
+          description: No content
   /inlined:
     post:
       operationId: inlinedRequest_send
@@ -42,7 +44,7 @@ paths:
       parameters: []
       responses:
         '204':
-          description: ''
+          description: No content
       requestBody:
         required: true
         content:
@@ -53,13 +55,15 @@ paths:
                 operand:
                   $ref: '#/components/schemas/Operand'
                 maybeOperand:
-                  $ref: '#/components/schemas/Operand'
-                  nullable: true
+                  anyOf:
+                    - $ref: '#/components/schemas/Operand'
+                    - type: 'null'
                 operandOrColor:
                   $ref: '#/components/schemas/ColorOrOperand'
                 maybeOperandOrColor:
-                  $ref: '#/components/schemas/ColorOrOperand'
-                  nullable: true
+                  anyOf:
+                    - $ref: '#/components/schemas/ColorOrOperand'
+                    - type: 'null'
               required:
                 - operand
                 - operandOrColor
@@ -76,7 +80,7 @@ paths:
       parameters: []
       responses:
         '204':
-          description: ''
+          description: No content
       requestBody:
         required: true
         content:
@@ -87,17 +91,19 @@ paths:
                 color:
                   $ref: '#/components/schemas/Color'
                 maybeColor:
-                  $ref: '#/components/schemas/Color'
-                  nullable: true
+                  anyOf:
+                    - $ref: '#/components/schemas/Color'
+                    - type: 'null'
                 colorList:
                   type: array
                   items:
                     $ref: '#/components/schemas/Color'
                 maybeColorList:
-                  type: array
+                  type:
+                    - array
+                    - 'null'
                   items:
                     $ref: '#/components/schemas/Color'
-                  nullable: true
   /path/{operand}/{operandOrColor}:
     post:
       operationId: pathParam_send
@@ -109,7 +115,6 @@ paths:
           required: true
           schema:
             $ref: '#/components/schemas/Operand'
-          example: '>'
           examples:
             Example1:
               value: '>'
@@ -118,13 +123,12 @@ paths:
           required: true
           schema:
             $ref: '#/components/schemas/ColorOrOperand'
-          example: red
           examples:
             Example1:
               value: red
       responses:
         '204':
-          description: ''
+          description: No content
   /query:
     post:
       operationId: queryParam_send
@@ -136,7 +140,6 @@ paths:
           required: true
           schema:
             $ref: '#/components/schemas/Operand'
-          example: '>'
           examples:
             Example1:
               value: '>'
@@ -144,14 +147,14 @@ paths:
           in: query
           required: false
           schema:
-            $ref: '#/components/schemas/Operand'
-            nullable: true
+            anyOf:
+              - $ref: '#/components/schemas/Operand'
+              - type: 'null'
         - name: operandOrColor
           in: query
           required: true
           schema:
             $ref: '#/components/schemas/ColorOrOperand'
-          example: red
           examples:
             Example1:
               value: red
@@ -159,11 +162,12 @@ paths:
           in: query
           required: false
           schema:
-            $ref: '#/components/schemas/ColorOrOperand'
-            nullable: true
+            anyOf:
+              - $ref: '#/components/schemas/ColorOrOperand'
+              - type: 'null'
       responses:
         '204':
-          description: ''
+          description: No content
   /query-list:
     post:
       operationId: queryParam_sendList
@@ -183,8 +187,9 @@ paths:
           schema:
             type: array
             items:
-              $ref: '#/components/schemas/Operand'
-              nullable: true
+              anyOf:
+                - $ref: '#/components/schemas/Operand'
+                - type: 'null'
         - name: operandOrColor
           in: query
           required: true
@@ -198,11 +203,12 @@ paths:
           schema:
             type: array
             items:
-              $ref: '#/components/schemas/ColorOrOperand'
-              nullable: true
+              anyOf:
+                - $ref: '#/components/schemas/ColorOrOperand'
+                - type: 'null'
       responses:
         '204':
-          description: ''
+          description: No content
 components:
   schemas:
     Operand:

--- a/seed/openapi/enum/no-custom-config/openapi.yml
+++ b/seed/openapi/enum/no-custom-config/openapi.yml
@@ -1,7 +1,7 @@
-openapi: 3.0.1
+openapi: 3.1.0
 info:
   title: enum
-  version: ''
+  version: 0.0.0
 paths:
   /headers:
     post:
@@ -18,8 +18,9 @@ paths:
           in: header
           required: false
           schema:
-            $ref: '#/components/schemas/Operand'
-            nullable: true
+            anyOf:
+              - $ref: '#/components/schemas/Operand'
+              - type: 'null'
         - name: operandOrColor
           in: header
           required: true
@@ -29,11 +30,12 @@ paths:
           in: header
           required: false
           schema:
-            $ref: '#/components/schemas/ColorOrOperand'
-            nullable: true
+            anyOf:
+              - $ref: '#/components/schemas/ColorOrOperand'
+              - type: 'null'
       responses:
         '204':
-          description: ''
+          description: No content
   /inlined:
     post:
       operationId: inlinedRequest_send
@@ -42,7 +44,7 @@ paths:
       parameters: []
       responses:
         '204':
-          description: ''
+          description: No content
       requestBody:
         required: true
         content:
@@ -53,13 +55,15 @@ paths:
                 operand:
                   $ref: '#/components/schemas/Operand'
                 maybeOperand:
-                  $ref: '#/components/schemas/Operand'
-                  nullable: true
+                  anyOf:
+                    - $ref: '#/components/schemas/Operand'
+                    - type: 'null'
                 operandOrColor:
                   $ref: '#/components/schemas/ColorOrOperand'
                 maybeOperandOrColor:
-                  $ref: '#/components/schemas/ColorOrOperand'
-                  nullable: true
+                  anyOf:
+                    - $ref: '#/components/schemas/ColorOrOperand'
+                    - type: 'null'
               required:
                 - operand
                 - operandOrColor
@@ -76,7 +80,7 @@ paths:
       parameters: []
       responses:
         '204':
-          description: ''
+          description: No content
       requestBody:
         required: true
         content:
@@ -87,17 +91,19 @@ paths:
                 color:
                   $ref: '#/components/schemas/Color'
                 maybeColor:
-                  $ref: '#/components/schemas/Color'
-                  nullable: true
+                  anyOf:
+                    - $ref: '#/components/schemas/Color'
+                    - type: 'null'
                 colorList:
                   type: array
                   items:
                     $ref: '#/components/schemas/Color'
                 maybeColorList:
-                  type: array
+                  type:
+                    - array
+                    - 'null'
                   items:
                     $ref: '#/components/schemas/Color'
-                  nullable: true
   /path/{operand}/{operandOrColor}:
     post:
       operationId: pathParam_send
@@ -109,7 +115,6 @@ paths:
           required: true
           schema:
             $ref: '#/components/schemas/Operand'
-          example: '>'
           examples:
             Example1:
               value: '>'
@@ -118,13 +123,12 @@ paths:
           required: true
           schema:
             $ref: '#/components/schemas/ColorOrOperand'
-          example: red
           examples:
             Example1:
               value: red
       responses:
         '204':
-          description: ''
+          description: No content
   /query:
     post:
       operationId: queryParam_send
@@ -136,7 +140,6 @@ paths:
           required: true
           schema:
             $ref: '#/components/schemas/Operand'
-          example: '>'
           examples:
             Example1:
               value: '>'
@@ -144,14 +147,14 @@ paths:
           in: query
           required: false
           schema:
-            $ref: '#/components/schemas/Operand'
-            nullable: true
+            anyOf:
+              - $ref: '#/components/schemas/Operand'
+              - type: 'null'
         - name: operandOrColor
           in: query
           required: true
           schema:
             $ref: '#/components/schemas/ColorOrOperand'
-          example: red
           examples:
             Example1:
               value: red
@@ -159,11 +162,12 @@ paths:
           in: query
           required: false
           schema:
-            $ref: '#/components/schemas/ColorOrOperand'
-            nullable: true
+            anyOf:
+              - $ref: '#/components/schemas/ColorOrOperand'
+              - type: 'null'
       responses:
         '204':
-          description: ''
+          description: No content
   /query-list:
     post:
       operationId: queryParam_sendList
@@ -183,8 +187,9 @@ paths:
           schema:
             type: array
             items:
-              $ref: '#/components/schemas/Operand'
-              nullable: true
+              anyOf:
+                - $ref: '#/components/schemas/Operand'
+                - type: 'null'
         - name: operandOrColor
           in: query
           required: true
@@ -198,11 +203,12 @@ paths:
           schema:
             type: array
             items:
-              $ref: '#/components/schemas/ColorOrOperand'
-              nullable: true
+              anyOf:
+                - $ref: '#/components/schemas/ColorOrOperand'
+                - type: 'null'
       responses:
         '204':
-          description: ''
+          description: No content
 components:
   schemas:
     Operand:

--- a/seed/openapi/error-property/openapi.yml
+++ b/seed/openapi/error-property/openapi.yml
@@ -1,7 +1,7 @@
-openapi: 3.0.1
+openapi: 3.1.0
 info:
   title: error-property
-  version: ''
+  version: 0.0.0
 paths:
   /property-based-error:
     get:
@@ -12,13 +12,13 @@ paths:
       parameters: []
       responses:
         '200':
-          description: ''
+          description: Success
           content:
             application/json:
               schema:
                 type: string
         '400':
-          description: ''
+          description: PropertyBasedErrorTest
           content:
             application/json:
               schema:

--- a/seed/openapi/errors/openapi.yml
+++ b/seed/openapi/errors/openapi.yml
@@ -1,7 +1,7 @@
-openapi: 3.0.1
+openapi: 3.1.0
 info:
   title: errors
-  version: ''
+  version: 0.0.0
 paths:
   /foo1:
     post:
@@ -11,25 +11,25 @@ paths:
       parameters: []
       responses:
         '200':
-          description: ''
+          description: Success
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/FooResponse'
         '400':
-          description: ''
+          description: BadRequestError
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorBody'
         '404':
-          description: ''
+          description: NotFoundError
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorBody'
         '500':
-          description: ''
+          description: InternalServerError
           content:
             application/json:
               schema:
@@ -48,31 +48,31 @@ paths:
       parameters: []
       responses:
         '200':
-          description: ''
+          description: Success
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/FooResponse'
         '400':
-          description: ''
+          description: BadRequestError
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorBody'
         '404':
-          description: ''
+          description: NotFoundError
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorBody'
         '429':
-          description: ''
+          description: FooTooMuch
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorBody'
         '500':
-          description: ''
+          description: InternalServerError
           content:
             application/json:
               schema:
@@ -91,7 +91,7 @@ paths:
       parameters: []
       responses:
         '200':
-          description: ''
+          description: Success
           content:
             application/json:
               schema:
@@ -101,19 +101,19 @@ paths:
                   value:
                     bar: hello
         '400':
-          description: ''
+          description: BadRequestError
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorBody'
         '404':
-          description: ''
+          description: NotFoundError
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorBody'
         '429':
-          description: ''
+          description: FooTooMuch
           content:
             application/json:
               schema:
@@ -124,7 +124,7 @@ paths:
                     message: Too much foo
                     code: 1
         '500':
-          description: ''
+          description: InternalServerError
           content:
             application/json:
               schema:
@@ -164,7 +164,8 @@ components:
       properties:
         bar:
           type: string
-          example: hello
+          examples:
+            - hello
       required:
         - bar
     FooResponse:
@@ -173,7 +174,8 @@ components:
       properties:
         bar:
           type: string
-          example: hello
+          examples:
+            - hello
       required:
         - bar
   securitySchemes: {}

--- a/seed/openapi/extends/openapi.yml
+++ b/seed/openapi/extends/openapi.yml
@@ -1,7 +1,7 @@
-openapi: 3.0.1
+openapi: 3.1.0
 info:
   title: extends
-  version: ''
+  version: 0.0.0
 paths:
   /extends/extended-inline-request-body:
     post:
@@ -11,7 +11,7 @@ paths:
       parameters: []
       responses:
         '204':
-          description: ''
+          description: No content
       requestBody:
         required: true
         content:
@@ -33,7 +33,8 @@ components:
       properties:
         name:
           type: string
-          example: Example
+          examples:
+            - Example
       required:
         - name
       allOf:
@@ -44,7 +45,8 @@ components:
       properties:
         name:
           type: string
-          example: NestedExample
+          examples:
+            - NestedExample
       required:
         - name
       allOf:
@@ -55,7 +57,8 @@ components:
       properties:
         docs:
           type: string
-          example: Types extend this type to include a docs property.
+          examples:
+            - Types extend this type to include a docs property.
       required:
         - docs
     JSON:
@@ -64,7 +67,8 @@ components:
       properties:
         raw:
           type: string
-          example: '{"docs": true, "json": true}'
+          examples:
+            - '{"docs": true, "json": true}'
       required:
         - raw
       allOf:

--- a/seed/openapi/extra-properties/openapi.yml
+++ b/seed/openapi/extra-properties/openapi.yml
@@ -1,7 +1,7 @@
-openapi: 3.0.1
+openapi: 3.1.0
 info:
   title: extra-properties
-  version: ''
+  version: 0.0.0
 paths:
   /user:
     post:
@@ -11,7 +11,7 @@ paths:
       parameters: []
       responses:
         '200':
-          description: ''
+          description: Success
           content:
             application/json:
               schema:
@@ -37,7 +37,8 @@ paths:
                   const: v1
                 name:
                   type: string
-                  example: Alice
+                  examples:
+                    - Alice
               required:
                 - _type
                 - _version
@@ -67,7 +68,8 @@ components:
       properties:
         name:
           type: string
-          example: Alice
+          examples:
+            - Alice
       required:
         - name
   securitySchemes: {}

--- a/seed/openapi/file-download/openapi.yml
+++ b/seed/openapi/file-download/openapi.yml
@@ -1,7 +1,7 @@
-openapi: 3.0.1
+openapi: 3.1.0
 info:
   title: file-download
-  version: ''
+  version: 0.0.0
 paths:
   /snippet:
     post:
@@ -11,7 +11,7 @@ paths:
       parameters: []
       responses:
         '204':
-          description: ''
+          description: No content
   /:
     post:
       operationId: service_downloadFile
@@ -20,7 +20,7 @@ paths:
       parameters: []
       responses:
         '204':
-          description: ''
+          description: No content
 components:
   schemas: {}
   securitySchemes: {}

--- a/seed/openapi/file-upload-openapi/openapi.yml
+++ b/seed/openapi/file-upload-openapi/openapi.yml
@@ -1,7 +1,7 @@
-openapi: 3.0.1
+openapi: 3.1.0
 info:
   title: api
-  version: ''
+  version: 0.0.0
 paths:
   /upload-file:
     post:
@@ -12,7 +12,7 @@ paths:
       parameters: []
       responses:
         '200':
-          description: ''
+          description: Success
           content:
             application/json:
               schema:

--- a/seed/openapi/header-auth-environment-variable/openapi.yml
+++ b/seed/openapi/header-auth-environment-variable/openapi.yml
@@ -1,7 +1,7 @@
-openapi: 3.0.1
+openapi: 3.1.0
 info:
   title: header-token-environment-variable
-  version: ''
+  version: 0.0.0
 paths:
   /apiKey:
     get:
@@ -12,7 +12,7 @@ paths:
       parameters: []
       responses:
         '200':
-          description: ''
+          description: Success
           content:
             application/json:
               schema:

--- a/seed/openapi/header-auth/openapi.yml
+++ b/seed/openapi/header-auth/openapi.yml
@@ -1,7 +1,7 @@
-openapi: 3.0.1
+openapi: 3.1.0
 info:
   title: header-token
-  version: ''
+  version: 0.0.0
 paths:
   /apiKey:
     get:
@@ -12,7 +12,7 @@ paths:
       parameters: []
       responses:
         '200':
-          description: ''
+          description: Success
           content:
             application/json:
               schema:

--- a/seed/openapi/http-head/openapi.yml
+++ b/seed/openapi/http-head/openapi.yml
@@ -1,7 +1,7 @@
-openapi: 3.0.1
+openapi: 3.1.0
 info:
   title: http-head
-  version: ''
+  version: 0.0.0
 paths:
   /users:
     head:
@@ -11,7 +11,7 @@ paths:
       parameters: []
       responses:
         '204':
-          description: ''
+          description: No content
     get:
       operationId: user_list
       tags:
@@ -24,7 +24,7 @@ paths:
             type: integer
       responses:
         '200':
-          description: ''
+          description: Success
           content:
             application/json:
               schema:

--- a/seed/openapi/idempotency-headers/openapi.yml
+++ b/seed/openapi/idempotency-headers/openapi.yml
@@ -1,7 +1,7 @@
-openapi: 3.0.1
+openapi: 3.1.0
 info:
   title: idempotency-headers
-  version: ''
+  version: 0.0.0
 paths:
   /payment:
     post:
@@ -11,7 +11,7 @@ paths:
       parameters: []
       responses:
         '200':
-          description: ''
+          description: Success
           content:
             application/json:
               schema:
@@ -46,7 +46,7 @@ paths:
             type: string
       responses:
         '204':
-          description: ''
+          description: No content
       security:
         - Bearer: []
 components:

--- a/seed/openapi/imdb/custom-filename/imdb.yaml
+++ b/seed/openapi/imdb/custom-filename/imdb.yaml
@@ -1,7 +1,7 @@
-openapi: 3.0.1
+openapi: 3.1.0
 info:
   title: api
-  version: ''
+  version: 0.0.0
 paths:
   /movies/create-movie:
     post:
@@ -12,7 +12,7 @@ paths:
       parameters: []
       responses:
         '201':
-          description: ''
+          description: Success
           content:
             application/json:
               schema:
@@ -37,13 +37,13 @@ paths:
             $ref: '#/components/schemas/MovieId'
       responses:
         '200':
-          description: ''
+          description: Success
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/Movie'
         '404':
-          description: ''
+          description: MovieDoesNotExistError
           content:
             application/json:
               schema:

--- a/seed/openapi/imdb/custom-overrides/openapi.yml
+++ b/seed/openapi/imdb/custom-overrides/openapi.yml
@@ -2,7 +2,8 @@ openapi: 3.1.0
 info:
   title: api
   version: 0.0.0
-  license: MIT
+  license:
+    name: MIT
 paths:
   /movies/create-movie:
     post:

--- a/seed/openapi/imdb/custom-overrides/openapi.yml
+++ b/seed/openapi/imdb/custom-overrides/openapi.yml
@@ -1,7 +1,7 @@
-openapi: 3.0.1
+openapi: 3.1.0
 info:
   title: api
-  version: ''
+  version: 0.0.0
   license: MIT
 paths:
   /movies/create-movie:
@@ -13,7 +13,7 @@ paths:
       parameters: []
       responses:
         '201':
-          description: ''
+          description: Success
           content:
             application/json:
               schema:
@@ -38,13 +38,13 @@ paths:
             $ref: '#/components/schemas/MovieId'
       responses:
         '200':
-          description: ''
+          description: Success
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/Movie'
         '404':
-          description: ''
+          description: MovieDoesNotExistError
           content:
             application/json:
               schema:

--- a/seed/openapi/imdb/json-format/openapi.json
+++ b/seed/openapi/imdb/json-format/openapi.json
@@ -1,8 +1,8 @@
 {
-  "openapi": "3.0.1",
+  "openapi": "3.1.0",
   "info": {
     "title": "api",
-    "version": ""
+    "version": "0.0.0"
   },
   "paths": {
     "/movies/create-movie": {
@@ -15,7 +15,7 @@
         "parameters": [],
         "responses": {
           "201": {
-            "description": "",
+            "description": "Success",
             "content": {
               "application/json": {
                 "schema": {
@@ -56,7 +56,7 @@
         ],
         "responses": {
           "200": {
-            "description": "",
+            "description": "Success",
             "content": {
               "application/json": {
                 "schema": {
@@ -66,7 +66,7 @@
             }
           },
           "404": {
-            "description": "",
+            "description": "MovieDoesNotExistError",
             "content": {
               "application/json": {
                 "schema": {

--- a/seed/openapi/imdb/no-custom-config/openapi.yml
+++ b/seed/openapi/imdb/no-custom-config/openapi.yml
@@ -1,7 +1,7 @@
-openapi: 3.0.1
+openapi: 3.1.0
 info:
   title: api
-  version: ''
+  version: 0.0.0
 paths:
   /movies/create-movie:
     post:
@@ -12,7 +12,7 @@ paths:
       parameters: []
       responses:
         '201':
-          description: ''
+          description: Success
           content:
             application/json:
               schema:
@@ -37,13 +37,13 @@ paths:
             $ref: '#/components/schemas/MovieId'
       responses:
         '200':
-          description: ''
+          description: Success
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/Movie'
         '404':
-          description: ''
+          description: MovieDoesNotExistError
           content:
             application/json:
               schema:

--- a/seed/openapi/imdb/override/openapi.yml
+++ b/seed/openapi/imdb/override/openapi.yml
@@ -1,7 +1,7 @@
-openapi: 3.0.1
+openapi: 3.1.0
 info:
   title: api
-  version: ''
+  version: 0.0.0
 paths:
   /movies/create-movie:
     post:
@@ -12,7 +12,7 @@ paths:
       parameters: []
       responses:
         '201':
-          description: ''
+          description: Success
           content:
             application/json:
               schema:
@@ -37,13 +37,13 @@ paths:
             $ref: '#/components/schemas/MovieId'
       responses:
         '200':
-          description: ''
+          description: Success
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/Movie'
         '404':
-          description: ''
+          description: MovieDoesNotExistError
           content:
             application/json:
               schema:

--- a/seed/openapi/inferred-auth-explicit/openapi.yml
+++ b/seed/openapi/inferred-auth-explicit/openapi.yml
@@ -1,7 +1,7 @@
-openapi: 3.0.1
+openapi: 3.1.0
 info:
   title: inferred-auth-explicit
-  version: ''
+  version: 0.0.0
 paths:
   /token:
     post:
@@ -16,7 +16,7 @@ paths:
             type: string
       responses:
         '200':
-          description: ''
+          description: Success
           content:
             application/json:
               schema:
@@ -39,8 +39,9 @@ paths:
                   type: string
                   const: client_credentials
                 scope:
-                  type: string
-                  nullable: true
+                  type:
+                    - string
+                    - 'null'
               required:
                 - client_id
                 - client_secret
@@ -59,7 +60,7 @@ paths:
             type: string
       responses:
         '200':
-          description: ''
+          description: Success
           content:
             application/json:
               schema:
@@ -84,8 +85,9 @@ paths:
                   type: string
                   const: refresh_token
                 scope:
-                  type: string
-                  nullable: true
+                  type:
+                    - string
+                    - 'null'
               required:
                 - client_id
                 - client_secret
@@ -100,7 +102,7 @@ paths:
       parameters: []
       responses:
         '204':
-          description: ''
+          description: No content
   /nested/get-something:
     get:
       operationId: nested_api_getSomething
@@ -109,7 +111,7 @@ paths:
       parameters: []
       responses:
         '204':
-          description: ''
+          description: No content
       security:
         - InferredAuthScheme: []
   /get-something:
@@ -120,7 +122,7 @@ paths:
       parameters: []
       responses:
         '204':
-          description: ''
+          description: No content
       security:
         - InferredAuthScheme: []
 components:
@@ -135,8 +137,9 @@ components:
         expires_in:
           type: integer
         refresh_token:
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
       required:
         - access_token
         - expires_in

--- a/seed/openapi/inferred-auth-implicit-api-key/openapi.yml
+++ b/seed/openapi/inferred-auth-implicit-api-key/openapi.yml
@@ -1,7 +1,7 @@
-openapi: 3.0.1
+openapi: 3.1.0
 info:
   title: inferred-auth-implicit-api-key
-  version: ''
+  version: 0.0.0
 paths:
   /token:
     post:
@@ -16,7 +16,7 @@ paths:
             type: string
       responses:
         '200':
-          description: ''
+          description: Success
           content:
             application/json:
               schema:
@@ -29,7 +29,7 @@ paths:
       parameters: []
       responses:
         '204':
-          description: ''
+          description: No content
   /nested/get-something:
     get:
       operationId: nested_api_getSomething
@@ -38,7 +38,7 @@ paths:
       parameters: []
       responses:
         '204':
-          description: ''
+          description: No content
       security:
         - InferredAuthScheme: []
   /get-something:
@@ -49,7 +49,7 @@ paths:
       parameters: []
       responses:
         '204':
-          description: ''
+          description: No content
       security:
         - InferredAuthScheme: []
 components:
@@ -66,8 +66,9 @@ components:
         expires_in:
           type: integer
         scope:
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
       required:
         - access_token
         - token_type

--- a/seed/openapi/inferred-auth-implicit-no-expiry/openapi.yml
+++ b/seed/openapi/inferred-auth-implicit-no-expiry/openapi.yml
@@ -1,7 +1,7 @@
-openapi: 3.0.1
+openapi: 3.1.0
 info:
   title: inferred-auth-implicit-no-expiry
-  version: ''
+  version: 0.0.0
 paths:
   /token:
     post:
@@ -16,7 +16,7 @@ paths:
             type: string
       responses:
         '200':
-          description: ''
+          description: Success
           content:
             application/json:
               schema:
@@ -39,8 +39,9 @@ paths:
                   type: string
                   const: client_credentials
                 scope:
-                  type: string
-                  nullable: true
+                  type:
+                    - string
+                    - 'null'
               required:
                 - client_id
                 - client_secret
@@ -59,7 +60,7 @@ paths:
             type: string
       responses:
         '200':
-          description: ''
+          description: Success
           content:
             application/json:
               schema:
@@ -84,8 +85,9 @@ paths:
                   type: string
                   const: refresh_token
                 scope:
-                  type: string
-                  nullable: true
+                  type:
+                    - string
+                    - 'null'
               required:
                 - client_id
                 - client_secret
@@ -100,7 +102,7 @@ paths:
       parameters: []
       responses:
         '204':
-          description: ''
+          description: No content
   /nested/get-something:
     get:
       operationId: nested_api_getSomething
@@ -109,7 +111,7 @@ paths:
       parameters: []
       responses:
         '204':
-          description: ''
+          description: No content
       security:
         - InferredAuthScheme: []
   /get-something:
@@ -120,7 +122,7 @@ paths:
       parameters: []
       responses:
         '204':
-          description: ''
+          description: No content
       security:
         - InferredAuthScheme: []
 components:
@@ -133,8 +135,9 @@ components:
         access_token:
           type: string
         refresh_token:
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
       required:
         - access_token
   securitySchemes:

--- a/seed/openapi/inferred-auth-implicit-reference/openapi.yml
+++ b/seed/openapi/inferred-auth-implicit-reference/openapi.yml
@@ -1,7 +1,7 @@
-openapi: 3.0.1
+openapi: 3.1.0
 info:
   title: inferred-auth-implicit
-  version: ''
+  version: 0.0.0
 paths:
   /token:
     post:
@@ -11,7 +11,7 @@ paths:
       parameters: []
       responses:
         '200':
-          description: ''
+          description: Success
           content:
             application/json:
               schema:
@@ -30,7 +30,7 @@ paths:
       parameters: []
       responses:
         '200':
-          description: ''
+          description: Success
           content:
             application/json:
               schema:
@@ -49,7 +49,7 @@ paths:
       parameters: []
       responses:
         '204':
-          description: ''
+          description: No content
   /nested/get-something:
     get:
       operationId: nested_api_getSomething
@@ -58,7 +58,7 @@ paths:
       parameters: []
       responses:
         '204':
-          description: ''
+          description: No content
       security:
         - InferredAuthScheme: []
   /get-something:
@@ -69,7 +69,7 @@ paths:
       parameters: []
       responses:
         '204':
-          description: ''
+          description: No content
       security:
         - InferredAuthScheme: []
 components:
@@ -90,8 +90,9 @@ components:
           type: string
           const: client_credentials
         scope:
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
       required:
         - client_id
         - client_secret
@@ -115,8 +116,9 @@ components:
           type: string
           const: refresh_token
         scope:
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
       required:
         - client_id
         - client_secret
@@ -133,8 +135,9 @@ components:
         expires_in:
           type: integer
         refresh_token:
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
       required:
         - access_token
         - expires_in

--- a/seed/openapi/inferred-auth-implicit/openapi.yml
+++ b/seed/openapi/inferred-auth-implicit/openapi.yml
@@ -1,7 +1,7 @@
-openapi: 3.0.1
+openapi: 3.1.0
 info:
   title: inferred-auth-implicit
-  version: ''
+  version: 0.0.0
 paths:
   /token:
     post:
@@ -16,7 +16,7 @@ paths:
             type: string
       responses:
         '200':
-          description: ''
+          description: Success
           content:
             application/json:
               schema:
@@ -39,8 +39,9 @@ paths:
                   type: string
                   const: client_credentials
                 scope:
-                  type: string
-                  nullable: true
+                  type:
+                    - string
+                    - 'null'
               required:
                 - client_id
                 - client_secret
@@ -59,7 +60,7 @@ paths:
             type: string
       responses:
         '200':
-          description: ''
+          description: Success
           content:
             application/json:
               schema:
@@ -84,8 +85,9 @@ paths:
                   type: string
                   const: refresh_token
                 scope:
-                  type: string
-                  nullable: true
+                  type:
+                    - string
+                    - 'null'
               required:
                 - client_id
                 - client_secret
@@ -100,7 +102,7 @@ paths:
       parameters: []
       responses:
         '204':
-          description: ''
+          description: No content
   /nested/get-something:
     get:
       operationId: nested_api_getSomething
@@ -109,7 +111,7 @@ paths:
       parameters: []
       responses:
         '204':
-          description: ''
+          description: No content
       security:
         - InferredAuthScheme: []
   /get-something:
@@ -120,7 +122,7 @@ paths:
       parameters: []
       responses:
         '204':
-          description: ''
+          description: No content
       security:
         - InferredAuthScheme: []
 components:
@@ -135,8 +137,9 @@ components:
         expires_in:
           type: integer
         refresh_token:
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
       required:
         - access_token
         - expires_in

--- a/seed/openapi/license/openapi.yml
+++ b/seed/openapi/license/openapi.yml
@@ -1,7 +1,7 @@
-openapi: 3.0.1
+openapi: 3.1.0
 info:
   title: license
-  version: ''
+  version: 0.0.0
 paths:
   /:
     get:
@@ -11,7 +11,7 @@ paths:
       parameters: []
       responses:
         '204':
-          description: ''
+          description: No content
 components:
   schemas:
     Type:

--- a/seed/openapi/literal/openapi.yml
+++ b/seed/openapi/literal/openapi.yml
@@ -1,7 +1,7 @@
-openapi: 3.0.1
+openapi: 3.1.0
 info:
   title: literal
-  version: ''
+  version: 0.0.0
   description: Test definition for literal schemas.
 paths:
   /headers:
@@ -16,7 +16,6 @@ paths:
           schema:
             type: string
             const: 02-12-2024
-          example: 02-12-2024
           examples:
             Example1:
               value: 02-12-2024
@@ -26,13 +25,12 @@ paths:
           schema:
             type: boolean
             const: true
-          example: true
           examples:
             Example1:
               value: true
       responses:
         '200':
-          description: ''
+          description: Success
           content:
             application/json:
               schema:
@@ -52,7 +50,8 @@ paths:
               properties:
                 query:
                   type: string
-                  example: What is the weather today
+                  examples:
+                    - What is the weather today
               required:
                 - query
             examples:
@@ -67,7 +66,7 @@ paths:
       parameters: []
       responses:
         '200':
-          description: ''
+          description: Success
           content:
             application/json:
               schema:
@@ -89,24 +88,28 @@ paths:
                   type: string
                   const: You are a helpful assistant
                 context:
-                  type: string
+                  type:
+                    - string
+                    - 'null'
                   const: You're super wise
-                  nullable: true
                 query:
                   type: string
-                  example: What is the weather today
+                  examples:
+                    - What is the weather today
                 temperature:
-                  type: number
+                  type:
+                    - number
+                    - 'null'
                   format: double
-                  nullable: true
                 stream:
                   type: boolean
                   const: false
                 aliasedContext:
                   $ref: '#/components/schemas/SomeAliasedLiteral'
                 maybeContext:
-                  $ref: '#/components/schemas/SomeAliasedLiteral'
-                  nullable: true
+                  anyOf:
+                    - $ref: '#/components/schemas/SomeAliasedLiteral'
+                    - type: 'null'
                 objectWithLiteral:
                   $ref: '#/components/schemas/ATopLevelLiteral'
               required:
@@ -140,13 +143,12 @@ paths:
           schema:
             type: string
             const: '123'
-          example: '123'
           examples:
             Example1:
               value: '123'
       responses:
         '200':
-          description: ''
+          description: Success
           content:
             application/json:
               schema:
@@ -169,7 +171,6 @@ paths:
           schema:
             type: string
             const: You are a helpful assistant
-          example: You are a helpful assistant
           examples:
             Example1:
               value: You are a helpful assistant
@@ -177,10 +178,10 @@ paths:
           in: query
           required: false
           schema:
-            type: string
+            type:
+              - string
+              - 'null'
             const: You are a helpful assistant
-            nullable: true
-          example: You are a helpful assistant
           examples:
             Example1:
               value: You are a helpful assistant
@@ -189,7 +190,6 @@ paths:
           required: true
           schema:
             $ref: '#/components/schemas/AliasToPrompt'
-          example: You are a helpful assistant
           examples:
             Example1:
               value: You are a helpful assistant
@@ -197,9 +197,9 @@ paths:
           in: query
           required: false
           schema:
-            $ref: '#/components/schemas/AliasToPrompt'
-            nullable: true
-          example: You are a helpful assistant
+            anyOf:
+              - $ref: '#/components/schemas/AliasToPrompt'
+              - type: 'null'
           examples:
             Example1:
               value: You are a helpful assistant
@@ -208,7 +208,6 @@ paths:
           required: true
           schema:
             type: string
-          example: What is the weather today
           examples:
             Example1:
               value: What is the weather today
@@ -218,7 +217,6 @@ paths:
           schema:
             type: boolean
             const: false
-          example: false
           examples:
             Example1:
               value: false
@@ -226,10 +224,10 @@ paths:
           in: query
           required: false
           schema:
-            type: boolean
+            type:
+              - boolean
+              - 'null'
             const: false
-            nullable: true
-          example: false
           examples:
             Example1:
               value: false
@@ -238,7 +236,6 @@ paths:
           required: true
           schema:
             $ref: '#/components/schemas/AliasToStream'
-          example: false
           examples:
             Example1:
               value: false
@@ -246,15 +243,15 @@ paths:
           in: query
           required: false
           schema:
-            $ref: '#/components/schemas/AliasToStream'
-            nullable: true
-          example: false
+            anyOf:
+              - $ref: '#/components/schemas/AliasToStream'
+              - type: 'null'
           examples:
             Example1:
               value: false
       responses:
         '200':
-          description: ''
+          description: Success
           content:
             application/json:
               schema:
@@ -273,7 +270,7 @@ paths:
       parameters: []
       responses:
         '200':
-          description: ''
+          description: Success
           content:
             application/json:
               schema:
@@ -310,10 +307,12 @@ components:
       properties:
         message:
           type: string
-          example: The weather is sunny
+          examples:
+            - The weather is sunny
         status:
           type: integer
-          example: 200
+          examples:
+            - 200
         success:
           type: boolean
           const: true
@@ -349,8 +348,7 @@ components:
           properties:
             type:
               type: string
-              enum:
-                - customName
+              const: customName
             value:
               type: string
           required:
@@ -359,8 +357,7 @@ components:
           properties:
             type:
               type: string
-              enum:
-                - defaultName
+              const: defaultName
             value:
               type: string
               const: Bob
@@ -370,8 +367,7 @@ components:
           properties:
             type:
               type: string
-              enum:
-                - george
+              const: george
             value:
               type: boolean
           required:
@@ -380,8 +376,7 @@ components:
           properties:
             type:
               type: string
-              enum:
-                - literalGeorge
+              const: literalGeorge
             value:
               type: boolean
               const: true
@@ -419,7 +414,8 @@ components:
           const: You are a helpful assistant
         query:
           type: string
-          example: What is the weather today
+          examples:
+            - What is the weather today
         stream:
           type: boolean
           const: false
@@ -429,8 +425,9 @@ components:
         context:
           $ref: '#/components/schemas/SomeLiteral'
         maybeContext:
-          $ref: '#/components/schemas/SomeLiteral'
-          nullable: true
+          anyOf:
+            - $ref: '#/components/schemas/SomeLiteral'
+            - type: 'null'
         containerObject:
           $ref: '#/components/schemas/ContainerObject'
       required:

--- a/seed/openapi/literals-unions/openapi.yml
+++ b/seed/openapi/literals-unions/openapi.yml
@@ -1,7 +1,7 @@
-openapi: 3.0.1
+openapi: 3.1.0
 info:
   title: literals-unions
-  version: ''
+  version: 0.0.0
 paths: {}
 components:
   schemas:

--- a/seed/openapi/mixed-case/openapi.yml
+++ b/seed/openapi/mixed-case/openapi.yml
@@ -1,7 +1,7 @@
-openapi: 3.0.1
+openapi: 3.1.0
 info:
   title: mixed-case
-  version: ''
+  version: 0.0.0
 paths:
   /resource/{ResourceID}:
     get:
@@ -14,13 +14,12 @@ paths:
           required: true
           schema:
             type: string
-          example: rsc-xyz
           examples:
             Example1:
               value: rsc-xyz
       responses:
         '200':
-          description: ''
+          description: Success
           content:
             application/json:
               schema:
@@ -48,7 +47,6 @@ paths:
           required: true
           schema:
             type: integer
-          example: 10
           examples:
             One:
               value: 10
@@ -58,13 +56,12 @@ paths:
           schema:
             type: string
             format: date
-          example: '2023-01-01'
           examples:
             One:
               value: '2023-01-01'
       responses:
         '200':
-          description: ''
+          description: Success
           content:
             application/json:
               schema:
@@ -91,7 +88,8 @@ components:
       properties:
         name:
           type: string
-          example: orgName
+          examples:
+            - orgName
       required:
         - name
     User:
@@ -100,14 +98,15 @@ components:
       properties:
         userName:
           type: string
-          example: username
+          examples:
+            - username
         metadata_tags:
           type: array
           items:
             type: string
-          example:
-            - tag1
-            - tag2
+          examples:
+            - - tag1
+              - tag2
         EXTRA_PROPERTIES:
           type: object
           additionalProperties:
@@ -122,7 +121,8 @@ components:
       properties:
         Name:
           type: string
-          example: username
+          examples:
+            - username
         NestedUser:
           $ref: '#/components/schemas/User'
       required:
@@ -143,8 +143,7 @@ components:
               properties:
                 resource_type:
                   type: string
-                  enum:
-                    - user
+                  const: user
             - $ref: '#/components/schemas/User'
           required:
             - resource_type
@@ -154,8 +153,7 @@ components:
               properties:
                 resource_type:
                   type: string
-                  enum:
-                    - Organization
+                  const: Organization
             - $ref: '#/components/schemas/Organization'
           required:
             - resource_type

--- a/seed/openapi/mixed-file-directory/openapi.yml
+++ b/seed/openapi/mixed-file-directory/openapi.yml
@@ -1,7 +1,7 @@
-openapi: 3.0.1
+openapi: 3.1.0
 info:
   title: mixed-file-directory
-  version: ''
+  version: 0.0.0
 paths:
   /organizations/:
     post:
@@ -12,7 +12,7 @@ paths:
       parameters: []
       responses:
         '200':
-          description: ''
+          description: Success
           content:
             application/json:
               schema:
@@ -35,11 +35,12 @@ paths:
           description: The maximum number of results to return.
           required: false
           schema:
-            type: integer
-            nullable: true
+            type:
+              - integer
+              - 'null'
       responses:
         '200':
-          description: ''
+          description: Success
           content:
             application/json:
               schema:
@@ -58,11 +59,12 @@ paths:
           description: The maximum number of results to return.
           required: false
           schema:
-            type: integer
-            nullable: true
+            type:
+              - integer
+              - 'null'
       responses:
         '200':
-          description: ''
+          description: Success
           content:
             application/json:
               schema:
@@ -83,7 +85,7 @@ paths:
             $ref: '#/components/schemas/Id'
       responses:
         '200':
-          description: ''
+          description: Success
           content:
             application/json:
               schema:

--- a/seed/openapi/multi-line-docs/openapi.yml
+++ b/seed/openapi/multi-line-docs/openapi.yml
@@ -1,7 +1,7 @@
-openapi: 3.0.1
+openapi: 3.1.0
 info:
   title: multi-line-docs
-  version: ''
+  version: 0.0.0
 paths:
   /users/{userId}:
     get:
@@ -22,7 +22,7 @@ paths:
             type: string
       responses:
         '204':
-          description: ''
+          description: No content
   /users:
     post:
       description: |-
@@ -34,7 +34,7 @@ paths:
       parameters: []
       responses:
         '200':
-          description: ''
+          description: Success
           content:
             application/json:
               schema:
@@ -52,8 +52,9 @@ paths:
                     The name of the user to create.
                     This name is unique to each user.
                 age:
-                  type: integer
-                  nullable: true
+                  type:
+                    - integer
+                    - 'null'
                   description: |-
                     The age of the user.
                     This property is not required.
@@ -90,8 +91,9 @@ components:
              - Bob
              - Charlie
         age:
-          type: integer
-          nullable: true
+          type:
+            - integer
+            - 'null'
           description: The user's age.
       required:
         - id

--- a/seed/openapi/multi-url-environment-no-default/openapi.yml
+++ b/seed/openapi/multi-url-environment-no-default/openapi.yml
@@ -1,7 +1,7 @@
-openapi: 3.0.1
+openapi: 3.1.0
 info:
   title: multi-url-environment-no-default
-  version: ''
+  version: 0.0.0
 paths:
   /ec2/boot:
     post:
@@ -11,7 +11,7 @@ paths:
       parameters: []
       responses:
         '204':
-          description: ''
+          description: No content
       servers:
         - url: https://ec2.aws.com
         - url: https://staging.ec2.aws.com
@@ -36,7 +36,7 @@ paths:
       parameters: []
       responses:
         '200':
-          description: ''
+          description: Success
           content:
             application/json:
               schema:

--- a/seed/openapi/multi-url-environment/openapi.yml
+++ b/seed/openapi/multi-url-environment/openapi.yml
@@ -1,7 +1,7 @@
-openapi: 3.0.1
+openapi: 3.1.0
 info:
   title: multi-url-environment
-  version: ''
+  version: 0.0.0
 paths:
   /ec2/boot:
     post:
@@ -11,7 +11,7 @@ paths:
       parameters: []
       responses:
         '204':
-          description: ''
+          description: No content
       servers:
         - url: https://ec2.aws.com
         - url: https://staging.ec2.aws.com
@@ -36,7 +36,7 @@ paths:
       parameters: []
       responses:
         '200':
-          description: ''
+          description: Success
           content:
             application/json:
               schema:

--- a/seed/openapi/no-content-response/openapi.yml
+++ b/seed/openapi/no-content-response/openapi.yml
@@ -1,7 +1,7 @@
-openapi: 3.0.1
+openapi: 3.1.0
 info:
   title: no-content-response
-  version: ''
+  version: 0.0.0
 paths:
   /contacts:
     post:
@@ -18,8 +18,9 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Contact'
-                nullable: true
+                anyOf:
+                  - $ref: '#/components/schemas/Contact'
+                  - type: 'null'
               examples:
                 Example1:
                   value:
@@ -36,10 +37,12 @@ paths:
               properties:
                 name:
                   type: string
-                  example: name
+                  examples:
+                    - name
                 email:
-                  type: string
-                  nullable: true
+                  type:
+                    - string
+                    - 'null'
               required:
                 - name
             examples:
@@ -58,7 +61,6 @@ paths:
           required: true
           schema:
             type: string
-          example: id
           examples:
             Example1:
               value: id
@@ -84,13 +86,16 @@ components:
       properties:
         id:
           type: string
-          example: id
+          examples:
+            - id
         name:
           type: string
-          example: name
+          examples:
+            - name
         email:
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
       required:
         - id
         - name

--- a/seed/openapi/no-environment/openapi.yml
+++ b/seed/openapi/no-environment/openapi.yml
@@ -1,7 +1,7 @@
-openapi: 3.0.1
+openapi: 3.1.0
 info:
   title: no-environment
-  version: ''
+  version: 0.0.0
 paths:
   /dummy:
     get:
@@ -11,7 +11,7 @@ paths:
       parameters: []
       responses:
         '200':
-          description: ''
+          description: Success
           content:
             application/json:
               schema:

--- a/seed/openapi/no-retries/openapi.yml
+++ b/seed/openapi/no-retries/openapi.yml
@@ -1,7 +1,7 @@
-openapi: 3.0.1
+openapi: 3.1.0
 info:
   title: no-retries
-  version: ''
+  version: 0.0.0
 paths:
   /users:
     get:
@@ -11,7 +11,7 @@ paths:
       parameters: []
       responses:
         '200':
-          description: ''
+          description: Success
           content:
             application/json:
               schema:

--- a/seed/openapi/null-type/openapi.yml
+++ b/seed/openapi/null-type/openapi.yml
@@ -1,7 +1,7 @@
-openapi: 3.0.1
+openapi: 3.1.0
 info:
   title: null-type
-  version: ''
+  version: 0.0.0
 paths:
   /conversations/outbound-call:
     post:
@@ -34,10 +34,12 @@ paths:
                 to_phone_number:
                   type: string
                   description: The phone number to call in E.164 format.
-                  example: to_phone_number
+                  examples:
+                    - to_phone_number
                 dry_run:
-                  type: boolean
-                  nullable: true
+                  type:
+                    - boolean
+                    - 'null'
                   description: >-
                     If true, validates the outbound call setup without placing a
                     call.
@@ -59,7 +61,6 @@ paths:
           required: true
           schema:
             type: string
-          example: id
           examples:
             Example1:
               value: id
@@ -85,12 +86,12 @@ components:
       type: object
       properties:
         conversation_id:
-          nullable: true
           description: Always null when dry_run is true.
         dry_run:
           type: boolean
           description: Always true for this response.
-          example: true
+          examples:
+            - true
       required:
         - conversation_id
         - dry_run
@@ -100,12 +101,13 @@ components:
       properties:
         id:
           type: string
-          example: id
+          examples:
+            - id
         name:
           type: string
-          example: name
+          examples:
+            - name
         deleted_at:
-          nullable: true
           description: Always null for active users.
       required:
         - id

--- a/seed/openapi/nullable-allof-extends/openapi.yml
+++ b/seed/openapi/nullable-allof-extends/openapi.yml
@@ -1,7 +1,7 @@
-openapi: 3.0.1
+openapi: 3.1.0
 info:
   title: Nullable AllOf Extends Test
-  version: ''
+  version: 0.0.0
 paths:
   /test:
     get:
@@ -65,16 +65,18 @@ components:
       description: A standard object with no nullable issues.
       properties:
         normalField:
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
     NullableObject:
       title: NullableObject
       type: object
       description: This schema has nullable:true at the top level.
       properties:
         nullableField:
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
   securitySchemes: {}
 servers:
   - url: https://api.example.com

--- a/seed/openapi/nullable-optional/openapi.yml
+++ b/seed/openapi/nullable-optional/openapi.yml
@@ -1,7 +1,7 @@
-openapi: 3.0.1
+openapi: 3.1.0
 info:
   title: nullable-optional
-  version: ''
+  version: 0.0.0
 paths:
   /api/users/{userId}:
     get:
@@ -17,7 +17,7 @@ paths:
             type: string
       responses:
         '200':
-          description: ''
+          description: Success
           content:
             application/json:
               schema:
@@ -35,7 +35,7 @@ paths:
             type: string
       responses:
         '200':
-          description: ''
+          description: Success
           content:
             application/json:
               schema:
@@ -55,7 +55,7 @@ paths:
       parameters: []
       responses:
         '200':
-          description: ''
+          description: Success
           content:
             application/json:
               schema:
@@ -76,29 +76,33 @@ paths:
           in: query
           required: false
           schema:
-            type: integer
-            nullable: true
+            type:
+              - integer
+              - 'null'
         - name: offset
           in: query
           required: false
           schema:
-            type: integer
-            nullable: true
+            type:
+              - integer
+              - 'null'
         - name: includeDeleted
           in: query
           required: false
           schema:
-            type: boolean
-            nullable: true
+            type:
+              - boolean
+              - 'null'
         - name: sortBy
           in: query
           required: false
           schema:
-            type: string
-            nullable: true
+            type:
+              - string
+              - 'null'
       responses:
         '200':
-          description: ''
+          description: Success
           content:
             application/json:
               schema:
@@ -121,23 +125,26 @@ paths:
           in: query
           required: true
           schema:
-            type: string
-            nullable: true
+            type:
+              - string
+              - 'null'
         - name: role
           in: query
           required: false
           schema:
-            type: string
-            nullable: true
+            type:
+              - string
+              - 'null'
         - name: isActive
           in: query
           required: false
           schema:
-            type: boolean
-            nullable: true
+            type:
+              - boolean
+              - 'null'
       responses:
         '200':
-          description: ''
+          description: Success
           content:
             application/json:
               schema:
@@ -153,7 +160,7 @@ paths:
       parameters: []
       responses:
         '200':
-          description: ''
+          description: Success
           content:
             application/json:
               schema:
@@ -178,7 +185,7 @@ paths:
             type: string
       responses:
         '200':
-          description: ''
+          description: Success
           content:
             application/json:
               schema:
@@ -196,7 +203,7 @@ paths:
             type: string
       responses:
         '200':
-          description: ''
+          description: Success
           content:
             application/json:
               schema:
@@ -209,22 +216,27 @@ paths:
               type: object
               properties:
                 nullableRole:
-                  $ref: '#/components/schemas/UserRole'
-                  nullable: true
+                  anyOf:
+                    - $ref: '#/components/schemas/UserRole'
+                    - type: 'null'
                 nullableStatus:
-                  $ref: '#/components/schemas/UserStatus'
-                  nullable: true
+                  anyOf:
+                    - $ref: '#/components/schemas/UserStatus'
+                    - type: 'null'
                 nullableNotification:
-                  $ref: '#/components/schemas/NotificationMethod'
-                  nullable: true
+                  anyOf:
+                    - $ref: '#/components/schemas/NotificationMethod'
+                    - type: 'null'
                 nullableSearchResult:
-                  $ref: '#/components/schemas/SearchResult'
-                  nullable: true
+                  anyOf:
+                    - $ref: '#/components/schemas/SearchResult'
+                    - type: 'null'
                 nullableArray:
-                  type: array
+                  type:
+                    - array
+                    - 'null'
                   items:
                     type: string
-                  nullable: true
   /api/test/deserialization:
     post:
       description: Test endpoint for validating null deserialization
@@ -234,7 +246,7 @@ paths:
       parameters: []
       responses:
         '200':
-          description: ''
+          description: Success
           content:
             application/json:
               schema:
@@ -256,23 +268,26 @@ paths:
           in: query
           required: true
           schema:
-            $ref: '#/components/schemas/UserRole'
-            nullable: true
+            anyOf:
+              - $ref: '#/components/schemas/UserRole'
+              - type: 'null'
         - name: status
           in: query
           required: false
           schema:
-            $ref: '#/components/schemas/UserStatus'
-            nullable: true
+            anyOf:
+              - $ref: '#/components/schemas/UserStatus'
+              - type: 'null'
         - name: secondaryRole
           in: query
           required: false
           schema:
-            $ref: '#/components/schemas/UserRole'
-            nullable: true
+            anyOf:
+              - $ref: '#/components/schemas/UserRole'
+              - type: 'null'
       responses:
         '200':
-          description: ''
+          description: Success
           content:
             application/json:
               schema:
@@ -297,8 +312,9 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/NotificationMethod'
-                nullable: true
+                anyOf:
+                  - $ref: '#/components/schemas/NotificationMethod'
+                  - type: 'null'
   /api/users/{userId}/tags:
     put:
       description: Update tags to test array handling
@@ -328,20 +344,23 @@ paths:
               type: object
               properties:
                 tags:
-                  type: array
+                  type:
+                    - array
+                    - 'null'
                   items:
                     type: string
-                  nullable: true
                 categories:
-                  type: array
+                  type:
+                    - array
+                    - 'null'
                   items:
                     type: string
-                  nullable: true
                 labels:
-                  type: array
+                  type:
+                    - array
+                    - 'null'
                   items:
                     type: string
-                  nullable: true
               required:
                 - tags
   /api/search:
@@ -357,10 +376,11 @@ paths:
           content:
             application/json:
               schema:
-                type: array
+                type:
+                  - array
+                  - 'null'
                 items:
                   $ref: '#/components/schemas/SearchResult'
-                nullable: true
       requestBody:
         required: true
         content:
@@ -371,16 +391,19 @@ paths:
                 query:
                   type: string
                 filters:
-                  type: object
+                  type:
+                    - object
+                    - 'null'
                   additionalProperties:
-                    type: string
-                    nullable: true
-                  nullable: true
+                    type:
+                      - string
+                      - 'null'
                 includeTypes:
-                  type: array
+                  type:
+                    - array
+                    - 'null'
                   items:
                     type: string
-                  nullable: true
               required:
                 - query
                 - includeTypes
@@ -388,13 +411,15 @@ components:
   schemas:
     NullableUserId:
       title: NullableUserId
-      type: string
-      nullable: true
+      type:
+        - string
+        - 'null'
       description: An alias for a nullable user ID
     OptionalUserId:
       title: OptionalUserId
-      type: string
-      nullable: true
+      type:
+        - string
+        - 'null'
       description: An alias for an optional user ID
     UserProfile:
       title: UserProfile
@@ -406,63 +431,79 @@ components:
         username:
           type: string
         nullableString:
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
         nullableInteger:
-          type: integer
-          nullable: true
+          type:
+            - integer
+            - 'null'
         nullableBoolean:
-          type: boolean
-          nullable: true
+          type:
+            - boolean
+            - 'null'
         nullableDate:
-          type: string
+          type:
+            - string
+            - 'null'
           format: date-time
-          nullable: true
         nullableObject:
-          $ref: '#/components/schemas/Address'
-          nullable: true
+          anyOf:
+            - $ref: '#/components/schemas/Address'
+            - type: 'null'
         nullableList:
-          type: array
+          type:
+            - array
+            - 'null'
           items:
             type: string
-          nullable: true
         nullableMap:
-          type: object
+          type:
+            - object
+            - 'null'
           additionalProperties:
             type: string
-          nullable: true
         optionalString:
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
         optionalInteger:
-          type: integer
-          nullable: true
+          type:
+            - integer
+            - 'null'
         optionalBoolean:
-          type: boolean
-          nullable: true
+          type:
+            - boolean
+            - 'null'
         optionalDate:
-          type: string
+          type:
+            - string
+            - 'null'
           format: date-time
-          nullable: true
         optionalObject:
-          $ref: '#/components/schemas/Address'
-          nullable: true
+          anyOf:
+            - $ref: '#/components/schemas/Address'
+            - type: 'null'
         optionalList:
-          type: array
+          type:
+            - array
+            - 'null'
           items:
             type: string
-          nullable: true
         optionalMap:
-          type: object
+          type:
+            - object
+            - 'null'
           additionalProperties:
             type: string
-          nullable: true
         optionalNullableString:
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
         optionalNullableObject:
-          $ref: '#/components/schemas/Address'
-          nullable: true
+          anyOf:
+            - $ref: '#/components/schemas/Address'
+            - type: 'null'
       required:
         - id
         - username
@@ -481,16 +522,19 @@ components:
         street:
           type: string
         city:
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
         state:
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
         zipCode:
           type: string
         country:
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
         buildingId:
           $ref: '#/components/schemas/NullableUserId'
         tenantId:
@@ -508,14 +552,17 @@ components:
         username:
           type: string
         email:
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
         phone:
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
         address:
-          $ref: '#/components/schemas/Address'
-          nullable: true
+          anyOf:
+            - $ref: '#/components/schemas/Address'
+            - type: 'null'
       required:
         - username
         - email
@@ -525,17 +572,21 @@ components:
       description: For testing PATCH operations
       properties:
         username:
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
         email:
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
         phone:
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
         address:
-          $ref: '#/components/schemas/Address'
-          nullable: true
+          anyOf:
+            - $ref: '#/components/schemas/Address'
+            - type: 'null'
     UserRole:
       title: UserRole
       type: string
@@ -563,8 +614,7 @@ components:
               properties:
                 type:
                   type: string
-                  enum:
-                    - email
+                  const: email
             - $ref: '#/components/schemas/EmailNotification'
           required:
             - type
@@ -574,8 +624,7 @@ components:
               properties:
                 type:
                   type: string
-                  enum:
-                    - sms
+                  const: sms
             - $ref: '#/components/schemas/SmsNotification'
           required:
             - type
@@ -585,8 +634,7 @@ components:
               properties:
                 type:
                   type: string
-                  enum:
-                    - push
+                  const: push
             - $ref: '#/components/schemas/PushNotification'
           required:
             - type
@@ -600,8 +648,9 @@ components:
         subject:
           type: string
         htmlContent:
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
       required:
         - emailAddress
         - subject
@@ -614,8 +663,9 @@ components:
         message:
           type: string
         shortCode:
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
       required:
         - phoneNumber
         - message
@@ -630,8 +680,9 @@ components:
         body:
           type: string
         badge:
-          type: integer
-          nullable: true
+          type:
+            - integer
+            - 'null'
       required:
         - deviceToken
         - title
@@ -645,8 +696,7 @@ components:
               properties:
                 type:
                   type: string
-                  enum:
-                    - user
+                  const: user
             - $ref: '#/components/schemas/UserResponse'
           required:
             - type
@@ -656,8 +706,7 @@ components:
               properties:
                 type:
                   type: string
-                  enum:
-                    - organization
+                  const: organization
             - $ref: '#/components/schemas/Organization'
           required:
             - type
@@ -667,8 +716,7 @@ components:
               properties:
                 type:
                   type: string
-                  enum:
-                    - document
+                  const: document
             - $ref: '#/components/schemas/Document'
           required:
             - type
@@ -682,11 +730,13 @@ components:
         name:
           type: string
         domain:
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
         employeeCount:
-          type: integer
-          nullable: true
+          type:
+            - integer
+            - 'null'
       required:
         - id
         - name
@@ -702,13 +752,15 @@ components:
         content:
           type: string
         author:
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
         tags:
-          type: array
+          type:
+            - array
+            - 'null'
           items:
             type: string
-          nullable: true
       required:
         - id
         - title
@@ -722,75 +774,95 @@ components:
         id:
           type: string
         nullableRole:
-          $ref: '#/components/schemas/UserRole'
-          nullable: true
+          anyOf:
+            - $ref: '#/components/schemas/UserRole'
+            - type: 'null'
         optionalRole:
-          $ref: '#/components/schemas/UserRole'
-          nullable: true
+          anyOf:
+            - $ref: '#/components/schemas/UserRole'
+            - type: 'null'
         optionalNullableRole:
-          $ref: '#/components/schemas/UserRole'
-          nullable: true
+          anyOf:
+            - $ref: '#/components/schemas/UserRole'
+            - type: 'null'
         nullableStatus:
-          $ref: '#/components/schemas/UserStatus'
-          nullable: true
+          anyOf:
+            - $ref: '#/components/schemas/UserStatus'
+            - type: 'null'
         optionalStatus:
-          $ref: '#/components/schemas/UserStatus'
-          nullable: true
+          anyOf:
+            - $ref: '#/components/schemas/UserStatus'
+            - type: 'null'
         optionalNullableStatus:
-          $ref: '#/components/schemas/UserStatus'
-          nullable: true
+          anyOf:
+            - $ref: '#/components/schemas/UserStatus'
+            - type: 'null'
         nullableNotification:
-          $ref: '#/components/schemas/NotificationMethod'
-          nullable: true
+          anyOf:
+            - $ref: '#/components/schemas/NotificationMethod'
+            - type: 'null'
         optionalNotification:
-          $ref: '#/components/schemas/NotificationMethod'
-          nullable: true
+          anyOf:
+            - $ref: '#/components/schemas/NotificationMethod'
+            - type: 'null'
         optionalNullableNotification:
-          $ref: '#/components/schemas/NotificationMethod'
-          nullable: true
+          anyOf:
+            - $ref: '#/components/schemas/NotificationMethod'
+            - type: 'null'
         nullableSearchResult:
-          $ref: '#/components/schemas/SearchResult'
-          nullable: true
+          anyOf:
+            - $ref: '#/components/schemas/SearchResult'
+            - type: 'null'
         optionalSearchResult:
-          $ref: '#/components/schemas/SearchResult'
-          nullable: true
+          anyOf:
+            - $ref: '#/components/schemas/SearchResult'
+            - type: 'null'
         nullableArray:
-          type: array
+          type:
+            - array
+            - 'null'
           items:
             type: string
-          nullable: true
         optionalArray:
-          type: array
+          type:
+            - array
+            - 'null'
           items:
             type: string
-          nullable: true
         optionalNullableArray:
-          type: array
+          type:
+            - array
+            - 'null'
           items:
             type: string
-          nullable: true
         nullableListOfNullables:
-          type: array
+          type:
+            - array
+            - 'null'
           items:
-            type: string
-            nullable: true
-          nullable: true
+            type:
+              - string
+              - 'null'
         nullableMapOfNullables:
-          type: object
+          type:
+            - object
+            - 'null'
           additionalProperties:
-            $ref: '#/components/schemas/Address'
-            nullable: true
-          nullable: true
+            anyOf:
+              - $ref: '#/components/schemas/Address'
+              - type: 'null'
         nullableListOfUnions:
-          type: array
+          type:
+            - array
+            - 'null'
           items:
             $ref: '#/components/schemas/NotificationMethod'
-          nullable: true
         optionalMapOfEnums:
-          type: object
+          type:
+            - object
+            - 'null'
           additionalProperties:
             $ref: '#/components/schemas/UserRole'
-          nullable: true
       required:
         - id
         - nullableRole
@@ -809,42 +881,53 @@ components:
         requiredString:
           type: string
         nullableString:
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
         optionalString:
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
         optionalNullableString:
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
         nullableEnum:
-          $ref: '#/components/schemas/UserRole'
-          nullable: true
+          anyOf:
+            - $ref: '#/components/schemas/UserRole'
+            - type: 'null'
         optionalEnum:
-          $ref: '#/components/schemas/UserStatus'
-          nullable: true
+          anyOf:
+            - $ref: '#/components/schemas/UserStatus'
+            - type: 'null'
         nullableUnion:
-          $ref: '#/components/schemas/NotificationMethod'
-          nullable: true
+          anyOf:
+            - $ref: '#/components/schemas/NotificationMethod'
+            - type: 'null'
         optionalUnion:
-          $ref: '#/components/schemas/SearchResult'
-          nullable: true
+          anyOf:
+            - $ref: '#/components/schemas/SearchResult'
+            - type: 'null'
         nullableList:
-          type: array
+          type:
+            - array
+            - 'null'
           items:
             type: string
-          nullable: true
         nullableMap:
-          type: object
+          type:
+            - object
+            - 'null'
           additionalProperties:
             type: integer
-          nullable: true
         nullableObject:
-          $ref: '#/components/schemas/Address'
-          nullable: true
+          anyOf:
+            - $ref: '#/components/schemas/Address'
+            - type: 'null'
         optionalObject:
-          $ref: '#/components/schemas/Organization'
-          nullable: true
+          anyOf:
+            - $ref: '#/components/schemas/Organization'
+            - type: 'null'
       required:
         - requiredString
         - nullableString
@@ -881,21 +964,25 @@ components:
         username:
           type: string
         email:
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
         phone:
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
         createdAt:
           type: string
           format: date-time
         updatedAt:
-          type: string
+          type:
+            - string
+            - 'null'
           format: date-time
-          nullable: true
         address:
-          $ref: '#/components/schemas/Address'
-          nullable: true
+          anyOf:
+            - $ref: '#/components/schemas/Address'
+            - type: 'null'
       required:
         - id
         - username

--- a/seed/openapi/nullable-request-body/openapi.yml
+++ b/seed/openapi/nullable-request-body/openapi.yml
@@ -1,7 +1,7 @@
-openapi: 3.0.1
+openapi: 3.1.0
 info:
   title: nullable-request-body
-  version: ''
+  version: 0.0.0
 paths:
   /optional-request-body/{path_param}:
     post:
@@ -15,7 +15,6 @@ paths:
           required: true
           schema:
             type: string
-          example: path_param
           examples:
             Example1:
               value: path_param
@@ -23,14 +22,16 @@ paths:
           in: query
           required: false
           schema:
-            $ref: '#/components/schemas/PlainObject'
-            nullable: true
+            anyOf:
+              - $ref: '#/components/schemas/PlainObject'
+              - type: 'null'
         - name: query_param_integer
           in: query
           required: false
           schema:
-            type: integer
-            nullable: true
+            type:
+              - integer
+              - 'null'
       responses:
         '200':
           description: Successful Response
@@ -42,7 +43,7 @@ paths:
                   value:
                     key: value
         '422':
-          description: ''
+          description: UnprocessableEntityError
           content:
             application/json:
               schema:
@@ -53,8 +54,9 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/PlainObject'
-              nullable: true
+              anyOf:
+                - $ref: '#/components/schemas/PlainObject'
+                - type: 'null'
             examples:
               Example1:
                 value: {}
@@ -65,9 +67,11 @@ components:
       type: object
       properties:
         id:
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
         name:
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
   securitySchemes: {}

--- a/seed/openapi/nullable/openapi.yml
+++ b/seed/openapi/nullable/openapi.yml
@@ -1,7 +1,7 @@
-openapi: 3.0.1
+openapi: 3.1.0
 info:
   title: nullable
-  version: ''
+  version: 0.0.0
 paths:
   /users:
     get:
@@ -15,39 +15,44 @@ paths:
           schema:
             type: array
             items:
-              type: string
-              nullable: true
+              type:
+                - string
+                - 'null'
         - name: avatar
           in: query
           required: false
           schema:
-            type: string
-            nullable: true
+            type:
+              - string
+              - 'null'
         - name: activated
           in: query
           required: false
           schema:
             type: array
             items:
-              type: boolean
-              nullable: true
+              type:
+                - boolean
+                - 'null'
         - name: tags
           in: query
           required: false
           schema:
             type: array
             items:
-              type: string
-              nullable: true
+              type:
+                - string
+                - 'null'
         - name: extra
           in: query
           required: false
           schema:
-            type: boolean
-            nullable: true
+            type:
+              - boolean
+              - 'null'
       responses:
         '200':
-          description: ''
+          description: Success
           content:
             application/json:
               schema:
@@ -61,7 +66,7 @@ paths:
       parameters: []
       responses:
         '200':
-          description: ''
+          description: Success
           content:
             application/json:
               schema:
@@ -76,16 +81,19 @@ paths:
                 username:
                   type: string
                 tags:
-                  type: array
+                  type:
+                    - array
+                    - 'null'
                   items:
                     type: string
-                  nullable: true
                 metadata:
-                  $ref: '#/components/schemas/Metadata'
-                  nullable: true
+                  anyOf:
+                    - $ref: '#/components/schemas/Metadata'
+                    - type: 'null'
                 avatar:
-                  type: string
-                  nullable: true
+                  type:
+                    - string
+                    - 'null'
               required:
                 - username
     delete:
@@ -95,7 +103,7 @@ paths:
       parameters: []
       responses:
         '200':
-          description: ''
+          description: Success
           content:
             application/json:
               schema:
@@ -108,17 +116,19 @@ paths:
               type: object
               properties:
                 username:
-                  type: string
+                  type:
+                    - string
+                    - 'null'
                   minLength: 2
                   maxLength: 1024
-                  nullable: true
                   description: The user to delete.
 components:
   schemas:
     Email:
       title: Email
-      type: string
-      nullable: true
+      type:
+        - string
+        - 'null'
     UserId:
       title: UserId
       type: string
@@ -126,11 +136,13 @@ components:
       title: WeirdNumber
       oneOf:
         - type: integer
-        - type: integer
+        - type:
+            - integer
+            - 'null'
           format: float
-          nullable: true
-        - type: string
-          nullable: true
+        - type:
+            - string
+            - 'null'
         - type: number
           format: double
     User:
@@ -142,26 +154,29 @@ components:
         id:
           $ref: '#/components/schemas/UserId'
         tags:
-          type: array
+          type:
+            - array
+            - 'null'
           items:
             type: string
-          nullable: true
         metadata:
-          $ref: '#/components/schemas/Metadata'
-          nullable: true
+          anyOf:
+            - $ref: '#/components/schemas/Metadata'
+            - type: 'null'
         email:
           $ref: '#/components/schemas/Email'
         favorite-number:
           $ref: '#/components/schemas/WeirdNumber'
         numbers:
-          type: array
+          type:
+            - array
+            - 'null'
           items:
             type: integer
-          nullable: true
         strings:
-          type: object
-          additionalProperties: true
-          nullable: true
+          type:
+            - object
+            - 'null'
       required:
         - name
         - id
@@ -175,32 +190,31 @@ components:
           properties:
             type:
               type: string
-              enum:
-                - active
+              const: active
           required:
             - type
         - type: object
           properties:
             type:
               type: string
-              enum:
-                - archived
+              const: archived
             value:
-              type: string
+              type:
+                - string
+                - 'null'
               format: date-time
-              nullable: true
           required:
             - type
         - type: object
           properties:
             type:
               type: string
-              enum:
-                - soft-deleted
+              const: soft-deleted
             value:
-              type: string
+              type:
+                - string
+                - 'null'
               format: date-time
-              nullable: true
           required:
             - type
     Metadata:
@@ -214,19 +228,23 @@ components:
           type: string
           format: date-time
         avatar:
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
         activated:
-          type: boolean
-          nullable: true
+          type:
+            - boolean
+            - 'null'
         status:
           $ref: '#/components/schemas/Status'
         values:
-          type: object
+          type:
+            - object
+            - 'null'
           additionalProperties:
-            type: string
-            nullable: true
-          nullable: true
+            type:
+              - string
+              - 'null'
       required:
         - createdAt
         - updatedAt

--- a/seed/openapi/oauth-client-credentials-default/openapi.yml
+++ b/seed/openapi/oauth-client-credentials-default/openapi.yml
@@ -1,7 +1,7 @@
-openapi: 3.0.1
+openapi: 3.1.0
 info:
   title: oauth-client-credentials-default
-  version: ''
+  version: 0.0.0
 paths:
   /token:
     post:
@@ -11,7 +11,7 @@ paths:
       parameters: []
       responses:
         '200':
-          description: ''
+          description: Success
           content:
             application/json:
               schema:
@@ -42,7 +42,7 @@ paths:
       parameters: []
       responses:
         '204':
-          description: ''
+          description: No content
   /nested/get-something:
     get:
       operationId: nested_api_getSomething
@@ -51,7 +51,7 @@ paths:
       parameters: []
       responses:
         '204':
-          description: ''
+          description: No content
       security:
         - OAuthScheme: []
   /get-something:
@@ -62,7 +62,7 @@ paths:
       parameters: []
       responses:
         '204':
-          description: ''
+          description: No content
       security:
         - OAuthScheme: []
 components:

--- a/seed/openapi/oauth-client-credentials-nested-root/openapi.yml
+++ b/seed/openapi/oauth-client-credentials-nested-root/openapi.yml
@@ -1,7 +1,7 @@
-openapi: 3.0.1
+openapi: 3.1.0
 info:
   title: oauth-client-credentials
-  version: ''
+  version: 0.0.0
 paths:
   /token:
     post:
@@ -11,7 +11,7 @@ paths:
       parameters: []
       responses:
         '200':
-          description: ''
+          description: Success
           content:
             application/json:
               schema:
@@ -34,8 +34,9 @@ paths:
                   type: string
                   const: client_credentials
                 scope:
-                  type: string
-                  nullable: true
+                  type:
+                    - string
+                    - 'null'
               required:
                 - client_id
                 - client_secret
@@ -49,7 +50,7 @@ paths:
       parameters: []
       responses:
         '204':
-          description: ''
+          description: No content
   /nested/get-something:
     get:
       operationId: nested_api_getSomething
@@ -58,7 +59,7 @@ paths:
       parameters: []
       responses:
         '204':
-          description: ''
+          description: No content
       security:
         - OAuthScheme: []
   /get-something:
@@ -69,7 +70,7 @@ paths:
       parameters: []
       responses:
         '204':
-          description: ''
+          description: No content
       security:
         - OAuthScheme: []
 components:
@@ -84,8 +85,9 @@ components:
         expires_in:
           type: integer
         refresh_token:
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
       required:
         - access_token
         - expires_in

--- a/seed/openapi/oauth-client-credentials-openapi/openapi.yml
+++ b/seed/openapi/oauth-client-credentials-openapi/openapi.yml
@@ -1,7 +1,7 @@
-openapi: 3.0.1
+openapi: 3.1.0
 info:
   title: OAuth Client Credentials OpenAPI
-  version: ''
+  version: 0.0.0
 paths:
   /identity/token:
     post:
@@ -32,10 +32,12 @@ paths:
               properties:
                 username:
                   type: string
-                  example: username
+                  examples:
+                    - username
                 password:
                   type: string
-                  example: password
+                  examples:
+                    - password
               required:
                 - username
                 - password
@@ -79,7 +81,6 @@ paths:
           required: true
           schema:
             type: string
-          example: plantId
           examples:
             Example1:
               value: plantId
@@ -107,13 +108,16 @@ components:
       properties:
         access_token:
           type: string
-          example: access_token
+          examples:
+            - access_token
         expires_in:
           type: integer
-          example: 1
+          examples:
+            - 1
         refresh_token:
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
       required:
         - access_token
         - expires_in
@@ -123,13 +127,16 @@ components:
       properties:
         id:
           type: string
-          example: id
+          examples:
+            - id
         name:
           type: string
-          example: name
+          examples:
+            - name
         species:
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
       required:
         - id
         - name

--- a/seed/openapi/oauth-client-credentials-reference/openapi.yml
+++ b/seed/openapi/oauth-client-credentials-reference/openapi.yml
@@ -1,7 +1,7 @@
-openapi: 3.0.1
+openapi: 3.1.0
 info:
   title: oauth-client-credentials-reference
-  version: ''
+  version: 0.0.0
 paths:
   /token:
     post:
@@ -11,7 +11,7 @@ paths:
       parameters: []
       responses:
         '200':
-          description: ''
+          description: Success
           content:
             application/json:
               schema:
@@ -40,7 +40,7 @@ paths:
       parameters: []
       responses:
         '204':
-          description: ''
+          description: No content
       security:
         - OAuthScheme: []
 components:
@@ -52,10 +52,12 @@ components:
       properties:
         access_token:
           type: string
-          example: access_token
+          examples:
+            - access_token
         expires_in:
           type: integer
-          example: 3600
+          examples:
+            - 3600
       required:
         - access_token
         - expires_in
@@ -66,10 +68,12 @@ components:
       properties:
         client_id:
           type: string
-          example: client_id
+          examples:
+            - client_id
         client_secret:
           type: string
-          example: client_secret
+          examples:
+            - client_secret
       required:
         - client_id
         - client_secret

--- a/seed/openapi/object/openapi.yml
+++ b/seed/openapi/object/openapi.yml
@@ -1,7 +1,7 @@
-openapi: 3.0.1
+openapi: 3.1.0
 info:
   title: object
-  version: ''
+  version: 0.0.0
 paths: {}
 components:
   schemas:
@@ -12,44 +12,53 @@ components:
       properties:
         one:
           type: integer
-          example: 1
+          examples:
+            - 1
         two:
           type: number
           format: double
-          example: 2
+          examples:
+            - 2
         three:
           type: string
-          example: three
+          examples:
+            - three
         four:
           type: boolean
-          example: true
+          examples:
+            - true
         five:
           type: integer
           format: int64
-          example: 5
+          examples:
+            - 5
         six:
           type: string
           format: date-time
-          example: '1994-01-01T01:01:01Z'
+          examples:
+            - '1994-01-01T01:01:01Z'
         seven:
           type: string
           format: date
-          example: '1994-01-01'
+          examples:
+            - '1994-01-01'
         eight:
           type: string
           format: uuid
-          example: 7f71f677-e138-4a5c-bb01-e4453a19bfef
+          examples:
+            - 7f71f677-e138-4a5c-bb01-e4453a19bfef
         nine:
           type: string
           format: byte
-          example: TWFueSBoYW5kcyBtYWtlIGxpZ2h0IHdvcmsu
+          examples:
+            - TWFueSBoYW5kcyBtYWtlIGxpZ2h0IHdvcmsu
         ten:
           type: array
           items:
             type: integer
-          example:
-            - 10
-            - 10
+          examples:
+            - - 10
+              - 10
         eleven:
           type: array
           items:
@@ -60,9 +69,10 @@ components:
           additionalProperties:
             type: boolean
         thirteen:
-          type: integer
+          type:
+            - integer
+            - 'null'
           format: int64
-          nullable: true
         fourteen: {}
         fifteen:
           type: array
@@ -79,9 +89,10 @@ components:
         seventeen:
           type: array
           items:
-            type: string
+            type:
+              - string
+              - 'null'
             format: uuid
-            nullable: true
         eighteen:
           type: string
           const: eighteen
@@ -90,27 +101,33 @@ components:
         twenty:
           type: integer
           format: int64
-          example: 20
+          examples:
+            - 20
         twentyone:
           type: integer
           format: int64
-          example: 21
+          examples:
+            - 21
         twentytwo:
           type: integer
           format: float
-          example: 22.22
+          examples:
+            - 22.22
         twentythree:
           type: integer
           format: bigint
-          example: '23'
+          examples:
+            - '23'
         twentyfour:
-          type: string
+          type:
+            - string
+            - 'null'
           format: date-time
-          nullable: true
         twentyfive:
-          type: string
+          type:
+            - string
+            - 'null'
           format: date
-          nullable: true
       required:
         - one
         - two
@@ -140,10 +157,12 @@ components:
       properties:
         id:
           type: string
-          example: name-sdfg8ajk
+          examples:
+            - name-sdfg8ajk
         value:
           type: string
-          example: name
+          examples:
+            - name
       required:
         - id
         - value

--- a/seed/openapi/objects-with-imports/openapi.yml
+++ b/seed/openapi/objects-with-imports/openapi.yml
@@ -1,7 +1,7 @@
-openapi: 3.0.1
+openapi: 3.1.0
 info:
   title: objects-with-imports
-  version: ''
+  version: 0.0.0
 paths: {}
 components:
   schemas:
@@ -11,13 +11,16 @@ components:
       properties:
         id:
           type: string
-          example: node-8dvgfja2
+          examples:
+            - node-8dvgfja2
         label:
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
         metadata:
-          $ref: '#/components/schemas/commonsMetadata'
-          nullable: true
+          anyOf:
+            - $ref: '#/components/schemas/commonsMetadata'
+            - type: 'null'
       required:
         - id
     Tree:
@@ -25,22 +28,25 @@ components:
       type: object
       properties:
         nodes:
-          type: array
+          type:
+            - array
+            - 'null'
           items:
             $ref: '#/components/schemas/Node'
-          nullable: true
     commonsMetadata:
       title: commonsMetadata
       type: object
       properties:
         id:
           type: string
-          example: metadata-js8dg24b
+          examples:
+            - metadata-js8dg24b
         data:
-          type: object
+          type:
+            - object
+            - 'null'
           additionalProperties:
             type: string
-          nullable: true
       required:
         - id
     File:
@@ -49,10 +55,12 @@ components:
       properties:
         name:
           type: string
-          example: file.txt
+          examples:
+            - file.txt
         contents:
           type: string
-          example: ...
+          examples:
+            - ...
         info:
           $ref: '#/components/schemas/FileInfo'
       required:
@@ -71,17 +79,20 @@ components:
       properties:
         name:
           type: string
-          example: root
+          examples:
+            - root
         files:
-          type: array
+          type:
+            - array
+            - 'null'
           items:
             $ref: '#/components/schemas/File'
-          nullable: true
         directories:
-          type: array
+          type:
+            - array
+            - 'null'
           items:
             $ref: '#/components/schemas/fileDirectory'
-          nullable: true
       required:
         - name
   securitySchemes: {}

--- a/seed/openapi/optional/openapi.yml
+++ b/seed/openapi/optional/openapi.yml
@@ -1,7 +1,7 @@
-openapi: 3.0.1
+openapi: 3.1.0
 info:
   title: objects-with-imports
-  version: ''
+  version: 0.0.0
 paths:
   /send-optional-body:
     post:
@@ -21,9 +21,9 @@ paths:
         content:
           application/json:
             schema:
-              type: object
-              additionalProperties: true
-              nullable: true
+              type:
+                - object
+                - 'null'
   /send-optional-typed-body:
     post:
       operationId: optional_sendOptionalTypedBody
@@ -42,8 +42,9 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/SendOptionalBodyRequest'
-              nullable: true
+              anyOf:
+                - $ref: '#/components/schemas/SendOptionalBodyRequest'
+                - type: 'null'
   /deploy/{actionId}/versions/{id}:
     post:
       description: >-
@@ -67,7 +68,7 @@ paths:
             type: string
       responses:
         '200':
-          description: ''
+          description: Success
           content:
             application/json:
               schema:
@@ -77,8 +78,9 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/DeployParams'
-              nullable: true
+              anyOf:
+                - $ref: '#/components/schemas/DeployParams'
+                - type: 'null'
 components:
   schemas:
     SendOptionalBodyRequest:
@@ -94,8 +96,9 @@ components:
       type: object
       properties:
         updateDraft:
-          type: boolean
-          nullable: true
+          type:
+            - boolean
+            - 'null'
     DeployResponse:
       title: DeployResponse
       type: object

--- a/seed/openapi/package-yml/openapi.yml
+++ b/seed/openapi/package-yml/openapi.yml
@@ -1,7 +1,7 @@
-openapi: 3.0.1
+openapi: 3.1.0
 info:
   title: package-yml
-  version: ''
+  version: 0.0.0
 paths:
   /{id}/:
     post:
@@ -14,13 +14,12 @@ paths:
           required: true
           schema:
             type: string
-          example: id-ksfd9c1
           examples:
             Example1:
               value: id-ksfd9c1
       responses:
         '200':
-          description: ''
+          description: Success
           content:
             application/json:
               schema:
@@ -50,7 +49,6 @@ paths:
           required: true
           schema:
             type: string
-          example: id-a2ijs82
           examples:
             Example1:
               value: id-a2ijs82
@@ -59,13 +57,12 @@ paths:
           required: true
           schema:
             type: string
-          example: id-219xca8
           examples:
             Example1:
               value: id-219xca8
       responses:
         '204':
-          description: ''
+          description: No content
 components:
   schemas:
     EchoRequest:
@@ -74,10 +71,12 @@ components:
       properties:
         name:
           type: string
-          example: Hello world!
+          examples:
+            - Hello world!
         size:
           type: integer
-          example: 20
+          examples:
+            - 20
       required:
         - name
         - size

--- a/seed/openapi/pagination-custom/openapi.yml
+++ b/seed/openapi/pagination-custom/openapi.yml
@@ -1,7 +1,7 @@
-openapi: 3.0.1
+openapi: 3.1.0
 info:
   title: pagination
-  version: ''
+  version: 0.0.0
 paths:
   /users:
     get:
@@ -14,18 +14,20 @@ paths:
           description: The maximum number of results to return.
           required: false
           schema:
-            type: integer
-            nullable: true
+            type:
+              - integer
+              - 'null'
         - name: starting_after
           in: query
           description: The cursor used for pagination.
           required: false
           schema:
-            type: string
-            nullable: true
+            type:
+              - string
+              - 'null'
       responses:
         '200':
-          description: ''
+          description: Success
           content:
             application/json:
               schema:
@@ -37,14 +39,17 @@ components:
       type: object
       properties:
         limit:
-          type: integer
-          nullable: true
+          type:
+            - integer
+            - 'null'
         count:
-          type: integer
-          nullable: true
+          type:
+            - integer
+            - 'null'
         has_more:
-          type: boolean
-          nullable: true
+          type:
+            - boolean
+            - 'null'
         links:
           type: array
           items:

--- a/seed/openapi/pagination-uri-path/openapi.yml
+++ b/seed/openapi/pagination-uri-path/openapi.yml
@@ -1,7 +1,7 @@
-openapi: 3.0.1
+openapi: 3.1.0
 info:
   title: pagination-uri-path
-  version: ''
+  version: 0.0.0
 paths:
   /users/uri:
     get:
@@ -11,7 +11,7 @@ paths:
       parameters: []
       responses:
         '200':
-          description: ''
+          description: Success
           content:
             application/json:
               schema:
@@ -24,7 +24,7 @@ paths:
       parameters: []
       responses:
         '200':
-          description: ''
+          description: Success
           content:
             application/json:
               schema:
@@ -51,8 +51,9 @@ components:
           items:
             $ref: '#/components/schemas/User'
         next:
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
       required:
         - data
     ListUsersPathPaginationResponse:
@@ -64,8 +65,9 @@ components:
           items:
             $ref: '#/components/schemas/User'
         next:
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
       required:
         - data
   securitySchemes:

--- a/seed/openapi/path-parameters/openapi.yml
+++ b/seed/openapi/path-parameters/openapi.yml
@@ -1,7 +1,7 @@
-openapi: 3.0.1
+openapi: 3.1.0
 info:
   title: path-parameters
-  version: ''
+  version: 0.0.0
 paths:
   /{tenant_id}/organizations/{organization_id}/:
     get:
@@ -21,7 +21,7 @@ paths:
             type: string
       responses:
         '200':
-          description: ''
+          description: Success
           content:
             application/json:
               schema:
@@ -49,7 +49,7 @@ paths:
             type: string
       responses:
         '200':
-          description: ''
+          description: Success
           content:
             application/json:
               schema:
@@ -74,11 +74,12 @@ paths:
           in: query
           required: false
           schema:
-            type: integer
-            nullable: true
+            type:
+              - integer
+              - 'null'
       responses:
         '200':
-          description: ''
+          description: Success
           content:
             application/json:
               schema:
@@ -103,7 +104,7 @@ paths:
             type: string
       responses:
         '200':
-          description: ''
+          description: Success
           content:
             application/json:
               schema:
@@ -125,7 +126,7 @@ paths:
             type: string
       responses:
         '200':
-          description: ''
+          description: Success
           content:
             application/json:
               schema:
@@ -149,7 +150,7 @@ paths:
             type: string
       responses:
         '200':
-          description: ''
+          description: Success
           content:
             application/json:
               schema:
@@ -180,11 +181,12 @@ paths:
           in: query
           required: false
           schema:
-            type: integer
-            nullable: true
+            type:
+              - integer
+              - 'null'
       responses:
         '200':
-          description: ''
+          description: Success
           content:
             application/json:
               schema:
@@ -215,7 +217,7 @@ paths:
             type: integer
       responses:
         '200':
-          description: ''
+          description: Success
           content:
             application/json:
               schema:
@@ -251,7 +253,7 @@ paths:
             type: string
       responses:
         '200':
-          description: ''
+          description: Success
           content:
             application/json:
               schema:

--- a/seed/openapi/plain-text/openapi.yml
+++ b/seed/openapi/plain-text/openapi.yml
@@ -1,7 +1,7 @@
-openapi: 3.0.1
+openapi: 3.1.0
 info:
   title: plain-text
-  version: ''
+  version: 0.0.0
 paths:
   /text:
     post:
@@ -11,7 +11,7 @@ paths:
       parameters: []
       responses:
         '204':
-          description: ''
+          description: No content
 components:
   schemas: {}
   securitySchemes: {}

--- a/seed/openapi/property-access/openapi.yml
+++ b/seed/openapi/property-access/openapi.yml
@@ -1,7 +1,7 @@
-openapi: 3.0.1
+openapi: 3.1.0
 info:
   title: property-access
-  version: ''
+  version: 0.0.0
 paths:
   /users:
     post:
@@ -11,7 +11,7 @@ paths:
       parameters: []
       responses:
         '200':
-          description: ''
+          description: Success
           content:
             application/json:
               schema:
@@ -101,8 +101,7 @@ components:
               properties:
                 type:
                   type: string
-                  enum:
-                    - user
+                  const: user
             - $ref: '#/components/schemas/User'
           required:
             - type
@@ -110,8 +109,7 @@ components:
           properties:
             type:
               type: string
-              enum:
-                - admin
+              const: admin
             admin:
               $ref: '#/components/schemas/Admin'
           required:
@@ -120,8 +118,7 @@ components:
           properties:
             type:
               type: string
-              enum:
-                - empty
+              const: empty
           required:
             - type
       description: Example of an discriminated union

--- a/seed/openapi/public-object/openapi.yml
+++ b/seed/openapi/public-object/openapi.yml
@@ -1,7 +1,7 @@
-openapi: 3.0.1
+openapi: 3.1.0
 info:
   title: public-object
-  version: ''
+  version: 0.0.0
 paths:
   /helloworld.txt:
     get:
@@ -11,7 +11,7 @@ paths:
       parameters: []
       responses:
         '204':
-          description: ''
+          description: No content
 components:
   schemas: {}
   securitySchemes: {}

--- a/seed/openapi/query-param-name-conflict/openapi.yml
+++ b/seed/openapi/query-param-name-conflict/openapi.yml
@@ -1,7 +1,7 @@
-openapi: 3.0.1
+openapi: 3.1.0
 info:
   title: Query Param Name Conflict API
-  version: ''
+  version: 0.0.0
 paths:
   /task/:
     put:
@@ -13,27 +13,31 @@ paths:
           in: query
           required: false
           schema:
-            type: string
-            nullable: true
+            type:
+              - string
+              - 'null'
         - name: is_complete
           in: query
           required: false
           schema:
-            type: string
-            nullable: true
+            type:
+              - string
+              - 'null'
         - name: date
           in: query
           required: false
           schema:
-            type: string
-            nullable: true
+            type:
+              - string
+              - 'null'
         - name: _fields
           in: query
           description: Comma-separated list of fields to include in the response.
           required: false
           schema:
-            type: string
-            nullable: true
+            type:
+              - string
+              - 'null'
       responses:
         '200':
           description: Successful response
@@ -54,18 +58,22 @@ paths:
               type: object
               properties:
                 assigned_to:
-                  type: string
-                  nullable: true
+                  type:
+                    - string
+                    - 'null'
                 date:
-                  type: string
+                  type:
+                    - string
+                    - 'null'
                   format: date
-                  nullable: true
                 is_complete:
-                  type: boolean
-                  nullable: true
+                  type:
+                    - boolean
+                    - 'null'
                 text:
-                  type: string
-                  nullable: true
+                  type:
+                    - string
+                    - 'null'
             examples:
               Example1:
                 value: {}
@@ -76,6 +84,7 @@ components:
       type: object
       properties:
         updated_count:
-          type: integer
-          nullable: true
+          type:
+            - integer
+            - 'null'
   securitySchemes: {}

--- a/seed/openapi/query-parameters-openapi-as-objects/openapi.yml
+++ b/seed/openapi/query-parameters-openapi-as-objects/openapi.yml
@@ -1,7 +1,7 @@
-openapi: 3.0.1
+openapi: 3.1.0
 info:
   title: Query Parameters API
-  version: ''
+  version: 0.0.0
 paths:
   /user/getUsername:
     get:
@@ -47,57 +47,65 @@ paths:
           schema:
             type: array
             items:
-              $ref: '#/components/schemas/User'
-              nullable: true
+              anyOf:
+                - $ref: '#/components/schemas/User'
+                - type: 'null'
         - name: optionalDeadline
           in: query
           required: false
           schema:
-            type: string
+            type:
+              - string
+              - 'null'
             format: date-time
-            nullable: true
         - name: keyValue
           in: query
           required: false
           schema:
-            type: object
+            type:
+              - object
+              - 'null'
             additionalProperties:
               type: string
-            nullable: true
         - name: optionalString
           in: query
           required: false
           schema:
-            type: string
-            nullable: true
+            type:
+              - string
+              - 'null'
         - name: nestedUser
           in: query
           required: false
           schema:
-            $ref: '#/components/schemas/NestedUser'
-            nullable: true
+            anyOf:
+              - $ref: '#/components/schemas/NestedUser'
+              - type: 'null'
         - name: optionalUser
           in: query
           required: false
           schema:
-            $ref: '#/components/schemas/User'
-            nullable: true
+            anyOf:
+              - $ref: '#/components/schemas/User'
+              - type: 'null'
         - name: excludeUser
           in: query
           required: false
           schema:
             type: array
             items:
-              $ref: '#/components/schemas/User'
-              nullable: true
+              anyOf:
+                - $ref: '#/components/schemas/User'
+                - type: 'null'
         - name: filter
           in: query
           required: false
           schema:
             type: array
             items:
-              type: string
-              nullable: true
+              type:
+                - string
+                - 'null'
         - name: tags
           in: query
           description: List of tags. Serialized as a comma-separated list.
@@ -105,8 +113,9 @@ paths:
           schema:
             type: array
             items:
-              type: string
-              nullable: true
+              type:
+                - string
+                - 'null'
         - name: optionalTags
           in: query
           description: Optional list of tags. Serialized as a comma-separated list.
@@ -114,14 +123,16 @@ paths:
           schema:
             type: array
             items:
-              type: string
-              nullable: true
+              type:
+                - string
+                - 'null'
         - name: neighbor
           in: query
           required: false
           schema:
-            $ref: '#/components/schemas/SearchRequestNeighbor'
-            nullable: true
+            anyOf:
+              - $ref: '#/components/schemas/SearchRequestNeighbor'
+              - type: 'null'
         - name: neighborRequired
           in: query
           required: true
@@ -155,30 +166,35 @@ components:
       type: object
       properties:
         results:
-          type: array
+          type:
+            - array
+            - 'null'
           items:
             type: string
-          nullable: true
     User:
       title: User
       type: object
       properties:
         name:
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
         tags:
-          type: array
+          type:
+            - array
+            - 'null'
           items:
             type: string
-          nullable: true
     NestedUser:
       title: NestedUser
       type: object
       properties:
         name:
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
         user:
-          $ref: '#/components/schemas/User'
-          nullable: true
+          anyOf:
+            - $ref: '#/components/schemas/User'
+            - type: 'null'
   securitySchemes: {}

--- a/seed/openapi/query-parameters-openapi/openapi.yml
+++ b/seed/openapi/query-parameters-openapi/openapi.yml
@@ -1,7 +1,7 @@
-openapi: 3.0.1
+openapi: 3.1.0
 info:
   title: Query Parameters API
-  version: ''
+  version: 0.0.0
 paths:
   /user/getUsername:
     get:
@@ -47,57 +47,65 @@ paths:
           schema:
             type: array
             items:
-              $ref: '#/components/schemas/User'
-              nullable: true
+              anyOf:
+                - $ref: '#/components/schemas/User'
+                - type: 'null'
         - name: optionalDeadline
           in: query
           required: false
           schema:
-            type: string
+            type:
+              - string
+              - 'null'
             format: date-time
-            nullable: true
         - name: keyValue
           in: query
           required: false
           schema:
-            type: object
+            type:
+              - object
+              - 'null'
             additionalProperties:
               type: string
-            nullable: true
         - name: optionalString
           in: query
           required: false
           schema:
-            type: string
-            nullable: true
+            type:
+              - string
+              - 'null'
         - name: nestedUser
           in: query
           required: false
           schema:
-            $ref: '#/components/schemas/NestedUser'
-            nullable: true
+            anyOf:
+              - $ref: '#/components/schemas/NestedUser'
+              - type: 'null'
         - name: optionalUser
           in: query
           required: false
           schema:
-            $ref: '#/components/schemas/User'
-            nullable: true
+            anyOf:
+              - $ref: '#/components/schemas/User'
+              - type: 'null'
         - name: excludeUser
           in: query
           required: false
           schema:
             type: array
             items:
-              $ref: '#/components/schemas/User'
-              nullable: true
+              anyOf:
+                - $ref: '#/components/schemas/User'
+                - type: 'null'
         - name: filter
           in: query
           required: false
           schema:
             type: array
             items:
-              type: string
-              nullable: true
+              type:
+                - string
+                - 'null'
         - name: tags
           in: query
           description: List of tags. Serialized as a comma-separated list.
@@ -105,8 +113,9 @@ paths:
           schema:
             type: array
             items:
-              type: string
-              nullable: true
+              type:
+                - string
+                - 'null'
         - name: optionalTags
           in: query
           description: Optional list of tags. Serialized as a comma-separated list.
@@ -114,14 +123,16 @@ paths:
           schema:
             type: array
             items:
-              type: string
-              nullable: true
+              type:
+                - string
+                - 'null'
         - name: neighbor
           in: query
           required: false
           schema:
-            $ref: '#/components/schemas/SearchRequestNeighbor'
-            nullable: true
+            anyOf:
+              - $ref: '#/components/schemas/SearchRequestNeighbor'
+              - type: 'null'
         - name: neighborRequired
           in: query
           required: true
@@ -155,30 +166,35 @@ components:
       type: object
       properties:
         results:
-          type: array
+          type:
+            - array
+            - 'null'
           items:
             type: string
-          nullable: true
     User:
       title: User
       type: object
       properties:
         name:
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
         tags:
-          type: array
+          type:
+            - array
+            - 'null'
           items:
             type: string
-          nullable: true
     NestedUser:
       title: NestedUser
       type: object
       properties:
         name:
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
         user:
-          $ref: '#/components/schemas/User'
-          nullable: true
+          anyOf:
+            - $ref: '#/components/schemas/User'
+            - type: 'null'
   securitySchemes: {}

--- a/seed/openapi/query-parameters/openapi.yml
+++ b/seed/openapi/query-parameters/openapi.yml
@@ -1,7 +1,7 @@
-openapi: 3.0.1
+openapi: 3.1.0
 info:
   title: query-parameters
-  version: ''
+  version: 0.0.0
 paths:
   /user:
     get:
@@ -54,9 +54,10 @@ paths:
           in: query
           required: false
           schema:
-            type: string
+            type:
+              - string
+              - 'null'
             format: date-time
-            nullable: true
         - name: keyValue
           in: query
           required: true
@@ -68,8 +69,9 @@ paths:
           in: query
           required: false
           schema:
-            type: string
-            nullable: true
+            type:
+              - string
+              - 'null'
         - name: nestedUser
           in: query
           required: true
@@ -79,8 +81,9 @@ paths:
           in: query
           required: false
           schema:
-            $ref: '#/components/schemas/User'
-            nullable: true
+            anyOf:
+              - $ref: '#/components/schemas/User'
+              - type: 'null'
         - name: excludeUser
           in: query
           required: true
@@ -97,7 +100,7 @@ paths:
               type: string
       responses:
         '200':
-          description: ''
+          description: Success
           content:
             application/json:
               schema:

--- a/seed/openapi/request-parameters/openapi.yml
+++ b/seed/openapi/request-parameters/openapi.yml
@@ -1,7 +1,7 @@
-openapi: 3.0.1
+openapi: 3.1.0
 info:
   title: request-parameters
-  version: ''
+  version: 0.0.0
 paths:
   /user/username:
     post:
@@ -18,7 +18,7 @@ paths:
               type: string
       responses:
         '204':
-          description: ''
+          description: No content
       requestBody:
         required: true
         content:
@@ -51,7 +51,7 @@ paths:
               type: string
       responses:
         '204':
-          description: ''
+          description: No content
       requestBody:
         required: true
         content:
@@ -66,14 +66,15 @@ paths:
       parameters: []
       responses:
         '204':
-          description: ''
+          description: No content
       requestBody:
         required: false
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/CreateUsernameBodyOptionalProperties'
-              nullable: true
+              anyOf:
+                - $ref: '#/components/schemas/CreateUsernameBodyOptionalProperties'
+                - type: 'null'
             examples:
               empty-object:
                 value: {}
@@ -128,9 +129,10 @@ paths:
           in: query
           required: false
           schema:
-            type: string
+            type:
+              - string
+              - 'null'
             format: date-time
-            nullable: true
         - name: keyValue
           in: query
           required: true
@@ -142,8 +144,9 @@ paths:
           in: query
           required: false
           schema:
-            type: string
-            nullable: true
+            type:
+              - string
+              - 'null'
         - name: nestedUser
           in: query
           required: true
@@ -153,8 +156,9 @@ paths:
           in: query
           required: false
           schema:
-            $ref: '#/components/schemas/User'
-            nullable: true
+            anyOf:
+              - $ref: '#/components/schemas/User'
+              - type: 'null'
         - name: excludeUser
           in: query
           required: true
@@ -183,7 +187,7 @@ paths:
             format: bigint
       responses:
         '200':
-          description: ''
+          description: Success
           content:
             application/json:
               schema:
@@ -233,12 +237,15 @@ components:
       type: object
       properties:
         username:
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
         password:
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
         name:
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
   securitySchemes: {}

--- a/seed/openapi/required-nullable/openapi.yml
+++ b/seed/openapi/required-nullable/openapi.yml
@@ -1,7 +1,7 @@
-openapi: 3.0.1
+openapi: 3.1.0
 info:
   title: Required nullable example
-  version: ''
+  version: 0.0.0
 paths:
   /foo:
     get:
@@ -14,22 +14,23 @@ paths:
           description: An optional baz
           required: false
           schema:
-            type: string
-            nullable: true
+            type:
+              - string
+              - 'null'
         - name: optional_nullable_baz
           in: query
           description: An optional baz
           required: false
           schema:
-            type: string
-            nullable: true
+            type:
+              - string
+              - 'null'
         - name: required_baz
           in: query
           description: A required baz
           required: true
           schema:
             type: string
-          example: required_baz
           examples:
             Example1:
               value: required_baz
@@ -38,9 +39,9 @@ paths:
           description: A required baz
           required: true
           schema:
-            type: string
-            nullable: true
-          example: required_nullable_baz
+            type:
+              - string
+              - 'null'
           examples:
             Example1:
               value: required_nullable_baz
@@ -91,17 +92,20 @@ paths:
               type: object
               properties:
                 nullable_text:
-                  type: string
-                  nullable: true
+                  type:
+                    - string
+                    - 'null'
                   description: Can be explicitly set to null to clear the value
                 nullable_number:
-                  type: number
+                  type:
+                    - number
+                    - 'null'
                   format: double
-                  nullable: true
                   description: Can be explicitly set to null to clear the value
                 non_nullable_text:
-                  type: string
-                  nullable: true
+                  type:
+                    - string
+                    - 'null'
                   description: Regular non-nullable field
 components:
   schemas:
@@ -110,17 +114,21 @@ components:
       type: object
       properties:
         bar:
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
         nullable_bar:
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
         nullable_required_bar:
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
         required_bar:
           type: string
-          example: required_bar
+          examples:
+            - required_bar
       required:
         - nullable_required_bar
         - required_bar

--- a/seed/openapi/reserved-keywords/openapi.yml
+++ b/seed/openapi/reserved-keywords/openapi.yml
@@ -1,7 +1,7 @@
-openapi: 3.0.1
+openapi: 3.1.0
 info:
   title: nursery-api
-  version: ''
+  version: 0.0.0
 paths:
   /:
     post:
@@ -16,7 +16,7 @@ paths:
             type: string
       responses:
         '204':
-          description: ''
+          description: No content
 components:
   schemas:
     Package:

--- a/seed/openapi/schemaless-request-body-examples/openapi.yml
+++ b/seed/openapi/schemaless-request-body-examples/openapi.yml
@@ -1,7 +1,7 @@
-openapi: 3.0.1
+openapi: 3.1.0
 info:
   title: Schemaless Request Body Examples API
-  version: ''
+  version: 0.0.0
 paths:
   /plants:
     post:
@@ -52,7 +52,6 @@ paths:
           required: true
           schema:
             type: string
-          example: plantId
           examples:
             Example1:
               value: plantId
@@ -108,11 +107,13 @@ paths:
               type: object
               properties:
                 name:
-                  type: string
-                  nullable: true
+                  type:
+                    - string
+                    - 'null'
                 species:
-                  type: string
-                  nullable: true
+                  type:
+                    - string
+                    - 'null'
             examples:
               Example1:
                 value:
@@ -125,29 +126,35 @@ components:
       type: object
       properties:
         id:
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
         name:
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
     UpdatePlantResponse:
       title: UpdatePlantResponse
       type: object
       properties:
         id:
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
         name:
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
     CreatePlantWithSchemaResponse:
       title: CreatePlantWithSchemaResponse
       type: object
       properties:
         id:
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
         name:
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
   securitySchemes: {}

--- a/seed/openapi/seed.yml
+++ b/seed/openapi/seed.yml
@@ -33,8 +33,9 @@ fixtures:
       outputFolder: override
     - customConfig:
         customOverrides:
-          info: 
-            license: MIT
+          info:
+            license:
+              name: MIT
       outputFolder: custom-overrides
     - customConfig:
         filename: imdb.yaml

--- a/seed/openapi/server-sent-event-examples/openapi.yml
+++ b/seed/openapi/server-sent-event-examples/openapi.yml
@@ -1,7 +1,7 @@
-openapi: 3.0.1
+openapi: 3.1.0
 info:
   title: server-sent-events
-  version: ''
+  version: 0.0.0
 paths:
   /stream:
     post:
@@ -11,9 +11,9 @@ paths:
       parameters: []
       responses:
         '204':
-          description: ''
+          description: No content
         '400':
-          description: ''
+          description: BadRequestError
           content:
             application/json:
               schema:
@@ -30,7 +30,8 @@ paths:
               properties:
                 query:
                   type: string
-                  example: foo
+                  examples:
+                    - foo
               required:
                 - query
             examples:
@@ -48,9 +49,9 @@ paths:
       parameters: []
       responses:
         '204':
-          description: ''
+          description: No content
         '400':
-          description: ''
+          description: BadRequestError
           content:
             application/json:
               schema:
@@ -67,7 +68,8 @@ paths:
               properties:
                 query:
                   type: string
-                  example: query
+                  examples:
+                    - query
               required:
                 - query
             examples:
@@ -85,9 +87,9 @@ paths:
       parameters: []
       responses:
         '204':
-          description: ''
+          description: No content
         '400':
-          description: ''
+          description: BadRequestError
           content:
             application/json:
               schema:
@@ -104,7 +106,8 @@ paths:
               properties:
                 query:
                   type: string
-                  example: query
+                  examples:
+                    - query
               required:
                 - query
             examples:
@@ -123,8 +126,9 @@ components:
         delta:
           type: string
         tokens:
-          type: integer
-          nullable: true
+          type:
+            - integer
+            - 'null'
       required:
         - delta
     CompletionEvent:
@@ -153,8 +157,9 @@ components:
         error:
           type: string
         code:
-          type: integer
-          nullable: true
+          type:
+            - integer
+            - 'null'
       required:
         - error
     StreamEventContextProtocol:
@@ -166,8 +171,7 @@ components:
               properties:
                 event:
                   type: string
-                  enum:
-                    - completion
+                  const: completion
             - $ref: '#/components/schemas/CompletionEvent'
           required:
             - event
@@ -177,8 +181,7 @@ components:
               properties:
                 event:
                   type: string
-                  enum:
-                    - error
+                  const: error
             - $ref: '#/components/schemas/ErrorEvent'
           required:
             - event
@@ -188,8 +191,7 @@ components:
               properties:
                 event:
                   type: string
-                  enum:
-                    - event
+                  const: event
             - $ref: '#/components/schemas/EventEvent'
           required:
             - event
@@ -202,8 +204,7 @@ components:
               properties:
                 event:
                   type: string
-                  enum:
-                    - completion
+                  const: completion
             - $ref: '#/components/schemas/CompletionEvent'
           required:
             - event
@@ -213,8 +214,7 @@ components:
               properties:
                 event:
                   type: string
-                  enum:
-                    - error
+                  const: error
             - $ref: '#/components/schemas/ErrorEvent'
           required:
             - event

--- a/seed/openapi/server-sent-events/openapi.yml
+++ b/seed/openapi/server-sent-events/openapi.yml
@@ -1,7 +1,7 @@
-openapi: 3.0.1
+openapi: 3.1.0
 info:
   title: server-sent-events
-  version: ''
+  version: 0.0.0
 paths:
   /stream:
     post:
@@ -11,7 +11,7 @@ paths:
       parameters: []
       responses:
         '204':
-          description: ''
+          description: No content
       requestBody:
         required: true
         content:
@@ -21,7 +21,8 @@ paths:
               properties:
                 query:
                   type: string
-                  example: foo
+                  examples:
+                    - foo
               required:
                 - query
             examples:
@@ -36,7 +37,7 @@ paths:
       parameters: []
       responses:
         '204':
-          description: ''
+          description: No content
       requestBody:
         required: true
         content:
@@ -46,7 +47,8 @@ paths:
               properties:
                 query:
                   type: string
-                  example: query
+                  examples:
+                    - query
               required:
                 - query
             examples:
@@ -62,8 +64,9 @@ components:
         delta:
           type: string
         tokens:
-          type: integer
-          nullable: true
+          type:
+            - integer
+            - 'null'
       required:
         - delta
   securitySchemes: {}

--- a/seed/openapi/server-url-templating/openapi.yml
+++ b/seed/openapi/server-url-templating/openapi.yml
@@ -1,7 +1,7 @@
-openapi: 3.0.1
+openapi: 3.1.0
 info:
   title: Server URL Templating API
-  version: ''
+  version: 0.0.0
 paths:
   /users:
     get:
@@ -38,7 +38,6 @@ paths:
           required: true
           schema:
             type: string
-          example: userId
           examples:
             Example1:
               value: userId
@@ -88,10 +87,12 @@ paths:
               properties:
                 client_id:
                   type: string
-                  example: client_id
+                  examples:
+                    - client_id
                 client_secret:
                   type: string
-                  example: client_secret
+                  examples:
+                    - client_secret
               required:
                 - client_id
                 - client_secret
@@ -108,13 +109,16 @@ components:
       properties:
         id:
           type: string
-          example: id
+          examples:
+            - id
         name:
           type: string
-          example: name
+          examples:
+            - name
         email:
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
       required:
         - id
         - name
@@ -124,10 +128,12 @@ components:
       properties:
         access_token:
           type: string
-          example: access_token
+          examples:
+            - access_token
         expires_in:
           type: integer
-          example: 1
+          examples:
+            - 1
       required:
         - access_token
         - expires_in

--- a/seed/openapi/simple-api/openapi.yml
+++ b/seed/openapi/simple-api/openapi.yml
@@ -1,7 +1,7 @@
-openapi: 3.0.1
+openapi: 3.1.0
 info:
   title: simple-api
-  version: ''
+  version: 0.0.0
 paths:
   /users/{id}:
     get:
@@ -16,7 +16,7 @@ paths:
             type: string
       responses:
         '200':
-          description: ''
+          description: Success
           content:
             application/json:
               schema:

--- a/seed/openapi/simple-fhir/openapi.yml
+++ b/seed/openapi/simple-fhir/openapi.yml
@@ -1,7 +1,7 @@
-openapi: 3.0.1
+openapi: 3.1.0
 info:
   title: api
-  version: ''
+  version: 0.0.0
 paths:
   /account/{account_id}:
     get:
@@ -16,7 +16,7 @@ paths:
             type: string
       responses:
         '200':
-          description: ''
+          description: Success
           content:
             application/json:
               schema:
@@ -30,8 +30,9 @@ components:
         description:
           type: string
         account:
-          $ref: '#/components/schemas/Account'
-          nullable: true
+          anyOf:
+            - $ref: '#/components/schemas/Account'
+            - type: 'null'
       required:
         - description
     BaseResource:
@@ -67,11 +68,13 @@ components:
         name:
           type: string
         patient:
-          $ref: '#/components/schemas/Patient'
-          nullable: true
+          anyOf:
+            - $ref: '#/components/schemas/Patient'
+            - type: 'null'
         practitioner:
-          $ref: '#/components/schemas/Practitioner'
-          nullable: true
+          anyOf:
+            - $ref: '#/components/schemas/Practitioner'
+            - type: 'null'
       required:
         - resource_type
         - name

--- a/seed/openapi/single-url-environment-default/openapi.yml
+++ b/seed/openapi/single-url-environment-default/openapi.yml
@@ -1,7 +1,7 @@
-openapi: 3.0.1
+openapi: 3.1.0
 info:
   title: single-url-environment-default
-  version: ''
+  version: 0.0.0
 paths:
   /dummy:
     get:
@@ -11,7 +11,7 @@ paths:
       parameters: []
       responses:
         '200':
-          description: ''
+          description: Success
           content:
             application/json:
               schema:

--- a/seed/openapi/single-url-environment-no-default/openapi.yml
+++ b/seed/openapi/single-url-environment-no-default/openapi.yml
@@ -1,7 +1,7 @@
-openapi: 3.0.1
+openapi: 3.1.0
 info:
   title: single-url-environment-no-default
-  version: ''
+  version: 0.0.0
 paths:
   /dummy:
     get:
@@ -11,7 +11,7 @@ paths:
       parameters: []
       responses:
         '200':
-          description: ''
+          description: Success
           content:
             application/json:
               schema:

--- a/seed/openapi/streaming-parameter/openapi.yml
+++ b/seed/openapi/streaming-parameter/openapi.yml
@@ -1,7 +1,7 @@
-openapi: 3.0.1
+openapi: 3.1.0
 info:
   title: streaming
-  version: ''
+  version: 0.0.0
 paths:
   /generate:
     post:
@@ -11,7 +11,7 @@ paths:
       parameters: []
       responses:
         '204':
-          description: ''
+          description: No content
       requestBody:
         required: true
         content:
@@ -21,10 +21,12 @@ paths:
               properties:
                 stream:
                   type: boolean
-                  example: false
+                  examples:
+                    - false
                 num_events:
                   type: integer
-                  example: 5
+                  examples:
+                    - 5
               required:
                 - stream
                 - num_events
@@ -42,8 +44,9 @@ components:
         id:
           type: string
         name:
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
       required:
         - id
     StreamResponse:
@@ -53,8 +56,9 @@ components:
         id:
           type: string
         name:
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
       required:
         - id
   securitySchemes: {}

--- a/seed/openapi/streaming/openapi.yml
+++ b/seed/openapi/streaming/openapi.yml
@@ -1,7 +1,7 @@
-openapi: 3.0.1
+openapi: 3.1.0
 info:
   title: streaming
-  version: ''
+  version: 0.0.0
 paths:
   /generate-stream:
     post:
@@ -11,7 +11,7 @@ paths:
       parameters: []
       responses:
         '204':
-          description: ''
+          description: No content
       requestBody:
         required: true
         content:
@@ -35,7 +35,7 @@ paths:
       parameters: []
       responses:
         '200':
-          description: ''
+          description: Success
           content:
             application/json:
               schema:
@@ -57,7 +57,8 @@ paths:
                   const: false
                 num_events:
                   type: integer
-                  example: 5
+                  examples:
+                    - 5
               required:
                 - stream
                 - num_events
@@ -74,10 +75,12 @@ components:
       properties:
         id:
           type: string
-          example: id
+          examples:
+            - id
         name:
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
       required:
         - id
   securitySchemes: {}

--- a/seed/openapi/undiscriminated-union-with-response-property/openapi.yml
+++ b/seed/openapi/undiscriminated-union-with-response-property/openapi.yml
@@ -1,7 +1,7 @@
-openapi: 3.0.1
+openapi: 3.1.0
 info:
   title: undiscriminated-union-with-response-property
-  version: ''
+  version: 0.0.0
 paths:
   /union:
     get:
@@ -11,7 +11,7 @@ paths:
       parameters: []
       responses:
         '200':
-          description: ''
+          description: Success
           content:
             application/json:
               schema:
@@ -24,7 +24,7 @@ paths:
       parameters: []
       responses:
         '200':
-          description: ''
+          description: Success
           content:
             application/json:
               schema:

--- a/seed/openapi/undiscriminated-unions/openapi.yml
+++ b/seed/openapi/undiscriminated-unions/openapi.yml
@@ -1,7 +1,7 @@
-openapi: 3.0.1
+openapi: 3.1.0
 info:
   title: undiscriminated-unions
-  version: ''
+  version: 0.0.0
 paths:
   /:
     post:
@@ -11,7 +11,7 @@ paths:
       parameters: []
       responses:
         '200':
-          description: ''
+          description: Success
           content:
             application/json:
               schema:
@@ -30,7 +30,7 @@ paths:
       parameters: []
       responses:
         '200':
-          description: ''
+          description: Success
           content:
             application/json:
               schema:
@@ -48,7 +48,7 @@ paths:
       parameters: []
       responses:
         '200':
-          description: ''
+          description: Success
           content:
             application/json:
               schema:
@@ -75,7 +75,7 @@ paths:
       parameters: []
       responses:
         '200':
-          description: ''
+          description: Success
           content:
             application/json:
               schema:
@@ -103,7 +103,7 @@ paths:
       parameters: []
       responses:
         '200':
-          description: ''
+          description: Success
           content:
             application/json:
               schema:
@@ -122,7 +122,7 @@ paths:
       parameters: []
       responses:
         '200':
-          description: ''
+          description: Success
           content:
             application/json:
               schema:
@@ -141,7 +141,7 @@ paths:
       parameters: []
       responses:
         '200':
-          description: ''
+          description: Success
           content:
             application/json:
               schema:
@@ -173,15 +173,17 @@ components:
       type: object
       properties:
         union:
-          $ref: '#/components/schemas/MetadataUnion'
-          nullable: true
+          anyOf:
+            - $ref: '#/components/schemas/MetadataUnion'
+            - type: 'null'
     TypeWithOptionalUnion:
       title: TypeWithOptionalUnion
       type: object
       properties:
         myUnion:
-          $ref: '#/components/schemas/MyUnion'
-          nullable: true
+          anyOf:
+            - $ref: '#/components/schemas/MyUnion'
+            - type: 'null'
     MyUnion:
       title: MyUnion
       oneOf:
@@ -259,15 +261,14 @@ components:
           type: string
         value:
           type: object
-          additionalProperties: true
       required:
         - name
         - value
     OptionalMetadata:
       title: OptionalMetadata
-      type: object
-      additionalProperties: true
-      nullable: true
+      type:
+        - object
+        - 'null'
     Metadata:
       title: Metadata
       type: object

--- a/seed/openapi/unknown/openapi.yml
+++ b/seed/openapi/unknown/openapi.yml
@@ -1,7 +1,7 @@
-openapi: 3.0.1
+openapi: 3.1.0
 info:
   title: unknown-as-any
-  version: ''
+  version: 0.0.0
 paths:
   /:
     post:
@@ -11,7 +11,7 @@ paths:
       parameters: []
       responses:
         '200':
-          description: ''
+          description: Success
           content:
             application/json:
               schema:
@@ -30,7 +30,7 @@ paths:
       parameters: []
       responses:
         '200':
-          description: ''
+          description: Success
           content:
             application/json:
               schema:

--- a/seed/openapi/url-form-encoded/openapi.yml
+++ b/seed/openapi/url-form-encoded/openapi.yml
@@ -1,7 +1,7 @@
-openapi: 3.0.1
+openapi: 3.1.0
 info:
   title: URL Form Encoded API
-  version: ''
+  version: 0.0.0
 paths:
   /submit:
     post:
@@ -32,12 +32,14 @@ paths:
                 username:
                   type: string
                   description: The user's username
-                  example: johndoe
+                  examples:
+                    - johndoe
                 email:
                   type: string
                   format: email
                   description: The user's email address
-                  example: john@example.com
+                  examples:
+                    - john@example.com
               required:
                 - username
                 - email
@@ -83,11 +85,13 @@ components:
       type: object
       properties:
         status:
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
         message:
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
     TokenRequest:
       title: TokenRequest
       type: object
@@ -95,11 +99,13 @@ components:
         client_id:
           type: string
           description: Client identifier
-          example: client_id
+          examples:
+            - client_id
         client_secret:
           type: string
           description: Client secret
-          example: client_secret
+          examples:
+            - client_secret
       required:
         - client_id
         - client_secret
@@ -108,9 +114,11 @@ components:
       type: object
       properties:
         access_token:
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
         expires_in:
-          type: integer
-          nullable: true
+          type:
+            - integer
+            - 'null'
   securitySchemes: {}

--- a/seed/openapi/validation/openapi.yml
+++ b/seed/openapi/validation/openapi.yml
@@ -1,7 +1,7 @@
-openapi: 3.0.1
+openapi: 3.1.0
 info:
   title: validation
-  version: ''
+  version: 0.0.0
 paths:
   /create:
     post:
@@ -11,7 +11,7 @@ paths:
       parameters: []
       responses:
         '200':
-          description: ''
+          description: Success
           content:
             application/json:
               schema:
@@ -26,15 +26,13 @@ paths:
                 decimal:
                   type: number
                   format: double
-                  minimum: 1.1
+                  exclusiveMinimum: 1.1
                   maximum: 2.2
-                  exclusiveMinimum: true
                   multipleOf: 1.1
                 even:
                   type: integer
                   minimum: 0
-                  maximum: 100
-                  exclusiveMaximum: true
+                  exclusiveMaximum: 100
                   multipleOf: 2
                 name:
                   type: string
@@ -61,9 +59,8 @@ paths:
           schema:
             type: number
             format: double
-            minimum: 1.1
+            exclusiveMinimum: 1.1
             maximum: 2.2
-            exclusiveMinimum: true
             multipleOf: 1.1
         - name: even
           in: query
@@ -71,8 +68,7 @@ paths:
           schema:
             type: integer
             minimum: 0
-            maximum: 100
-            exclusiveMaximum: true
+            exclusiveMaximum: 100
             multipleOf: 2
         - name: name
           in: query
@@ -85,7 +81,7 @@ paths:
             maxLength: 10
       responses:
         '200':
-          description: ''
+          description: Success
           content:
             application/json:
               schema:
@@ -95,10 +91,8 @@ components:
     SmallInteger:
       title: SmallInteger
       type: integer
-      minimum: 0
-      maximum: 10
-      exclusiveMinimum: true
-      exclusiveMaximum: true
+      exclusiveMinimum: 0
+      exclusiveMaximum: 10
       multipleOf: 1
     LargeInteger:
       title: LargeInteger
@@ -136,25 +130,26 @@ components:
         decimal:
           type: number
           format: double
-          minimum: 1.1
+          exclusiveMinimum: 1.1
           maximum: 2.2
-          exclusiveMinimum: true
           multipleOf: 1.1
-          example: 1.1
+          examples:
+            - 1.1
         even:
           type: integer
           minimum: 0
-          maximum: 100
-          exclusiveMaximum: true
+          exclusiveMaximum: 100
           multipleOf: 2
-          example: 2
+          examples:
+            - 2
         name:
           type: string
           format: custom
           pattern: ^[a-z]+$
           minLength: 3
           maxLength: 10
-          example: rules
+          examples:
+            - rules
         shape:
           $ref: '#/components/schemas/Shape'
       required:

--- a/seed/openapi/variables/openapi.yml
+++ b/seed/openapi/variables/openapi.yml
@@ -1,7 +1,7 @@
-openapi: 3.0.1
+openapi: 3.1.0
 info:
   title: variables
-  version: ''
+  version: 0.0.0
 paths:
   /{endpointParam}:
     post:
@@ -14,13 +14,12 @@ paths:
           required: true
           schema:
             type: string
-          example: endpointParam
           examples:
             Example1:
               value: endpointParam
       responses:
         '204':
-          description: ''
+          description: No content
 components:
   schemas: {}
   securitySchemes: {}

--- a/seed/openapi/version-no-default/openapi.yml
+++ b/seed/openapi/version-no-default/openapi.yml
@@ -1,7 +1,7 @@
-openapi: 3.0.1
+openapi: 3.1.0
 info:
   title: version
-  version: ''
+  version: 0.0.0
 paths:
   /users/{userId}:
     get:
@@ -16,7 +16,7 @@ paths:
             $ref: '#/components/schemas/UserId'
       responses:
         '200':
-          description: ''
+          description: Success
           content:
             application/json:
               schema:

--- a/seed/openapi/version/openapi.yml
+++ b/seed/openapi/version/openapi.yml
@@ -1,7 +1,7 @@
-openapi: 3.0.1
+openapi: 3.1.0
 info:
   title: version
-  version: ''
+  version: 0.0.0
 paths:
   /users/{userId}:
     get:
@@ -16,7 +16,7 @@ paths:
             $ref: '#/components/schemas/UserId'
       responses:
         '200':
-          description: ''
+          description: Success
           content:
             application/json:
               schema:

--- a/seed/openapi/webhook-audience/openapi.yml
+++ b/seed/openapi/webhook-audience/openapi.yml
@@ -1,7 +1,7 @@
-openapi: 3.0.1
+openapi: 3.1.0
 info:
   title: Webhook Audience Test
-  version: ''
+  version: 0.0.0
 paths: {}
 components:
   schemas:

--- a/seed/openapi/webhooks/openapi.yml
+++ b/seed/openapi/webhooks/openapi.yml
@@ -1,7 +1,7 @@
-openapi: 3.0.1
+openapi: 3.1.0
 info:
   title: webhooks
-  version: ''
+  version: 0.0.0
 paths: {}
 components:
   schemas:
@@ -59,8 +59,9 @@ components:
           type: number
           format: double
         reason:
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
       required:
         - refundId
         - amount

--- a/seed/openapi/websocket-bearer-auth/openapi.yml
+++ b/seed/openapi/websocket-bearer-auth/openapi.yml
@@ -1,7 +1,7 @@
-openapi: 3.0.1
+openapi: 3.1.0
 info:
   title: websocket-bearer-auth
-  version: ''
+  version: 0.0.0
 paths: {}
 components:
   schemas:

--- a/seed/openapi/websocket-inferred-auth/openapi.yml
+++ b/seed/openapi/websocket-inferred-auth/openapi.yml
@@ -1,7 +1,7 @@
-openapi: 3.0.1
+openapi: 3.1.0
 info:
   title: websocket-auth
-  version: ''
+  version: 0.0.0
 paths:
   /token:
     post:
@@ -16,7 +16,7 @@ paths:
             type: string
       responses:
         '200':
-          description: ''
+          description: Success
           content:
             application/json:
               schema:
@@ -39,8 +39,9 @@ paths:
                   type: string
                   const: client_credentials
                 scope:
-                  type: string
-                  nullable: true
+                  type:
+                    - string
+                    - 'null'
               required:
                 - client_id
                 - client_secret
@@ -59,7 +60,7 @@ paths:
             type: string
       responses:
         '200':
-          description: ''
+          description: Success
           content:
             application/json:
               schema:
@@ -84,8 +85,9 @@ paths:
                   type: string
                   const: refresh_token
                 scope:
-                  type: string
-                  nullable: true
+                  type:
+                    - string
+                    - 'null'
               required:
                 - client_id
                 - client_secret
@@ -102,8 +104,9 @@ components:
         access_token:
           type: string
         refresh_token:
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
       required:
         - access_token
     SendEvent:

--- a/seed/openapi/websocket-multi-url/openapi.yml
+++ b/seed/openapi/websocket-multi-url/openapi.yml
@@ -1,7 +1,7 @@
-openapi: 3.0.1
+openapi: 3.1.0
 info:
   title: websocket-multi-url
-  version: ''
+  version: 0.0.0
 paths: {}
 components:
   schemas:

--- a/seed/openapi/websocket/openapi.yml
+++ b/seed/openapi/websocket/openapi.yml
@@ -1,7 +1,7 @@
-openapi: 3.0.1
+openapi: 3.1.0
 info:
   title: websocket
-  version: ''
+  version: 0.0.0
 paths: {}
 components:
   schemas:

--- a/seed/openapi/x-fern-default/openapi.yml
+++ b/seed/openapi/x-fern-default/openapi.yml
@@ -1,7 +1,7 @@
-openapi: 3.0.1
+openapi: 3.1.0
 info:
   title: x-fern-default test
-  version: ''
+  version: 0.0.0
 paths:
   /test/{region}/resource:
     get:
@@ -14,7 +14,6 @@ paths:
           required: true
           schema:
             type: string
-          example: region
           examples:
             Example1:
               value: region
@@ -22,8 +21,9 @@ paths:
           in: query
           required: false
           schema:
-            type: string
-            nullable: true
+            type:
+              - string
+              - 'null'
       responses:
         '200':
           description: Success
@@ -42,6 +42,7 @@ components:
       type: object
       properties:
         message:
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
   securitySchemes: {}


### PR DESCRIPTION
## Description

Migrates the `fernapi/fern-openapi` generator from emitting OAS 3.0.1 to 3.1.0, fixing multiple spec-compliance bugs reported by customers and adopting idiomatic JSON Schema 2020-12 patterns throughout.

## Changes Made

### Core migration (3.0.1 → 3.1.0)
- **Version bump**: `openapi: "3.0.1"` → `"3.1.0"` in `convertToOpenApi.ts`
- **Return type**: Public API returns `OpenAPIV3_1.Document` (assembled internally with `OpenAPIV3` types due to broken 3.1 types in `openapi-types` v12)

### Nullability rewrite
- Removed all `nullable: true` emission (keyword does not exist in OAS 3.1)
- Added `makeNullable()` helper in `typeConverter.ts` with four branches:
  - `$ref` → `{ anyOf: [$ref, { type: "null" }] }`
  - Primitive `type` → `type: [T, "null"]`
  - Existing type array → append `"null"` if missing
  - No type / no `$ref` (unknown) → leave untouched (unconstrained schema already admits null)

### Parameter example/examples mutual exclusivity
- Parameters no longer emit both `example` and `examples` (mutually exclusive per OAS 3.0 and 3.1)
- `examples` (named map) is preferred when present; `example` (singular) only emitted as fallback

### `exclusiveMinimum` / `exclusiveMaximum` format
- Changed from OAS 3.0 boolean format (`exclusiveMinimum: true` + `minimum: 5`) to OAS 3.1 numeric format (`exclusiveMinimum: 5`, no `minimum`)

### Single-element enum → `const`
- `convertEnum` now emits `const: "value"` instead of `enum: ["value"]` for single-member enums
- Union discriminant properties also emit `const` instead of `enum: [discriminantValue]`

### Other OAS 3.1 cleanup
- **`additionalProperties: true`** removed from unconstrained map schemas (defaults to `true` in JSON Schema 2020-12)
- **Schema-level `example`** (deprecated in 3.1) replaced with `examples: [value]` array in `convertObject.ts`
- **Empty `description: ""`** on response objects replaced with meaningful defaults ("Success", "No content", or error name)
- **`info.version`** now defaults to `"0.0.0"` instead of empty string (which violated the spec)

## Testing
- [x] Unit tests added/updated — 6 new tests for `makeNullable()` in `nullability.test.ts` (14 total pass)
- [x] All 121 seed fixtures regenerated and passing