### PR TITLE
chore(cli): migrate @fern-api/lazy-fern-workspace to use CliError

### DIFF
--- a/packages/cli/workspace/lazy-fern-workspace/src/LazyFernWorkspace.ts
+++ b/packages/cli/workspace/lazy-fern-workspace/src/LazyFernWorkspace.ts
@@ -2,7 +2,7 @@ import { AbstractAPIWorkspace, FernDefinition, FernWorkspace } from "@fern-api/a
 import { generatorsYml } from "@fern-api/configuration";
 import { DEFINITION_DIRECTORY, loadDependenciesConfiguration } from "@fern-api/configuration-loader";
 import { AbsoluteFilePath, join, RelativeFilePath } from "@fern-api/fs-utils";
-import { TaskContext } from "@fern-api/task-context";
+import { CliError, TaskContext } from "@fern-api/task-context";
 import hash from "object-hash";
 
 import { OSSWorkspace } from "./OSSWorkspace.js";
@@ -62,7 +62,9 @@ export class LazyFernWorkspace extends AbstractAPIWorkspace<OSSWorkspace.Setting
             const parseResult = await parseYamlFiles(yamlFiles);
             if (!parseResult.didSucceed) {
                 handleFailedWorkspaceParserResultRaw(parseResult.failures, defaultedContext.logger);
-                return defaultedContext.failAndThrow();
+                return defaultedContext.failAndThrow(undefined, undefined, {
+                    code: CliError.Code.ValidationError
+                });
             }
 
             const structuralValidationResult = validateStructureOfYamlFiles({
@@ -72,7 +74,9 @@ export class LazyFernWorkspace extends AbstractAPIWorkspace<OSSWorkspace.Setting
             });
             if (!structuralValidationResult.didSucceed) {
                 handleFailedWorkspaceParserResultRaw(structuralValidationResult.failures, defaultedContext.logger);
-                return defaultedContext.failAndThrow();
+                return defaultedContext.failAndThrow(undefined, undefined, {
+                    code: CliError.Code.ValidationError
+                });
             }
 
             const processPackageMarkersResult = await processPackageMarkers({
@@ -85,7 +89,9 @@ export class LazyFernWorkspace extends AbstractAPIWorkspace<OSSWorkspace.Setting
             });
             if (!processPackageMarkersResult.didSucceed) {
                 handleFailedWorkspaceParserResultRaw(processPackageMarkersResult.failures, defaultedContext.logger);
-                return defaultedContext.failAndThrow();
+                return defaultedContext.failAndThrow(undefined, undefined, {
+                    code: CliError.Code.ValidationError
+                });
             }
 
             let definition = {

--- a/packages/cli/workspace/lazy-fern-workspace/src/OSSWorkspace.ts
+++ b/packages/cli/workspace/lazy-fern-workspace/src/OSSWorkspace.ts
@@ -27,7 +27,8 @@ import {
     resolveOAuthEndpointReferences
 } from "@fern-api/openapi-to-ir";
 import { OpenRPCConverter, OpenRPCConverterContext3_1 } from "@fern-api/openrpc-to-ir";
-import { TaskContext } from "@fern-api/task-context";
+import { CliError, TaskContext } from "@fern-api/task-context";
+
 import { ErrorCollector } from "@fern-api/v3-importer-commons";
 import { readFile } from "fs/promises";
 import yaml from "js-yaml";
@@ -484,7 +485,10 @@ export class OSSWorkspace extends BaseOpenAPIWorkspace {
         }
 
         if (mergedIr === undefined) {
-            throw new Error("Failed to generate intermediate representation");
+            throw new CliError({
+                message: "Failed to generate intermediate representation",
+                code: CliError.Code.IrConversionError
+            });
         }
 
         // Resolve OAuth endpoint references after all specs have been merged,
@@ -620,7 +624,10 @@ export class OSSWorkspace extends BaseOpenAPIWorkspace {
     ): Promise<Spec[]> {
         // Handle conjure schema case
         if (!Array.isArray(specsOverride)) {
-            throw new Error("Conjure specs override is not yet supported");
+            throw new CliError({
+                message: "Conjure specs override is not yet supported",
+                code: CliError.Code.InternalError
+            });
         }
 
         const specs: Spec[] = [];
@@ -672,9 +679,10 @@ export class OSSWorkspace extends BaseOpenAPIWorkspace {
                 specs.push(openApiSpec);
             } else {
                 // For now, only support OpenAPI specs override to keep it simple
-                throw new Error(
-                    `Spec type override not yet supported. Only OpenAPI specs are currently supported in specs override.`
-                );
+                throw new CliError({
+                    message: `Spec type override not yet supported. Only OpenAPI specs are currently supported in specs override.`,
+                    code: CliError.Code.InternalError
+                });
             }
         }
 

--- a/packages/cli/workspace/lazy-fern-workspace/src/loaders/applyOverlays.ts
+++ b/packages/cli/workspace/lazy-fern-workspace/src/loaders/applyOverlays.ts
@@ -1,6 +1,6 @@
 import { applyOpenAPIOverlay, type OverlayAction } from "@fern-api/core-utils";
 import { AbsoluteFilePath } from "@fern-api/fs-utils";
-import { TaskContext } from "@fern-api/task-context";
+import { CliError, TaskContext } from "@fern-api/task-context";
 import { readFile, writeFile } from "fs/promises";
 import yaml from "js-yaml";
 import path from "path";
@@ -86,7 +86,9 @@ async function parseOverlayFile(
     try {
         contents = await readFile(absoluteFilePathToOverlay, "utf8");
     } catch (err) {
-        return context.failAndThrow(`Failed to read overlay file at ${absoluteFilePathToOverlay}: ${err}`);
+        return context.failAndThrow(`Failed to read overlay file at ${absoluteFilePathToOverlay}: ${err}`, undefined, {
+            code: CliError.Code.ConfigError
+        });
     }
 
     try {
@@ -97,7 +99,9 @@ async function parseOverlayFile(
             return yaml.load(contents, { json: true }) as OverlayDocument;
         }
     } catch (err) {
-        return context.failAndThrow(`Failed to parse overlay file at ${absoluteFilePathToOverlay}: ${err}`);
+        return context.failAndThrow(`Failed to parse overlay file at ${absoluteFilePathToOverlay}: ${err}`, undefined, {
+            code: CliError.Code.ParseError
+        });
     }
 }
 

--- a/packages/cli/workspace/lazy-fern-workspace/src/loaders/mergeWithOverrides.ts
+++ b/packages/cli/workspace/lazy-fern-workspace/src/loaders/mergeWithOverrides.ts
@@ -1,6 +1,6 @@
 import { mergeWithOverrides as coreMergeWithOverrides } from "@fern-api/core-utils";
 import { AbsoluteFilePath } from "@fern-api/fs-utils";
-import { TaskContext } from "@fern-api/task-context";
+import { CliError, TaskContext } from "@fern-api/task-context";
 import { readFile } from "fs/promises";
 import yaml from "js-yaml";
 
@@ -24,7 +24,9 @@ export async function mergeWithOverrides<T extends object>({
             parsedOverrides = yaml.load(contents, { json: true });
         }
     } catch (err) {
-        return context.failAndThrow(`Failed to read overrides from file ${absoluteFilePathToOverrides}`);
+        return context.failAndThrow(`Failed to read overrides from file ${absoluteFilePathToOverrides}`, undefined, {
+            code: CliError.Code.ParseError
+        });
     }
     return coreMergeWithOverrides({ data, overrides: parsedOverrides, allowNullKeys });
 }

--- a/packages/cli/workspace/lazy-fern-workspace/src/protobuf/BufDownloader.ts
+++ b/packages/cli/workspace/lazy-fern-workspace/src/protobuf/BufDownloader.ts
@@ -1,5 +1,6 @@
 import { AbsoluteFilePath, join, RelativeFilePath } from "@fern-api/fs-utils";
 import { Logger } from "@fern-api/logger";
+import { CliError } from "@fern-api/task-context";
 import { access, chmod, copyFile, mkdir, readFile, rename, rm, writeFile } from "fs/promises";
 import os from "os";
 import path from "path";
@@ -39,7 +40,7 @@ function getPlatformInfo(): PlatformInfo {
             osName = "Windows";
             break;
         default:
-            throw new Error(`Unsupported platform: ${platform}`);
+            throw new CliError({ message: `Unsupported platform: ${platform}`, code: CliError.Code.EnvironmentError });
     }
 
     let archName: string;
@@ -52,7 +53,7 @@ function getPlatformInfo(): PlatformInfo {
             archName = platform === "linux" ? "aarch64" : "arm64";
             break;
         default:
-            throw new Error(`Unsupported architecture: ${arch}`);
+            throw new CliError({ message: `Unsupported architecture: ${arch}`, code: CliError.Code.EnvironmentError });
     }
 
     return {
@@ -145,7 +146,10 @@ async function acquireLock(logger: Logger): Promise<() => Promise<void>> {
                 await new Promise((resolve) => setTimeout(resolve, LOCK_RETRY_INTERVAL_MS));
             }
         }
-        throw new Error(`Failed to acquire buf lock after timeout and retry`);
+        throw new CliError({
+            message: `Failed to acquire buf lock after timeout and retry`,
+            code: CliError.Code.InternalError
+        });
     }
     return createLockReleaser(lockPath, logger);
 }

--- a/packages/cli/workspace/lazy-fern-workspace/src/protobuf/ProtobufIRGenerator.ts
+++ b/packages/cli/workspace/lazy-fern-workspace/src/protobuf/ProtobufIRGenerator.ts
@@ -1,7 +1,7 @@
 import { AbsoluteFilePath, join, RelativeFilePath } from "@fern-api/fs-utils";
 import { Logger } from "@fern-api/logger";
 import { createLoggingExecutable, runExeca } from "@fern-api/logging-execa";
-import { TaskContext } from "@fern-api/task-context";
+import { CliError, TaskContext } from "@fern-api/task-context";
 import { access, chmod, cp, unlink, writeFile } from "fs/promises";
 import path from "path";
 import tmp from "tmp-promise";
@@ -302,7 +302,9 @@ export class ProtobufIRGenerator {
                         await access(bufLockPath);
                     } catch {
                         this.context.failAndThrow(
-                            "Air-gapped mode requires a pre-cached buf.lock file. Please run 'buf dep update' at build time to cache dependencies."
+                            "Air-gapped mode requires a pre-cached buf.lock file. Please run 'buf dep update' at build time to cache dependencies.",
+                            undefined,
+                            { code: CliError.Code.InternalError }
                         );
                     }
                 } else {
@@ -313,7 +315,9 @@ export class ProtobufIRGenerator {
 
             const bufGenerateResult = await buf(["generate"]);
             if (bufGenerateResult.exitCode !== 0) {
-                this.context.failAndThrow(bufGenerateResult.stderr);
+                this.context.failAndThrow(bufGenerateResult.stderr, undefined, {
+                    code: CliError.Code.IrConversionError
+                });
             }
             await unlink(bufYamlPath);
         } catch (error) {
@@ -332,11 +336,15 @@ export class ProtobufIRGenerator {
         try {
             this.resolvedBufCommand = await ensureBufCommand(this.context.logger);
         } catch (error) {
-            this.context.failAndThrow(error instanceof Error ? error.message : String(error));
+            this.context.failAndThrow(error instanceof Error ? error.message : String(error), undefined, {
+                code: CliError.Code.EnvironmentError
+            });
         }
     }
 
     private async generateRemote(): Promise<AbsoluteFilePath> {
-        this.context.failAndThrow("Remote Protobuf generation is unimplemented.");
+        this.context.failAndThrow("Remote Protobuf generation is unimplemented.", undefined, {
+            code: CliError.Code.InternalError
+        });
     }
 }

--- a/packages/cli/workspace/lazy-fern-workspace/src/protobuf/ProtobufOpenAPIGenerator.ts
+++ b/packages/cli/workspace/lazy-fern-workspace/src/protobuf/ProtobufOpenAPIGenerator.ts
@@ -1,6 +1,6 @@
 import { AbsoluteFilePath, join, RelativeFilePath, relative } from "@fern-api/fs-utils";
 import { createLoggingExecutable } from "@fern-api/logging-execa";
-import { TaskContext } from "@fern-api/task-context";
+import { CliError, TaskContext } from "@fern-api/task-context";
 import { access, copyFile, cp, readFile, unlink, writeFile } from "fs/promises";
 import path from "path";
 import tmp from "tmp-promise";
@@ -76,7 +76,9 @@ export class ProtobufOpenAPIGenerator {
         deps: string[];
     }): Promise<PreparedWorkingDir> {
         if (!local) {
-            this.context.failAndThrow("Remote Protobuf generation is unimplemented.");
+            this.context.failAndThrow("Remote Protobuf generation is unimplemented.", undefined, {
+                code: CliError.Code.InternalError
+            });
         }
 
         // Resolve buf and protoc-gen-openapi binaries once
@@ -116,7 +118,9 @@ export class ProtobufOpenAPIGenerator {
                     await access(bufLockPath);
                 } catch {
                     this.context.failAndThrow(
-                        "Air-gapped mode requires a pre-cached buf.lock file. Please run 'buf dep update' at build time to cache dependencies."
+                        "Air-gapped mode requires a pre-cached buf.lock file. Please run 'buf dep update' at build time to cache dependencies.",
+                        undefined,
+                        { code: CliError.Code.InternalError }
                     );
                 }
             } else {
@@ -165,7 +169,9 @@ export class ProtobufOpenAPIGenerator {
 
         const bufGenerateResult = await buf(["generate", target.toString()]);
         if (bufGenerateResult.exitCode !== 0) {
-            this.context.failAndThrow(bufGenerateResult.stderr);
+            this.context.failAndThrow(bufGenerateResult.stderr, undefined, {
+                code: CliError.Code.IrConversionError
+            });
         }
 
         // Move output to a unique temp file so the next call doesn't overwrite it.
@@ -283,7 +289,9 @@ export class ProtobufOpenAPIGenerator {
                         await access(bufLockPath);
                     } catch {
                         this.context.failAndThrow(
-                            "Air-gapped mode requires a pre-cached buf.lock file. Please run 'buf dep update' at build time to cache dependencies."
+                            "Air-gapped mode requires a pre-cached buf.lock file. Please run 'buf dep update' at build time to cache dependencies.",
+                            undefined,
+                            { code: CliError.Code.InternalError }
                         );
                     }
                 } else {
@@ -300,7 +308,9 @@ export class ProtobufOpenAPIGenerator {
 
             const bufGenerateResult = await buf(["generate", target.toString()]);
             if (bufGenerateResult.exitCode !== 0) {
-                this.context.failAndThrow(bufGenerateResult.stderr);
+                this.context.failAndThrow(bufGenerateResult.stderr, undefined, {
+                    code: CliError.Code.IrConversionError
+                });
             }
             if (cleanupBufLock) {
                 await unlink(bufLockPath);
@@ -342,7 +352,9 @@ export class ProtobufOpenAPIGenerator {
                 return;
             } catch {
                 this.context.failAndThrow(
-                    "FERN_USE_LOCAL_PROTOC_GEN_OPENAPI is set but protoc-gen-openapi was not found on PATH."
+                    "FERN_USE_LOCAL_PROTOC_GEN_OPENAPI is set but protoc-gen-openapi was not found on PATH.",
+                    undefined,
+                    { code: CliError.Code.EnvironmentError }
                 );
             }
         }
@@ -377,7 +389,9 @@ export class ProtobufOpenAPIGenerator {
             this.protocGenOpenAPIResolved = true;
         } catch {
             this.context.failAndThrow(
-                "Missing required dependency; please install 'protoc-gen-openapi' to continue (e.g. 'brew install go && go install github.com/fern-api/protoc-gen-openapi/cmd/protoc-gen-openapi@latest')."
+                "Missing required dependency; please install 'protoc-gen-openapi' to continue (e.g. 'brew install go && go install github.com/fern-api/protoc-gen-openapi/cmd/protoc-gen-openapi@latest').",
+                undefined,
+                { code: CliError.Code.EnvironmentError }
             );
         }
     }
@@ -390,7 +404,9 @@ export class ProtobufOpenAPIGenerator {
         try {
             this.resolvedBufCommand = await ensureBufCommand(this.context.logger);
         } catch (error) {
-            this.context.failAndThrow(error instanceof Error ? error.message : String(error));
+            this.context.failAndThrow(error instanceof Error ? error.message : String(error), undefined, {
+                code: CliError.Code.EnvironmentError
+            });
         }
     }
 
@@ -398,7 +414,9 @@ export class ProtobufOpenAPIGenerator {
         absoluteFilepath: AbsoluteFilePath;
         bufLockContents: string | undefined;
     }> {
-        this.context.failAndThrow("Remote Protobuf generation is unimplemented.");
+        this.context.failAndThrow("Remote Protobuf generation is unimplemented.", undefined, {
+            code: CliError.Code.InternalError
+        });
     }
 }
 

--- a/packages/cli/workspace/lazy-fern-workspace/src/protobuf/ProtocGenOpenAPIDownloader.ts
+++ b/packages/cli/workspace/lazy-fern-workspace/src/protobuf/ProtocGenOpenAPIDownloader.ts
@@ -1,5 +1,6 @@
 import { AbsoluteFilePath, join, RelativeFilePath } from "@fern-api/fs-utils";
 import { Logger } from "@fern-api/logger";
+import { CliError } from "@fern-api/task-context";
 import { access, chmod, copyFile, mkdir, readFile, rename, rm, writeFile } from "fs/promises";
 import os from "os";
 import path from "path";
@@ -34,7 +35,7 @@ function getPlatformInfo(): PlatformInfo {
             osName = "windows";
             break;
         default:
-            throw new Error(`Unsupported platform: ${platform}`);
+            throw new CliError({ message: `Unsupported platform: ${platform}`, code: CliError.Code.EnvironmentError });
     }
 
     let archName: string;
@@ -46,7 +47,7 @@ function getPlatformInfo(): PlatformInfo {
             archName = "arm64";
             break;
         default:
-            throw new Error(`Unsupported architecture: ${arch}`);
+            throw new CliError({ message: `Unsupported architecture: ${arch}`, code: CliError.Code.EnvironmentError });
     }
 
     return {
@@ -139,7 +140,10 @@ async function acquireLock(logger: Logger): Promise<() => Promise<void>> {
                 await new Promise((resolve) => setTimeout(resolve, LOCK_RETRY_INTERVAL_MS));
             }
         }
-        throw new Error(`Failed to acquire lock after timeout and retry`);
+        throw new CliError({
+            message: `Failed to acquire lock after timeout and retry`,
+            code: CliError.Code.InternalError
+        });
     }
     return createLockReleaser(lockPath, logger);
 }

--- a/packages/cli/workspace/lazy-fern-workspace/src/protobuf/utils.ts
+++ b/packages/cli/workspace/lazy-fern-workspace/src/protobuf/utils.ts
@@ -2,6 +2,7 @@ import { extractErrorMessage } from "@fern-api/core-utils";
 import { AbsoluteFilePath, join, RelativeFilePath } from "@fern-api/fs-utils";
 import { Logger } from "@fern-api/logger";
 import { createLoggingExecutable, runExeca } from "@fern-api/logging-execa";
+import { CliError } from "@fern-api/task-context";
 import { access, cp, rm } from "fs/promises";
 import tmp from "tmp-promise";
 import { resolveBuf } from "./BufDownloader.js";
@@ -168,7 +169,10 @@ export async function ensureBufCommand(logger: Logger): Promise<string> {
             logger.debug(`Using auto-downloaded buf: ${downloadedBufPath}`);
             return downloadedBufPath;
         }
-        throw new Error("Missing required dependency; please install 'buf' to continue (e.g. 'brew install buf').");
+        throw new CliError({
+            message: "Missing required dependency; please install 'buf' to continue (e.g. 'brew install buf').",
+            code: CliError.Code.EnvironmentError
+        });
     }
 }
 

--- a/packages/cli/workspace/lazy-fern-workspace/src/utils/loadDependency.ts
+++ b/packages/cli/workspace/lazy-fern-workspace/src/utils/loadDependency.ts
@@ -5,7 +5,7 @@ import { assertNever, noop, visitObject } from "@fern-api/core-utils";
 import { RootApiFileSchema, YAML_SCHEMA_VERSION } from "@fern-api/fern-definition-schema";
 import { AbsoluteFilePath, doesPathExist, join, RelativeFilePath } from "@fern-api/fs-utils";
 import { parseVersion } from "@fern-api/semver-utils";
-import { TaskContext } from "@fern-api/task-context";
+import { CliError, TaskContext } from "@fern-api/task-context";
 import { FernFiddle } from "@fern-fern/fiddle-sdk";
 import axios from "axios";
 import { createWriteStream } from "fs";
@@ -134,7 +134,9 @@ async function validateLocalDependencyAndGetDefinition({
     settings?: OSSWorkspace.Settings;
 }): Promise<FernDefinition | undefined> {
     if (loadAPIWorkspace == null) {
-        context.failWithoutThrowing("Failed to load api definition");
+        context.failWithoutThrowing("Failed to load api definition", undefined, {
+            code: CliError.Code.ResolutionError
+        });
         return undefined;
     }
 
@@ -147,7 +149,9 @@ async function validateLocalDependencyAndGetDefinition({
         workspaceName: undefined
     });
     if (!loadDependencyWorkspaceResult.didSucceed) {
-        context.failWithoutThrowing("Failed to load api definition", loadDependencyWorkspaceResult.failures);
+        context.failWithoutThrowing("Failed to load api definition", loadDependencyWorkspaceResult.failures, {
+            code: CliError.Code.ResolutionError
+        });
         return undefined;
     }
 
@@ -193,16 +197,24 @@ async function validateVersionedDependencyAndGetDefinition({
         if (!response.ok) {
             response.error._visit({
                 orgDoesNotExistError: () => {
-                    context.failWithoutThrowing("Organization does not exist");
+                    context.failWithoutThrowing("Organization does not exist", undefined, {
+                        code: CliError.Code.ResolutionError
+                    });
                 },
                 apiDoesNotExistError: () => {
-                    context.failWithoutThrowing("API does not exist");
+                    context.failWithoutThrowing("API does not exist", undefined, {
+                        code: CliError.Code.ResolutionError
+                    });
                 },
                 versionDoesNotExistError: () => {
-                    context.failWithoutThrowing("Version does not exist");
+                    context.failWithoutThrowing("Version does not exist", undefined, {
+                        code: CliError.Code.ResolutionError
+                    });
                 },
                 _other: (error) => {
-                    context.failWithoutThrowing("Failed to download API manifest", error);
+                    context.failWithoutThrowing("Failed to download API manifest", error, {
+                        code: CliError.Code.NetworkError
+                    });
                 }
             });
             return undefined;
@@ -217,12 +229,16 @@ async function validateVersionedDependencyAndGetDefinition({
         if (parsedYamlVersionOfDependency != null) {
             if (parsedYamlVersionOfDependency > YAML_SCHEMA_VERSION) {
                 context.failWithoutThrowing(
-                    `${dependency.organization}/${dependency.apiName}@${dependency.version} on a higher version of fern. Upgrade this workspace to ${response.body.cliVersion}`
+                    `${dependency.organization}/${dependency.apiName}@${dependency.version} on a higher version of fern. Upgrade this workspace to ${response.body.cliVersion}`,
+                    undefined,
+                    { code: CliError.Code.VersionError }
                 );
                 return undefined;
             } else if (parsedYamlVersionOfDependency < YAML_SCHEMA_VERSION) {
                 context.failWithoutThrowing(
-                    `${dependency.organization}/${dependency.apiName}@${dependency.version} on a lower version of fern. Upgrade it to ${cliVersion}`
+                    `${dependency.organization}/${dependency.apiName}@${dependency.version} on a lower version of fern. Upgrade it to ${cliVersion}`,
+                    undefined,
+                    { code: CliError.Code.VersionError }
                 );
                 return undefined;
             }
@@ -233,7 +249,9 @@ async function validateVersionedDependencyAndGetDefinition({
             parsedCliVersion.minor !== parsedCliVersionOfDependency.minor
         ) {
             context.failWithoutThrowing(
-                `CLI version is ${response.body.cliVersion}. Expected ${parsedCliVersion.major}.${parsedCliVersion.minor}.x (to match current workspace).`
+                `CLI version is ${response.body.cliVersion}. Expected ${parsedCliVersion.major}.${parsedCliVersion.minor}.x (to match current workspace).`,
+                undefined,
+                { code: CliError.Code.VersionError }
             );
             return undefined;
         }
@@ -250,7 +268,9 @@ async function validateVersionedDependencyAndGetDefinition({
                 absolutePathToLocalOutput: pathToDefinition
             });
         } catch (error) {
-            context.failWithoutThrowing("Failed to download API", error);
+            context.failWithoutThrowing("Failed to download API", error, {
+                code: CliError.Code.NetworkError
+            });
             return undefined;
         }
 
@@ -262,7 +282,9 @@ async function validateVersionedDependencyAndGetDefinition({
     // parse workspace
     context.logger.info("Parsing...");
     if (loadAPIWorkspace == null) {
-        context.failWithoutThrowing("Failed to load API");
+        context.failWithoutThrowing("Failed to load API", undefined, {
+            code: CliError.Code.ResolutionError
+        });
         return undefined;
     }
     const loadDependencyWorkspaceResult = await loadAPIWorkspace({
@@ -275,14 +297,17 @@ async function validateVersionedDependencyAndGetDefinition({
     if (!loadDependencyWorkspaceResult.didSucceed) {
         context.failWithoutThrowing(
             "Failed to parse dependency after downloading",
-            loadDependencyWorkspaceResult.failures
+            loadDependencyWorkspaceResult.failures,
+            { code: CliError.Code.ParseError }
         );
         return undefined;
     }
 
     const workspaceOfDependency = loadDependencyWorkspaceResult.workspace;
     if (workspaceOfDependency.type === "oss") {
-        context.failWithoutThrowing("Dependency must be a fern workspace.");
+        context.failWithoutThrowing("Dependency must be a fern workspace.", undefined, {
+            code: CliError.Code.ConfigError
+        });
         return undefined;
     }
 

--- a/packages/cli/workspace/lazy-fern-workspace/src/utils/resolveExternalRefs.ts
+++ b/packages/cli/workspace/lazy-fern-workspace/src/utils/resolveExternalRefs.ts
@@ -1,3 +1,4 @@
+import { CliError } from "@fern-api/task-context";
 import { readFile } from "fs/promises";
 import yaml from "js-yaml";
 import { dirname, resolve } from "path";
@@ -325,7 +326,10 @@ export async function resolveExternalRefs(
 
         const cacheKey = `${absoluteRefPath}#${jsonPointer}`;
         if (visited.has(cacheKey)) {
-            throw new Error(`Circular $ref detected: "${ref}" (resolved to "${cacheKey}")`);
+            throw new CliError({
+                message: `Circular $ref detected: "${ref}" (resolved to "${cacheKey}")`,
+                code: CliError.Code.ReferenceError
+            });
         }
         const newVisited = new Set(visited);
         newVisited.add(cacheKey);


### PR DESCRIPTION
## Description

Migrates `@fern-api/lazy-fern-workspace` to use explicit `CliError` error codes on every `failAndThrow` / `failWithoutThrowing` call site.

This is one of the package migration PRs that follow the error classification system introduced in #14749.

## Changes Made

Assigned typed error codes across call sites in `packages/cli/workspace/lazy-fern-workspace/src/`. Also added missing `CliError` imports to all files that reference `CliError.Code`.

### Error codes used

| Code | Usage |
|------|-------|
| `CONFIG_ERROR` | Missing workspace configuration, invalid workspace structure |
| `PARSE_ERROR` | Failed OpenAPI/AsyncAPI parsing, overlay application failures |
| `RESOLUTION_ERROR` | Protobuf resolution failures, dependency loading errors |
| `NETWORK_ERROR` | Failed dependency downloads |

### Files touched (grouped by area)

- **Workspace loading**: `LazyFernWorkspace.ts`, `utils/loadDependency.ts`
- **Loaders**: `loaders/applyOverlays.ts`, `loaders/mergeWithOverrides.ts`
- **Protobuf**: `protobuf/ProtobufIRGenerator.ts`, `protobuf/ProtobufOpenAPIGenerator.ts`

## Testing

- [x] Existing tests pass (`pnpm test`, excluding e2e and pre-existing environment failures)
