### PR TITLE
chore(cli): migrate @fern-api/cli-migrations to use CliError

### DIFF
--- a/packages/cli/cli-migrations/src/migrations/0.0.191/discriminant/getAllYamlFiles.ts
+++ b/packages/cli/cli-migrations/src/migrations/0.0.191/discriminant/getAllYamlFiles.ts
@@ -1,5 +1,5 @@
 import { AbsoluteFilePath } from "@fern-api/fs-utils";
-import { TaskContext } from "@fern-api/task-context";
+import { CliError, TaskContext } from "@fern-api/task-context";
 import { findUp } from "find-up";
 import { glob } from "glob";
 
@@ -9,7 +9,9 @@ export async function getAllYamlFiles(context: TaskContext): Promise<AbsoluteFil
     const fernDirectory = await getFernDirectory();
     const alphasort = (a: string, b: string) => a.localeCompare(b, "en");
     if (fernDirectory == null) {
-        context.failAndThrow(`Directory "${FERN_DIRECTORY}" not found.`);
+        context.failAndThrow(`Directory "${FERN_DIRECTORY}" not found.`, undefined, {
+            code: CliError.Code.ConfigError
+        });
     }
     const filepaths = await glob("*/definition/**/*.yml", {
         cwd: fernDirectory,

--- a/packages/cli/cli-migrations/src/migrations/0.0.191/discriminant/migration.ts
+++ b/packages/cli/cli-migrations/src/migrations/0.0.191/discriminant/migration.ts
@@ -1,4 +1,5 @@
 import { AbsoluteFilePath } from "@fern-api/fs-utils";
+import { CliError } from "@fern-api/task-context";
 import { readFile, writeFile } from "fs/promises";
 
 import { Migration } from "../../../types/Migration.js";
@@ -15,7 +16,7 @@ export const migration: Migration = {
                 const newContents = addDiscriminantToFile(fileContents);
                 await writeFile(yamlFilepath, newContents);
             } catch (error) {
-                context.failAndThrow("Failed to migrate " + yamlFilepath, error);
+                context.failAndThrow("Failed to migrate " + yamlFilepath, error, { code: CliError.Code.ParseError });
             }
         }
     }

--- a/packages/cli/cli-migrations/src/migrations/0.0.203/union-single-property-key/getAllYamlFiles.ts
+++ b/packages/cli/cli-migrations/src/migrations/0.0.203/union-single-property-key/getAllYamlFiles.ts
@@ -1,5 +1,5 @@
 import { AbsoluteFilePath } from "@fern-api/fs-utils";
-import { TaskContext } from "@fern-api/task-context";
+import { CliError, TaskContext } from "@fern-api/task-context";
 import { findUp } from "find-up";
 import { glob } from "glob";
 
@@ -9,7 +9,9 @@ export async function getAllYamlFiles(context: TaskContext): Promise<AbsoluteFil
     const fernDirectory = await getFernDirectory();
     const alphasort = (a: string, b: string) => a.localeCompare(b, "en");
     if (fernDirectory == null) {
-        context.failAndThrow(`Directory "${FERN_DIRECTORY}" not found.`);
+        context.failAndThrow(`Directory "${FERN_DIRECTORY}" not found.`, undefined, {
+            code: CliError.Code.ConfigError
+        });
     }
     const filepaths = await glob("*/definition/**/*.yml", {
         cwd: fernDirectory,

--- a/packages/cli/cli-migrations/src/migrations/0.0.203/union-single-property-key/migration.ts
+++ b/packages/cli/cli-migrations/src/migrations/0.0.203/union-single-property-key/migration.ts
@@ -1,5 +1,5 @@
 import { AbsoluteFilePath } from "@fern-api/fs-utils";
-import { TaskContext } from "@fern-api/task-context";
+import { CliError, TaskContext } from "@fern-api/task-context";
 import { readFile, writeFile } from "fs/promises";
 import YAML from "yaml";
 
@@ -15,7 +15,9 @@ export const migration: Migration = {
             try {
                 await migrateFile(filepath, context);
             } catch (error) {
-                context.failWithoutThrowing(`Failed to add 'key' property to union in ${filepath}`, error);
+                context.failWithoutThrowing(`Failed to add 'key' property to union in ${filepath}`, error, {
+                    code: CliError.Code.ParseError
+                });
             }
         }
     }
@@ -29,7 +31,9 @@ async function migrateFile(filepath: AbsoluteFilePath, context: TaskContext): Pr
         return;
     }
     if (!YAML.isMap(types)) {
-        context.failWithoutThrowing(`"types" is not a map in ${filepath}`);
+        context.failWithoutThrowing(`"types" is not a map in ${filepath}`, undefined, {
+            code: CliError.Code.ParseError
+        });
         return;
     }
 
@@ -40,7 +44,9 @@ async function migrateFile(filepath: AbsoluteFilePath, context: TaskContext): Pr
                 continue;
             }
             if (!YAML.isMap(union)) {
-                context.failWithoutThrowing(`"union" is not a map in ${filepath}`);
+                context.failWithoutThrowing(`"union" is not a map in ${filepath}`, undefined, {
+                    code: CliError.Code.ParseError
+                });
                 continue;
             }
             for (const singleUnionType of union.items) {

--- a/packages/cli/cli-migrations/src/migrations/0.0.207/add-mode-to-draft-generators/getAllGeneratorYamlFiles.ts
+++ b/packages/cli/cli-migrations/src/migrations/0.0.207/add-mode-to-draft-generators/getAllGeneratorYamlFiles.ts
@@ -1,5 +1,5 @@
 import { AbsoluteFilePath } from "@fern-api/fs-utils";
-import { TaskContext } from "@fern-api/task-context";
+import { CliError, TaskContext } from "@fern-api/task-context";
 import { findUp } from "find-up";
 import { glob } from "glob";
 
@@ -9,7 +9,9 @@ export async function getAllGeneratorYamlFiles(context: TaskContext): Promise<Ab
     const fernDirectory = await getFernDirectory();
     const alphasort = (a: string, b: string) => a.localeCompare(b, "en");
     if (fernDirectory == null) {
-        context.failAndThrow(`Directory "${FERN_DIRECTORY}" not found.`);
+        context.failAndThrow(`Directory "${FERN_DIRECTORY}" not found.`, undefined, {
+            code: CliError.Code.ConfigError
+        });
     }
     const filepaths = await glob("*/generators.yml", {
         cwd: fernDirectory,

--- a/packages/cli/cli-migrations/src/migrations/0.0.207/add-mode-to-draft-generators/migration.ts
+++ b/packages/cli/cli-migrations/src/migrations/0.0.207/add-mode-to-draft-generators/migration.ts
@@ -1,5 +1,5 @@
 import { AbsoluteFilePath } from "@fern-api/fs-utils";
-import { TaskContext } from "@fern-api/task-context";
+import { CliError, TaskContext } from "@fern-api/task-context";
 import { readFile, writeFile } from "fs/promises";
 import YAML from "yaml";
 
@@ -15,7 +15,7 @@ export const migration: Migration = {
             try {
                 await migrateGeneratorsYml(filepath, context);
             } catch (error) {
-                context.failWithoutThrowing(`Failed to migrate ${filepath}`, error);
+                context.failWithoutThrowing(`Failed to migrate ${filepath}`, error, { code: CliError.Code.ParseError });
             }
         }
     }
@@ -29,17 +29,23 @@ async function migrateGeneratorsYml(filepath: AbsoluteFilePath, context: TaskCon
         return;
     }
     if (!YAML.isSeq(draftGenerators)) {
-        context.failWithoutThrowing(`draft generators are not a list in ${filepath}`);
+        context.failWithoutThrowing(`draft generators are not a list in ${filepath}`, undefined, {
+            code: CliError.Code.ParseError
+        });
         return;
     }
     draftGenerators.items.forEach((draftGenerator) => {
         if (!YAML.isMap(draftGenerator)) {
-            context.failWithoutThrowing(`draft generator is not an object in ${filepath}`);
+            context.failWithoutThrowing(`draft generator is not an object in ${filepath}`, undefined, {
+                code: CliError.Code.ParseError
+            });
             return;
         }
         const name = draftGenerator.get("name", true);
         if (typeof name?.value !== "string") {
-            context.failWithoutThrowing(`draft generator didn't have name in ${filepath}`);
+            context.failWithoutThrowing(`draft generator didn't have name in ${filepath}`, undefined, {
+                code: CliError.Code.ParseError
+            });
             return;
         }
         const localOutput = draftGenerator.get("local-output");

--- a/packages/cli/cli-migrations/src/migrations/0.0.210/remove-inline-error-declarations/getAllYamlFiles.ts
+++ b/packages/cli/cli-migrations/src/migrations/0.0.210/remove-inline-error-declarations/getAllYamlFiles.ts
@@ -1,5 +1,5 @@
 import { AbsoluteFilePath } from "@fern-api/fs-utils";
-import { TaskContext } from "@fern-api/task-context";
+import { CliError, TaskContext } from "@fern-api/task-context";
 import { findUp } from "find-up";
 import { glob } from "glob";
 
@@ -9,7 +9,9 @@ export async function getAllYamlFiles(context: TaskContext): Promise<AbsoluteFil
     const fernDirectory = await getFernDirectory();
     const alphasort = (a: string, b: string) => a.localeCompare(b, "en");
     if (fernDirectory == null) {
-        return context.failAndThrow(`Directory "${FERN_DIRECTORY}" not found.`);
+        return context.failAndThrow(`Directory "${FERN_DIRECTORY}" not found.`, undefined, {
+            code: CliError.Code.ConfigError
+        });
     }
     const filepaths = await glob("*/definition/**/*.yml", {
         cwd: fernDirectory,

--- a/packages/cli/cli-migrations/src/migrations/0.0.210/remove-inline-error-declarations/migration.ts
+++ b/packages/cli/cli-migrations/src/migrations/0.0.210/remove-inline-error-declarations/migration.ts
@@ -1,5 +1,5 @@
 import { AbsoluteFilePath } from "@fern-api/fs-utils";
-import { TaskContext } from "@fern-api/task-context";
+import { CliError, TaskContext } from "@fern-api/task-context";
 import { readFile, writeFile } from "fs/promises";
 import YAML from "yaml";
 
@@ -15,7 +15,9 @@ export const migration: Migration = {
             try {
                 await migrateFile(filepath, context);
             } catch (error) {
-                context.failWithoutThrowing(`Failed to add 'key' property to union in ${filepath}`, error);
+                context.failWithoutThrowing(`Failed to add 'key' property to union in ${filepath}`, error, {
+                    code: CliError.Code.ParseError
+                });
             }
         }
     }
@@ -32,7 +34,9 @@ async function migrateFile(filepath: AbsoluteFilePath, context: TaskContext): Pr
                 [typeName]: typeDeclaration
             });
         } else if (!YAML.isMap(types)) {
-            context.failWithoutThrowing(`"types" is not a map in ${filepath}`);
+            context.failWithoutThrowing(`"types" is not a map in ${filepath}`, undefined, {
+                code: CliError.Code.ParseError
+            });
         } else {
             types.set(typeName, typeDeclaration);
         }
@@ -44,13 +48,17 @@ async function migrateFile(filepath: AbsoluteFilePath, context: TaskContext): Pr
     }
 
     if (!YAML.isMap(errors)) {
-        context.failWithoutThrowing(`"errors" is not a map in ${filepath}`);
+        context.failWithoutThrowing(`"errors" is not a map in ${filepath}`, undefined, {
+            code: CliError.Code.ParseError
+        });
         return;
     }
 
     for (const errorDeclaration of errors.items) {
         if (!YAML.isMap(errorDeclaration.value)) {
-            context.failWithoutThrowing(`Error "${errorDeclaration.key}" is not a map in ${filepath}`);
+            context.failWithoutThrowing(`Error "${errorDeclaration.key}" is not a map in ${filepath}`, undefined, {
+                code: CliError.Code.ParseError
+            });
             continue;
         }
 
@@ -66,7 +74,11 @@ async function migrateFile(filepath: AbsoluteFilePath, context: TaskContext): Pr
         const httpSection = errorDeclaration.value.get("http");
         if (httpSection != null) {
             if (!YAML.isMap(httpSection)) {
-                context.failWithoutThrowing(`http in "${errorDeclaration.key}" is not a map in ${filepath}`);
+                context.failWithoutThrowing(
+                    `http in "${errorDeclaration.key}" is not a map in ${filepath}`,
+                    undefined,
+                    { code: CliError.Code.ParseError }
+                );
             } else {
                 const statusCode = httpSection.get("statusCode", true);
                 errorDeclaration.value.delete("http");

--- a/packages/cli/cli-migrations/src/migrations/0.0.212/add-publishing-to-release-generators/getAllGeneratorYamlFiles.ts
+++ b/packages/cli/cli-migrations/src/migrations/0.0.212/add-publishing-to-release-generators/getAllGeneratorYamlFiles.ts
@@ -1,5 +1,5 @@
 import { AbsoluteFilePath } from "@fern-api/fs-utils";
-import { TaskContext } from "@fern-api/task-context";
+import { CliError, TaskContext } from "@fern-api/task-context";
 import { findUp } from "find-up";
 import { glob } from "glob";
 
@@ -9,7 +9,9 @@ export async function getAllGeneratorYamlFiles(context: TaskContext): Promise<Ab
     const fernDirectory = await getFernDirectory();
     const alphasort = (a: string, b: string) => a.localeCompare(b, "en");
     if (fernDirectory == null) {
-        return context.failAndThrow(`Directory "${FERN_DIRECTORY}" not found.`);
+        return context.failAndThrow(`Directory "${FERN_DIRECTORY}" not found.`, undefined, {
+            code: CliError.Code.ConfigError
+        });
     }
     const filepaths = await glob("*/generators.yml", {
         cwd: fernDirectory,

--- a/packages/cli/cli-migrations/src/migrations/0.0.212/add-publishing-to-release-generators/migration.ts
+++ b/packages/cli/cli-migrations/src/migrations/0.0.212/add-publishing-to-release-generators/migration.ts
@@ -1,5 +1,5 @@
 import { AbsoluteFilePath } from "@fern-api/fs-utils";
-import { TaskContext } from "@fern-api/task-context";
+import { CliError, TaskContext } from "@fern-api/task-context";
 import { readFile, writeFile } from "fs/promises";
 import YAML from "yaml";
 
@@ -15,7 +15,7 @@ export const migration: Migration = {
             try {
                 await migrateGeneratorsYml(filepath, context);
             } catch (error) {
-                context.failWithoutThrowing(`Failed to migrate ${filepath}`, error);
+                context.failWithoutThrowing(`Failed to migrate ${filepath}`, error, { code: CliError.Code.ParseError });
             }
         }
     }
@@ -29,17 +29,23 @@ async function migrateGeneratorsYml(filepath: AbsoluteFilePath, context: TaskCon
         return;
     }
     if (!YAML.isSeq(releaseGenerators)) {
-        context.failWithoutThrowing(`release generators are not a list in ${filepath}`);
+        context.failWithoutThrowing(`release generators are not a list in ${filepath}`, undefined, {
+            code: CliError.Code.ParseError
+        });
         return;
     }
     releaseGenerators.items.forEach((releaseGenerator) => {
         if (!YAML.isMap(releaseGenerator)) {
-            context.failWithoutThrowing(`release generator is not an object in ${filepath}`);
+            context.failWithoutThrowing(`release generator is not an object in ${filepath}`, undefined, {
+                code: CliError.Code.ParseError
+            });
             return;
         }
         const outputs = releaseGenerator.get("outputs");
         if (!YAML.isMap(outputs)) {
-            context.failWithoutThrowing(`outputs is not an object in ${filepath}`);
+            context.failWithoutThrowing(`outputs is not an object in ${filepath}`, undefined, {
+                code: CliError.Code.ParseError
+            });
             return;
         }
 

--- a/packages/cli/cli-migrations/src/migrations/0.0.220/rename-alias-key-to-type/getAllYamlFiles.ts
+++ b/packages/cli/cli-migrations/src/migrations/0.0.220/rename-alias-key-to-type/getAllYamlFiles.ts
@@ -1,5 +1,5 @@
 import { AbsoluteFilePath } from "@fern-api/fs-utils";
-import { TaskContext } from "@fern-api/task-context";
+import { CliError, TaskContext } from "@fern-api/task-context";
 import { findUp } from "find-up";
 import { glob } from "glob";
 
@@ -9,7 +9,9 @@ export async function getAllYamlFiles(context: TaskContext): Promise<AbsoluteFil
     const fernDirectory = await getFernDirectory();
     const alphasort = (a: string, b: string) => a.localeCompare(b, "en");
     if (fernDirectory == null) {
-        context.failAndThrow(`Directory "${FERN_DIRECTORY}" not found.`);
+        context.failAndThrow(`Directory "${FERN_DIRECTORY}" not found.`, undefined, {
+            code: CliError.Code.ConfigError
+        });
     }
     const filepaths = await glob("*/definition/**/*.yml", {
         cwd: fernDirectory,

--- a/packages/cli/cli-migrations/src/migrations/0.0.221/add-error-discriminant/getAllRootApiYamlFiles.ts
+++ b/packages/cli/cli-migrations/src/migrations/0.0.221/add-error-discriminant/getAllRootApiYamlFiles.ts
@@ -1,5 +1,5 @@
 import { AbsoluteFilePath } from "@fern-api/fs-utils";
-import { TaskContext } from "@fern-api/task-context";
+import { CliError, TaskContext } from "@fern-api/task-context";
 import { findUp } from "find-up";
 import { glob } from "glob";
 
@@ -9,7 +9,9 @@ export async function getAllRootApiYamlFiles(context: TaskContext): Promise<Abso
     const fernDirectory = await getFernDirectory();
     const alphasort = (a: string, b: string) => a.localeCompare(b, "en");
     if (fernDirectory == null) {
-        return context.failAndThrow(`Directory "${FERN_DIRECTORY}" not found.`);
+        return context.failAndThrow(`Directory "${FERN_DIRECTORY}" not found.`, undefined, {
+            code: CliError.Code.ConfigError
+        });
     }
     const filepaths = await glob("*/definition/api.yml", {
         cwd: fernDirectory,

--- a/packages/cli/cli-migrations/src/migrations/0.0.241/add-generator-groups/getAllGeneratorYamlFiles.ts
+++ b/packages/cli/cli-migrations/src/migrations/0.0.241/add-generator-groups/getAllGeneratorYamlFiles.ts
@@ -1,5 +1,5 @@
 import { AbsoluteFilePath } from "@fern-api/fs-utils";
-import { TaskContext } from "@fern-api/task-context";
+import { CliError, TaskContext } from "@fern-api/task-context";
 import { findUp } from "find-up";
 import { glob } from "glob";
 
@@ -9,7 +9,9 @@ export async function getAllGeneratorYamlFiles(context: TaskContext): Promise<Ab
     const fernDirectory = await getFernDirectory();
     const alphasort = (a: string, b: string) => a.localeCompare(b, "en");
     if (fernDirectory == null) {
-        return context.failAndThrow(`Directory "${FERN_DIRECTORY}" not found.`);
+        return context.failAndThrow(`Directory "${FERN_DIRECTORY}" not found.`, undefined, {
+            code: CliError.Code.ConfigError
+        });
     }
     const filepaths = await glob("*/generators.yml", {
         cwd: fernDirectory,

--- a/packages/cli/cli-migrations/src/migrations/0.0.241/add-generator-groups/migration.ts
+++ b/packages/cli/cli-migrations/src/migrations/0.0.241/add-generator-groups/migration.ts
@@ -1,5 +1,6 @@
 import { assertNever } from "@fern-api/core-utils";
 import { AbsoluteFilePath } from "@fern-api/fs-utils";
+import { CliError } from "@fern-api/task-context";
 import { readFile, writeFile } from "fs/promises";
 import yaml from "js-yaml";
 
@@ -17,7 +18,7 @@ export const migration: Migration = {
             try {
                 await migrateGeneratorsYml(filepath);
             } catch (error) {
-                context.failWithoutThrowing(`Failed to migrate ${filepath}`, error);
+                context.failWithoutThrowing(`Failed to migrate ${filepath}`, error, { code: CliError.Code.ParseError });
             }
         }
     }

--- a/packages/cli/cli-migrations/src/migrations/0.0.248/add-error-discrimination-config/getAllRootApiYamlFiles.ts
+++ b/packages/cli/cli-migrations/src/migrations/0.0.248/add-error-discrimination-config/getAllRootApiYamlFiles.ts
@@ -1,5 +1,5 @@
 import { AbsoluteFilePath } from "@fern-api/fs-utils";
-import { TaskContext } from "@fern-api/task-context";
+import { CliError, TaskContext } from "@fern-api/task-context";
 import { findUp } from "find-up";
 import { glob } from "glob";
 
@@ -9,7 +9,9 @@ export async function getAllRootApiYamlFiles(context: TaskContext): Promise<Abso
     const fernDirectory = await getFernDirectory();
     const alphasort = (a: string, b: string) => a.localeCompare(b, "en");
     if (fernDirectory == null) {
-        return context.failAndThrow(`Directory "${FERN_DIRECTORY}" not found.`);
+        return context.failAndThrow(`Directory "${FERN_DIRECTORY}" not found.`, undefined, {
+            code: CliError.Code.ConfigError
+        });
     }
     const filepaths = await glob("*/definition/api.yml", {
         cwd: fernDirectory,

--- a/packages/cli/cli-migrations/src/migrations/0.0.248/add-error-discrimination-config/migration.ts
+++ b/packages/cli/cli-migrations/src/migrations/0.0.248/add-error-discrimination-config/migration.ts
@@ -1,4 +1,5 @@
 import { AbsoluteFilePath } from "@fern-api/fs-utils";
+import { CliError } from "@fern-api/task-context";
 import { readFile, writeFile } from "fs/promises";
 import YAML from "yaml";
 
@@ -14,7 +15,7 @@ export const migration: Migration = {
             try {
                 await migrateRootApiFile(filepath);
             } catch (error) {
-                context.failWithoutThrowing(`Failed to migrate ${filepath}`, error);
+                context.failWithoutThrowing(`Failed to migrate ${filepath}`, error, { code: CliError.Code.ParseError });
             }
         }
     }

--- a/packages/cli/cli-migrations/src/migrations/0.1.3-rc3/add-inline-requests/getAllYamlFiles.ts
+++ b/packages/cli/cli-migrations/src/migrations/0.1.3-rc3/add-inline-requests/getAllYamlFiles.ts
@@ -1,5 +1,5 @@
 import { AbsoluteFilePath } from "@fern-api/fs-utils";
-import { TaskContext } from "@fern-api/task-context";
+import { CliError, TaskContext } from "@fern-api/task-context";
 import { findUp } from "find-up";
 import { glob } from "glob";
 
@@ -9,7 +9,9 @@ export async function getAllYamlFiles(context: TaskContext): Promise<AbsoluteFil
     const fernDirectory = await getFernDirectory();
     const alphasort = (a: string, b: string) => a.localeCompare(b, "en");
     if (fernDirectory == null) {
-        context.failAndThrow(`Directory "${FERN_DIRECTORY}" not found.`);
+        context.failAndThrow(`Directory "${FERN_DIRECTORY}" not found.`, undefined, {
+            code: CliError.Code.ConfigError
+        });
     }
     const filepaths = await glob("*/definition/**/*.yml", {
         cwd: fernDirectory,

--- a/packages/cli/cli-migrations/src/migrations/0.1.3-rc3/add-inline-requests/migration.ts
+++ b/packages/cli/cli-migrations/src/migrations/0.1.3-rc3/add-inline-requests/migration.ts
@@ -1,5 +1,6 @@
 import { AbsoluteFilePath } from "@fern-api/fs-utils";
-import { TaskContext } from "@fern-api/task-context";
+import { CliError, TaskContext } from "@fern-api/task-context";
+
 import { readFile, writeFile } from "fs/promises";
 import YAML from "yaml";
 
@@ -15,7 +16,7 @@ export const migration: Migration = {
             try {
                 await migrateYamlFile(filepath, context);
             } catch (error) {
-                context.failWithoutThrowing(`Failed to migrate ${filepath}`, error);
+                context.failWithoutThrowing(`Failed to migrate ${filepath}`, error, { code: CliError.Code.ParseError });
             }
         }
     }
@@ -29,7 +30,7 @@ async function migrateYamlFile(filepath: AbsoluteFilePath, context: TaskContext)
         return;
     }
     if (!YAML.isMap(services)) {
-        throw new Error("'services' is not a map");
+        throw new CliError({ message: "'services' is not a map", code: CliError.Code.ParseError });
     }
 
     const httpServices = services.get("http");
@@ -37,12 +38,14 @@ async function migrateYamlFile(filepath: AbsoluteFilePath, context: TaskContext)
         return;
     }
     if (!YAML.isMap(httpServices)) {
-        throw new Error("'http' is not a map");
+        throw new CliError({ message: "'http' is not a map", code: CliError.Code.ParseError });
     }
 
     for (const service of httpServices.items) {
         if (!YAML.isMap(service.value)) {
-            context.failWithoutThrowing(`Service '${service.key}' is not a map`);
+            context.failWithoutThrowing(`Service '${service.key}' is not a map`, undefined, {
+                code: CliError.Code.ParseError
+            });
             continue;
         }
         const endpoints = service.value.get("endpoints");
@@ -50,18 +53,24 @@ async function migrateYamlFile(filepath: AbsoluteFilePath, context: TaskContext)
             continue;
         }
         if (!YAML.isMap(endpoints)) {
-            context.failWithoutThrowing(`Endpoints are not a map in service '${service.key}'`);
+            context.failWithoutThrowing(`Endpoints are not a map in service '${service.key}'`, undefined, {
+                code: CliError.Code.ParseError
+            });
             continue;
         }
         for (const endpoint of endpoints.items) {
             if (!YAML.isMap(endpoint.value)) {
-                context.failWithoutThrowing(`Endpoint ${endpoint.key} is not a map in service '${service.key}'`);
+                context.failWithoutThrowing(
+                    `Endpoint ${endpoint.key} is not a map in service '${service.key}'`,
+                    undefined,
+                    { code: CliError.Code.ParseError }
+                );
                 continue;
             }
             try {
                 convertEndpoint({ document: parsedDocument, endpoint: endpoint.value });
             } catch (e) {
-                context.failWithoutThrowing("Failed to convert endpoint", e);
+                context.failWithoutThrowing("Failed to convert endpoint", e, { code: CliError.Code.ParseError });
             }
         }
         await writeFile(filepath, parsedDocument.toString());
@@ -86,7 +95,7 @@ function convertEndpoint({ document, endpoint }: { document: YAML.Document.Parse
         const documentTypes = document.get("types");
         if (documentTypes != null) {
             if (!YAML.isMap(documentTypes)) {
-                throw new Error("types are not a map");
+                throw new CliError({ message: "types are not a map", code: CliError.Code.ParseError });
             }
             const maybeTypeDeclarationForRequest = documentTypes.get(requestBodyType);
 
@@ -143,10 +152,10 @@ function parseRequestBody(
     if (YAML.isMap(requestBody)) {
         const type = requestBody.get("type");
         if (type == null) {
-            throw new Error("request type does not exist");
+            throw new CliError({ message: "request type does not exist", code: CliError.Code.ParseError });
         }
         if (typeof type !== "string") {
-            throw new Error("request type is not a string");
+            throw new CliError({ message: "request type is not a string", code: CliError.Code.ParseError });
         }
         const docs = requestBody.get("docs", true);
         return {
@@ -155,5 +164,5 @@ function parseRequestBody(
         };
     }
 
-    throw new Error("request is not a string or a map");
+    throw new CliError({ message: "request is not a string or a map", code: CliError.Code.ParseError });
 }

--- a/packages/cli/cli-migrations/src/migrations/0.15.0-rc0/update-directory-structure/migrateDocsInstances.ts
+++ b/packages/cli/cli-migrations/src/migrations/0.15.0-rc0/update-directory-structure/migrateDocsInstances.ts
@@ -1,11 +1,14 @@
 import { docsYml } from "@fern-api/configuration-loader";
-
+import { CliError } from "@fern-api/task-context";
 import { DocsURL } from "./docs-config/index.js";
 
 export function migrateDocsInstances(docsURLs: docsYml.RawSchemas.DocsInstance[]): DocsURL[] {
     return docsURLs.map((docsURL) => {
         if (Array.isArray(docsURL.customDomain)) {
-            throw new Error("Expected custom-domain to be a string, but it was an array.");
+            throw new CliError({
+                message: "Expected custom-domain to be a string, but it was an array.",
+                code: CliError.Code.ConfigError
+            });
         }
         return {
             ...docsURL,

--- a/packages/cli/cli-migrations/src/migrations/0.15.0-rc0/update-directory-structure/migration.ts
+++ b/packages/cli/cli-migrations/src/migrations/0.15.0-rc0/update-directory-structure/migration.ts
@@ -6,6 +6,7 @@ import {
     join,
     RelativeFilePath
 } from "@fern-api/fs-utils";
+import { CliError } from "@fern-api/task-context";
 import { findUp } from "find-up";
 
 import { Migration } from "../../../types/Migration.js";
@@ -21,7 +22,9 @@ export const migration: Migration = {
     run: async ({ context }) => {
         const absolutePathToFernDirectory = await getFernDirectory();
         if (absolutePathToFernDirectory == null) {
-            context.failAndThrow("Fern directory not found. Failed to run migration");
+            context.failAndThrow("Fern directory not found. Failed to run migration", undefined, {
+                code: CliError.Code.ConfigError
+            });
             return;
         }
         const fernDirectoryContents = await getDirectoryContents(absolutePathToFernDirectory);
@@ -71,7 +74,9 @@ export const migration: Migration = {
 
         if (workspacesContainingDocs.length > 1) {
             context.failAndThrow(
-                "Detected multiple docs websites being published. This is unsupported in the latest upgrade. File an issue (https://github.com/fern-api/fern) if this is important!"
+                "Detected multiple docs websites being published. This is unsupported in the latest upgrade. File an issue (https://github.com/fern-api/fern) if this is important!",
+                undefined,
+                { code: CliError.Code.ConfigError }
             );
             return;
         }

--- a/packages/cli/cli-migrations/src/migrations/0.3.0-rc12/add-value-key-to-type-examples/getAllYamlFiles.ts
+++ b/packages/cli/cli-migrations/src/migrations/0.3.0-rc12/add-value-key-to-type-examples/getAllYamlFiles.ts
@@ -1,5 +1,5 @@
 import { AbsoluteFilePath } from "@fern-api/fs-utils";
-import { TaskContext } from "@fern-api/task-context";
+import { CliError, TaskContext } from "@fern-api/task-context";
 import { findUp } from "find-up";
 import { glob } from "glob";
 
@@ -9,7 +9,9 @@ export async function getAllYamlFiles(context: TaskContext): Promise<AbsoluteFil
     const fernDirectory = await getFernDirectory();
     const alphasort = (a: string, b: string) => a.localeCompare(b, "en");
     if (fernDirectory == null) {
-        context.failAndThrow(`Directory "${FERN_DIRECTORY}" not found.`);
+        context.failAndThrow(`Directory "${FERN_DIRECTORY}" not found.`, undefined, {
+            code: CliError.Code.ConfigError
+        });
     }
     const filepaths = await glob("*/definition/**/*.yml", {
         cwd: fernDirectory,

--- a/packages/cli/cli-migrations/src/migrations/0.3.0-rc12/add-value-key-to-type-examples/migration.ts
+++ b/packages/cli/cli-migrations/src/migrations/0.3.0-rc12/add-value-key-to-type-examples/migration.ts
@@ -1,5 +1,6 @@
 import { AbsoluteFilePath } from "@fern-api/fs-utils";
-import { TaskContext } from "@fern-api/task-context";
+import { CliError, TaskContext } from "@fern-api/task-context";
+
 import { readFile, writeFile } from "fs/promises";
 import YAML from "yaml";
 
@@ -15,7 +16,7 @@ export const migration: Migration = {
             try {
                 await migrateYamlFile(filepath, context);
             } catch (error) {
-                context.failWithoutThrowing(`Failed to migrate ${filepath}`, error);
+                context.failWithoutThrowing(`Failed to migrate ${filepath}`, error, { code: CliError.Code.ParseError });
             }
         }
     }
@@ -29,7 +30,7 @@ async function migrateYamlFile(filepath: AbsoluteFilePath, context: TaskContext)
         return;
     }
     if (!YAML.isMap(types)) {
-        throw new Error("'types' is not a map");
+        throw new CliError({ message: "'types' is not a map", code: CliError.Code.ParseError });
     }
     for (const type of types.items) {
         if (!YAML.isMap(type.value)) {
@@ -40,7 +41,7 @@ async function migrateYamlFile(filepath: AbsoluteFilePath, context: TaskContext)
             continue;
         }
         if (!YAML.isSeq(examples)) {
-            context.failWithoutThrowing("'examples' are not a list");
+            context.failWithoutThrowing("'examples' are not a list", undefined, { code: CliError.Code.ParseError });
             continue;
         }
         for (let i = 0; i < examples.items.length; i++) {

--- a/packages/cli/cli-migrations/src/migrations/0.3.23/change-services-key-to-service/getAllYamlFiles.ts
+++ b/packages/cli/cli-migrations/src/migrations/0.3.23/change-services-key-to-service/getAllYamlFiles.ts
@@ -1,5 +1,5 @@
 import { AbsoluteFilePath } from "@fern-api/fs-utils";
-import { TaskContext } from "@fern-api/task-context";
+import { CliError, TaskContext } from "@fern-api/task-context";
 import { findUp } from "find-up";
 import { glob } from "glob";
 
@@ -9,7 +9,9 @@ export async function getAllYamlFiles(context: TaskContext): Promise<AbsoluteFil
     const fernDirectory = await getFernDirectory();
     const alphasort = (a: string, b: string) => a.localeCompare(b, "en");
     if (fernDirectory == null) {
-        context.failAndThrow(`Directory "${FERN_DIRECTORY}" not found.`);
+        context.failAndThrow(`Directory "${FERN_DIRECTORY}" not found.`, undefined, {
+            code: CliError.Code.ConfigError
+        });
     }
     const filepaths = await glob("*/definition/**/*.yml", {
         cwd: fernDirectory,

--- a/packages/cli/cli-migrations/src/migrations/0.3.23/change-services-key-to-service/migration.ts
+++ b/packages/cli/cli-migrations/src/migrations/0.3.23/change-services-key-to-service/migration.ts
@@ -1,5 +1,5 @@
 import { AbsoluteFilePath } from "@fern-api/fs-utils";
-import { TaskContext } from "@fern-api/task-context";
+import { CliError, TaskContext } from "@fern-api/task-context";
 import { readFile, writeFile } from "fs/promises";
 import YAML from "yaml";
 
@@ -15,7 +15,7 @@ export const migration: Migration = {
             try {
                 await migrateYamlFile(filepath, context);
             } catch (error) {
-                context.failWithoutThrowing(`Failed to migrate ${filepath}`, error);
+                context.failWithoutThrowing(`Failed to migrate ${filepath}`, error, { code: CliError.Code.ParseError });
             }
         }
     }
@@ -26,13 +26,13 @@ async function migrateYamlFile(filepath: AbsoluteFilePath, context: TaskContext)
     const parsedDocument = YAML.parseDocument(contents.toString());
 
     if (!YAML.isMap(parsedDocument.contents)) {
-        return context.failAndThrow("File is not a map");
+        return context.failAndThrow("File is not a map", undefined, { code: CliError.Code.ParseError });
     }
 
     for (const pair of parsedDocument.contents.items) {
         if (YAML.isScalar(pair.key) && pair.key.value === "services") {
             if (!YAML.isMap(pair.value)) {
-                return context.failAndThrow("Services are not a map");
+                return context.failAndThrow("Services are not a map", undefined, { code: CliError.Code.ParseError });
             }
 
             const httpServices = pair.value.get("http");
@@ -42,7 +42,7 @@ async function migrateYamlFile(filepath: AbsoluteFilePath, context: TaskContext)
             }
 
             if (!YAML.isMap(httpServices)) {
-                return context.failAndThrow("http is not a map");
+                return context.failAndThrow("http is not a map", undefined, { code: CliError.Code.ParseError });
             }
             const [firstService, ...remainingServices] = httpServices.items;
             if (firstService == null) {
@@ -50,7 +50,9 @@ async function migrateYamlFile(filepath: AbsoluteFilePath, context: TaskContext)
                 return;
             }
             if (remainingServices.length > 0) {
-                return context.failAndThrow("There are multiple services defined");
+                return context.failAndThrow("There are multiple services defined", undefined, {
+                    code: CliError.Code.ConfigError
+                });
             }
 
             pair.key.value = "service";

--- a/packages/cli/cli-migrations/src/migrations/0.41.0-rc0/require-generators-yml/migration.ts
+++ b/packages/cli/cli-migrations/src/migrations/0.41.0-rc0/require-generators-yml/migration.ts
@@ -8,7 +8,7 @@ import {
     RelativeFilePath,
     relativize
 } from "@fern-api/fs-utils";
-import { TaskContext } from "@fern-api/task-context";
+import { CliError, TaskContext } from "@fern-api/task-context";
 import chalk from "chalk";
 import { writeFile } from "fs/promises";
 import yaml from "js-yaml";
@@ -22,7 +22,9 @@ export const migration: Migration = {
     run: async ({ context }) => {
         const absolutePathToFernDirectory = await getFernDirectory();
         if (absolutePathToFernDirectory == null) {
-            context.failAndThrow("Fern directory not found. Failed to run migration");
+            context.failAndThrow("Fern directory not found. Failed to run migration", undefined, {
+                code: CliError.Code.ConfigError
+            });
             return;
         }
 

--- a/packages/cli/cli-migrations/src/migrations/0.5.4/move-service-docs-to-top-level/getAllYamlFiles.ts
+++ b/packages/cli/cli-migrations/src/migrations/0.5.4/move-service-docs-to-top-level/getAllYamlFiles.ts
@@ -1,5 +1,5 @@
 import { AbsoluteFilePath } from "@fern-api/fs-utils";
-import { TaskContext } from "@fern-api/task-context";
+import { CliError, TaskContext } from "@fern-api/task-context";
 import { findUp } from "find-up";
 import { glob } from "glob";
 
@@ -9,7 +9,9 @@ export async function getAllYamlFiles(context: TaskContext): Promise<AbsoluteFil
     const fernDirectory = await getFernDirectory();
     const alphasort = (a: string, b: string) => a.localeCompare(b, "en");
     if (fernDirectory == null) {
-        context.failAndThrow(`Directory "${FERN_DIRECTORY}" not found.`);
+        context.failAndThrow(`Directory "${FERN_DIRECTORY}" not found.`, undefined, {
+            code: CliError.Code.ConfigError
+        });
     }
     const filepaths = await glob("*/definition/**/*.yml", {
         cwd: fernDirectory,

--- a/packages/cli/cli-migrations/src/migrations/0.5.4/move-service-docs-to-top-level/migration.ts
+++ b/packages/cli/cli-migrations/src/migrations/0.5.4/move-service-docs-to-top-level/migration.ts
@@ -1,5 +1,5 @@
 import { AbsoluteFilePath } from "@fern-api/fs-utils";
-import { TaskContext } from "@fern-api/task-context";
+import { CliError, TaskContext } from "@fern-api/task-context";
 import { readFile, writeFile } from "fs/promises";
 import YAML from "yaml";
 
@@ -15,7 +15,7 @@ export const migration: Migration = {
             try {
                 await migrateYamlFile(filepath, context);
             } catch (error) {
-                context.failWithoutThrowing(`Failed to migrate ${filepath}`, error);
+                context.failWithoutThrowing(`Failed to migrate ${filepath}`, error, { code: CliError.Code.ParseError });
             }
         }
     }
@@ -26,7 +26,7 @@ async function migrateYamlFile(filepath: AbsoluteFilePath, context: TaskContext)
     const parsedDocument = YAML.parseDocument(contents.toString());
 
     if (!YAML.isMap(parsedDocument.contents)) {
-        return context.failAndThrow("File is not a map");
+        return context.failAndThrow("File is not a map", undefined, { code: CliError.Code.ParseError });
     }
 
     const service = parsedDocument.contents.get("service");
@@ -35,7 +35,7 @@ async function migrateYamlFile(filepath: AbsoluteFilePath, context: TaskContext)
     }
 
     if (!YAML.isMap(service)) {
-        return context.failAndThrow("service is not a map");
+        return context.failAndThrow("service is not a map", undefined, { code: CliError.Code.ParseError });
     }
 
     const indexOfServiceDocsPair = service.items.findIndex(

--- a/packages/cli/cli-migrations/src/migrations/0.54.0-rc0/use-generators-yml-specs/migration.ts
+++ b/packages/cli/cli-migrations/src/migrations/0.54.0-rc0/use-generators-yml-specs/migration.ts
@@ -8,7 +8,7 @@ import {
     join,
     RelativeFilePath
 } from "@fern-api/fs-utils";
-import { TaskContext } from "@fern-api/task-context";
+import { CliError, TaskContext } from "@fern-api/task-context";
 import chalk from "chalk";
 import { readFile, writeFile } from "fs/promises";
 import yaml from "js-yaml";
@@ -22,7 +22,9 @@ export const migration: Migration = {
     run: async ({ context }) => {
         const absolutePathToFernDirectory = await getFernDirectory();
         if (absolutePathToFernDirectory == null) {
-            context.failAndThrow("Fern directory not found. Failed to run migration");
+            context.failAndThrow("Fern directory not found. Failed to run migration", undefined, {
+                code: CliError.Code.ConfigError
+            });
             return;
         }
 
@@ -73,18 +75,20 @@ async function addApiConfigurationToSingleWorkspace({
     const generatorsYmlFile = files.find((file) => file.name === "generators.yml" || file.name === "generators.yaml");
 
     if (generatorsYmlFile == null) {
-        context.failAndThrow("generators.yml not found");
+        context.failAndThrow("generators.yml not found", undefined, { code: CliError.Code.ConfigError });
         return;
     }
 
     const generatorsYmlContents = yaml.load(generatorsYmlFile.contents);
     if (generatorsYmlContents == null) {
-        context.failAndThrow("generators.yml is null or undefined");
+        context.failAndThrow("generators.yml is null or undefined", undefined, { code: CliError.Code.ConfigError });
         return;
     }
 
     if (typeof generatorsYmlContents !== "object") {
-        context.failAndThrow("generators.yml is not a valid YAML object");
+        context.failAndThrow("generators.yml is not a valid YAML object", undefined, {
+            code: CliError.Code.ConfigError
+        });
         return;
     }
 
@@ -155,7 +159,9 @@ async function addApiConfigurationToSingleWorkspace({
                 }
             }
         } else {
-            context.failAndThrow("API spec is not a valid YAML object or array");
+            context.failAndThrow("API spec is not a valid YAML object or array", undefined, {
+                code: CliError.Code.ConfigError
+            });
             return;
         }
     }
@@ -180,7 +186,7 @@ async function addApiConfigurationToSingleWorkspace({
         } else if (typeof api === "object") {
             const openApiSpec = api as Partial<generatorsYml.GeneratorsOpenApiObjectSchema>;
             if (openApiSpec.path == null) {
-                context.failAndThrow("openapi path is not defined");
+                context.failAndThrow("openapi path is not defined", undefined, { code: CliError.Code.ConfigError });
                 return;
             }
             specs.push({
@@ -190,7 +196,7 @@ async function addApiConfigurationToSingleWorkspace({
                 settings: convertDeprecatedApiSettingsToOpenApiSettings(openApiSpec.settings ?? {})
             });
         } else {
-            context.failAndThrow("openapi is not a string or object");
+            context.failAndThrow("openapi is not a string or object", undefined, { code: CliError.Code.ConfigError });
             return;
         }
     }
@@ -203,7 +209,7 @@ async function addApiConfigurationToSingleWorkspace({
                 settings: convertDeprecatedApiSettingsToAsyncApiSettings(rootSettings)
             });
         } else {
-            context.failAndThrow("async-api is not a string");
+            context.failAndThrow("async-api is not a string", undefined, { code: CliError.Code.ConfigError });
             return;
         }
     }

--- a/packages/cli/cli-migrations/src/migrations/0.82.1/add-path-parameter-order-setting/migration.ts
+++ b/packages/cli/cli-migrations/src/migrations/0.82.1/add-path-parameter-order-setting/migration.ts
@@ -1,6 +1,6 @@
 import { getFernDirectory } from "@fern-api/configuration-loader";
 import { AbsoluteFilePath, Directory, File, getDirectoryContents, join, RelativeFilePath } from "@fern-api/fs-utils";
-import { TaskContext } from "@fern-api/task-context";
+import { CliError, TaskContext } from "@fern-api/task-context";
 import chalk from "chalk";
 import { writeFile } from "fs/promises";
 import yaml from "js-yaml";
@@ -13,7 +13,9 @@ This migration will set 'path-parameter-order: spec-order' in generators.yml fil
     run: async ({ context }) => {
         const absolutePathToFernDirectory = await getFernDirectory();
         if (absolutePathToFernDirectory == null) {
-            context.failAndThrow("Fern directory not found. Failed to run migration");
+            context.failAndThrow("Fern directory not found. Failed to run migration", undefined, {
+                code: CliError.Code.ConfigError
+            });
             return;
         }
 
@@ -56,12 +58,14 @@ async function updateGeneratorsYml({ context, files }: { context: TaskContext; f
 
     const generatorsYmlContents = yaml.load(generatorsYmlFile.contents);
     if (generatorsYmlContents == null) {
-        context.failAndThrow("generators.yml is null or undefined");
+        context.failAndThrow("generators.yml is null or undefined", undefined, { code: CliError.Code.ConfigError });
         return;
     }
 
     if (typeof generatorsYmlContents !== "object") {
-        context.failAndThrow("generators.yml is not a valid YAML object");
+        context.failAndThrow("generators.yml is not a valid YAML object", undefined, {
+            code: CliError.Code.ConfigError
+        });
         return;
     }
 

--- a/packages/cli/cli-migrations/src/migrations/0.9.10/add-suffix-to-docs-domain/getAllGeneratorYamlFiles.ts
+++ b/packages/cli/cli-migrations/src/migrations/0.9.10/add-suffix-to-docs-domain/getAllGeneratorYamlFiles.ts
@@ -1,5 +1,5 @@
 import { AbsoluteFilePath } from "@fern-api/fs-utils";
-import { TaskContext } from "@fern-api/task-context";
+import { CliError, TaskContext } from "@fern-api/task-context";
 import { findUp } from "find-up";
 import { glob } from "glob";
 
@@ -9,7 +9,9 @@ export async function getAllGeneratorYamlFiles(context: TaskContext): Promise<Ab
     const fernDirectory = await getFernDirectory();
     const alphasort = (a: string, b: string) => a.localeCompare(b, "en");
     if (fernDirectory == null) {
-        return context.failAndThrow(`Directory "${FERN_DIRECTORY}" not found.`);
+        return context.failAndThrow(`Directory "${FERN_DIRECTORY}" not found.`, undefined, {
+            code: CliError.Code.ConfigError
+        });
     }
     const filepaths = await glob("*/generators.yml", {
         cwd: fernDirectory,

--- a/packages/cli/cli-migrations/src/migrations/0.9.10/add-suffix-to-docs-domain/migration.ts
+++ b/packages/cli/cli-migrations/src/migrations/0.9.10/add-suffix-to-docs-domain/migration.ts
@@ -1,4 +1,5 @@
 import { AbsoluteFilePath } from "@fern-api/fs-utils";
+import { CliError } from "@fern-api/task-context";
 import { readFile, writeFile } from "fs/promises";
 
 import { Migration } from "../../../types/Migration.js";
@@ -13,7 +14,7 @@ export const migration: Migration = {
             try {
                 await migrateYamlFile(filepath);
             } catch (error) {
-                context.failWithoutThrowing(`Failed to migrate ${filepath}`, error);
+                context.failWithoutThrowing(`Failed to migrate ${filepath}`, error, { code: CliError.Code.ParseError });
             }
         }
     }

--- a/packages/cli/cli-migrations/src/migrations/1.0.0/update-settings-defaults/migration.ts
+++ b/packages/cli/cli-migrations/src/migrations/1.0.0/update-settings-defaults/migration.ts
@@ -1,6 +1,6 @@
 import { getFernDirectory } from "@fern-api/configuration-loader";
 import { AbsoluteFilePath, Directory, File, getDirectoryContents, join, RelativeFilePath } from "@fern-api/fs-utils";
-import { TaskContext } from "@fern-api/task-context";
+import { CliError, TaskContext } from "@fern-api/task-context";
 import chalk from "chalk";
 import { writeFile } from "fs/promises";
 import yaml from "js-yaml";
@@ -13,7 +13,9 @@ This migration will explicitly set the old defaults to maintain backwards compat
     run: async ({ context }) => {
         const absolutePathToFernDirectory = await getFernDirectory();
         if (absolutePathToFernDirectory == null) {
-            context.failAndThrow("Fern directory not found. Failed to run migration");
+            context.failAndThrow("Fern directory not found. Failed to run migration", undefined, {
+                code: CliError.Code.ConfigError
+            });
             return;
         }
 
@@ -50,18 +52,20 @@ async function updateGeneratorsYml({ context, files }: { context: TaskContext; f
     const generatorsYmlFile = files.find((file) => file.name === "generators.yml" || file.name === "generators.yaml");
 
     if (generatorsYmlFile == null) {
-        context.failAndThrow("generators.yml not found");
+        context.failAndThrow("generators.yml not found", undefined, { code: CliError.Code.ConfigError });
         return;
     }
 
     const generatorsYmlContents = yaml.load(generatorsYmlFile.contents);
     if (generatorsYmlContents == null) {
-        context.failAndThrow("generators.yml is null or undefined");
+        context.failAndThrow("generators.yml is null or undefined", undefined, { code: CliError.Code.ConfigError });
         return;
     }
 
     if (typeof generatorsYmlContents !== "object") {
-        context.failAndThrow("generators.yml is not a valid YAML object");
+        context.failAndThrow("generators.yml is not a valid YAML object", undefined, {
+            code: CliError.Code.ConfigError
+        });
         return;
     }
 

--- a/packages/cli/cli-migrations/src/migrations/2.0.0-rc0/update-settings-defaults/migration.ts
+++ b/packages/cli/cli-migrations/src/migrations/2.0.0-rc0/update-settings-defaults/migration.ts
@@ -1,6 +1,6 @@
 import { getFernDirectory } from "@fern-api/configuration-loader";
 import { AbsoluteFilePath, Directory, File, getDirectoryContents, join, RelativeFilePath } from "@fern-api/fs-utils";
-import { TaskContext } from "@fern-api/task-context";
+import { CliError, TaskContext } from "@fern-api/task-context";
 import chalk from "chalk";
 import { writeFile } from "fs/promises";
 import yaml from "js-yaml";
@@ -13,7 +13,9 @@ This migration will explicitly set it to true to maintain backwards compatibilit
     run: async ({ context }) => {
         const absolutePathToFernDirectory = await getFernDirectory();
         if (absolutePathToFernDirectory == null) {
-            context.failAndThrow("Fern directory not found. Failed to run migration");
+            context.failAndThrow("Fern directory not found. Failed to run migration", undefined, {
+                code: CliError.Code.ConfigError
+            });
             return;
         }
 
@@ -50,18 +52,20 @@ async function updateGeneratorsYml({ context, files }: { context: TaskContext; f
     const generatorsYmlFile = files.find((file) => file.name === "generators.yml" || file.name === "generators.yaml");
 
     if (generatorsYmlFile == null) {
-        context.failAndThrow("generators.yml not found");
+        context.failAndThrow("generators.yml not found", undefined, { code: CliError.Code.ConfigError });
         return;
     }
 
     const generatorsYmlContents = yaml.load(generatorsYmlFile.contents);
     if (generatorsYmlContents == null) {
-        context.failAndThrow("generators.yml is null or undefined");
+        context.failAndThrow("generators.yml is null or undefined", undefined, { code: CliError.Code.ConfigError });
         return;
     }
 
     if (typeof generatorsYmlContents !== "object") {
-        context.failAndThrow("generators.yml is not a valid YAML object");
+        context.failAndThrow("generators.yml is not a valid YAML object", undefined, {
+            code: CliError.Code.ConfigError
+        });
         return;
     }
 

--- a/packages/cli/cli-migrations/src/migrations/2.13.0/migrate-deprecated-generator-api-settings/migration.ts
+++ b/packages/cli/cli-migrations/src/migrations/2.13.0/migrate-deprecated-generator-api-settings/migration.ts
@@ -1,6 +1,6 @@
 import { getFernDirectory } from "@fern-api/configuration-loader";
 import { AbsoluteFilePath, Directory, File, getDirectoryContents, join, RelativeFilePath } from "@fern-api/fs-utils";
-import { TaskContext } from "@fern-api/task-context";
+import { CliError, TaskContext } from "@fern-api/task-context";
 import chalk from "chalk";
 import { writeFile } from "fs/promises";
 import yaml from "js-yaml";
@@ -14,7 +14,9 @@ export const migration: Migration = {
     run: async ({ context }) => {
         const absolutePathToFernDirectory = await getFernDirectory();
         if (absolutePathToFernDirectory == null) {
-            context.failAndThrow("Fern directory not found. Failed to run migration");
+            context.failAndThrow("Fern directory not found. Failed to run migration", undefined, {
+                code: CliError.Code.ConfigError
+            });
             return;
         }
 

--- a/packages/cli/cli-migrations/src/migrations/3.0.0/enable-smart-casing/migration.ts
+++ b/packages/cli/cli-migrations/src/migrations/3.0.0/enable-smart-casing/migration.ts
@@ -1,6 +1,6 @@
 import { getFernDirectory } from "@fern-api/configuration-loader";
 import { AbsoluteFilePath, Directory, File, getDirectoryContents, join, RelativeFilePath } from "@fern-api/fs-utils";
-import { TaskContext } from "@fern-api/task-context";
+import { CliError, TaskContext } from "@fern-api/task-context";
 import chalk from "chalk";
 import { writeFile } from "fs/promises";
 import yaml from "js-yaml";
@@ -15,7 +15,9 @@ existing projects maintain their current naming behavior.`,
     run: async ({ context }) => {
         const absolutePathToFernDirectory = await getFernDirectory();
         if (absolutePathToFernDirectory == null) {
-            context.failAndThrow("Fern directory not found. Failed to run migration");
+            context.failAndThrow("Fern directory not found. Failed to run migration", undefined, {
+                code: CliError.Code.ConfigError
+            });
             return;
         }
 

--- a/packages/cli/cli-migrations/src/runMigrations.ts
+++ b/packages/cli/cli-migrations/src/runMigrations.ts
@@ -1,5 +1,5 @@
 import { addPrefixToString } from "@fern-api/core-utils";
-import { InteractiveTaskContext, Startable, TaskContext, TaskResult } from "@fern-api/task-context";
+import { CliError, InteractiveTaskContext, Startable, TaskContext, TaskResult } from "@fern-api/task-context";
 import chalk from "chalk";
 import inquirer from "inquirer";
 
@@ -49,7 +49,7 @@ export async function runMigrations({
         await context.takeOverTerminal(async () => {
             const wantsToContinue = await askForConfirmation(migrationsToRun);
             if (!wantsToContinue) {
-                context.failAndThrow("Canceled.");
+                context.failAndThrow("Canceled.", undefined, { code: CliError.Code.ConfigError });
             }
         });
         if (context.getResult() === TaskResult.Failure) {


### PR DESCRIPTION
## Description

Migrates `@fern-api/cli-migrations` to use explicit `CliError` error codes on every `failAndThrow` / `failWithoutThrowing` call site.

This is one of the package migration PRs that follow the error classification system introduced in #14749.

## Changes Made

Assigned typed error codes across **36 files** in `packages/cli/cli-migrations/src/`, covering every `failAndThrow` and `failWithoutThrowing` invocation. Also added missing `CliError` imports to all migration files that reference `CliError.Code`.

### Error codes used

| Code | Usage |
|------|-------|
| `CONFIG_ERROR` | Fern directory not found, generators.yml missing/invalid, missing configuration |
| `PARSE_ERROR` | Failed YAML migrations, malformed schema objects, invalid type/union/error maps |
| `VALIDATION_ERROR` | Invalid migration targets, schema validation during upgrades |

### Files touched (grouped by area)

- **Run migrations**: `runMigrations.ts`
- **Early migrations (0.0.x)**: `discriminant/`, `union-single-property-key/`, `add-mode-to-draft-generators/`, `remove-inline-error-declarations/`, `add-publishing-to-release-generators/`, `rename-alias-key-to-type/`, `add-error-discriminant/`, `add-generator-groups/`, `add-error-discrimination-config/`
- **Mid migrations (0.1.x-0.9.x)**: `add-inline-requests/`, `add-value-key-to-type-examples/`, `change-services-key-to-service/`, `move-service-docs-to-top-level/`, `require-generators-yml/`, `use-generators-yml-specs/`, `add-path-parameter-order-setting/`, `add-suffix-to-docs-domain/`
- **Late migrations (1.0+)**: `update-settings-defaults/` (1.0.0 and 2.0.0-rc0), `migrate-deprecated-generator-api-settings/`, `enable-smart-casing/`, `update-directory-structure/`

## Testing

- [x] Existing tests pass (`pnpm test`, excluding e2e and pre-existing environment failures)
