### PR TITLE
chore(cli): add changelog entry for global headers fix and document versioning in CLAUDE.md

### DIFF
--- a/packages/cli/CLAUDE.md
+++ b/packages/cli/CLAUDE.md
@@ -131,6 +131,25 @@ pnpm format:fix                # Fix formatting issues
 pnpm check:fix                 # Run all checks with fixes
 ```
 
+### Changelog & Versioning
+
+Every CLI change (`packages/cli/` tree) **must** include an unreleased changelog entry. Do **not** hand-edit `versions.yml`; versioning and releases are handled by automation.
+
+1. Create a new YAML file under `packages/cli/cli/changes/unreleased/` with a descriptive filename (e.g., `fix-global-headers.yml`). Copy `.template.yml` from that folder as a starting point.
+2. Each file is a YAML array of objects with two fields:
+   - `summary`: description of the change (multi-line `|` allowed)
+   - `type`: one of `fix`, `chore`, `feat`, `internal`, `break`
+3. These types drive semver bumps automatically: `fix`/`chore` → patch, `feat`/`internal` → minor, `break` → major.
+
+```yaml
+# Example: packages/cli/cli/changes/unreleased/fix-global-headers.yml
+- summary: |
+    Fix global headers from generators.yml not appearing in documentation.
+  type: fix
+```
+
+See `.claude/release-versioning.md` and `release-config.json` for full details.
+
 ## Generation Pipeline Flow
 
 ### 1. Workspace Discovery

--- a/packages/cli/cli/changes/unreleased/fix-global-headers-v3-parser.yml
+++ b/packages/cli/cli/changes/unreleased/fix-global-headers-v3-parser.yml
@@ -1,0 +1,3 @@
+- summary: |
+    Fix global headers from `generators.yml` not appearing in documentation endpoints. The new OpenAPI v3 parser (`openapi-to-ir`) had a TODO placeholder but never converted `globalHeaderOverrides` into IR headers.
+  type: fix


### PR DESCRIPTION
## Description

Follow-up to https://github.com/fern-api/fern/pull/14985. Adds the missing unreleased changelog entry for the global headers fix and documents the changelog/versioning workflow in the CLI `CLAUDE.md`.

## Changes Made

- Added `packages/cli/cli/changes/unreleased/fix-global-headers-v3-parser.yml` with a changelog entry for the global headers fix (type: `fix`)
- Added a "Changelog & Versioning" section to `packages/cli/CLAUDE.md` documenting:
  - Requirement to add unreleased changelog entries for all CLI changes
  - File location and format (`packages/cli/cli/changes/unreleased/`)
  - Allowed types and their semver impact
  - Example changelog file
  - Reference to `.claude/release-versioning.md` for full details

## Testing

- [x] No code changes — changelog and documentation only

Link to Devin session: https://app.devin.ai/sessions/31b7c30a53a44d6ea12efbfc89c5e249
Requested by: @dsinghvi