### PR TITLE
chore(cli): keep @fern-api/docker-utils as plain Error, add CONTAINER_ERROR wrappers at call sites

### DIFF
--- a/packages/cli/generation/local-generation/local-workspace-runner/src/ContainerExecutionEnvironment.ts
+++ b/packages/cli/generation/local-generation/local-workspace-runner/src/ContainerExecutionEnvironment.ts
@@ -1,5 +1,6 @@
 import { ContainerRunner } from "@fern-api/core-utils";
 import { runContainer } from "@fern-api/docker-utils";
+import { CliError } from "@fern-api/task-context";
 import {
     CONTAINER_CODEGEN_OUTPUT_DIRECTORY,
     CONTAINER_GENERATOR_CONFIG_PATH,
@@ -79,15 +80,25 @@ export class ContainerExecutionEnvironment implements ExecutionEnvironment {
             ports[DEFAULT_NODE_DEBUG_PORT] = DEFAULT_NODE_DEBUG_PORT;
         }
 
-        await runContainer({
-            logger: context.logger,
-            imageName: this.containerImage,
-            args: [CONTAINER_GENERATOR_CONFIG_PATH],
-            binds,
-            envVars,
-            ports,
-            removeAfterCompletion: !this.keepContainer,
-            runner: this.runner ?? runner
-        });
+        try {
+            await runContainer({
+                logger: context.logger,
+                imageName: this.containerImage,
+                args: [CONTAINER_GENERATOR_CONFIG_PATH],
+                binds,
+                envVars,
+                ports,
+                removeAfterCompletion: !this.keepContainer,
+                runner: this.runner ?? runner
+            });
+        } catch (error) {
+            if (error instanceof CliError) {
+                throw error;
+            }
+            throw new CliError({
+                message: `Container execution failed: ${error instanceof Error ? error.message : String(error)}`,
+                code: CliError.Code.ContainerError
+            });
+        }
     }
 }

--- a/packages/cli/generation/local-generation/local-workspace-runner/src/ReusableContainerExecutionEnvironment.ts
+++ b/packages/cli/generation/local-generation/local-workspace-runner/src/ReusableContainerExecutionEnvironment.ts
@@ -8,6 +8,7 @@ import {
 } from "@fern-api/docker-utils";
 import { Logger, LogLevel } from "@fern-api/logger";
 import { loggingExeca } from "@fern-api/logging-execa";
+import { CliError } from "@fern-api/task-context";
 import {
     CONTAINER_CODEGEN_OUTPUT_DIRECTORY,
     CONTAINER_FERN_DIRECTORY,
@@ -90,7 +91,13 @@ export class ReusableContainerExecutionEnvironment implements ExecutionEnvironme
             }
             this.containers = [];
             this.availableContainers = [];
-            throw error;
+            if (error instanceof CliError) {
+                throw error;
+            }
+            throw new CliError({
+                message: `Failed to start containers: ${error instanceof Error ? error.message : String(error)}`,
+                code: CliError.Code.ContainerError
+            });
         }
 
         if (isDebug) {
@@ -108,6 +115,14 @@ export class ReusableContainerExecutionEnvironment implements ExecutionEnvironme
         const containerId = await this.acquire();
         try {
             await this.doExecute(containerId, args);
+        } catch (error) {
+            if (error instanceof CliError) {
+                throw error;
+            }
+            throw new CliError({
+                message: `Container execution failed: ${error instanceof Error ? error.message : String(error)}`,
+                code: CliError.Code.ContainerError
+            });
         } finally {
             this.release(containerId);
         }


### PR DESCRIPTION
## Description

Keeps `@fern-api/docker-utils` as a plain Error utility package and adds `CONTAINER_ERROR` wrappers at the call sites that invoke docker-utils functions.

This is one of the package migration PRs that follow the error classification system introduced in #14749.

## Changes Made

Since `docker-utils` is a low-level utility that doesn't depend on `@fern-api/task-context`, the package itself is left unchanged. Instead, call sites in higher-level packages now wrap docker-utils errors with `CliError.Code.ContainerError`.

### Error codes used

| Code | Usage |
|------|-------|
| `CONTAINER_ERROR` | Docker build/run/pull failures at call sites |

### Files touched (grouped by area)

- **Call site wrappers**: Higher-level packages that invoke docker-utils functions now catch and re-throw with `CONTAINER_ERROR` code

## Testing

- [x] Existing tests pass (`pnpm test`, excluding e2e and docker-utils tests which fail due to workspace path containing spaces — pre-existing environment issue)
