### PR TITLE
chore(cli): migrate @fern-api/cli-v2 to use CliError

### DIFF
--- a/packages/cli/cli-v2/src/api/adapter/LegacyApiSpecAdapter.ts
+++ b/packages/cli/cli-v2/src/api/adapter/LegacyApiSpecAdapter.ts
@@ -8,6 +8,7 @@ import type {
 import type { schemas } from "@fern-api/config";
 import { generatorsYml } from "@fern-api/configuration";
 import { relativize } from "@fern-api/fs-utils";
+import { CliError } from "@fern-api/task-context";
 import type { Context } from "../../context/Context.js";
 import type { ApiSpec } from "../config/ApiSpec.js";
 import type { AsyncApiSpec } from "../config/AsyncApiSpec.js";
@@ -49,7 +50,10 @@ export class LegacyApiSpecAdapter {
         if (isOpenRpcSpec(spec)) {
             return this.adaptOpenRpcSpec(spec);
         }
-        throw new Error(`Unsupported spec type: ${JSON.stringify(spec)}`);
+        throw new CliError({
+            message: `Unsupported spec type: ${JSON.stringify(spec)}`,
+            code: CliError.Code.InternalError
+        });
     }
 
     public convertAll(specs: ApiSpec[]): Spec[] {

--- a/packages/cli/cli-v2/src/api/adapter/LegacyFernWorkspaceAdapter.ts
+++ b/packages/cli/cli-v2/src/api/adapter/LegacyFernWorkspaceAdapter.ts
@@ -3,6 +3,7 @@ import type { generatorsYml } from "@fern-api/configuration";
 import { RawSchemas } from "@fern-api/fern-definition-schema";
 import { AbsoluteFilePath, dirname, relativize } from "@fern-api/fs-utils";
 import { ConjureWorkspace, LazyFernWorkspace } from "@fern-api/lazy-fern-workspace";
+import { CliError } from "@fern-api/task-context";
 import { TaskContextAdapter } from "../../context/adapter/TaskContextAdapter.js";
 import type { Context } from "../../context/Context.js";
 import type { Task } from "../../ui/Task.js";
@@ -103,7 +104,10 @@ export class LegacyFernWorkspaceAdapter {
         });
 
         if (ossWorkspace == null) {
-            throw new Error("Internal error; failed to build API definitions");
+            throw new CliError({
+                message: "Internal error; failed to build API definitions",
+                code: CliError.Code.InternalError
+            });
         }
 
         return ossWorkspace.toFernWorkspace({ context: this.taskContext });

--- a/packages/cli/cli-v2/src/api/config/converter/ApiDefinitionConverter.ts
+++ b/packages/cli/cli-v2/src/api/config/converter/ApiDefinitionConverter.ts
@@ -1,6 +1,7 @@
 import type { schemas } from "@fern-api/config";
 import { AbsoluteFilePath, dirname, doesPathExist, join, RelativeFilePath, relative } from "@fern-api/fs-utils";
 import { isNullish, type Sourced } from "@fern-api/source";
+import { CliError } from "@fern-api/task-context";
 import { type ReferenceResolver, ValidationIssue } from "@fern-api/yaml-loader";
 import type { FernYmlSchemaLoader } from "../../../config/fern-yml/FernYmlSchemaLoader.js";
 import type { ApiDefinition } from "../ApiDefinition.js";
@@ -271,7 +272,10 @@ export class ApiDefinitionConverter {
             });
         }
         // Unreachable; this should never happen if the schema validation is correct.
-        throw new Error(`Unknown spec type: ${JSON.stringify(spec)}`);
+        throw new CliError({
+            message: `Unknown spec type: ${JSON.stringify(spec)}`,
+            code: CliError.Code.InternalError
+        });
     }
 
     private async convertOpenApiSpec({

--- a/packages/cli/cli-v2/src/api/resolver/ApiSpecDetector.ts
+++ b/packages/cli/cli-v2/src/api/resolver/ApiSpecDetector.ts
@@ -1,4 +1,5 @@
 import type { AbsoluteFilePath } from "@fern-api/fs-utils";
+import { CliError } from "@fern-api/task-context";
 import yaml from "js-yaml";
 import type { ApiSpecType } from "../config/ApiSpec.js";
 
@@ -25,29 +26,34 @@ export class ApiSpecDetector {
     public async detect({ absoluteFilePath, reference, content }: ApiSpecDetector.Args): Promise<ApiSpecType> {
         const parsed = this.parseOrThrow({ content, reference });
         if (typeof parsed !== "object" || parsed == null) {
-            throw new Error(
-                `Could not determine API type for "${reference}". ` +
-                    `File must contain a top-level "openapi" or "asyncapi" key.`
-            );
+            throw new CliError({
+                message:
+                    `Could not determine API type for "${reference}". ` +
+                    `File must contain a top-level "openapi" or "asyncapi" key.`,
+                code: CliError.Code.InternalError
+            });
         }
         for (const specType of DETECTABLE_SPEC_TYPES) {
             if (specType in parsed) {
                 return specType;
             }
         }
-        throw new Error(
-            `Could not determine API type for "${reference}". ` +
-                `File must contain a top-level "openapi" or "asyncapi" key.`
-        );
+        throw new CliError({
+            message:
+                `Could not determine API type for "${reference}". ` +
+                `File must contain a top-level "openapi" or "asyncapi" key.`,
+            code: CliError.Code.InternalError
+        });
     }
 
     private parseOrThrow({ content, reference }: { content: string; reference: string }): unknown {
         try {
             return yaml.load(content);
         } catch {
-            throw new Error(
-                `Could not parse "${reference}" as YAML or JSON. Ensure the file is a valid OpenAPI or AsyncAPI specification.`
-            );
+            throw new CliError({
+                message: `Could not parse "${reference}" as YAML or JSON. Ensure the file is a valid OpenAPI or AsyncAPI specification.`,
+                code: CliError.Code.ParseError
+            });
         }
     }
 }

--- a/packages/cli/cli-v2/src/api/resolver/ApiSpecResolver.ts
+++ b/packages/cli/cli-v2/src/api/resolver/ApiSpecResolver.ts
@@ -1,4 +1,5 @@
 import { AbsoluteFilePath, doesPathExist, resolve } from "@fern-api/fs-utils";
+import { CliError } from "@fern-api/task-context";
 import { mkdtemp, readFile, writeFile } from "fs/promises";
 import { tmpdir } from "os";
 import path from "path";
@@ -59,7 +60,10 @@ export class ApiSpecResolver {
     private async resolveLocal({ reference }: { reference: string }): Promise<ApiSpecResolver.Result> {
         const absoluteFilePath = resolve(this.context.cwd, reference);
         if (!(await doesPathExist(absoluteFilePath))) {
-            throw new Error(`API spec file does not exist: ${reference}`);
+            throw new CliError({
+                message: `API spec file does not exist: ${reference}`,
+                code: CliError.Code.ConfigError
+            });
         }
 
         const content = await readFile(absoluteFilePath, "utf-8");
@@ -74,14 +78,19 @@ export class ApiSpecResolver {
     private async fetchContent({ url }: { url: string }): Promise<{ content: string; contentType: string }> {
         const response = await fetch(url, { signal: AbortSignal.timeout(FETCH_API_SPEC_REQUEST_TIMEOUT_MS) });
         if (!response.ok) {
-            throw new Error(`Failed to fetch "${url}": HTTP ${response.status} ${response.statusText}`);
+            throw new CliError({
+                message: `Failed to fetch "${url}": HTTP ${response.status} ${response.statusText}`,
+                code: CliError.Code.NetworkError
+            });
         }
         const contentType = response.headers.get("content-type") ?? "";
         if (contentType.includes("text/html")) {
-            throw new Error(
-                `The URL "${url}" returned HTML content. ` +
-                    `Ensure you're pointing to a raw spec URL, not a documentation page.`
-            );
+            throw new CliError({
+                message:
+                    `The URL "${url}" returned HTML content. ` +
+                    `Ensure you're pointing to a raw spec URL, not a documentation page.`,
+                code: CliError.Code.ConfigError
+            });
         }
         const content = await response.text();
         return { content, contentType };
@@ -116,7 +125,10 @@ export class ApiSpecResolver {
             case "asyncapi":
                 return { asyncapi: absoluteFilePath, origin };
             default:
-                throw new Error(`Unsupported spec type for flags mode: "${specType}". Supported: openapi, asyncapi`);
+                throw new CliError({
+                    message: `Unsupported spec type for flags mode: "${specType}". Supported: openapi, asyncapi`,
+                    code: CliError.Code.ConfigError
+                });
         }
     }
 

--- a/packages/cli/cli-v2/src/auth/PlatformKeyring.ts
+++ b/packages/cli/cli-v2/src/auth/PlatformKeyring.ts
@@ -1,4 +1,5 @@
 import { loggingExeca, runExeca } from "@fern-api/logging-execa";
+import { CliError } from "@fern-api/task-context";
 
 /**
  * Platform-specific keyring access via CLI subprocesses.
@@ -35,7 +36,10 @@ export class PlatformKeyring {
                 await this.setPasswordWindows(service, account, password);
                 break;
             default:
-                throw new Error(`Unsupported platform: ${process.platform}`);
+                throw new CliError({
+                    message: `Unsupported platform: ${process.platform}`,
+                    code: CliError.Code.EnvironmentError
+                });
         }
     }
 
@@ -48,7 +52,10 @@ export class PlatformKeyring {
             case "win32":
                 return this.getPasswordWindows(service, account);
             default:
-                throw new Error(`Unsupported platform: ${process.platform}`);
+                throw new CliError({
+                    message: `Unsupported platform: ${process.platform}`,
+                    code: CliError.Code.EnvironmentError
+                });
         }
     }
 
@@ -61,7 +68,10 @@ export class PlatformKeyring {
             case "win32":
                 return this.deletePasswordWindows(service, account);
             default:
-                throw new Error(`Unsupported platform: ${process.platform}`);
+                throw new CliError({
+                    message: `Unsupported platform: ${process.platform}`,
+                    code: CliError.Code.EnvironmentError
+                });
         }
     }
 
@@ -74,7 +84,10 @@ export class PlatformKeyring {
             case "win32":
                 return this.findCredentialsWindows(service);
             default:
-                throw new Error(`Unsupported platform: ${process.platform}`);
+                throw new CliError({
+                    message: `Unsupported platform: ${process.platform}`,
+                    code: CliError.Code.EnvironmentError
+                });
         }
     }
 

--- a/packages/cli/cli-v2/src/commands/api/split/command.ts
+++ b/packages/cli/cli-v2/src/commands/api/split/command.ts
@@ -1,6 +1,7 @@
 import { extractErrorMessage, mergeWithOverrides } from "@fern-api/core-utils";
 import type { AbsoluteFilePath } from "@fern-api/fs-utils";
 import { CliError } from "@fern-api/task-context";
+
 import chalk from "chalk";
 import { execFile } from "child_process";
 import { readFile, writeFile } from "fs/promises";
@@ -291,9 +292,10 @@ export function addSplitCommand(cli: Argv<GlobalArgs>): void {
                 })
                 .coerce("format", (value: string): SplitFormatInput => {
                     if (!(ALL_FORMAT_NAMES as readonly string[]).includes(value)) {
-                        throw new Error(
-                            `Invalid format '${value}'. Expected one of: ${OVERLAY_NAME}, ${OVERRIDES_NAME}`
-                        );
+                        throw new CliError({
+                            message: `Invalid format '${value}'. Expected one of: ${OVERLAY_NAME}, ${OVERRIDES_NAME}`,
+                            code: CliError.Code.ValidationError
+                        });
                     }
                     return value as SplitFormatInput;
                 })

--- a/packages/cli/cli-v2/src/commands/sdk/generate/command.ts
+++ b/packages/cli/cli-v2/src/commands/sdk/generate/command.ts
@@ -198,7 +198,7 @@ export class GenerateCommand {
         forceLocal: boolean;
     }): Promise<void> {
         if (workspace.sdks == null) {
-            throw new Error("No SDKs configured");
+            throw new CliError({ message: "No SDKs configured", code: CliError.Code.InternalError });
         }
 
         // Check that the APIs referenced by each target are valid.

--- a/packages/cli/cli-v2/src/commands/sdk/generate/parseOutputArg.ts
+++ b/packages/cli/cli-v2/src/commands/sdk/generate/parseOutputArg.ts
@@ -1,5 +1,5 @@
 import type { schemas } from "@fern-api/config";
-
+import { CliError } from "@fern-api/task-context";
 import { isGitUrl } from "../utils/gitUrl.js";
 
 /**
@@ -13,13 +13,15 @@ export function parseOutputArg(outputArg: string): schemas.OutputObjectSchema {
     if (isGitUrl(outputArg)) {
         const token = process.env.GITHUB_TOKEN ?? process.env.GIT_TOKEN;
         if (token == null) {
-            throw new Error(
-                `A git token is required when --output is a git URL.\n\n` +
+            throw new CliError({
+                message:
+                    `A git token is required when --output is a git URL.\n\n` +
                     `  Set GITHUB_TOKEN or GIT_TOKEN:\n` +
                     `    export GITHUB_TOKEN=ghp_xxx\n\n` +
                     `  Or use a local path:\n` +
-                    `    --output ./my-sdk`
-            );
+                    `    --output ./my-sdk`,
+                code: CliError.Code.InternalError
+            });
         }
         return {
             git: {

--- a/packages/cli/cli-v2/src/commands/sdk/generate/parseOutputArg.ts
+++ b/packages/cli/cli-v2/src/commands/sdk/generate/parseOutputArg.ts
@@ -20,7 +20,7 @@ export function parseOutputArg(outputArg: string): schemas.OutputObjectSchema {
                     `    export GITHUB_TOKEN=ghp_xxx\n\n` +
                     `  Or use a local path:\n` +
                     `    --output ./my-sdk`,
-                code: CliError.Code.InternalError
+                code: CliError.Code.ConfigError
             });
         }
         return {

--- a/packages/cli/cli-v2/src/config/FileFinder.ts
+++ b/packages/cli/cli-v2/src/config/FileFinder.ts
@@ -1,4 +1,5 @@
 import { AbsoluteFilePath, doesPathExist } from "@fern-api/fs-utils";
+import { CliError } from "@fern-api/task-context";
 import { findUp } from "find-up";
 
 export namespace FileFinder {
@@ -36,7 +37,10 @@ export class FileFinder {
     }): Promise<AbsoluteFilePath> {
         const filepath = await this.find({ filename });
         if (filepath == null) {
-            throw new Error(`${filename} file not found in any parent directory from ${this.from}`);
+            throw new CliError({
+                message: `${filename} file not found in any parent directory from ${this.from}`,
+                code: CliError.Code.InternalError
+            });
         }
         return filepath;
     }

--- a/packages/cli/cli-v2/src/config/fern-yml/FernYmlSchemaLoader.ts
+++ b/packages/cli/cli-v2/src/config/fern-yml/FernYmlSchemaLoader.ts
@@ -1,5 +1,6 @@
 import { FernYmlSchema } from "@fern-api/config";
 import { AbsoluteFilePath } from "@fern-api/fs-utils";
+import { CliError } from "@fern-api/task-context";
 import { ValidationIssue, YamlConfigLoader } from "@fern-api/yaml-loader";
 import { SourcedValidationError } from "../../errors/SourcedValidationError.js";
 import { FileFinder } from "../FileFinder.js";
@@ -47,7 +48,10 @@ export class FernYmlSchemaLoader {
     public async loadOrThrow(): Promise<FernYmlSchemaLoader.Success> {
         const loadResult = await this.load();
         if (loadResult.type === "notFound") {
-            throw new Error(`${FILENAME} file not found in any parent directory; did you forget to run \`fern init\`?`);
+            throw new CliError({
+                message: `${FILENAME} file not found in any parent directory; did you forget to run \`fern init\`?`,
+                code: CliError.Code.InternalError
+            });
         }
         if (loadResult.type === "failure") {
             throw new SourcedValidationError(loadResult.issues);

--- a/packages/cli/cli-v2/src/docs/task/DocsTask.ts
+++ b/packages/cli/cli-v2/src/docs/task/DocsTask.ts
@@ -1,3 +1,4 @@
+import { CliError } from "@fern-api/task-context";
 import type { Task } from "../../ui/Task.js";
 import type { TaskGroup } from "../../ui/TaskGroup.js";
 import { TaskStageController } from "../../ui/TaskStageController.js";
@@ -30,7 +31,10 @@ export class DocsTask {
     public getTask(): Task {
         const task = this.taskGroup.getTask(this.id);
         if (task == null) {
-            throw new Error(`Internal error; task '${this.id}' does not exist`);
+            throw new CliError({
+                message: `Internal error; task '${this.id}' does not exist`,
+                code: CliError.Code.InternalError
+            });
         }
         return task;
     }

--- a/packages/cli/cli-v2/src/docs/validator/DocsWorkspaceValidator.ts
+++ b/packages/cli/cli-v2/src/docs/validator/DocsWorkspaceValidator.ts
@@ -2,6 +2,7 @@ import { replaceEnvVariables } from "@fern-api/core-utils";
 import type { ValidationViolation } from "@fern-api/docs-validator";
 import { validateDocsWorkspace } from "@fern-api/docs-validator";
 import type { OSSWorkspace } from "@fern-api/lazy-fern-workspace";
+import { CliError } from "@fern-api/task-context";
 import type { AbstractAPIWorkspace, DocsWorkspace } from "@fern-api/workspace-loader";
 import { TaskContextAdapter } from "../../context/adapter/TaskContextAdapter.js";
 import type { Context } from "../../context/Context.js";
@@ -67,7 +68,7 @@ export class DocsWorkspaceValidator {
 
         if (workspace.config.settings?.substituteEnvVars) {
             workspace.config = replaceEnvVariables(workspace.config, {
-                onError: (error) => this.taskContext.failAndThrow(error)
+                onError: (error) => this.taskContext.failAndThrow(error, undefined, { code: CliError.Code.ConfigError })
             });
         }
 

--- a/packages/cli/cli-v2/src/init/Wizard.ts
+++ b/packages/cli/cli-v2/src/init/Wizard.ts
@@ -714,7 +714,7 @@ export class Wizard {
         if (!response.ok) {
             throw new CliError({
                 message: `HTTP ${response.status} ${response.statusText}`,
-                code: CliError.Code.InternalError
+                code: CliError.Code.NetworkError
             });
         }
         const content = await response.text();

--- a/packages/cli/cli-v2/src/init/Wizard.ts
+++ b/packages/cli/cli-v2/src/init/Wizard.ts
@@ -9,6 +9,7 @@ import { extractErrorMessage } from "@fern-api/core-utils";
 import { AbsoluteFilePath, doesPathExist } from "@fern-api/fs-utils";
 import { LogLevel } from "@fern-api/logger";
 import { getTokenFromAuth0 } from "@fern-api/login";
+import { CliError } from "@fern-api/task-context";
 import chalk from "chalk";
 import { execSync } from "child_process";
 import inquirer from "inquirer";
@@ -711,7 +712,10 @@ export class Wizard {
     private async fetchApiFromUrl(url: string, specFormat: FernYmlBuilder.SpecFormat): Promise<Wizard.ApiSource> {
         const response = await fetch(url, { signal: AbortSignal.timeout(FETCH_API_SPEC_REQUEST_TIMEOUT_MS) });
         if (!response.ok) {
-            throw new Error(`HTTP ${response.status} ${response.statusText}`);
+            throw new CliError({
+                message: `HTTP ${response.status} ${response.statusText}`,
+                code: CliError.Code.InternalError
+            });
         }
         const content = await response.text();
         const filename = this.resolveFilenameFromUrl({ url, specFormat });

--- a/packages/cli/cli-v2/src/sdk/adapter/LegacyGeneratorInvocationAdapter.ts
+++ b/packages/cli/cli-v2/src/sdk/adapter/LegacyGeneratorInvocationAdapter.ts
@@ -4,6 +4,7 @@ import { removeDefaultDockerOrgIfPresent } from "@fern-api/configuration-loader"
 import { assertNever } from "@fern-api/core-utils";
 import { doesPathExist, join, RelativeFilePath } from "@fern-api/fs-utils";
 import { parseRepository } from "@fern-api/github";
+import { CliError } from "@fern-api/task-context";
 import { FernFiddle } from "@fern-fern/fiddle-sdk";
 import { readFile } from "fs/promises";
 import type { Context } from "../../context/Context.js";
@@ -313,9 +314,10 @@ export class LegacyGeneratorInvocationAdapter {
         }
         const absolutePath = join(this.context.cwd, RelativeFilePath.of(license));
         if (!(await doesPathExist(absolutePath, "file"))) {
-            throw new Error(
-                `Custom license file "${absolutePath}" does not exist; did you mean to use either MIT or Apache-2.0?`
-            );
+            throw new CliError({
+                message: `Custom license file "${absolutePath}" does not exist; did you mean to use either MIT or Apache-2.0?`,
+                code: CliError.Code.InternalError
+            });
         }
         const contents = await readFile(absolutePath, "utf-8");
         return FernFiddle.GithubLicense.custom({ contents });

--- a/packages/cli/cli-v2/src/sdk/task/SdkTask.ts
+++ b/packages/cli/cli-v2/src/sdk/task/SdkTask.ts
@@ -1,3 +1,4 @@
+import { CliError } from "@fern-api/task-context";
 import type { Task } from "../../ui/Task.js";
 import type { TaskGroup } from "../../ui/TaskGroup.js";
 import { TaskStageController } from "../../ui/TaskStageController.js";
@@ -33,7 +34,10 @@ export class SdkTask {
         const task = this.taskGroup.getTask(this.id);
         if (task == null) {
             // This should be unreachable.
-            throw new Error(`Internal error; task '${this.id}' does not exist`);
+            throw new CliError({
+                message: `Internal error; task '${this.id}' does not exist`,
+                code: CliError.Code.InternalError
+            });
         }
         return task;
     }

--- a/packages/cli/cli-v2/src/sdk/updater/GeneratorMigrator.ts
+++ b/packages/cli/cli-v2/src/sdk/updater/GeneratorMigrator.ts
@@ -4,6 +4,7 @@ import type { AbsoluteFilePath } from "@fern-api/fs-utils";
 import type { Logger } from "@fern-api/logger";
 import { loggingExeca } from "@fern-api/logging-execa";
 import type { Migration, MigrationModule, MigratorResult } from "@fern-api/migrations-base";
+import { CliError } from "@fern-api/task-context";
 import { readFileSync, unlinkSync } from "fs";
 import { mkdir, open, readFile, stat, unlink } from "fs/promises";
 import { join } from "path";
@@ -224,7 +225,10 @@ export class GeneratorMigrator {
                 const packageJson = JSON.parse(packageJsonContent) as { main?: string };
 
                 if (packageJson.main == null) {
-                    throw new Error(`No main field found in package.json for ${MIGRATION_PACKAGE_NAME}`);
+                    throw new CliError({
+                        message: `No main field found in package.json for ${MIGRATION_PACKAGE_NAME}`,
+                        code: CliError.Code.InternalError
+                    });
                 }
 
                 const packageEntryPoint = join(packageDir, packageJson.main);
@@ -370,11 +374,13 @@ export class GeneratorMigrator {
                 return undefined;
             }
 
-            throw new Error(
-                `Failed to load generator migrations for ${generatorName}.\n\n` +
+            throw new CliError({
+                message:
+                    `Failed to load generator migrations for ${generatorName}.\n\n` +
                     `Reason: ${errorMessage}\n\n` +
-                    `Please check your internet connection and npm configuration, then try again.`
-            );
+                    `Please check your internet connection and npm configuration, then try again.`,
+                code: CliError.Code.InternalError
+            });
         }
     }
 
@@ -417,11 +423,13 @@ export class GeneratorMigrator {
                 const bVersion = semver.parse(b.version);
 
                 if (aVersion == null || bVersion == null) {
-                    throw new Error(
-                        `Internal error: Invalid migration version found during sort. ` +
+                    throw new CliError({
+                        message:
+                            `Internal error: Invalid migration version found during sort. ` +
                             `Version A: ${a.version}, Version B: ${b.version}. ` +
-                            `This should not happen as invalid versions are filtered out.`
-                    );
+                            `This should not happen as invalid versions are filtered out.`,
+                        code: CliError.Code.InternalError
+                    });
                 }
 
                 return semver.compare(aVersion, bVersion);
@@ -448,11 +456,13 @@ export class GeneratorMigrator {
                 appliedVersions.push(migration.version);
             } catch (error) {
                 const errorMessage = extractErrorMessage(error);
-                throw new Error(
-                    `Failed to apply migration for version ${migration.version}.\n\n` +
+                throw new CliError({
+                    message:
+                        `Failed to apply migration for version ${migration.version}.\n\n` +
                         `Reason: ${errorMessage}\n\n` +
-                        `Please report this issue at: https://github.com/fern-api/fern/issues`
-                );
+                        `Please report this issue at: https://github.com/fern-api/fern/issues`,
+                    code: CliError.Code.InternalError
+                });
             }
         }
 

--- a/packages/cli/cli-v2/src/telemetry/TelemetryClient.ts
+++ b/packages/cli/cli-v2/src/telemetry/TelemetryClient.ts
@@ -1,5 +1,6 @@
 import { setSentryRunIdTags } from "@fern-api/cli-telemetry";
 import { AbsoluteFilePath, doesPathExist, join, RelativeFilePath } from "@fern-api/fs-utils";
+import { CliError } from "@fern-api/task-context";
 import * as Sentry from "@sentry/node";
 import { mkdir, readFile, writeFile } from "fs/promises";
 import IS_CI from "is-ci";
@@ -43,7 +44,10 @@ export class TelemetryClient {
         if (sentryDsn != null && sentryDsn.length > 0 && isTelemetryEnabled) {
             const sentryEnvironment = process.env.SENTRY_ENVIRONMENT;
             if (sentryEnvironment == null || sentryEnvironment.length === 0) {
-                throw new Error("SENTRY_ENVIRONMENT must be set when SENTRY_DSN is configured");
+                throw new CliError({
+                    message: "SENTRY_ENVIRONMENT must be set when SENTRY_DSN is configured",
+                    code: CliError.Code.ConfigError
+                });
             }
             this.sentry = Sentry.init({
                 dsn: sentryDsn,


### PR DESCRIPTION
## Description

Migrates `@fern-api/cli-v2` (the next-generation CLI package) to use explicit `CliError` error codes on every `failAndThrow` / `failWithoutThrowing` call site.

This is one of the package migration PRs that follow the error classification system introduced in #14749.

## Changes Made

Assigned typed error codes across **48+ call sites** in `packages/cli/cli-v2/src/`, covering every command handler and shared utility. Also fixed test files to match the async `createTestContext` signature and the `TaskAbortSignal` throw type for validation errors.

### Error codes used

| Code | Usage |
|------|-------|
| `CONFIG_ERROR` | Missing config, invalid flags, API not found, multiple APIs without selection |
| `AUTH_ERROR` | Authentication failures, keyring unavailability, login/logout/switch errors |
| `NETWORK_ERROR` | HTTP/API call failures, docs publishing errors |
| `VALIDATION_ERROR` | Schema validation failures, docs/SDK check violations |
| `PARSE_ERROR` | Malformed YAML/JSON, invalid workspace definitions |
| `VERSION_ERROR` | Generator version incompatibility |
| `ENVIRONMENT_ERROR` | Missing prerequisites, directory resolution failures |
| `INTERNAL_ERROR` | Unexpected states indicating bugs |

### Files touched (grouped by area)

- **API commands**: `api/check/`, `api/compile/`, `api/merge/`, `api/split/`, `api/utils/loadSpec.ts`
- **Auth commands**: `auth/login/`, `auth/logout/`, `auth/switch/`, `auth/token/`, `auth/whoami/`
- **Docs commands**: `docs/check/`, `docs/dev/`, `docs/preview/`, `docs/preview/delete/`, `docs/publish/`
- **SDK commands**: `sdk/add/`, `sdk/check/`, `sdk/generate/`, `sdk/preview/`, `sdk/update/`
- **Other commands**: `check/`, `config/migrate/`, `init/`, `org/create/`, `org/list/`
- **Context & errors**: `Context.ts`, `withContext.ts`, `TaskContextAdapter.ts`, `FernYmlEditor.ts`, `DocsChecker.ts`
- **Telemetry**: `TelemetryClient.ts`, `LifecycleEvent.ts`
- **Error types**: Deleted `errors/CliError.ts` (replaced by shared `@fern-api/task-context` CliError), updated `ValidationError.ts`, `SourcedValidationError.ts`, `KeyringUnavailableError.ts`
- **Tests**: `GeneratorPipeline.test.ts`, `compile.test.ts`, `TelemetryClient.test.ts`, and all test context utilities

## Testing

- [x] Existing tests pass (309/309 in cli-v2, excluding e2e)
