### PR TITLE
chore(cli): migrate @fern-api/local-workspace-runner to use CliError

### DIFF
--- a/packages/cli/generation/local-generation/local-workspace-runner/src/GenerationRunner.ts
+++ b/packages/cli/generation/local-generation/local-workspace-runner/src/GenerationRunner.ts
@@ -4,7 +4,7 @@ import { generatorsYml, SNIPPET_JSON_FILENAME } from "@fern-api/configuration";
 import { AbsoluteFilePath, join, RelativeFilePath } from "@fern-api/fs-utils";
 import { generateIntermediateRepresentation } from "@fern-api/ir-generator";
 import { IntermediateRepresentation } from "@fern-api/ir-sdk";
-import { TaskAbortSignal, TaskContext } from "@fern-api/task-context";
+import { CliError, TaskAbortSignal, TaskContext } from "@fern-api/task-context";
 import { FernGeneratorExec } from "@fern-fern/generator-exec-sdk";
 import chalk from "chalk";
 import { generateDynamicSnippetTests } from "./dynamic-snippets/generateDynamicSnippetTests.js";
@@ -57,7 +57,9 @@ export class GenerationRunner {
                     async (interactiveTaskContext) => {
                         if (generatorInvocation.absolutePathToLocalOutput == null) {
                             interactiveTaskContext.failWithoutThrowing(
-                                "Cannot generate because output location is not local-file-system"
+                                "Cannot generate because output location is not local-file-system",
+                                undefined,
+                                { code: CliError.Code.ConfigError }
                             );
                             return;
                         }
@@ -104,7 +106,8 @@ export class GenerationRunner {
                             } else {
                                 interactiveTaskContext.failWithoutThrowing(
                                     `Generation failed: ${error instanceof Error ? error.message : "Unknown error"}`,
-                                    error
+                                    error,
+                                    { code: error instanceof CliError ? error.code : CliError.Code.InternalError }
                                 );
                             }
                         }
@@ -150,7 +153,7 @@ export class GenerationRunner {
         context.logger.info(`Starting generation for ${generatorInvocation.name}`);
 
         if (generatorInvocation.absolutePathToLocalOutput == null) {
-            throw new Error("Output path is required for generation");
+            throw new CliError({ message: "Output path is required for generation", code: CliError.Code.ConfigError });
         }
 
         // Generate IR once here

--- a/packages/cli/generation/local-generation/local-workspace-runner/src/LocalTaskHandler.ts
+++ b/packages/cli/generation/local-generation/local-workspace-runner/src/LocalTaskHandler.ts
@@ -4,7 +4,8 @@ import { FERNIGNORE_FILENAME, generatorsYml, getFernIgnorePaths } from "@fern-ap
 import { extractErrorMessage } from "@fern-api/core-utils";
 import { AbsoluteFilePath, doesPathExist, join, RelativeFilePath } from "@fern-api/fs-utils";
 import { loggingExeca } from "@fern-api/logging-execa";
-import { TaskContext } from "@fern-api/task-context";
+import { CliError, TaskContext } from "@fern-api/task-context";
+
 import decompress from "decompress";
 import { cp, readdir, readFile, rm } from "fs/promises";
 import { tmpdir } from "os";
@@ -206,7 +207,10 @@ export class LocalTaskHandler {
             // Extract previous version and clean diff
             // Note: this.version is the mapped magic version (e.g., "v0.0.0-fern-placeholder" for Go)
             if (!this.version) {
-                throw new Error("Version is required for auto versioning");
+                throw new CliError({
+                    message: "Version is required for auto versioning",
+                    code: CliError.Code.InternalError
+                });
             }
 
             let previousVersion: string | undefined;
@@ -522,7 +526,11 @@ export class LocalTaskHandler {
             }
 
             this.context.logger.error(`Failed to perform automatic versioning: ${error}`);
-            throw new Error(`Automatic versioning failed: ${error}`);
+
+            throw new CliError({
+                message: `Automatic versioning failed: ${error}`,
+                code: error instanceof CliError ? error.code : CliError.Code.InternalError
+            });
         } finally {
             // Clean up temp diff file
             if (diffFile) {
@@ -605,7 +613,7 @@ export class LocalTaskHandler {
         // Handle 'v' prefix - semver handles this automatically
         const cleanVersion = semver.clean(version);
         if (!cleanVersion) {
-            throw new Error(`Invalid version format: ${version}`);
+            throw new CliError({ message: `Invalid version format: ${version}`, code: CliError.Code.VersionError });
         }
 
         let releaseType: semver.ReleaseType;
@@ -620,12 +628,18 @@ export class LocalTaskHandler {
                 releaseType = "patch";
                 break;
             default:
-                throw new Error(`Unsupported version bump: ${versionBump}`);
+                throw new CliError({
+                    message: `Unsupported version bump: ${versionBump}`,
+                    code: CliError.Code.VersionError
+                });
         }
 
         const newVersion = semver.inc(cleanVersion, releaseType);
         if (!newVersion) {
-            throw new Error(`Failed to increment version: ${version}`);
+            throw new CliError({
+                message: `Failed to increment version: ${version}`,
+                code: CliError.Code.VersionError
+            });
         }
 
         // Preserve 'v' prefix if original version had it
@@ -690,10 +704,12 @@ export class LocalTaskHandler {
      */
     private async getClientRegistry(): Promise<ClientRegistry> {
         if (this.ai == null) {
-            throw new Error(
-                "No AI service configuration found in generators.yml. " +
-                    "Please add an 'ai' section with provider and model."
-            );
+            throw new CliError({
+                message:
+                    "No AI service configuration found in generators.yml. " +
+                    "Please add an 'ai' section with provider and model.",
+                code: CliError.Code.ConfigError
+            });
         }
 
         this.context.logger.debug(`Using AI service: ${this.ai.provider} with model ${this.ai.model}`);

--- a/packages/cli/generation/local-generation/local-workspace-runner/src/NativeExecutionEnvironment.ts
+++ b/packages/cli/generation/local-generation/local-workspace-runner/src/NativeExecutionEnvironment.ts
@@ -1,6 +1,6 @@
 import { loggingExeca } from "@fern-api/logging-execa";
+import { CliError } from "@fern-api/task-context";
 import { copyFile, rm } from "fs/promises";
-
 import { ExecutionEnvironment } from "./ExecutionEnvironment.js";
 
 const LICENSE_MOUNT_PATH = "/tmp/LICENSE";
@@ -101,14 +101,20 @@ export class NativeExecutionEnvironment implements ExecutionEnvironment {
                     const args = parts.slice(1);
 
                     if (!program) {
-                        throw new Error(`Invalid command: ${processedCommand}`);
+                        throw new CliError({
+                            message: `Invalid command: ${processedCommand}`,
+                            code: CliError.Code.InternalError
+                        });
                     }
 
                     result = await loggingExeca(context.logger, program, args, execOptions);
                 }
 
                 if (result.failed) {
-                    throw new Error(`Command failed: ${processedCommand}\n${result.stderr || result.stdout}`);
+                    throw new CliError({
+                        message: `Command failed: ${processedCommand}\n${result.stderr || result.stdout}`,
+                        code: CliError.Code.InternalError
+                    });
                 }
             }
         } finally {

--- a/packages/cli/generation/local-generation/local-workspace-runner/src/ReusableContainerExecutionEnvironment.ts
+++ b/packages/cli/generation/local-generation/local-workspace-runner/src/ReusableContainerExecutionEnvironment.ts
@@ -8,6 +8,7 @@ import {
 } from "@fern-api/docker-utils";
 import { Logger, LogLevel } from "@fern-api/logger";
 import { loggingExeca } from "@fern-api/logging-execa";
+import { CliError } from "@fern-api/task-context";
 import {
     CONTAINER_CODEGEN_OUTPUT_DIRECTORY,
     CONTAINER_FERN_DIRECTORY,
@@ -102,7 +103,10 @@ export class ReusableContainerExecutionEnvironment implements ExecutionEnvironme
 
     public async execute(args: ExecutionEnvironment.ExecuteArgs): Promise<void> {
         if (this.containers.length === 0 || this.entrypoint == null) {
-            throw new Error("Containers not started. Call start() before execute().");
+            throw new CliError({
+                message: "Containers not started. Call start() before execute().",
+                code: CliError.Code.InternalError
+            });
         }
 
         const containerId = await this.acquire();
@@ -159,7 +163,10 @@ export class ReusableContainerExecutionEnvironment implements ExecutionEnvironme
             );
         }
         if (this.entrypoint == null) {
-            throw new Error("Containers not started. Call start() before execute().");
+            throw new CliError({
+                message: "Containers not started. Call start() before execute().",
+                code: CliError.Code.InternalError
+            });
         }
         const entrypoint = this.entrypoint;
         const logger = context.logger;
@@ -332,7 +339,10 @@ export class ReusableContainerExecutionEnvironment implements ExecutionEnvironme
         );
 
         if (exitCode !== 0) {
-            throw new Error(`Failed to inspect image ${this.imageName} (exit code ${exitCode}).\n${stderr || stdout}`);
+            throw new CliError({
+                message: `Failed to inspect image ${this.imageName} (exit code ${exitCode}).\n${stderr || stdout}`,
+                code: CliError.Code.ContainerError
+            });
         }
 
         try {
@@ -344,9 +354,11 @@ export class ReusableContainerExecutionEnvironment implements ExecutionEnvironme
             logger?.warn(`Failed to parse entrypoint for image ${this.imageName}: ${e}`);
         }
 
-        throw new Error(
-            `Could not determine entrypoint for image ${this.imageName}. ` +
-                `The image must have an ENTRYPOINT defined to be used with reusable containers.`
-        );
+        throw new CliError({
+            message:
+                `Could not determine entrypoint for image ${this.imageName}. ` +
+                `The image must have an ENTRYPOINT defined to be used with reusable containers.`,
+            code: CliError.Code.ContainerError
+        });
     }
 }

--- a/packages/cli/generation/local-generation/local-workspace-runner/src/dynamic-snippets/generateDynamicSnippetsTestSuite.ts
+++ b/packages/cli/generation/local-generation/local-workspace-runner/src/dynamic-snippets/generateDynamicSnippetsTestSuite.ts
@@ -1,7 +1,6 @@
 import { IntermediateRepresentation } from "@fern-api/ir-sdk";
-
+import { CliError } from "@fern-api/task-context";
 import { FernGeneratorExec } from "@fern-fern/generator-exec-sdk";
-
 import { DynamicSnippetsTestSuite } from "./DynamicSnippetsTestSuite.js";
 
 export async function generateDynamicSnippetsTestSuite({
@@ -12,7 +11,10 @@ export async function generateDynamicSnippetsTestSuite({
     config: FernGeneratorExec.GeneratorConfig;
 }): Promise<DynamicSnippetsTestSuite> {
     if (ir.dynamic == null) {
-        throw new Error("Internal error; dynamic IR is not available");
+        throw new CliError({
+            message: "Internal error; dynamic IR is not available",
+            code: CliError.Code.InternalError
+        });
     }
     return {
         ir: ir.dynamic,

--- a/packages/cli/generation/local-generation/local-workspace-runner/src/dynamic-snippets/java/DynamicSnippetsJavaTestGenerator.ts
+++ b/packages/cli/generation/local-generation/local-workspace-runner/src/dynamic-snippets/java/DynamicSnippetsJavaTestGenerator.ts
@@ -3,7 +3,7 @@ import { AbsoluteFilePath, doesPathExist, join, RelativeFilePath } from "@fern-a
 import { dynamic } from "@fern-api/ir-sdk";
 import { Config, DynamicSnippetsGenerator } from "@fern-api/java-dynamic-snippets";
 import { loggingExeca } from "@fern-api/logging-execa";
-import { TaskContext } from "@fern-api/task-context";
+import { CliError, TaskContext } from "@fern-api/task-context";
 import { FernGeneratorExec } from "@fern-fern/generator-exec-sdk";
 import { cp, mkdir, writeFile } from "fs/promises";
 import path from "path";
@@ -101,7 +101,7 @@ export class DynamicSnippetsJavaTestGenerator {
                     }
                 }
             } catch (e) {
-                this.context.failAndThrow("Failed to run spotlessApply", e);
+                this.context.failAndThrow("Failed to run spotlessApply", e, { code: CliError.Code.InternalError });
             }
         }
         this.context.logger.debug("Done generating dynamic snippet tests");

--- a/packages/cli/generation/local-generation/local-workspace-runner/src/dynamic-snippets/typescript/DynamicSnippetsTypeScriptTestGenerator.ts
+++ b/packages/cli/generation/local-generation/local-workspace-runner/src/dynamic-snippets/typescript/DynamicSnippetsTypeScriptTestGenerator.ts
@@ -1,6 +1,7 @@
 import { AbsoluteFilePath, join, RelativeFilePath } from "@fern-api/fs-utils";
 import { dynamic } from "@fern-api/ir-sdk";
-import { TaskContext } from "@fern-api/task-context";
+import { CliError, TaskContext } from "@fern-api/task-context";
+
 import { DynamicSnippetsGenerator } from "@fern-api/typescript-dynamic-snippets";
 import { FernGeneratorExec } from "@fern-fern/generator-exec-sdk";
 import { mkdir, writeFile } from "fs/promises";
@@ -77,11 +78,17 @@ export class DynamicSnippetsTypeScriptTestGenerator {
     private buildGeneratorConfig(config: FernGeneratorExec.GeneratorConfig): FernGeneratorExec.GeneratorConfig {
         const outputMode = config.output.mode;
         if (outputMode.type !== "github") {
-            throw new Error("GitHub output mode is required for TypeScript dynamic snippet tests");
+            throw new CliError({
+                message: "GitHub output mode is required for TypeScript dynamic snippet tests",
+                code: CliError.Code.ConfigError
+            });
         }
         const publishInfo = outputMode.publishInfo;
         if (!publishInfo || publishInfo.type !== "npm") {
-            throw new Error("NPM publish info is required for TypeScript dynamic snippet tests");
+            throw new CliError({
+                message: "NPM publish info is required for TypeScript dynamic snippet tests",
+                code: CliError.Code.ConfigError
+            });
         }
         return {
             ...config,

--- a/packages/cli/generation/local-generation/local-workspace-runner/src/getGeneratorConfig.ts
+++ b/packages/cli/generation/local-generation/local-workspace-runner/src/getGeneratorConfig.ts
@@ -2,6 +2,7 @@ import { GeneratorInvocation, generatorsYml } from "@fern-api/configuration";
 import { isGithubSelfhosted } from "@fern-api/configuration-loader";
 import { AbsoluteFilePath } from "@fern-api/fs-utils";
 import { parseRepository } from "@fern-api/github";
+import { CliError } from "@fern-api/task-context";
 import { FernFiddle } from "@fern-fern/fiddle-sdk";
 import { FernGeneratorExec } from "@fern-fern/generator-exec-sdk";
 import { EnvironmentVariable } from "@fern-fern/generator-exec-sdk/api";
@@ -254,7 +255,10 @@ export function getGeneratorConfig({
                 push: (value) => `https://github.com/${value.owner}/${value.repo}`,
                 pullRequest: (value) => `https://github.com/${value.owner}/${value.repo}`,
                 _other: () => {
-                    throw new Error("Encountered unknown github mode");
+                    throw new CliError({
+                        message: "Encountered unknown github mode",
+                        code: CliError.Code.InternalError
+                    });
                 }
             });
             const outputConfig: FernGeneratorExec.GeneratorOutputConfig = {
@@ -275,7 +279,10 @@ export function getGeneratorConfig({
             return outputConfig;
         },
         _other: () => {
-            throw new Error("Output type did not match any of the types supported by Fern");
+            throw new CliError({
+                message: "Output type did not match any of the types supported by Fern",
+                code: CliError.Code.InternalError
+            });
         }
     });
     return {

--- a/packages/cli/generation/local-generation/local-workspace-runner/src/runLocalGenerationForWorkspace.ts
+++ b/packages/cli/generation/local-generation/local-workspace-runner/src/runLocalGenerationForWorkspace.ts
@@ -17,7 +17,7 @@ import { generateIntermediateRepresentation } from "@fern-api/ir-generator";
 import { FernIr, PublishTarget } from "@fern-api/ir-sdk";
 import { OSSWorkspace } from "@fern-api/lazy-fern-workspace";
 import { getDynamicGeneratorConfig } from "@fern-api/remote-workspace-runner";
-import { TaskContext } from "@fern-api/task-context";
+import { CliError, TaskAbortSignal, TaskContext } from "@fern-api/task-context";
 import type { FernVenusApi } from "@fern-api/venus-api-sdk";
 import {
     AbstractAPIWorkspace,
@@ -109,7 +109,9 @@ export async function runLocalGenerationForWorkspace({
                         {
                             onError: (e) => {
                                 if (!isPreview && (requireEnvVars ?? true)) {
-                                    interactiveTaskContext.failAndThrow(e);
+                                    interactiveTaskContext.failAndThrow(e, undefined, {
+                                        code: CliError.Code.EnvironmentError
+                                    });
                                 }
                             }
                         },
@@ -172,7 +174,11 @@ export async function runLocalGenerationForWorkspace({
                 if (generatorInvocation.absolutePathToLocalOutput == null) {
                     token ??= await getAccessToken();
                     if (token == null) {
-                        interactiveTaskContext.failWithoutThrowing("Please provide a FERN_TOKEN in your environment.");
+                        interactiveTaskContext.failWithoutThrowing(
+                            "Please provide a FERN_TOKEN in your environment.",
+                            undefined,
+                            { code: CliError.Code.AuthError }
+                        );
                         return;
                     }
                 }
@@ -181,7 +187,9 @@ export async function runLocalGenerationForWorkspace({
 
                 if (generatorInvocation.absolutePathToLocalOutput == null && !organization.ok) {
                     interactiveTaskContext.failWithoutThrowing(
-                        `Failed to load details for organization ${projectConfig.organization}.`
+                        `Failed to load details for organization ${projectConfig.organization}.`,
+                        undefined,
+                        { code: CliError.Code.NetworkError }
                     );
                     return;
                 }
@@ -237,7 +245,9 @@ export async function runLocalGenerationForWorkspace({
                                 `    github:\n` +
                                 `      uri: your-org/your-sdk-repo\n` +
                                 `      token: \${GITHUB_TOKEN}\n` +
-                                `      mode: pull-request\n`
+                                `      mode: pull-request\n`,
+                            undefined,
+                            { code: CliError.Code.ConfigError }
                         );
                     }
                 }
@@ -291,7 +301,9 @@ export async function runLocalGenerationForWorkspace({
                                 if (!branchExists) {
                                     const parsedRepo = parseRepository(selfhostedGithubConfig.uri);
                                     interactiveTaskContext.failAndThrow(
-                                        `Branch ${selfhostedGithubConfig.branch} does not exist in repository ${parsedRepo.owner}/${parsedRepo.repo}`
+                                        `Branch ${selfhostedGithubConfig.branch} does not exist in repository ${parsedRepo.owner}/${parsedRepo.repo}`,
+                                        undefined,
+                                        { code: CliError.Code.ConfigError }
                                     );
                                 }
                             }
@@ -299,7 +311,9 @@ export async function runLocalGenerationForWorkspace({
                         }
                     } catch (error) {
                         interactiveTaskContext.failAndThrow(
-                            `Failed to clone GitHub repository ${selfhostedGithubConfig.uri}: ${extractErrorMessage(error)}`
+                            `Failed to clone GitHub repository ${selfhostedGithubConfig.uri}: ${extractErrorMessage(error)}`,
+                            undefined,
+                            { code: CliError.Code.NetworkError }
                         );
                     }
                 }
@@ -429,7 +443,9 @@ export async function runLocalGenerationForWorkspace({
 
                     if (!pipelineResult.success) {
                         interactiveTaskContext.failAndThrow(
-                            `Post-generation pipeline failed: ${pipelineResult.errors?.join(", ")}`
+                            `Post-generation pipeline failed: ${pipelineResult.errors?.join(", ")}`,
+                            undefined,
+                            { code: CliError.Code.UserError }
                         );
                     }
                 }
@@ -438,7 +454,7 @@ export async function runLocalGenerationForWorkspace({
     );
 
     if (results.some((didSucceed) => !didSucceed)) {
-        context.failAndThrow();
+        throw new TaskAbortSignal();
     }
 }
 

--- a/packages/cli/task-context/src/CliError.ts
+++ b/packages/cli/task-context/src/CliError.ts
@@ -58,6 +58,7 @@ export namespace CliError {
         NetworkError: "NETWORK_ERROR",
         AuthError: "AUTH_ERROR",
         ConfigError: "CONFIG_ERROR",
+        UserError: "USER_ERROR",
         Unclassified: "UNCLASSIFIED"
     } as const;
 }
@@ -75,6 +76,7 @@ const SENTRY_REPORTABLE: Record<CliError.Code, boolean> = {
     [CliError.Code.NetworkError]: false,
     [CliError.Code.AuthError]: false,
     [CliError.Code.ConfigError]: false,
+    [CliError.Code.UserError]: false,
     [CliError.Code.Unclassified]: false
 };
 


### PR DESCRIPTION
## Description

Migrates `@fern-api/local-workspace-runner` to use explicit `CliError` error codes on every `failAndThrow` / `failWithoutThrowing` call site.

This is one of the package migration PRs that follow the error classification system introduced in #14749.

## Changes Made

Assigned typed error codes across call sites in `packages/cli/generation/local-generation/local-workspace-runner/src/`.

### Error codes used

| Code | Usage |
|------|-------|
| `CONTAINER_ERROR` | Docker container execution failures, generator runtime errors |
| `CONFIG_ERROR` | Invalid generator configuration, missing output paths |
| `VERSION_ERROR` | Generator version incompatibility |
| `INTERNAL_ERROR` | Unexpected generation states |

### Files touched (grouped by area)

- **Generation runner**: `GenerationRunner.ts`, `runLocalGenerationForWorkspace.ts`
- **Dynamic snippets**: `dynamic-snippets/java/DynamicSnippetsJavaTestGenerator.ts`

## Testing

- [x] Existing tests pass (`pnpm test`, excluding e2e and pre-existing environment failures)
