### PR TITLE
chore(cli): migrate @fern-api/ir-generator to use CliError

### DIFF
--- a/packages/cli/generation/ir-generator/src/PackageTreeGenerator.ts
+++ b/packages/cli/generation/ir-generator/src/PackageTreeGenerator.ts
@@ -14,6 +14,7 @@ import {
     WebSocketChannelId
 } from "@fern-api/ir-sdk";
 import { FilteredIr, getOriginalName, IdGenerator } from "@fern-api/ir-utils";
+import { CliError } from "@fern-api/task-context";
 import { mapValues } from "lodash-es";
 
 type UnprocessedPackage = Omit<Package, "hasEndpointsInTree">;
@@ -40,7 +41,10 @@ export class PackageTreeGenerator {
     public addPackageRedirection({ from, to }: { from: FernFilepath; to: FernFilepath }): void {
         const package_ = this.getPackageForFernFilepath(from);
         if (package_.navigationConfig != null) {
-            throw new Error("Found duplicate navigationConfig for package");
+            throw new CliError({
+                message: "Found duplicate navigationConfig for package",
+                code: CliError.Code.InternalError
+            });
         }
         package_.navigationConfig = {
             pointsTo: IdGenerator.generateSubpackageId(to)
@@ -50,7 +54,7 @@ export class PackageTreeGenerator {
     public addDocs(fernFilepath: FernFilepath, docs: string): void {
         const package_ = this.getPackageForFernFilepath(fernFilepath);
         if (package_.docs != null) {
-            throw new Error("Found duplicate docs for package");
+            throw new CliError({ message: "Found duplicate docs for package", code: CliError.Code.InternalError });
         }
         package_.docs = docs;
     }
@@ -70,7 +74,10 @@ export class PackageTreeGenerator {
     public addService(serviceId: ServiceId, service: HttpService): void {
         const package_ = this.getPackageForFernFilepath(service.name.fernFilepath);
         if (package_.service != null) {
-            throw new Error("Found duplicate service for " + serviceId);
+            throw new CliError({
+                message: "Found duplicate service for " + serviceId,
+                code: CliError.Code.InternalError
+            });
         }
         package_.service = serviceId;
     }
@@ -78,7 +85,10 @@ export class PackageTreeGenerator {
     public addWebhookGroup(webhookGroupId: WebhookGroupId, fernFilepath: FernFilepath): void {
         const package_ = this.getPackageForFernFilepath(fernFilepath);
         if (package_.webhooks != null) {
-            throw new Error("Found duplicate webhook group for " + webhookGroupId);
+            throw new CliError({
+                message: "Found duplicate webhook group for " + webhookGroupId,
+                code: CliError.Code.InternalError
+            });
         }
         package_.webhooks = webhookGroupId;
     }
@@ -86,7 +96,10 @@ export class PackageTreeGenerator {
     public addWebSocketChannel(websocketChannelId: WebSocketChannelId, fernFilepath: FernFilepath): void {
         const package_ = this.getPackageForFernFilepath(fernFilepath);
         if (package_.webhooks != null) {
-            throw new Error("Found duplicate webhook group for " + websocketChannelId);
+            throw new CliError({
+                message: "Found duplicate webhook group for " + websocketChannelId,
+                code: CliError.Code.InternalError
+            });
         }
         package_.websocket = websocketChannelId;
     }
@@ -152,7 +165,10 @@ export class PackageTreeGenerator {
 
     public sortRootPackage(subpackagesInOrder: SubpackageId[]): void {
         if (!isEqualIgnoreOrder(this.rootPackage.subpackages, subpackagesInOrder)) {
-            throw new Error("Sorted subpackages differ from unsorted packages in root");
+            throw new CliError({
+                message: "Sorted subpackages differ from unsorted packages in root",
+                code: CliError.Code.InternalError
+            });
         }
         this.rootPackage.subpackages = subpackagesInOrder;
     }
@@ -160,10 +176,16 @@ export class PackageTreeGenerator {
     public sortSubpackage(subpackageId: SubpackageId, subpackagesInOrder: SubpackageId[]): void {
         const subpackage = this.subpackages[subpackageId];
         if (subpackage == null) {
-            throw new Error("Subpackage does not exist: " + subpackageId);
+            throw new CliError({
+                message: "Subpackage does not exist: " + subpackageId,
+                code: CliError.Code.ResolutionError
+            });
         }
         if (!isEqualIgnoreOrder(subpackage.subpackages, subpackagesInOrder)) {
-            throw new Error("Sorted subpackages differ from unsorted packages");
+            throw new CliError({
+                message: "Sorted subpackages differ from unsorted packages",
+                code: CliError.Code.InternalError
+            });
         }
         subpackage.subpackages = subpackagesInOrder;
     }
@@ -171,7 +193,7 @@ export class PackageTreeGenerator {
     private getAllSubpackagesWithEndpoints(root: SubpackageId): SubpackageId[] {
         const subpackage = this.subpackages[root];
         if (subpackage == null) {
-            throw new Error("Subpackage does not exist: " + root);
+            throw new CliError({ message: "Subpackage does not exist: " + root, code: CliError.Code.ResolutionError });
         }
 
         const subpackagesWithEndpoints = this.getAllChildrenWithEndpoints(subpackage);
@@ -200,7 +222,10 @@ export class PackageTreeGenerator {
         const subpackagesInParent = parent.subpackages.map((subpackageId) => {
             const subpackage = this.subpackages[subpackageId];
             if (subpackage == null) {
-                throw new Error("Subpackage ID is invalid: " + subpackageId);
+                throw new CliError({
+                    message: "Subpackage ID is invalid: " + subpackageId,
+                    code: CliError.Code.InternalError
+                });
             }
             return subpackage;
         });

--- a/packages/cli/generation/ir-generator/src/converters/convertApiAuth.ts
+++ b/packages/cli/generation/ir-generator/src/converters/convertApiAuth.ts
@@ -7,6 +7,7 @@ import {
     InferredAuthSchemeTokenEndpoint,
     OAuthConfiguration
 } from "@fern-api/ir-sdk";
+import { CliError } from "@fern-api/task-context";
 
 import { FernFileContext } from "../FernFileContext.js";
 import { EndpointResolver } from "../resolvers/EndpointResolver.js";
@@ -105,7 +106,7 @@ function convertSchemeReference({
     const convertNamedAuthSchemeReference = (reference: string, docs: string | undefined) => {
         const declaration = authSchemeDeclarations?.[reference];
         if (declaration == null) {
-            throw new Error("Unknown auth scheme: " + reference);
+            throw new CliError({ message: "Unknown auth scheme: " + reference, code: CliError.Code.ReferenceError });
         }
         return visitRawAuthSchemeDeclaration<AuthScheme>(declaration, {
             header: (rawHeader) =>
@@ -265,7 +266,10 @@ function generateOAuth({
                 )
             });
         default:
-            throw new Error(`Unknown OAuth type: '${rawScheme?.type}'`);
+            throw new CliError({
+                message: `Unknown OAuth type: '${rawScheme?.type}'`,
+                code: CliError.Code.ValidationError
+            });
     }
 }
 

--- a/packages/cli/generation/ir-generator/src/converters/convertChannel.ts
+++ b/packages/cli/generation/ir-generator/src/converters/convertChannel.ts
@@ -16,6 +16,7 @@ import {
     WebSocketMessageBody
 } from "@fern-api/ir-sdk";
 import { constructHttpPath, getOriginalName } from "@fern-api/ir-utils";
+import { CliError } from "@fern-api/task-context";
 import { FernFileContext } from "../FernFileContext.js";
 import { getHeaderName } from "../index.js";
 import { ExampleResolver } from "../resolvers/ExampleResolver.js";
@@ -135,7 +136,10 @@ export function convertChannel({
                         ? Object.entries(example["query-parameters"]).map(([wireKey, value]) => {
                               const queryParameterDeclaration = channel["query-parameters"]?.[wireKey];
                               if (queryParameterDeclaration == null) {
-                                  throw new Error(`Query parameter ${wireKey} does not exist`);
+                                  throw new CliError({
+                                      message: `Query parameter ${wireKey} does not exist`,
+                                      code: CliError.Code.ReferenceError
+                                  });
                               }
                               return {
                                   name: file.casingsGenerator.generateNameAndWireValue({
@@ -164,7 +168,10 @@ export function convertChannel({
                 messages: example.messages.map((messageExample): ExampleWebSocketMessage => {
                     const message = channel.messages?.[messageExample.type];
                     if (message == null) {
-                        throw new Error(`Message ${messageExample.type} does not exist`);
+                        throw new CliError({
+                            message: `Message ${messageExample.type} does not exist`,
+                            code: CliError.Code.ReferenceError
+                        });
                     }
                     return {
                         type: messageExample.type,
@@ -225,7 +232,7 @@ function convertExampleWebSocketMessageBody({
     }
 
     if (!isPlainObject(example)) {
-        throw new Error("Example must be an object");
+        throw new CliError({ message: "Example must be an object", code: CliError.Code.ValidationError });
     }
 
     const exampleProperties: ExampleInlinedRequestBodyProperty[] = [];
@@ -259,7 +266,10 @@ function convertExampleWebSocketMessageBody({
                 file
             });
             if (originalTypeDeclaration == null) {
-                throw new Error("Could not find original type declaration for property: " + wireKey);
+                throw new CliError({
+                    message: "Could not find original type declaration for property: " + wireKey,
+                    code: CliError.Code.ResolutionError
+                });
             }
             exampleProperties.push({
                 name: file.casingsGenerator.generateNameAndWireValue({
@@ -391,7 +401,10 @@ function convertChannelPathParameters({
                     })
                 );
             } else {
-                throw new Error(`Path parameter ${key} does not exist`);
+                throw new CliError({
+                    message: `Path parameter ${key} does not exist`,
+                    code: CliError.Code.ReferenceError
+                });
             }
         }
     }

--- a/packages/cli/generation/ir-generator/src/converters/convertOAuthClientCredentials.ts
+++ b/packages/cli/generation/ir-generator/src/converters/convertOAuthClientCredentials.ts
@@ -1,6 +1,6 @@
 import { RawSchemas } from "@fern-api/fern-definition-schema";
 import { OAuthClientCredentials } from "@fern-api/ir-sdk";
-
+import { CliError } from "@fern-api/task-context";
 import { FernFileContext } from "../FernFileContext.js";
 import { EndpointResolver } from "../resolvers/EndpointResolver.js";
 import { PropertyResolver } from "../resolvers/PropertyResolver.js";
@@ -34,7 +34,10 @@ export function convertOAuthClientCredentials({
         tokenEndpoint
     });
     if (oauthTokenEndpoint == null) {
-        throw new Error("Failed to convert OAuth token endpoint.");
+        throw new CliError({
+            message: "Failed to convert OAuth token endpoint.",
+            code: CliError.Code.IrConversionError
+        });
     }
     const refreshEndpoint =
         refreshTokenEndpoint != null

--- a/packages/cli/generation/ir-generator/src/converters/convertReadmeConfig.ts
+++ b/packages/cli/generation/ir-generator/src/converters/convertReadmeConfig.ts
@@ -1,5 +1,6 @@
 import { generatorsYml } from "@fern-api/configuration";
 import { HttpEndpoint, HttpService, ReadmeConfig, ServiceId } from "@fern-api/ir-sdk";
+import { CliError } from "@fern-api/task-context";
 import urlJoin from "url-join";
 
 export function convertReadmeConfig({
@@ -58,7 +59,10 @@ class ReadmeEndpointCache {
     public getEndpointForReadmeOrThrow(readmeEndpoint: generatorsYml.ReadmeEndpointSchema): HttpEndpoint {
         const endpoint = this.getEndpointForReadme(readmeEndpoint);
         if (endpoint == null) {
-            throw new Error(`Endpoint not found for ${JSON.stringify(readmeEndpoint)}`);
+            throw new CliError({
+                message: `Endpoint not found for ${JSON.stringify(readmeEndpoint)}`,
+                code: CliError.Code.ResolutionError
+            });
         }
         return endpoint;
     }
@@ -117,7 +121,7 @@ function getReadmeEndpointObject({
     if (typeof endpoint === "string") {
         const split = endpoint.split(" ");
         if (split.length !== 2 || split[0] == null || split[1] == null) {
-            throw new Error(`invalid endpoint string: ${endpoint}`);
+            throw new CliError({ message: `invalid endpoint string: ${endpoint}`, code: CliError.Code.ParseError });
         }
         return {
             method: split[0],

--- a/packages/cli/generation/ir-generator/src/converters/convertWebhookGroup.ts
+++ b/packages/cli/generation/ir-generator/src/converters/convertWebhookGroup.ts
@@ -32,7 +32,7 @@ import {
     WebhookTimestampFormat
 } from "@fern-api/ir-sdk";
 import { IdGenerator, isReferencedWebhookPayloadSchema } from "@fern-api/ir-utils";
-
+import { CliError } from "@fern-api/task-context";
 import { FernFileContext } from "../FernFileContext.js";
 import { ExampleResolver } from "../resolvers/ExampleResolver.js";
 import { TypeResolver } from "../resolvers/TypeResolver.js";
@@ -200,7 +200,10 @@ function convertWebhookExamples({
         }));
     }
     if (!isPlainObject(webhook.payload)) {
-        throw new Error(`Example webhook payload is not an object. Got: ${JSON.stringify(webhook.payload)}`);
+        throw new CliError({
+            message: `Example webhook payload is not an object. Got: ${JSON.stringify(webhook.payload)}`,
+            code: CliError.Code.ValidationError
+        });
     }
     // The payload example is a simple object of key, value pairs, so we format the example as
     // a map<string, unknown> for simplicity. If we ever add support for webhooks in the generated

--- a/packages/cli/generation/ir-generator/src/converters/services/convertExampleEndpointCall.ts
+++ b/packages/cli/generation/ir-generator/src/converters/services/convertExampleEndpointCall.ts
@@ -24,8 +24,8 @@ import {
     NameOrString
 } from "@fern-api/ir-sdk";
 import { getOriginalName, hashJSON } from "@fern-api/ir-utils";
+import { CliError } from "@fern-api/task-context";
 import urlJoin from "url-join";
-
 import { FernFileContext } from "../../FernFileContext.js";
 import { ErrorResolver } from "../../resolvers/ErrorResolver.js";
 import { ExampleResolver } from "../../resolvers/ExampleResolver.js";
@@ -89,7 +89,10 @@ export function convertExampleEndpointCall({
                               ? endpoint.request?.["query-parameters"]?.[wireKey]
                               : undefined;
                       if (queryParameterDeclaration == null) {
-                          throw new Error(`Query parameter ${wireKey} does not exist`);
+                          throw new CliError({
+                              message: `Query parameter ${wireKey} does not exist`,
+                              code: CliError.Code.ReferenceError
+                          });
                       }
                       const isAllowMultiple =
                           typeof queryParameterDeclaration !== "string" &&
@@ -252,7 +255,10 @@ function convertPathParameters({
                     })
                 );
             } else {
-                throw new Error(`Path parameter ${key} does not exist`);
+                throw new CliError({
+                    message: `Path parameter ${key} does not exist`,
+                    code: CliError.Code.ReferenceError
+                });
             }
         }
     }
@@ -405,7 +411,10 @@ function convertExampleRequestBody({
     }
 
     if (!isPlainObject(example.request)) {
-        throw new Error(`Example is not an object. Got: ${JSON.stringify(example.request)}`);
+        throw new CliError({
+            message: `Example is not an object. Got: ${JSON.stringify(example.request)}`,
+            code: CliError.Code.ValidationError
+        });
     }
 
     const exampleProperties: ExampleInlinedRequestBodyProperty[] = [];
@@ -463,7 +472,10 @@ function convertExampleRequestBody({
                     });
                     continue;
                 }
-                throw new Error("Could not find original type declaration for property: " + wireKey);
+                throw new CliError({
+                    message: "Could not find original type declaration for property: " + wireKey,
+                    code: CliError.Code.ResolutionError
+                });
             }
             exampleProperties.push({
                 name: file.casingsGenerator.generateNameAndWireValue({

--- a/packages/cli/generation/ir-generator/src/converters/services/convertHttpRequestBody.ts
+++ b/packages/cli/generation/ir-generator/src/converters/services/convertHttpRequestBody.ts
@@ -13,7 +13,7 @@ import {
     HttpRequestBodyReference,
     InlinedRequestBodyProperty
 } from "@fern-api/ir-sdk";
-
+import { CliError } from "@fern-api/task-context";
 import { FernFileContext } from "../../FernFileContext.js";
 import { parseTypeName } from "../../utils/parseTypeName.js";
 import { convertAvailability } from "../convertDeclaration.js";
@@ -102,7 +102,7 @@ export function convertHttpRequestBody({
 
     if (isInlineRequestBody(request.body)) {
         if (request.name == null) {
-            throw new Error("Name is missing for inlined request");
+            throw new CliError({ message: "Name is missing for inlined request", code: CliError.Code.InternalError });
         }
 
         return HttpRequestBody.inlinedRequestBody({

--- a/packages/cli/generation/ir-generator/src/converters/services/convertHttpSdkRequest.ts
+++ b/packages/cli/generation/ir-generator/src/converters/services/convertHttpSdkRequest.ts
@@ -1,7 +1,7 @@
 import { isInlineRequestBody, parseRawBytesType, RawSchemas } from "@fern-api/fern-definition-schema";
 import { SdkRequest, SdkRequestBodyType, SdkRequestShape } from "@fern-api/ir-sdk";
+import { CliError } from "@fern-api/task-context";
 import { size } from "lodash-es";
-
 import { FernFileContext } from "../../FernFileContext.js";
 import { PropertyResolver } from "../../resolvers/PropertyResolver.js";
 import { TypeResolver } from "../../resolvers/TypeResolver.js";
@@ -59,7 +59,7 @@ function convertHttpSdkRequestShape({
 }): SdkRequestShape | undefined {
     const constructWrapper = () => {
         if (typeof request === "string" || request?.name == null) {
-            throw new Error("Name is missing for request wrapper");
+            throw new CliError({ message: "Name is missing for request wrapper", code: CliError.Code.InternalError });
         }
         return SdkRequestShape.wrapper({
             wrapperName: file.casingsGenerator.generateName(request.name),

--- a/packages/cli/generation/ir-generator/src/converters/services/convertHttpService.ts
+++ b/packages/cli/generation/ir-generator/src/converters/services/convertHttpService.ts
@@ -18,6 +18,7 @@ import {
 } from "@fern-api/ir-sdk";
 import { constructHttpPath, IdGenerator } from "@fern-api/ir-utils";
 import { SourceResolver } from "@fern-api/source-resolver";
+import { CliError } from "@fern-api/task-context";
 import urlJoin from "url-join";
 import { FernFileContext } from "../../FernFileContext.js";
 import { ErrorResolver } from "../../resolvers/ErrorResolver.js";
@@ -372,7 +373,7 @@ export function resolvePathParameterOrThrow({
         file
     });
     if (resolved == null) {
-        throw new Error("Cannot resolve path parameter");
+        throw new CliError({ message: "Cannot resolve path parameter", code: CliError.Code.InternalError });
     }
     return resolved;
 }

--- a/packages/cli/generation/ir-generator/src/converters/services/convertPaginationUtils.ts
+++ b/packages/cli/generation/ir-generator/src/converters/services/convertPaginationUtils.ts
@@ -1,5 +1,5 @@
 import { RawSchemas } from "@fern-api/fern-definition-schema";
-
+import { CliError } from "@fern-api/task-context";
 import { FernFileContext } from "../../FernFileContext.js";
 import { ResolvedType } from "../../resolvers/ResolvedType.js";
 import { TypeResolver } from "../../resolvers/TypeResolver.js";
@@ -83,7 +83,7 @@ export function getPaginationPropertyComponents(
             results: getResponsePropertyComponents(endpointPagination.results)
         };
     }
-    throw new Error("Invalid pagination schema");
+    throw new CliError({ message: "Invalid pagination schema", code: CliError.Code.ValidationError });
 }
 
 export function resolveResponseType({

--- a/packages/cli/generation/ir-generator/src/converters/services/convertProperty.ts
+++ b/packages/cli/generation/ir-generator/src/converters/services/convertProperty.ts
@@ -1,5 +1,6 @@
 import { isRawObjectDefinition, RawSchemas } from "@fern-api/fern-definition-schema";
 import { ObjectProperty } from "@fern-api/ir-sdk";
+import { CliError } from "@fern-api/task-context";
 
 import { FernFileContext } from "../../FernFileContext.js";
 import { ResolvedType } from "../../resolvers/ResolvedType.js";
@@ -101,7 +102,10 @@ export function getPropertyTypeFromObjectSchema({
     });
     const propertyType = properties[property];
     if (propertyType == null) {
-        throw new Error(`Response does not have a property named ${property}.`);
+        throw new CliError({
+            message: `Response does not have a property named ${property}.`,
+            code: CliError.Code.ReferenceError
+        });
     }
     return propertyType;
 }
@@ -164,7 +168,10 @@ function getAllPropertiesForExtendedType({
         });
     }
     // This should be unreachable; extended types must be named objects.
-    throw new Error(`Extended type ${extendedType} must be another named type.`);
+    throw new CliError({
+        message: `Extended type ${extendedType} must be another named type.`,
+        code: CliError.Code.InternalError
+    });
 }
 
 export function maybeFileFromResolvedType(resolvedType: ResolvedType | undefined): FernFileContext | undefined {

--- a/packages/cli/generation/ir-generator/src/converters/services/convertTransport.ts
+++ b/packages/cli/generation/ir-generator/src/converters/services/convertTransport.ts
@@ -1,7 +1,7 @@
 import { isRawProtobufSourceSchema, RawSchemas } from "@fern-api/fern-definition-schema";
 import { Transport } from "@fern-api/ir-sdk";
 import { SourceResolver } from "@fern-api/source-resolver";
-
+import { CliError } from "@fern-api/task-context";
 import { FernFileContext } from "../../FernFileContext.js";
 import { convertProtobufService } from "./convertProtobufService.js";
 
@@ -46,7 +46,10 @@ export function getTransportForEndpoint({
         return undefined;
     }
     if (isHttpService && isGrpcEndpoint) {
-        throw new Error("Cannot have a grpc endpoint on an http service");
+        throw new CliError({
+            message: "Cannot have a grpc endpoint on an http service",
+            code: CliError.Code.ValidationError
+        });
     }
     if (isGrpcService && isHttpEndpoint) {
         // if the service is grpc, but the endpoint is http, the endpoint should override the service transport
@@ -63,9 +66,10 @@ export function getTransportForEndpoint({
         }
     }
 
-    throw new Error(
-        `Internal error; failed to determine endpoint transport for\n  ${JSON.stringify(endpointDeclaration)}"`
-    );
+    throw new CliError({
+        message: `Internal error; failed to determine endpoint transport for\n  ${JSON.stringify(endpointDeclaration)}"`,
+        code: CliError.Code.InternalError
+    });
 }
 
 function createProtobufService(
@@ -79,14 +83,20 @@ function createProtobufService(
         relativeFilepath: file.relativeFilepath
     });
     if (resolvedSource == null || resolvedSource.type !== "protobuf") {
-        throw new Error(`Expected a protobuf source for ${source.proto}.`);
+        throw new CliError({
+            message: `Expected a protobuf source for ${source.proto}.`,
+            code: CliError.Code.ResolutionError
+        });
     }
     const protobufService = convertProtobufService({
         source: resolvedSource,
         serviceNameOverride
     });
     if (protobufService == null) {
-        throw new Error(`Failed to resolve service name from ${resolvedSource.relativeFilePath}.`);
+        throw new CliError({
+            message: `Failed to resolve service name from ${resolvedSource.relativeFilePath}.`,
+            code: CliError.Code.IrConversionError
+        });
     }
     return Transport.grpc({
         service: protobufService

--- a/packages/cli/generation/ir-generator/src/converters/services/getObjectPropertyFromResolvedType.ts
+++ b/packages/cli/generation/ir-generator/src/converters/services/getObjectPropertyFromResolvedType.ts
@@ -2,7 +2,7 @@ import { assertNever } from "@fern-api/core-utils";
 import { isRawObjectDefinition, RawSchemas } from "@fern-api/fern-definition-schema";
 import { ObjectProperty } from "@fern-api/ir-sdk";
 import { getOriginalName } from "@fern-api/ir-utils";
-
+import { CliError } from "@fern-api/task-context";
 import { FernFileContext } from "../../FernFileContext.js";
 import { ResolvedType } from "../../resolvers/ResolvedType.js";
 import { TypeResolver } from "../../resolvers/TypeResolver.js";
@@ -46,7 +46,10 @@ export function getObjectPropertyFromResolvedType({
         default:
             assertNever(resolvedType);
     }
-    throw new Error("Internal error; response must be an object in order to return a property as a response");
+    throw new CliError({
+        message: "Internal error; response must be an object in order to return a property as a response",
+        code: CliError.Code.InternalError
+    });
 }
 
 export function getObjectPropertyFromObjectSchema({
@@ -63,7 +66,10 @@ export function getObjectPropertyFromObjectSchema({
     const properties = getAllPropertiesForRawObjectSchema(objectSchema, file, typeResolver);
     const objectProperty = properties[property];
     if (objectProperty == null) {
-        throw new Error(`Object does not have a property named ${property}.`);
+        throw new CliError({
+            message: `Object does not have a property named ${property}.`,
+            code: CliError.Code.ReferenceError
+        });
     }
     return objectProperty;
 }
@@ -110,5 +116,8 @@ function getAllPropertiesForExtendedType(
         return getAllPropertiesForRawObjectSchema(resolvedType.declaration, file, typeResolver);
     }
     // This should be unreachable; extended types must be named objects.
-    throw new Error(`Extended type ${extendedType} must be another named type`);
+    throw new CliError({
+        message: `Extended type ${extendedType} must be another named type`,
+        code: CliError.Code.InternalError
+    });
 }

--- a/packages/cli/generation/ir-generator/src/converters/type-declarations/convertEnumTypeDeclaration.ts
+++ b/packages/cli/generation/ir-generator/src/converters/type-declarations/convertEnumTypeDeclaration.ts
@@ -1,6 +1,7 @@
 import { RawSchemas } from "@fern-api/fern-definition-schema";
 import { EnumTypeDeclaration, EnumValue } from "@fern-api/ir-sdk";
 import { getWireValue } from "@fern-api/ir-utils";
+import { CliError } from "@fern-api/task-context";
 import { FernFileContext } from "../../FernFileContext.js";
 import { convertDeclaration } from "../convertDeclaration.js";
 
@@ -27,7 +28,10 @@ export function convertEnumTypeDeclaration({
     if (_enum.default != null) {
         defaultValue = values.find((enumValue) => getWireValue(enumValue.name) === _enum.default);
         if (defaultValue == null) {
-            throw new Error(`Default value ${_enum.default} not found in enum values`);
+            throw new CliError({
+                message: `Default value ${_enum.default} not found in enum values`,
+                code: CliError.Code.ValidationError
+            });
         }
     }
     return {

--- a/packages/cli/generation/ir-generator/src/converters/type-declarations/convertExampleType.ts
+++ b/packages/cli/generation/ir-generator/src/converters/type-declarations/convertExampleType.ts
@@ -23,6 +23,7 @@ import {
     PrimitiveTypeV1
 } from "@fern-api/ir-sdk";
 import { getWireValue, IdGenerator } from "@fern-api/ir-utils";
+import { CliError } from "@fern-api/task-context";
 import { validateTypeReferenceExample } from "../../examples/validateTypeReferenceExample.js";
 import { FernFileContext } from "../../FernFileContext.js";
 import { ExampleResolver } from "../../resolvers/ExampleResolver.js";
@@ -95,19 +96,28 @@ export function convertTypeExample({
         discriminatedUnion: (rawUnion) => {
             const discriminant = getUnionDiscriminant(rawUnion);
             if (!isPlainObject(example)) {
-                throw new Error("Example is not an object");
+                throw new CliError({ message: "Example is not an object", code: CliError.Code.ValidationError });
             }
             const discriminantValueForExample = example[discriminant];
             if (discriminantValueForExample == null) {
-                throw new Error("Example is missing discriminant: " + discriminant);
+                throw new CliError({
+                    message: "Example is missing discriminant: " + discriminant,
+                    code: CliError.Code.ValidationError
+                });
             }
             if (typeof discriminantValueForExample !== "string") {
-                throw new Error("Discriminant value is not a string");
+                throw new CliError({
+                    message: "Discriminant value is not a string",
+                    code: CliError.Code.ValidationError
+                });
             }
 
             const rawSingleUnionType = rawUnion.union[discriminantValueForExample];
             if (rawSingleUnionType == null) {
-                throw new Error(`${discriminantValueForExample} is not one of the specified discriminant values.`);
+                throw new CliError({
+                    message: `${discriminantValueForExample} is not one of the specified discriminant values.`,
+                    code: CliError.Code.ValidationError
+                });
             }
 
             const rawValueType =
@@ -157,7 +167,10 @@ export function convertTypeExample({
                     resolvedExtendedType._type !== "named" ||
                     !isRawObjectDefinition(resolvedExtendedType.declaration)
                 ) {
-                    throw new Error("Extended type is not a named object");
+                    throw new CliError({
+                        message: "Extended type is not a named object",
+                        code: CliError.Code.InternalError
+                    });
                 }
                 const extendedObject = resolvedExtendedType.declaration;
                 const propertiesFromExtension: ExampleObjectProperty[] = Object.entries(extendedObject.properties ?? {})
@@ -216,7 +229,10 @@ export function convertTypeExample({
                     .map((enumEntry) => (typeof enumEntry === "string" ? enumEntry : enumEntry.value))
                     .join(", ");
 
-                throw new Error(`Expected one of ${validValues}. Received ${example}`);
+                throw new CliError({
+                    message: `Expected one of ${validValues}. Received ${example}`,
+                    code: CliError.Code.ValidationError
+                });
             }
             return ExampleTypeShape.enum({
                 value: fileContainingExample.casingsGenerator.generateNameAndWireValue({
@@ -257,7 +273,10 @@ export function convertTypeExample({
                 return typeof variant === "string" ? variant : variant.type;
             });
             const validValues = variantOptions.join(", ");
-            throw new Error(`Expected one of ${validValues}. Received ${example}`);
+            throw new CliError({
+                message: `Expected one of ${validValues}. Received ${example}`,
+                code: CliError.Code.ValidationError
+            });
         }
     });
 }
@@ -305,7 +324,7 @@ export function convertTypeReferenceExample({
             },
             map: ({ keyType, valueType }) => {
                 if (!isPlainObject(resolvedExample)) {
-                    throw new Error("Example is not an object");
+                    throw new CliError({ message: "Example is not an object", code: CliError.Code.ValidationError });
                 }
                 const nextContext: RecursionContext = { depth: ctx.depth + 1, seenTypeIds: ctx.seenTypeIds };
                 return ExampleTypeReferenceShape.container(
@@ -339,7 +358,7 @@ export function convertTypeReferenceExample({
             },
             list: (itemType) => {
                 if (!Array.isArray(resolvedExample)) {
-                    throw new Error("Example is not a list");
+                    throw new CliError({ message: "Example is not a list", code: CliError.Code.ValidationError });
                 }
                 const nextContext: RecursionContext = { depth: ctx.depth + 1, seenTypeIds: ctx.seenTypeIds };
                 return ExampleTypeReferenceShape.container(
@@ -362,7 +381,7 @@ export function convertTypeReferenceExample({
             },
             set: (itemType) => {
                 if (!Array.isArray(resolvedExample)) {
-                    throw new Error("Example is not a list");
+                    throw new CliError({ message: "Example is not a list", code: CliError.Code.ValidationError });
                 }
                 const nextContext: RecursionContext = { depth: ctx.depth + 1, seenTypeIds: ctx.seenTypeIds };
                 return ExampleTypeReferenceShape.container(
@@ -450,7 +469,10 @@ export function convertTypeReferenceExample({
                 });
                 const parsedReferenceToNamedType = fileContainingRawTypeReference.parseTypeReference(named);
                 if (parsedReferenceToNamedType.type !== "named") {
-                    throw new Error("Type reference is not to a named type.");
+                    throw new CliError({
+                        message: "Type reference is not to a named type.",
+                        code: CliError.Code.InternalError
+                    });
                 }
                 const typeName: DeclaredTypeName = {
                     typeId: parsedReferenceToNamedType.typeId,
@@ -650,7 +672,10 @@ function convertPrimitiveExample({
             );
         },
         _other: () => {
-            throw new Error("Unknown primitive type: " + typeBeingExemplified);
+            throw new CliError({
+                message: "Unknown primitive type: " + typeBeingExemplified,
+                code: CliError.Code.InternalError
+            });
         }
     });
 }
@@ -685,7 +710,10 @@ function convertObject({
     recursionContext?: RecursionContext;
 }): ExampleTypeShape.Object_ {
     if (!isPlainObject(example)) {
-        throw new Error(`Example is not an object. Got: ${JSON.stringify(example)}`);
+        throw new CliError({
+            message: `Example is not an object. Got: ${JSON.stringify(example)}`,
+            code: CliError.Code.ValidationError
+        });
     }
 
     const properties: [WireKey, PropertyExample, OriginalTypeDeclaration | undefined][] = Object.entries(example).map(
@@ -804,7 +832,10 @@ export function getOriginalTypeDeclarationForPropertyFromExtensions({
                 file
             });
             if (resolvedType._type !== "named" || !isRawObjectDefinition(resolvedType.declaration)) {
-                throw new Error("Extension is not of a named object");
+                throw new CliError({
+                    message: "Extension is not of a named object",
+                    code: CliError.Code.InternalError
+                });
             }
             const originalTypeDeclaration = getOriginalTypeDeclarationForProperty({
                 wirePropertyKey,
@@ -867,7 +898,7 @@ function convertSingleUnionType({
     switch (parsedSingleUnionTypeProperties.propertiesType) {
         case "singleProperty": {
             if (!isPlainObject(example)) {
-                throw new Error("Example is not an object");
+                throw new CliError({ message: "Example is not an object", code: CliError.Code.ValidationError });
             }
             return {
                 wireDiscriminantValue,
@@ -887,7 +918,7 @@ function convertSingleUnionType({
         }
         case "samePropertiesAsObject": {
             if (!isPlainObject(example)) {
-                throw new Error("Example is not an object");
+                throw new CliError({ message: "Example is not an object", code: CliError.Code.ValidationError });
             }
             let rawDeclaration = typeResolver.getDeclarationOfNamedTypeOrThrow({
                 referenceToNamedType: rawValueType,
@@ -903,7 +934,10 @@ function convertSingleUnionType({
                 });
             }
             if (!isRawObjectDefinition(rawDeclaration.declaration)) {
-                throw new Error(`${rawValueType} is not an object`);
+                throw new CliError({
+                    message: `${rawValueType} is not an object`,
+                    code: CliError.Code.ValidationError
+                });
             }
             const typeName: DeclaredTypeName = {
                 typeId: parsedSingleUnionTypeProperties.typeId,

--- a/packages/cli/generation/ir-generator/src/converters/type-declarations/convertGenericTypeDeclaration.ts
+++ b/packages/cli/generation/ir-generator/src/converters/type-declarations/convertGenericTypeDeclaration.ts
@@ -1,6 +1,6 @@
 import { isRawObjectDefinition, parseGeneric, RawSchemas } from "@fern-api/fern-definition-schema";
 import { Type } from "@fern-api/ir-sdk";
-
+import { CliError } from "@fern-api/task-context";
 import { FernFileContext } from "../../FernFileContext.js";
 import { TypeResolver } from "../../resolvers/TypeResolver.js";
 import { parseTypeName } from "../../utils/parseTypeName.js";
@@ -20,7 +20,10 @@ export function convertGenericTypeDeclaration({
 
     const maybeGeneric = parseGeneric(genericInstantiation);
     if (maybeGeneric == null) {
-        throw new Error(`Invalid generic type definition: ${genericInstantiation}`);
+        throw new CliError({
+            message: `Invalid generic type definition: ${genericInstantiation}`,
+            code: CliError.Code.ValidationError
+        });
     }
 
     const resolvedBaseGeneric = typeResolver.getDeclarationOfNamedTypeOrThrow({
@@ -57,5 +60,8 @@ export function convertGenericTypeDeclaration({
         });
     }
 
-    throw new Error(`Generic type definition not supported: ${genericInstantiation}`);
+    throw new CliError({
+        message: `Generic type definition not supported: ${genericInstantiation}`,
+        code: CliError.Code.ValidationError
+    });
 }

--- a/packages/cli/generation/ir-generator/src/dynamic-snippets/DynamicSnippetsConverter.ts
+++ b/packages/cli/generation/ir-generator/src/dynamic-snippets/DynamicSnippetsConverter.ts
@@ -44,9 +44,9 @@ import {
     UnionTypeDeclaration
 } from "@fern-api/ir-sdk";
 import { getOriginalName, getWireValue } from "@fern-api/ir-utils";
+import { CliError } from "@fern-api/task-context";
 import urlJoin from "url-join";
 import { v4 as uuidv4 } from "uuid";
-
 import { Version } from "./version.js";
 
 interface EndpointWithFilepath extends HttpEndpoint {
@@ -225,7 +225,10 @@ export class DynamicSnippetsConverter {
             return DynamicSnippets.Request.body({ pathParameters, body: undefined });
         }
         if (endpoint.sdkRequest == null) {
-            throw new Error(`Internal error; endpoint "${endpoint.id}" has a request body but no SDK request`);
+            throw new CliError({
+                message: `Internal error; endpoint "${endpoint.id}" has a request body but no SDK request`,
+                code: CliError.Code.InternalError
+            });
         }
         switch (endpoint.sdkRequest.shape.type) {
             case "justRequestBody":
@@ -933,7 +936,7 @@ export class DynamicSnippetsConverter {
                         }))
                     }),
                 _other: () => {
-                    throw new Error("Unknown environments type");
+                    throw new CliError({ message: "Unknown environments type", code: CliError.Code.InternalError });
                 }
             })
         };
@@ -983,10 +986,16 @@ export class DynamicSnippetsConverter {
     private resolveObjectTypeOrThrow(typeId: TypeId): ObjectTypeDeclaration {
         const typeDeclaration = this.ir.types[typeId];
         if (typeDeclaration == null) {
-            throw new Error(`Internal error; type "${typeId}" not found`);
+            throw new CliError({
+                message: `Internal error; type "${typeId}" not found`,
+                code: CliError.Code.InternalError
+            });
         }
         if (typeDeclaration.shape.type !== "object") {
-            throw new Error(`Internal error; type "${typeId}" is not an object`);
+            throw new CliError({
+                message: `Internal error; type "${typeId}" is not an object`,
+                code: CliError.Code.InternalError
+            });
         }
         return typeDeclaration.shape;
     }

--- a/packages/cli/generation/ir-generator/src/examples/validateObjectExample.ts
+++ b/packages/cli/generation/ir-generator/src/examples/validateObjectExample.ts
@@ -1,8 +1,8 @@
 import { FernWorkspace, getDefinitionFile } from "@fern-api/api-workspace-commons";
 import { isPlainObject } from "@fern-api/core-utils";
 import { RawSchemas } from "@fern-api/fern-definition-schema";
+import { CliError } from "@fern-api/task-context";
 import { keyBy } from "lodash-es";
-
 import { constructFernFileContext, FernFileContext } from "../FernFileContext.js";
 import { ExampleResolver } from "../resolvers/ExampleResolver.js";
 import { TypeResolver } from "../resolvers/TypeResolver.js";
@@ -92,7 +92,10 @@ export function validateObjectExample({
         } else {
             const definitionFile = getDefinitionFile(workspace, propertyWithPath.filepathOfDeclaration);
             if (definitionFile == null) {
-                throw new Error("Service file does not exist for property: " + propertyWithPath.wireKey);
+                throw new CliError({
+                    message: "Service file does not exist for property: " + propertyWithPath.wireKey,
+                    code: CliError.Code.InternalError
+                });
             }
             violations.push(
                 ...validateTypeReferenceExample({

--- a/packages/cli/generation/ir-generator/src/examples/validateTypeReferenceExample.ts
+++ b/packages/cli/generation/ir-generator/src/examples/validateTypeReferenceExample.ts
@@ -10,7 +10,7 @@ import {
     PrimitiveTypeV2,
     StringValidationRules
 } from "@fern-api/ir-sdk";
-
+import { CliError } from "@fern-api/task-context";
 import { FernFileContext } from "../FernFileContext.js";
 import { ExampleResolver } from "../resolvers/ExampleResolver.js";
 import { ResolvedType } from "../resolvers/ResolvedType.js";
@@ -294,7 +294,10 @@ function validatePrimitiveExample({
             base64: () => validateString(example),
             bigInteger: () => validateString(example),
             _other: () => {
-                throw new Error("Unknown primitive type v2: " + primitiveType.v2);
+                throw new CliError({
+                    message: "Unknown primitive type v2: " + primitiveType.v2,
+                    code: CliError.Code.InternalError
+                });
             }
         });
     }
@@ -314,7 +317,10 @@ function validatePrimitiveExample({
         base64: () => validateString(example),
         bigInteger: () => validateString(example),
         _other: () => {
-            throw new Error("Unknown primitive type: " + primitiveType.v1);
+            throw new CliError({
+                message: "Unknown primitive type: " + primitiveType.v1,
+                code: CliError.Code.InternalError
+            });
         }
     });
 }

--- a/packages/cli/generation/ir-generator/src/filterExamples.ts
+++ b/packages/cli/generation/ir-generator/src/filterExamples.ts
@@ -20,6 +20,7 @@ import {
     FernIr
 } from "@fern-api/ir-sdk";
 import { FilteredIr, getWireValue } from "@fern-api/ir-utils";
+import { CliError } from "@fern-api/task-context";
 
 function filterExampleSingleUnionTypeProperties({
     filteredIr,
@@ -59,7 +60,7 @@ function filterExampleSingleUnionTypeProperties({
         },
         noProperties: () => singleUnionTypeProperties,
         _other: () => {
-            throw new Error("Received unknown type for example.");
+            throw new CliError({ message: "Received unknown type for example.", code: CliError.Code.InternalError });
         }
     });
 }
@@ -157,7 +158,10 @@ function filterExampleTypeReference({
                 // This is just a primitive, don't do anything
                 literal: () => exampleTypeReference,
                 _other: () => {
-                    throw new Error("Received unknown type for example.");
+                    throw new CliError({
+                        message: "Received unknown type for example.",
+                        code: CliError.Code.InternalError
+                    });
                 }
             }),
         // If the type is allowed filter it's properties and return
@@ -242,7 +246,10 @@ function filterExampleTypeReference({
                               : undefined;
                       },
                       _other: () => {
-                          throw new Error("Received unknown type for example.");
+                          throw new CliError({
+                              message: "Received unknown type for example.",
+                              code: CliError.Code.InternalError
+                          });
                       }
                   })
                 : undefined,
@@ -351,7 +358,7 @@ function filterExampleRequestBody({
             return filteredReference !== undefined ? ExampleRequestBody.reference(filteredReference) : undefined;
         },
         _other: () => {
-            throw new Error("Received unknown type for example.");
+            throw new CliError({ message: "Received unknown type for example.", code: CliError.Code.InternalError });
         }
     });
 }
@@ -399,7 +406,10 @@ function filterExampleResponse({
                         )
                     ),
                 _other: ({ type }) => {
-                    throw new Error(`Received unknown type for OK example: ${type}`);
+                    throw new CliError({
+                        message: `Received unknown type for OK example: ${type}`,
+                        code: CliError.Code.InternalError
+                    });
                 }
             }),
         error: ({ error, body }) =>
@@ -408,7 +418,10 @@ function filterExampleResponse({
                 body: body != null ? filterExampleTypeReference({ filteredIr, exampleTypeReference: body }) : undefined
             }),
         _other: ({ type }) => {
-            throw new Error(`Received unknown type for example: ${type}`);
+            throw new CliError({
+                message: `Received unknown type for example: ${type}`,
+                code: CliError.Code.InternalError
+            });
         }
     });
 }
@@ -498,7 +511,7 @@ export function filterExampleType({
                 : undefined;
         },
         _other: () => {
-            throw new Error("Received unknown type for example.");
+            throw new CliError({ message: "Received unknown type for example.", code: CliError.Code.InternalError });
         }
     });
 }

--- a/packages/cli/generation/ir-generator/src/generateIntermediateRepresentation.ts
+++ b/packages/cli/generation/ir-generator/src/generateIntermediateRepresentation.ts
@@ -26,7 +26,8 @@ import {
 } from "@fern-api/ir-utils";
 import { dirname, join, RelativeFilePath } from "@fern-api/path-utils";
 import { SourceResolver } from "@fern-api/source-resolver";
-import { TaskContext } from "@fern-api/task-context";
+import { CliError, TaskContext } from "@fern-api/task-context";
+
 import { generateFernConstants } from "./converters/constants.js";
 import { convertApiAuth } from "./converters/convertApiAuth.js";
 import { convertApiVersionScheme } from "./converters/convertApiVersionScheme.js";
@@ -269,7 +270,10 @@ export function generateIntermediateRepresentation({
                 }
                 const errorDiscriminationSchema = workspace.definition.rootApiFile.contents["error-discrimination"];
                 if (errorDiscriminationSchema == null) {
-                    throw new Error("error-discrimination is missing in api.yml but there are declared errors.");
+                    throw new CliError({
+                        message: "error-discrimination is missing in api.yml but there are declared errors.",
+                        code: CliError.Code.ConfigError
+                    });
                 }
                 for (const [errorName, errorDeclaration] of Object.entries(errors)) {
                     const convertedErrorDeclaration = convertErrorDeclaration({

--- a/packages/cli/generation/ir-generator/src/resolvers/EndpointResolver.ts
+++ b/packages/cli/generation/ir-generator/src/resolvers/EndpointResolver.ts
@@ -7,7 +7,7 @@ import {
 import { CasingsGenerator } from "@fern-api/casings-generator";
 import { HttpEndpointReferenceParser } from "@fern-api/fern-definition-schema";
 import { HttpMethod } from "@fern-api/ir-sdk";
-
+import { CliError } from "@fern-api/task-context";
 import { constructFernFileContext, FernFileContext } from "../FernFileContext.js";
 import { parseReferenceToEndpointName } from "../utils/parseReferenceToEndpointName.js";
 import { ResolvedEndpoint } from "./ResolvedEndpoint.js";
@@ -29,7 +29,10 @@ export class EndpointResolverImpl implements EndpointResolver {
     public resolveEndpointOrThrow({ endpoint, file }: { endpoint: string; file: FernFileContext }): ResolvedEndpoint {
         const resolvedEndpoint = this.resolveEndpoint({ endpoint, file });
         if (resolvedEndpoint == null) {
-            throw new Error("Cannot resolve endpoint: " + endpoint + " in file " + file.relativeFilepath);
+            throw new CliError({
+                message: "Cannot resolve endpoint: " + endpoint + " in file " + file.relativeFilepath,
+                code: CliError.Code.ResolutionError
+            });
         }
         return resolvedEndpoint;
     }

--- a/packages/cli/generation/ir-generator/src/resolvers/ErrorResolver.ts
+++ b/packages/cli/generation/ir-generator/src/resolvers/ErrorResolver.ts
@@ -1,6 +1,6 @@
 import { FernWorkspace, getDefinitionFile } from "@fern-api/api-workspace-commons";
 import { RawSchemas } from "@fern-api/fern-definition-schema";
-
+import { CliError } from "@fern-api/task-context";
 import { constructFernFileContext, FernFileContext } from "../FernFileContext.js";
 import { parseReferenceToTypeName } from "../utils/parseReferenceToTypeName.js";
 
@@ -24,7 +24,10 @@ export class ErrorResolverImpl implements ErrorResolver {
     ): { declaration: RawSchemas.ErrorDeclarationSchema; file: FernFileContext } {
         const declaration = this.getDeclaration(referenceToError, file);
         if (declaration == null) {
-            throw new Error("Error does not exist: " + referenceToError);
+            throw new CliError({
+                message: "Error does not exist: " + referenceToError,
+                code: CliError.Code.ResolutionError
+            });
         }
         return declaration;
     }

--- a/packages/cli/generation/ir-generator/src/resolvers/ExampleResolver.ts
+++ b/packages/cli/generation/ir-generator/src/resolvers/ExampleResolver.ts
@@ -1,6 +1,6 @@
 import { isPlainObject } from "@fern-api/core-utils";
 import { EXAMPLE_REFERENCE_PREFIX } from "@fern-api/fern-definition-schema";
-
+import { CliError } from "@fern-api/task-context";
 import { FernFileContext } from "../FernFileContext.js";
 import { TypeResolver } from "./TypeResolver.js";
 
@@ -86,7 +86,7 @@ export class ExampleResolverImpl implements ExampleResolver {
     } {
         const resolvedExample = this.resolveAllReferencesInExample({ example, file });
         if (resolvedExample == null) {
-            throw new Error("Failed to resolve examples");
+            throw new CliError({ message: "Failed to resolve examples", code: CliError.Code.ResolutionError });
         }
         return resolvedExample;
     }
@@ -162,7 +162,7 @@ export class ExampleResolverImpl implements ExampleResolver {
     } {
         const resolvedExample = this.resolveExample({ example, file });
         if (resolvedExample == null) {
-            throw new Error("Cannot resolve example: " + example);
+            throw new CliError({ message: "Cannot resolve example: " + example, code: CliError.Code.ResolutionError });
         }
         return resolvedExample;
     }

--- a/packages/cli/generation/ir-generator/src/resolvers/PropertyResolver.ts
+++ b/packages/cli/generation/ir-generator/src/resolvers/PropertyResolver.ts
@@ -8,6 +8,7 @@ import {
     ResponseProperty
 } from "@fern-api/ir-sdk";
 import { getOriginalName } from "@fern-api/ir-utils";
+import { CliError } from "@fern-api/task-context";
 import {
     getNestedObjectPropertyFromObjectSchema,
     getNestedObjectPropertyFromResolvedType,
@@ -62,9 +63,11 @@ export class PropertyResolverImpl implements PropertyResolver {
     }): RequestProperty {
         const resolvedRequestProperty = this.resolveRequestProperty({ file, endpoint, propertyComponents });
         if (resolvedRequestProperty == null) {
-            throw new Error(
-                "Cannot resolve request property from endpoint: " + endpoint + " in file " + file.relativeFilepath
-            );
+            throw new CliError({
+                message:
+                    "Cannot resolve request property from endpoint: " + endpoint + " in file " + file.relativeFilepath,
+                code: CliError.Code.ResolutionError
+            });
         }
         return resolvedRequestProperty;
     }
@@ -126,9 +129,11 @@ export class PropertyResolverImpl implements PropertyResolver {
     }): ResponseProperty {
         const resolvedResponseProperty = this.resolveResponseProperty({ file, endpoint, propertyComponents });
         if (resolvedResponseProperty == null) {
-            throw new Error(
-                "Cannot resolve response property from endpoint: " + endpoint + " in file " + file.relativeFilepath
-            );
+            throw new CliError({
+                message:
+                    "Cannot resolve response property from endpoint: " + endpoint + " in file " + file.relativeFilepath,
+                code: CliError.Code.ResolutionError
+            });
         }
         return resolvedResponseProperty;
     }
@@ -360,9 +365,10 @@ export class PropertyResolverImpl implements PropertyResolver {
                 propertyComponents: breadcrumbs
             });
             if (!currentType) {
-                throw new Error(
-                    `Cannot find property '${breadcrumbs.join(".")}' in inline request body in file ${file.relativeFilepath}`
-                );
+                throw new CliError({
+                    message: `Cannot find property '${breadcrumbs.join(".")}' in inline request body in file ${file.relativeFilepath}`,
+                    code: CliError.Code.InternalError
+                });
             }
             result.push({
                 name: file.casingsGenerator.generateName(component),
@@ -395,7 +401,10 @@ function getNestedObjectPropertyTypeOrThrow({
         propertyName
     });
     if (!nestedPropertyType) {
-        throw new Error(`Cannot find property '${breadcrumbs.join(".")}' in ${rootTypeLabel}`);
+        throw new CliError({
+            message: `Cannot find property '${breadcrumbs.join(".")}' in ${rootTypeLabel}`,
+            code: CliError.Code.InternalError
+        });
     }
     return nestedPropertyType;
 }

--- a/packages/cli/generation/ir-generator/src/resolvers/TypeResolver.ts
+++ b/packages/cli/generation/ir-generator/src/resolvers/TypeResolver.ts
@@ -6,7 +6,7 @@ import {
     recursivelyVisitRawTypeReference
 } from "@fern-api/fern-definition-schema";
 import { ContainerType, TypeReference } from "@fern-api/ir-sdk";
-
+import { CliError } from "@fern-api/task-context";
 import { constructFernFileContext, FernFileContext } from "../FernFileContext.js";
 import { parseInlineType } from "../utils/parseInlineType.js";
 import { parseReferenceToTypeName } from "../utils/parseReferenceToTypeName.js";
@@ -39,7 +39,10 @@ export class TypeResolverImpl implements TypeResolver {
     public resolveTypeOrThrow({ type, file }: { type: string; file: FernFileContext }): ResolvedType {
         const resolvedType = this.resolveType({ type, file });
         if (resolvedType == null) {
-            throw new Error("Cannot resolve type: " + type + " in file " + file.relativeFilepath);
+            throw new CliError({
+                message: "Cannot resolve type: " + type + " in file " + file.relativeFilepath,
+                code: CliError.Code.ResolutionError
+            });
         }
         return resolvedType;
     }
@@ -53,9 +56,11 @@ export class TypeResolverImpl implements TypeResolver {
     }): RawTypeDeclarationInfo {
         const declaration = this.getDeclarationOfNamedType({ referenceToNamedType, file });
         if (declaration == null) {
-            throw new Error(
-                "Cannot find declaration of type: " + referenceToNamedType + " in file " + file.relativeFilepath
-            );
+            throw new CliError({
+                message:
+                    "Cannot find declaration of type: " + referenceToNamedType + " in file " + file.relativeFilepath,
+                code: CliError.Code.ResolutionError
+            });
         }
         return declaration;
     }
@@ -261,7 +266,10 @@ export class TypeResolverImpl implements TypeResolver {
     }): ResolvedType {
         const resolvedType = this.resolveNamedType({ referenceToNamedType, file });
         if (resolvedType == null) {
-            throw new Error("Cannot resolve type: " + referenceToNamedType);
+            throw new CliError({
+                message: "Cannot resolve type: " + referenceToNamedType,
+                code: CliError.Code.ResolutionError
+            });
         }
         return resolvedType;
     }

--- a/packages/cli/generation/ir-generator/src/resolvers/VariableResolver.ts
+++ b/packages/cli/generation/ir-generator/src/resolvers/VariableResolver.ts
@@ -1,6 +1,6 @@
 import { RawSchemas } from "@fern-api/fern-definition-schema";
 import { VariableId } from "@fern-api/ir-sdk";
-
+import { CliError } from "@fern-api/task-context";
 import { constructRootApiFileContext, FernFileContext } from "../FernFileContext.js";
 
 export interface VariableResolver {
@@ -25,7 +25,10 @@ export class VariableResolverImpl implements VariableResolver {
     ): { declaration: RawSchemas.VariableDeclarationSchema; file: FernFileContext } {
         const declaration = this.getDeclaration(referenceToVariable, file);
         if (declaration == null) {
-            throw new Error("Variable does not exist: " + referenceToVariable);
+            throw new CliError({
+                message: "Variable does not exist: " + referenceToVariable,
+                code: CliError.Code.ResolutionError
+            });
         }
         return declaration;
     }
@@ -55,7 +58,10 @@ export class VariableResolverImpl implements VariableResolver {
     public getVariableIdOrThrow(referenceToVariable: string): VariableId {
         const variableId = this.getVariableId(referenceToVariable);
         if (variableId == null) {
-            throw new Error("Variable reference does not start with " + VariableResolverImpl.VARIABLE_PREFIX);
+            throw new CliError({
+                message: "Variable reference does not start with " + VariableResolverImpl.VARIABLE_PREFIX,
+                code: CliError.Code.ResolutionError
+            });
         }
         return variableId;
     }

--- a/packages/cli/generation/ir-generator/src/utils/parseErrorName.ts
+++ b/packages/cli/generation/ir-generator/src/utils/parseErrorName.ts
@@ -1,6 +1,6 @@
 import { DeclaredErrorName } from "@fern-api/ir-sdk";
 import { IdGenerator } from "@fern-api/ir-utils";
-
+import { CliError } from "@fern-api/task-context";
 import { FernFileContext } from "../FernFileContext.js";
 import { convertToFernFilepath } from "./convertToFernFilepath.js";
 import { parseReferenceToTypeName } from "./parseReferenceToTypeName.js";
@@ -12,7 +12,7 @@ export function parseErrorName({ errorName, file }: { errorName: string; file: F
         imports: file.imports
     });
     if (reference == null) {
-        throw new Error("Failed to locate error " + errorName);
+        throw new CliError({ message: "Failed to locate error " + errorName, code: CliError.Code.ResolutionError });
     }
 
     const nameWithoutId = {

--- a/packages/cli/generation/ir-generator/src/utils/parseTypeName.ts
+++ b/packages/cli/generation/ir-generator/src/utils/parseTypeName.ts
@@ -1,6 +1,6 @@
 import { DeclaredTypeName } from "@fern-api/ir-sdk";
 import { IdGenerator } from "@fern-api/ir-utils";
-
+import { CliError } from "@fern-api/task-context";
 import { FernFileContext } from "../FernFileContext.js";
 import { convertToFernFilepath } from "./convertToFernFilepath.js";
 import { parseReferenceToTypeName } from "./parseReferenceToTypeName.js";
@@ -12,7 +12,7 @@ export function parseTypeName({ typeName, file }: { typeName: string; file: Fern
         imports: file.imports
     });
     if (reference == null) {
-        throw new Error("Failed to locate type: " + typeName);
+        throw new CliError({ message: "Failed to locate type: " + typeName, code: CliError.Code.ResolutionError });
     }
 
     const nameWithoutId = {


### PR DESCRIPTION
## Description

Migrates `@fern-api/ir-generator` to use explicit `CliError` error codes on every `failAndThrow` / `failWithoutThrowing` call site.

This is one of the package migration PRs that follow the error classification system introduced in #14749.

## Changes Made

Assigned typed error codes across call sites in `packages/cli/generation/ir-generator/src/`.

### Error codes used

| Code | Usage |
|------|-------|
| `IR_CONVERSION_ERROR` | IR generation/conversion failures, type resolution errors |
| `VALIDATION_ERROR` | Schema validation failures during IR generation |
| `REFERENCE_ERROR` | Unresolvable type references, missing declarations |
| `PARSE_ERROR` | Malformed input definitions |

### Files touched (grouped by area)

- **IR generation**: Various files in `ir-generator/src/` covering type declaration resolution, extended properties, and conversion utilities
- **Utils**: `getTypeDeclaration.ts`, `addExtendedPropertiesToIr.ts`

## Testing

- [x] Existing tests pass (`pnpm test`, excluding e2e and pre-existing environment failures)
