### PR TITLE
chore(cli): fix @fern-api/fern-definition-schema types field, keep plain Error (utility package)

### DIFF
--- a/packages/cli/fern-definition/schema/package.json
+++ b/packages/cli/fern-definition/schema/package.json
@@ -13,14 +13,14 @@
     ".": {
       "development": "./src/index.ts",
       "source": "./src/index.ts",
-      "types": "./lib/index.d.ts",
+      "types": "./src/index.ts",
       "import": "./lib/index.js",
       "default": "./lib/index.js"
     }
   },
   "main": "lib/index.js",
   "source": "src/index.ts",
-  "types": "lib/index.d.ts",
+  "types": "src/index.ts",
   "files": ["lib"],
   "scripts": {
     "clean": "rm -rf ./lib",


### PR DESCRIPTION
## Description

Fixes `@fern-api/fern-definition-schema` types field and keeps the package as a plain Error utility package (no `CliError` dependency needed).

This is one of the package migration PRs that follow the error classification system introduced in #14749.

## Changes Made

Since `fern-definition-schema` is a low-level utility/schema package, it doesn't need direct `CliError` integration. The changes in this PR fix type inconsistencies discovered during the migration audit.

### Files touched (grouped by area)

- **Schema types**: Fixed type field definitions in `fern-definition-schema`

## Testing

- [x] Existing tests pass (`pnpm test`, excluding e2e and pre-existing environment failures)
