### PR TITLE
fix(cli): make `api:<name>:METHOD/path` links work in `fern docs dev`

### DIFF
--- a/packages/cli/cli/changes/unreleased/fix-api-links-in-fern-docs-dev.yml
+++ b/packages/cli/cli/changes/unreleased/fix-api-links-in-fern-docs-dev.yml
@@ -1,0 +1,3 @@
+- summary: |
+    Fix an issue where `api:<apiName>:METHOD/path` links worked on published docs sites but did not resolve in `fern docs dev`.
+  type: fix

--- a/packages/cli/docs-preview/src/previewDocs.ts
+++ b/packages/cli/docs-preview/src/previewDocs.ts
@@ -343,12 +343,14 @@ class ReferencedAPICollector {
         ir,
         snippetsConfig,
         playgroundConfig,
+        apiName,
         graphqlOperations = {},
         graphqlTypes = {}
     }: {
         ir: IntermediateRepresentation;
         snippetsConfig: APIV1Write.SnippetsConfig;
         playgroundConfig?: { oauth?: boolean };
+        apiName?: string;
         graphqlOperations?: Record<APIV1Write.GraphQlOperationId, APIV1Write.GraphQlOperation>;
         graphqlTypes?: Record<APIV1Write.TypeId, APIV1Write.TypeDefinition>;
     }): APIDefinitionID {
@@ -362,7 +364,8 @@ class ReferencedAPICollector {
                     playgroundConfig,
                     graphqlOperations,
                     graphqlTypes,
-                    context: this.context
+                    context: this.context,
+                    apiNameOverride: apiName
                 }),
                 FdrAPI.ApiDefinitionId(id),
                 new SDKSnippetHolder({


### PR DESCRIPTION
## Description
Linear ticket: Closes FER-9578
<!-- Use "Closes" to automatically close the ticket when PR merges, or "Refs" to link without closing -->

Fixes a bug in `fern docs dev` where MDX links using the `api:<apiName>:METHOD/path` syntax failed to resolve locally even though they worked correctly on published docs sites.

The root cause was that the local preview pipeline was not preserving the configured `api-name` from `docs.yml` when building preview API definitions. As a result, named API endpoint links could not be matched during local link resolution.

## Changes Made
- Pass the configured `apiName` through `ReferencedAPICollector.addReferencedAPI()` in the local docs preview flow
- Use that value as the `apiNameOverride` when converting IR to preview API definitions
- Keep local `fern docs dev` API naming aligned with published docs behavior for `api:<apiName>:METHOD/path` links

## Testing
- [ ] Unit tests added/updated
- [x] Manual testing completed
