### PR TITLE
fix(cli): deduplicate global headers when merging IRs from multiple specs

### DIFF
--- a/packages/cli/cli/changes/unreleased/fix-dedupe-global-headers-merge.yml
+++ b/packages/cli/cli/changes/unreleased/fix-dedupe-global-headers-merge.yml
@@ -1,0 +1,3 @@
+- summary: |
+    Deduplicate global headers when merging IRs from multiple OpenAPI specs. Previously, if multiple specs shared the same `globalHeaderOverrides` from `generators.yml`, the same header would appear once per spec in the merged IR.
+  type: fix

--- a/packages/commons/ir-utils/src/__test__/mergeIntermediateRepresentation.test.ts
+++ b/packages/commons/ir-utils/src/__test__/mergeIntermediateRepresentation.test.ts
@@ -1,0 +1,169 @@
+import { constructCasingsGenerator } from "@fern-api/casings-generator";
+import * as FernIr from "@fern-api/ir-sdk";
+import { mergeIntermediateRepresentation } from "../mergeIntermediateRepresentation.js";
+
+const casingsGenerator = constructCasingsGenerator({
+    generationLanguage: undefined,
+    keywords: undefined,
+    smartCasing: false
+});
+
+function makeHeader(wireValue: string): FernIr.HttpHeader {
+    return {
+        name: {
+            wireValue,
+            name: casingsGenerator.generateName(wireValue)
+        },
+        valueType: FernIr.TypeReference.primitive({
+            v1: "STRING",
+            v2: FernIr.PrimitiveTypeV2.string({ default: undefined, validation: undefined })
+        }),
+        env: undefined,
+        availability: undefined,
+        docs: undefined,
+        clientDefault: undefined,
+        v2Examples: undefined
+    };
+}
+
+function makeMinimalIr(overrides: Partial<FernIr.IntermediateRepresentation> = {}): FernIr.IntermediateRepresentation {
+    return {
+        fdrApiDefinitionId: undefined,
+        apiVersion: undefined,
+        apiName: "test-api",
+        apiDisplayName: undefined,
+        apiDocs: undefined,
+        auth: { requirement: "ALL", schemes: [], docs: undefined },
+        headers: [],
+        idempotencyHeaders: [],
+        types: {},
+        services: {},
+        webhookGroups: {},
+        websocketChannels: undefined,
+        errors: {},
+        subpackages: {},
+        rootPackage: {
+            fernFilepath: { allParts: [], packagePath: [], file: undefined },
+            service: undefined,
+            types: [],
+            errors: [],
+            subpackages: [],
+            webhooks: undefined,
+            websocket: undefined,
+            hasEndpointsInTree: false,
+            navigationConfig: undefined,
+            docs: undefined
+        },
+        constants: {
+            errorInstanceIdKey: {
+                wireValue: "errorInstanceId",
+                name: casingsGenerator.generateName("errorInstanceId")
+            }
+        },
+        environments: undefined,
+        basePath: undefined,
+        pathParameters: [],
+        errorDiscriminationStrategy: FernIr.ErrorDiscriminationStrategy.statusCode(),
+        sdkConfig: {
+            isAuthMandatory: false,
+            hasStreamingEndpoints: false,
+            hasPaginatedEndpoints: false,
+            hasFileDownloadEndpoints: false,
+            platformHeaders: {
+                language: "X-Fern-Language",
+                sdkName: "X-Fern-SDK-Name",
+                sdkVersion: "X-Fern-SDK-Version",
+                userAgent: undefined
+            }
+        },
+        variables: [],
+        serviceTypeReferenceInfo: {
+            typesReferencedOnlyByService: {},
+            sharedTypes: []
+        },
+        readmeConfig: undefined,
+        sourceConfig: undefined,
+        publishConfig: undefined,
+        dynamic: undefined,
+        selfHosted: undefined,
+        audiences: undefined,
+        generationMetadata: undefined,
+        apiPlayground: undefined,
+        casingsConfig: undefined,
+        ...overrides
+    };
+}
+
+describe("mergeIntermediateRepresentation", () => {
+    describe("header deduplication", () => {
+        it("deduplicates global headers with the same wire value", () => {
+            const ir1 = makeMinimalIr({ headers: [makeHeader("custom_api_key")] });
+            const ir2 = makeMinimalIr({ headers: [makeHeader("custom_api_key")] });
+
+            const merged = mergeIntermediateRepresentation(ir1, ir2, casingsGenerator);
+
+            expect(merged.headers).toHaveLength(1);
+            expect(merged.headers[0]?.name).toHaveProperty("wireValue", "custom_api_key");
+        });
+
+        it("deduplicates global headers case-insensitively", () => {
+            const ir1 = makeMinimalIr({ headers: [makeHeader("X-Api-Key")] });
+            const ir2 = makeMinimalIr({ headers: [makeHeader("x-api-key")] });
+
+            const merged = mergeIntermediateRepresentation(ir1, ir2, casingsGenerator);
+
+            expect(merged.headers).toHaveLength(1);
+            expect(merged.headers[0]?.name).toHaveProperty("wireValue", "X-Api-Key");
+        });
+
+        it("keeps headers with different wire values", () => {
+            const ir1 = makeMinimalIr({ headers: [makeHeader("X-Api-Key")] });
+            const ir2 = makeMinimalIr({ headers: [makeHeader("X-Request-Id")] });
+
+            const merged = mergeIntermediateRepresentation(ir1, ir2, casingsGenerator);
+
+            expect(merged.headers).toHaveLength(2);
+        });
+
+        it("deduplicates across multiple specs with the same header", () => {
+            const ir1 = makeMinimalIr({ headers: [makeHeader("custom_api_key")] });
+            const ir2 = makeMinimalIr({ headers: [makeHeader("custom_api_key")] });
+            const ir3 = makeMinimalIr({ headers: [makeHeader("custom_api_key")] });
+            const ir4 = makeMinimalIr({ headers: [makeHeader("custom_api_key")] });
+
+            let merged = mergeIntermediateRepresentation(ir1, ir2, casingsGenerator);
+            merged = mergeIntermediateRepresentation(merged, ir3, casingsGenerator);
+            merged = mergeIntermediateRepresentation(merged, ir4, casingsGenerator);
+
+            expect(merged.headers).toHaveLength(1);
+        });
+
+        it("deduplicates idempotency headers by wire value", () => {
+            const ir1 = makeMinimalIr({ idempotencyHeaders: [makeHeader("Idempotency-Key")] });
+            const ir2 = makeMinimalIr({ idempotencyHeaders: [makeHeader("Idempotency-Key")] });
+
+            const merged = mergeIntermediateRepresentation(ir1, ir2, casingsGenerator);
+
+            expect(merged.idempotencyHeaders).toHaveLength(1);
+            expect(merged.idempotencyHeaders[0]?.name).toHaveProperty("wireValue", "Idempotency-Key");
+        });
+
+        it("handles empty headers gracefully", () => {
+            const ir1 = makeMinimalIr({ headers: [] });
+            const ir2 = makeMinimalIr({ headers: [] });
+
+            const merged = mergeIntermediateRepresentation(ir1, ir2, casingsGenerator);
+
+            expect(merged.headers).toHaveLength(0);
+        });
+
+        it("handles one IR with headers and one without", () => {
+            const ir1 = makeMinimalIr({ headers: [makeHeader("X-Api-Key")] });
+            const ir2 = makeMinimalIr({ headers: [] });
+
+            const merged = mergeIntermediateRepresentation(ir1, ir2, casingsGenerator);
+
+            expect(merged.headers).toHaveLength(1);
+        });
+    });
+});

--- a/packages/commons/ir-utils/src/mergeIntermediateRepresentation.ts
+++ b/packages/commons/ir-utils/src/mergeIntermediateRepresentation.ts
@@ -1,5 +1,6 @@
 import { CasingsGenerator } from "@fern-api/casings-generator";
 import * as FernIr from "@fern-api/ir-sdk";
+import { getWireValue } from "./utils/namesUtils.js";
 
 export function mergeIntermediateRepresentation(
     ir1: FernIr.IntermediateRepresentation,
@@ -27,7 +28,7 @@ export function mergeIntermediateRepresentation(
                     : (ir1.auth?.schemes ?? []),
             docs: ir1.auth?.docs ?? ir2.auth?.docs
         },
-        headers: [...(ir1.headers ?? []), ...(ir2.headers ?? [])],
+        headers: deduplicateHeaders([...(ir1.headers ?? []), ...(ir2.headers ?? [])]),
         environments,
         types: {
             ...(ir1.types ?? {}),
@@ -67,7 +68,7 @@ export function mergeIntermediateRepresentation(
         },
         fdrApiDefinitionId: ir1.fdrApiDefinitionId ?? ir2.fdrApiDefinitionId,
         apiVersion: ir1.apiVersion ?? ir2.apiVersion,
-        idempotencyHeaders: [...(ir1.idempotencyHeaders ?? []), ...(ir2.idempotencyHeaders ?? [])],
+        idempotencyHeaders: deduplicateHeaders([...(ir1.idempotencyHeaders ?? []), ...(ir2.idempotencyHeaders ?? [])]),
         pathParameters: [...(ir1.pathParameters ?? []), ...(ir2.pathParameters ?? [])],
         errorDiscriminationStrategy: ir1.errorDiscriminationStrategy ?? ir2.errorDiscriminationStrategy,
         variables: [...(ir1.variables ?? []), ...(ir2.variables ?? [])],
@@ -523,6 +524,23 @@ function isWebsocketEnvironment(environment: FernIr.EnvironmentsConfig): boolean
         );
     }
     return false;
+}
+
+/**
+ * Deduplicates headers by wire value (case-insensitive), keeping the first occurrence.
+ * This prevents the same global header from appearing multiple times when merging
+ * IRs from multiple specs that share the same globalHeaderOverrides.
+ */
+function deduplicateHeaders(headers: FernIr.HttpHeader[]): FernIr.HttpHeader[] {
+    const seen = new Set<string>();
+    return headers.filter((header) => {
+        const wireValue = getWireValue(header.name).toLowerCase();
+        if (seen.has(wireValue)) {
+            return false;
+        }
+        seen.add(wireValue);
+        return true;
+    });
 }
 
 function generateUniqueName(id: string, existingIds: Set<string>): string {


### PR DESCRIPTION
## Description

Fixes duplicate global headers appearing in docs when a workspace has multiple OpenAPI specs sharing the same `globalHeaderOverrides` from `generators.yml`.

Follow-up to https://github.com/fern-api/fern/pull/14985 which added global header override support to the v3 parser.

## Changes Made

- Added `deduplicateHeaders()` helper in `mergeIntermediateRepresentation.ts` that deduplicates headers by wire value (case-insensitive), keeping the first occurrence
- Applied deduplication to both `headers` and `idempotencyHeaders` during IR merge
- Added 7 unit tests covering: exact match dedup, case-insensitive dedup, different headers preserved, 4-spec merge (reproduces the reported bug), idempotency headers, empty headers, and mixed empty/non-empty

**Root cause:** When a workspace has multiple OpenAPI specs, each spec gets its own `OpenAPIConverter` instance with the same `globalHeaderOverrides`. Each converter adds the global header to its IR. When these IRs are merged via `mergeIntermediateRepresentation`, the headers were simply concatenated (`[...ir1.headers, ...ir2.headers]`), causing the same header to appear N times (once per spec).

## Testing

- [x] Unit tests added (`packages/commons/ir-utils/src/__test__/mergeIntermediateRepresentation.test.ts`)
- [x] Compilation passes (`pnpm turbo run compile --filter @fern-api/ir-utils`)
- [x] All tests pass (`pnpm turbo run test --filter @fern-api/ir-utils` — 50 tests, 6 test files)
- [x] Lint passes (`pnpm lint:biome`)

Link to Devin session: https://app.devin.ai/sessions/31b7c30a53a44d6ea12efbfc89c5e249
Requested by: @dsinghvi