### PR TITLE
chore(cli): migrate @fern-api/openapi-ir-parser to use CliError

### DIFF
--- a/packages/cli/api-importers/openapi/openapi-ir-parser/src/asyncapi/AbstractAsyncAPIParserContext.ts
+++ b/packages/cli/api-importers/openapi/openapi-ir-parser/src/asyncapi/AbstractAsyncAPIParserContext.ts
@@ -1,6 +1,7 @@
 import type { Logger } from "@fern-api/logger";
 import type { Namespace, SchemaId, SdkGroup, SdkGroupName } from "@fern-api/openapi-ir";
-import type { TaskContext } from "@fern-api/task-context";
+import { CliError, type TaskContext } from "@fern-api/task-context";
+
 import type { OpenAPIV3 } from "openapi-types";
 
 import type { ParseOpenAPIOptions } from "../options.js";
@@ -76,7 +77,10 @@ export abstract class AbstractAsyncAPIParserContext<TDocument extends object> im
      */
     public resolveSchemaReference(schema: OpenAPIV3.ReferenceObject): OpenAPIV3.SchemaObject {
         if (!schema.$ref.startsWith(SCHEMA_REFERENCE_PREFIX)) {
-            throw new Error(`Failed to resolve schema reference: ${schema.$ref}`);
+            throw new CliError({
+                message: `Failed to resolve schema reference: ${schema.$ref}`,
+                code: CliError.Code.ReferenceError
+            });
         }
 
         const schemaKey = schema.$ref.substring(SCHEMA_REFERENCE_PREFIX.length);
@@ -84,18 +88,27 @@ export abstract class AbstractAsyncAPIParserContext<TDocument extends object> im
 
         const components = (this.document as AsyncAPIV2.DocumentV2 | AsyncAPIV3.DocumentV3).components;
         if (components == null || components.schemas == null) {
-            throw new Error("Document does not have components.schemas.");
+            throw new CliError({
+                message: "Document does not have components.schemas.",
+                code: CliError.Code.ReferenceError
+            });
         }
 
         const [topKey, maybeProps, maybePropKey] = splitSchemaKey;
 
         if (topKey == null || topKey === "") {
-            throw new Error(`${schema.$ref} cannot be resolved. No schema key provided.`);
+            throw new CliError({
+                message: `${schema.$ref} cannot be resolved. No schema key provided.`,
+                code: CliError.Code.ReferenceError
+            });
         }
 
         let resolvedSchema = components.schemas[topKey];
         if (resolvedSchema == null) {
-            throw new Error(`Schema "${topKey}" is undefined in document.components.schemas.`);
+            throw new CliError({
+                message: `Schema "${topKey}" is undefined in document.components.schemas.`,
+                code: CliError.Code.ReferenceError
+            });
         }
 
         if (isReferenceObject(resolvedSchema)) {
@@ -105,7 +118,10 @@ export abstract class AbstractAsyncAPIParserContext<TDocument extends object> im
         if (maybeProps === "properties" && maybePropKey != null) {
             const resolvedProperty = resolvedSchema.properties?.[maybePropKey];
             if (resolvedProperty == null) {
-                throw new Error(`Property "${maybePropKey}" not found on "${topKey}". Full ref: ${schema.$ref}`);
+                throw new CliError({
+                    message: `Property "${maybePropKey}" not found on "${topKey}". Full ref: ${schema.$ref}`,
+                    code: CliError.Code.ReferenceError
+                });
             } else if (isReferenceObject(resolvedProperty)) {
                 resolvedSchema = this.resolveSchemaReference(resolvedProperty);
             } else {

--- a/packages/cli/api-importers/openapi/openapi-ir-parser/src/asyncapi/ExampleWebsocketSessionFactory.ts
+++ b/packages/cli/api-importers/openapi/openapi-ir-parser/src/asyncapi/ExampleWebsocketSessionFactory.ts
@@ -7,7 +7,7 @@ import {
     WebsocketMessageExample,
     WebsocketSessionExample
 } from "@fern-api/openapi-ir";
-
+import { CliError } from "@fern-api/task-context";
 import { isExamplePrimitive } from "../openapi/v3/converters/ExampleEndpointFactory.js";
 import { convertSchema } from "../schema/convertSchemas.js";
 import { ExampleTypeFactory } from "../schema/examples/ExampleTypeFactory.js";
@@ -245,7 +245,10 @@ export class ExampleWebsocketSessionFactory {
         while (schema.type === "reference") {
             const resolvedSchema = this.schemas[schema.schema];
             if (resolvedSchema == null) {
-                throw new Error(`Unexpected error: Failed to resolve schema reference: ${schema.schema}`);
+                throw new CliError({
+                    message: `Unexpected error: Failed to resolve schema reference: ${schema.schema}`,
+                    code: CliError.Code.InternalError
+                });
             }
             schema = resolvedSchema;
         }

--- a/packages/cli/api-importers/openapi/openapi-ir-parser/src/asyncapi/v2/AsyncAPIV2ParserContext.ts
+++ b/packages/cli/api-importers/openapi/openapi-ir-parser/src/asyncapi/v2/AsyncAPIV2ParserContext.ts
@@ -1,5 +1,5 @@
+import { CliError } from "@fern-api/task-context";
 import { OpenAPIV3 } from "openapi-types";
-
 import { AbstractAsyncAPIParserContext } from "../AbstractAsyncAPIParserContext.js";
 import { WebsocketSessionExampleMessage } from "../getFernExamples.js";
 import { AsyncAPIV2 } from "../v2/index.js";
@@ -14,13 +14,16 @@ export class AsyncAPIV2ParserContext extends AbstractAsyncAPIParserContext<Async
         const components = this.document.components;
 
         if (components == null || components.messages == null || !message.$ref.startsWith(MESSAGE_REFERENCE_PREFIX)) {
-            throw new Error(`Failed to resolve message reference: ${message.$ref} in v2 components`);
+            throw new CliError({
+                message: `Failed to resolve message reference: ${message.$ref} in v2 components`,
+                code: CliError.Code.ReferenceError
+            });
         }
 
         const messageKey = message.$ref.substring(MESSAGE_REFERENCE_PREFIX.length);
         const resolvedMessage = components.messages[messageKey];
         if (resolvedMessage == null) {
-            throw new Error(`${message.$ref} is undefined`);
+            throw new CliError({ message: `${message.$ref} is undefined`, code: CliError.Code.ReferenceError });
         }
         return resolvedMessage as AsyncAPIV2.MessageV2;
     }

--- a/packages/cli/api-importers/openapi/openapi-ir-parser/src/asyncapi/v3/AsyncAPIV3ParserContext.ts
+++ b/packages/cli/api-importers/openapi/openapi-ir-parser/src/asyncapi/v3/AsyncAPIV3ParserContext.ts
@@ -1,5 +1,5 @@
+import { CliError } from "@fern-api/task-context";
 import { OpenAPIV3 } from "openapi-types";
-
 import { AbstractAsyncAPIParserContext } from "../AbstractAsyncAPIParserContext.js";
 import { WebsocketSessionExampleMessage } from "../getFernExamples.js";
 import { AsyncAPIV3 } from "../v3/index.js";
@@ -8,9 +8,10 @@ export class AsyncAPIV3ParserContext extends AbstractAsyncAPIParserContext<Async
     public getExampleMessageReference(message: WebsocketSessionExampleMessage): string {
         const channelId = message.channelId ?? this.getDefaultChannelId();
         if (channelId == null) {
-            throw new Error(
-                `Cannot resolve example message reference: no channelId provided and no channels found in document`
-            );
+            throw new CliError({
+                message: `Cannot resolve example message reference: no channelId provided and no channels found in document`,
+                code: CliError.Code.InternalError
+            });
         }
         return `#/channels/${channelId}/messages/${message.messageId}`;
     }
@@ -32,12 +33,12 @@ export class AsyncAPIV3ParserContext extends AbstractAsyncAPIParserContext<Async
             this.document.components.parameters == null ||
             !parameter.$ref.startsWith(PARAMETER_REFERENCE_PREFIX)
         ) {
-            throw new Error(`Failed to resolve ${parameter.$ref}`);
+            throw new CliError({ message: `Failed to resolve ${parameter.$ref}`, code: CliError.Code.ReferenceError });
         }
         const parameterKey = parameter.$ref.substring(PARAMETER_REFERENCE_PREFIX.length);
         const resolvedParameter = this.document.components.parameters[parameterKey];
         if (resolvedParameter == null) {
-            throw new Error(`${parameter.$ref} is undefined`);
+            throw new CliError({ message: `${parameter.$ref} is undefined`, code: CliError.Code.ReferenceError });
         }
         if ("$ref" in resolvedParameter) {
             return this.resolveParameterReference(resolvedParameter as OpenAPIV3.ReferenceObject);
@@ -54,11 +55,17 @@ export class AsyncAPIV3ParserContext extends AbstractAsyncAPIParserContext<Async
         const MESSAGE_REFERENCE_PREFIX = "#/components/messages/";
 
         if (message == null) {
-            throw new Error("Cannot resolve message reference: message is null or undefined");
+            throw new CliError({
+                message: "Cannot resolve message reference: message is null or undefined",
+                code: CliError.Code.InternalError
+            });
         }
 
         if (!message.$ref) {
-            throw new Error("Cannot resolve message reference: message.$ref is undefined or empty");
+            throw new CliError({
+                message: "Cannot resolve message reference: message.$ref is undefined or empty",
+                code: CliError.Code.ReferenceError
+            });
         }
 
         if (message.$ref.startsWith(CHANNELS_PATH_PART)) {
@@ -68,13 +75,16 @@ export class AsyncAPIV3ParserContext extends AbstractAsyncAPIParserContext<Async
             const channelPath = rawChannelPath?.replace(/~1/g, "/").replace(/~0/g, "~");
 
             if (channelPath == null || messageKey == null || !this.document.channels?.[channelPath]) {
-                throw new Error(`Failed to resolve message reference ${message.$ref} in channel ${channelPath}`);
+                throw new CliError({
+                    message: `Failed to resolve message reference ${message.$ref} in channel ${channelPath}`,
+                    code: CliError.Code.ReferenceError
+                });
             }
 
             const channel = this.document.channels[channelPath] as AsyncAPIV3.ChannelV3;
             const resolvedInChannel = (channel as AsyncAPIV3.ChannelV3).messages?.[messageKey];
             if (resolvedInChannel == null) {
-                throw new Error(`${message.$ref} is undefined`);
+                throw new CliError({ message: `${message.$ref} is undefined`, code: CliError.Code.ReferenceError });
             }
             if ("$ref" in resolvedInChannel && !shallow) {
                 return this.resolveMessageReference(resolvedInChannel as OpenAPIV3.ReferenceObject);
@@ -88,13 +98,16 @@ export class AsyncAPIV3ParserContext extends AbstractAsyncAPIParserContext<Async
 
         const components = this.document.components;
         if (!message.$ref.startsWith(MESSAGE_REFERENCE_PREFIX) || !components?.messages) {
-            throw new Error(`Failed to resolve message reference: ${message.$ref} in v3 components`);
+            throw new CliError({
+                message: `Failed to resolve message reference: ${message.$ref} in v3 components`,
+                code: CliError.Code.ReferenceError
+            });
         }
 
         const messageKey = message.$ref.substring(MESSAGE_REFERENCE_PREFIX.length);
         const resolvedInComponents = components.messages[messageKey];
         if (resolvedInComponents == null) {
-            throw new Error(`${message.$ref} is undefined`);
+            throw new CliError({ message: `${message.$ref} is undefined`, code: CliError.Code.ReferenceError });
         }
 
         return {

--- a/packages/cli/api-importers/openapi/openapi-ir-parser/src/asyncapi/v3/parseAsyncAPIV3.ts
+++ b/packages/cli/api-importers/openapi/openapi-ir-parser/src/asyncapi/v3/parseAsyncAPIV3.ts
@@ -11,6 +11,7 @@ import {
     WebsocketMessageSchema,
     WebsocketSessionExample
 } from "@fern-api/openapi-ir";
+import { CliError } from "@fern-api/task-context";
 import { camelCase, upperFirst } from "lodash-es";
 import { OpenAPIV3 } from "openapi-types";
 import { getExtension } from "../../getExtension.js";
@@ -227,9 +228,10 @@ export function parseAsyncAPIV3({
 
         const channelEvent = channelEvents[channelPath];
         if (channelEvent == null) {
-            throw new Error(
-                `Internal error: channelEvents["${channelPath}"] is unexpectedly undefined for operation ${operationId}`
-            );
+            throw new CliError({
+                message: `Internal error: channelEvents["${channelPath}"] is unexpectedly undefined for operation ${operationId}`,
+                code: CliError.Code.InternalError
+            });
         }
 
         if (operation.action === "receive") {
@@ -237,7 +239,10 @@ export function parseAsyncAPIV3({
         } else if (operation.action === "send") {
             channelEvent.publish.push(...messagesWithMethodName);
         } else {
-            throw new Error(`Operation ${operationId} has an invalid action: ${operation.action}`);
+            throw new CliError({
+                message: `Operation ${operationId} has an invalid action: ${operation.action}`,
+                code: CliError.Code.ValidationError
+            });
         }
     }
 
@@ -639,13 +644,22 @@ function decodeJsonPointerSegment(segment: string): string {
 
 function getChannelPathFromOperation(operation: AsyncAPIV3.Operation): string {
     if (!operation.channel) {
-        throw new Error("Operation is missing required 'channel' field");
+        throw new CliError({
+            message: "Operation is missing required 'channel' field",
+            code: CliError.Code.ValidationError
+        });
     }
     if (!operation.channel.$ref) {
-        throw new Error("Operation channel is missing required '$ref' field");
+        throw new CliError({
+            message: "Operation channel is missing required '$ref' field",
+            code: CliError.Code.ValidationError
+        });
     }
     if (!operation.channel.$ref.startsWith(CHANNEL_REFERENCE_PREFIX)) {
-        throw new Error(`Failed to resolve channel path from operation ${operation.channel.$ref}`);
+        throw new CliError({
+            message: `Failed to resolve channel path from operation ${operation.channel.$ref}`,
+            code: CliError.Code.ReferenceError
+        });
     }
     return decodeJsonPointerSegment(operation.channel.$ref.substring(CHANNEL_REFERENCE_PREFIX.length));
 }
@@ -654,25 +668,31 @@ function convertChannelParameterLocation(location: string): {
     type: "header" | "path" | "payload";
     parameterKey: string;
 } {
-    try {
-        const [messageType, parameterKey] = location.split("#/");
-        if (messageType == null || parameterKey == null) {
-            throw new Error(`Invalid location format: ${location}; unable to parse message type and parameter key`);
-        }
-        if (!messageType.startsWith(LOCATION_PREFIX)) {
-            throw new Error(`Invalid location format: ${location}; expected ${LOCATION_PREFIX} prefix`);
-        }
-        const type = messageType.substring(LOCATION_PREFIX.length);
-        if (type !== "header" && type !== "path" && type !== "payload") {
-            throw new Error(`Invalid message type: ${type}. Must be one of: header, path, payload`);
-        }
-        return { type, parameterKey };
-    } catch (error) {
-        throw new Error(
-            `Invalid location format: ${location}; see here for more details: ` +
-                "https://www.asyncapi.com/docs/reference/specification/v3.0.0#runtimeExpression"
-        );
+    const ASYNCAPI_RUNTIME_EXPRESSION_DOCS =
+        "https://www.asyncapi.com/docs/reference/specification/v3.0.0#runtimeExpression";
+    const [messageType, parameterKey] = location.split("#/");
+    if (messageType == null || parameterKey == null) {
+        throw new CliError({
+            message:
+                `Invalid location format: ${location}; unable to parse message type and parameter key. ` +
+                `See ${ASYNCAPI_RUNTIME_EXPRESSION_DOCS} for the expected format.`,
+            code: CliError.Code.ValidationError
+        });
     }
+    if (!messageType.startsWith(LOCATION_PREFIX)) {
+        throw new CliError({
+            message: `Invalid location format: ${location}; expected ${LOCATION_PREFIX} prefix`,
+            code: CliError.Code.ValidationError
+        });
+    }
+    const type = messageType.substring(LOCATION_PREFIX.length);
+    if (type !== "header" && type !== "path" && type !== "payload") {
+        throw new CliError({
+            message: `Invalid message type: ${type}. Must be one of: header, path, payload`,
+            code: CliError.Code.ValidationError
+        });
+    }
+    return { type, parameterKey };
 }
 
 function getServerNameFromServerRef(
@@ -680,12 +700,18 @@ function getServerNameFromServerRef(
     serverRef: OpenAPIV3.ReferenceObject
 ): ServerContext {
     if (!serverRef.$ref.startsWith(SERVER_REFERENCE_PREFIX)) {
-        throw new Error(`Failed to resolve server name from server ref ${serverRef.$ref}`);
+        throw new CliError({
+            message: `Failed to resolve server name from server ref ${serverRef.$ref}`,
+            code: CliError.Code.ReferenceError
+        });
     }
     const serverName = serverRef.$ref.substring(SERVER_REFERENCE_PREFIX.length);
     const server = servers[serverName];
     if (server == null) {
-        throw new Error(`Failed to find server with name ${serverName}`);
+        throw new CliError({
+            message: `Failed to find server with name ${serverName}`,
+            code: CliError.Code.ReferenceError
+        });
     }
     return server;
 }

--- a/packages/cli/api-importers/openapi/openapi-ir-parser/src/openapi/v3/AbstractOpenAPIV3ParserContext.ts
+++ b/packages/cli/api-importers/openapi/openapi-ir-parser/src/openapi/v3/AbstractOpenAPIV3ParserContext.ts
@@ -1,6 +1,7 @@
 import type { Logger } from "@fern-api/logger";
 import type { Namespace, SchemaId, SdkGroup, SdkGroupName, Source } from "@fern-api/openapi-ir";
-import type { TaskContext } from "@fern-api/task-context";
+import { CliError, type TaskContext } from "@fern-api/task-context";
+
 import type { OpenAPIV3 } from "openapi-types";
 
 import { getExtension } from "../../getExtension.js";
@@ -156,12 +157,12 @@ export abstract class AbstractOpenAPIV3ParserContext implements SchemaParserCont
             this.document.components.parameters == null ||
             !parameter.$ref.startsWith(PARAMETER_REFERENCE_PREFIX)
         ) {
-            throw new Error(`Failed to resolve ${parameter.$ref}`);
+            throw new CliError({ message: `Failed to resolve ${parameter.$ref}`, code: CliError.Code.ReferenceError });
         }
         const parameterKey = parameter.$ref.substring(PARAMETER_REFERENCE_PREFIX.length);
         const resolvedParameter = this.document.components.parameters[parameterKey];
         if (resolvedParameter == null) {
-            throw new Error(`${parameter.$ref} is undefined`);
+            throw new CliError({ message: `${parameter.$ref} is undefined`, code: CliError.Code.ReferenceError });
         }
         if (isReferenceObject(resolvedParameter)) {
             return this.resolveParameterReference(resolvedParameter);
@@ -175,12 +176,15 @@ export abstract class AbstractOpenAPIV3ParserContext implements SchemaParserCont
             this.document.components.requestBodies == null ||
             !requestBody.$ref.startsWith(REQUEST_BODY_REFERENCE_PREFIX)
         ) {
-            throw new Error(`Failed to resolve ${requestBody.$ref}`);
+            throw new CliError({
+                message: `Failed to resolve ${requestBody.$ref}`,
+                code: CliError.Code.ReferenceError
+            });
         }
         const requestBodyKey = requestBody.$ref.substring(REQUEST_BODY_REFERENCE_PREFIX.length);
         const resolvedRequestBody = this.document.components.requestBodies[requestBodyKey];
         if (resolvedRequestBody == null) {
-            throw new Error(`${requestBody.$ref} is undefined`);
+            throw new CliError({ message: `${requestBody.$ref} is undefined`, code: CliError.Code.ReferenceError });
         }
         if (isReferenceObject(resolvedRequestBody)) {
             return this.resolveRequestBodyReference(resolvedRequestBody);
@@ -194,12 +198,12 @@ export abstract class AbstractOpenAPIV3ParserContext implements SchemaParserCont
             this.document.components.responses == null ||
             !response.$ref.startsWith(RESPONSE_REFERENCE_PREFIX)
         ) {
-            throw new Error(`Failed to resolve ${response.$ref}`);
+            throw new CliError({ message: `Failed to resolve ${response.$ref}`, code: CliError.Code.ReferenceError });
         }
         const parameterKey = response.$ref.substring(RESPONSE_REFERENCE_PREFIX.length);
         const resolvedResponse = this.document.components.responses[parameterKey];
         if (resolvedResponse == null) {
-            throw new Error(`${response.$ref} is undefined`);
+            throw new CliError({ message: `${response.$ref} is undefined`, code: CliError.Code.ReferenceError });
         }
         if (isReferenceObject(resolvedResponse)) {
             return this.resolveResponseReference(resolvedResponse);
@@ -213,12 +217,12 @@ export abstract class AbstractOpenAPIV3ParserContext implements SchemaParserCont
             this.document.components.examples == null ||
             !example.$ref.startsWith(EXAMPLES_REFERENCE_PREFIX)
         ) {
-            throw new Error(`Failed to resolve ${example.$ref}`);
+            throw new CliError({ message: `Failed to resolve ${example.$ref}`, code: CliError.Code.ReferenceError });
         }
         const parameterKey = example.$ref.substring(EXAMPLES_REFERENCE_PREFIX.length);
         const resolvedExample = this.document.components.examples[parameterKey];
         if (resolvedExample == null) {
-            throw new Error(`${example.$ref} is undefined`);
+            throw new CliError({ message: `${example.$ref} is undefined`, code: CliError.Code.ReferenceError });
         }
         if (isReferenceObject(resolvedExample)) {
             return this.resolveExampleReference(resolvedExample);
@@ -232,12 +236,15 @@ export abstract class AbstractOpenAPIV3ParserContext implements SchemaParserCont
             this.document.components.securitySchemes == null ||
             !securityScheme.$ref.startsWith(SECURITY_SCHEME_REFERENCE_PREFIX)
         ) {
-            throw new Error(`Failed to resolve ${securityScheme.$ref}`);
+            throw new CliError({
+                message: `Failed to resolve ${securityScheme.$ref}`,
+                code: CliError.Code.ReferenceError
+            });
         }
         const securitySchemeKey = securityScheme.$ref.substring(SECURITY_SCHEME_REFERENCE_PREFIX.length);
         const resolvedSecurityScheme = this.document.components.securitySchemes[securitySchemeKey];
         if (resolvedSecurityScheme == null) {
-            throw new Error(`${securityScheme.$ref} is undefined`);
+            throw new CliError({ message: `${securityScheme.$ref} is undefined`, code: CliError.Code.ReferenceError });
         }
         if (isReferenceObject(resolvedSecurityScheme)) {
             return this.resolveSecuritySchemeReference(resolvedSecurityScheme);

--- a/packages/cli/api-importers/openapi/openapi-ir-parser/src/openapi/v3/converters/convertSecurityScheme.ts
+++ b/packages/cli/api-importers/openapi/openapi-ir-parser/src/openapi/v3/converters/convertSecurityScheme.ts
@@ -1,5 +1,6 @@
 import { EnumSchema, SecurityScheme, Source } from "@fern-api/openapi-ir";
-import { TaskContext } from "@fern-api/task-context";
+import { CliError, TaskContext } from "@fern-api/task-context";
+
 import { OpenAPIV3 } from "openapi-types";
 import { getExtension } from "../../../getExtension.js";
 import { convertEnum } from "../../../schema/convertEnum.js";
@@ -23,9 +24,10 @@ export function convertSecurityScheme(
 ): SecurityScheme | undefined {
     if (isReferenceObject(securityScheme)) {
         if (context == null) {
-            throw new Error(
-                `Converting referenced security schemes requires context: ${JSON.stringify(securityScheme)}`
-            );
+            throw new CliError({
+                message: `Converting referenced security schemes requires context: ${JSON.stringify(securityScheme)}`,
+                code: CliError.Code.InternalError
+            });
         }
         const resolvedSecurityScheme = context.resolveSecuritySchemeReference(securityScheme);
         return convertSecuritySchemeHelper(resolvedSecurityScheme, source, taskContext);

--- a/packages/cli/api-importers/openapi/openapi-ir-parser/src/openapi/v3/converters/endpoint/convertRequest.ts
+++ b/packages/cli/api-importers/openapi/openapi-ir-parser/src/openapi/v3/converters/endpoint/convertRequest.ts
@@ -8,6 +8,8 @@ import {
     SchemaWithExample,
     Source
 } from "@fern-api/openapi-ir";
+import { CliError } from "@fern-api/task-context";
+
 import { OpenAPIV3 } from "openapi-types";
 import { getExtension } from "../../../../getExtension.js";
 import { isAdditionalPropertiesAny } from "../../../../schema/convertAdditionalProperties.js";
@@ -476,15 +478,24 @@ interface ResolvedSchema {
 // Hack: update to call context.resolveSchema()
 function resolveSchema(schema: OpenAPIV3.ReferenceObject, document: OpenAPIV3.Document): ResolvedSchema {
     if (!schema.$ref.startsWith(SCHEMA_REFERENCE_PREFIX)) {
-        throw new Error(`Failed to resolve schema reference because of unsupported prefix: ${schema.$ref}`);
+        throw new CliError({
+            message: `Failed to resolve schema reference because of unsupported prefix: ${schema.$ref}`,
+            code: CliError.Code.ReferenceError
+        });
     }
     const schemaId = getSchemaIdFromReference(schema);
     if (schemaId == null) {
-        throw new Error(`Failed to resolve schema reference because missing schema id: ${schema.$ref}`);
+        throw new CliError({
+            message: `Failed to resolve schema reference because missing schema id: ${schema.$ref}`,
+            code: CliError.Code.ReferenceError
+        });
     }
     const resolvedSchema = document.components?.schemas?.[schemaId];
     if (resolvedSchema == null) {
-        throw new Error(`Failed to resolve schema reference because missing: ${schema.$ref}`);
+        throw new CliError({
+            message: `Failed to resolve schema reference because missing: ${schema.$ref}`,
+            code: CliError.Code.ReferenceError
+        });
     }
     if (isReferenceObject(resolvedSchema)) {
         return resolveSchema(resolvedSchema, document);

--- a/packages/cli/api-importers/openapi/openapi-ir-parser/src/openapi/v3/extensions/getFernTypeExtension.ts
+++ b/packages/cli/api-importers/openapi/openapi-ir-parser/src/openapi/v3/extensions/getFernTypeExtension.ts
@@ -7,8 +7,8 @@ import {
     SchemaWithExample,
     Source
 } from "@fern-api/openapi-ir";
+import { CliError } from "@fern-api/task-context";
 import { OpenAPIV3 } from "openapi-types";
-
 import { getExtension } from "../../../getExtension.js";
 import { FernOpenAPIExtension } from "./fernExtensions.js";
 
@@ -356,7 +356,10 @@ export function getSchemaFromFernType({
                         string: (value) => LiteralSchemaValue.string(value),
                         boolean: (value) => LiteralSchemaValue.boolean(value),
                         _other: () => {
-                            throw new Error("Unexpected literal type");
+                            throw new CliError({
+                                message: "Unexpected literal type",
+                                code: CliError.Code.InternalError
+                            });
                         }
                     }),
                     description,

--- a/packages/cli/api-importers/openapi/openapi-ir-parser/src/openapi/v3/extensions/getPaginationExtension.ts
+++ b/packages/cli/api-importers/openapi/openapi-ir-parser/src/openapi/v3/extensions/getPaginationExtension.ts
@@ -1,6 +1,6 @@
 import { Pagination } from "@fern-api/openapi-ir";
+import { CliError } from "@fern-api/task-context";
 import { OpenAPIV3 } from "openapi-types";
-
 import { getExtension } from "../../../getExtension.js";
 import { FernOpenAPIExtension } from "./fernExtensions.js";
 
@@ -88,7 +88,7 @@ export function convertPaginationExtension(
             results: customPagination.results
         });
     }
-    throw new Error("Invalid pagination extension");
+    throw new CliError({ message: "Invalid pagination extension", code: CliError.Code.ValidationError });
 }
 
 export function getFernPaginationExtension(
@@ -106,9 +106,11 @@ export function getFernPaginationExtension(
             FernOpenAPIExtension.PAGINATION
         );
         if (typeof topLevelPagination === "boolean") {
-            throw new Error(
-                "Global pagination extension is a boolean, expected an object. Only endpoints may declare a boolean for x-fern-pagination."
-            );
+            throw new CliError({
+                message:
+                    "Global pagination extension is a boolean, expected an object. Only endpoints may declare a boolean for x-fern-pagination.",
+                code: CliError.Code.ValidationError
+            });
         }
         return topLevelPagination == null ? undefined : convertPaginationExtension(topLevelPagination);
     }

--- a/packages/cli/api-importers/openapi/openapi-ir-parser/src/openapi/v3/extensions/getVariableDefinitions.ts
+++ b/packages/cli/api-importers/openapi/openapi-ir-parser/src/openapi/v3/extensions/getVariableDefinitions.ts
@@ -1,6 +1,6 @@
 import { PrimitiveSchema, PrimitiveSchemaValue } from "@fern-api/openapi-ir";
+import { CliError } from "@fern-api/task-context";
 import { OpenAPIV3 } from "openapi-types";
-
 import { getExtension } from "../../../getExtension.js";
 import { getDefaultAsString } from "../../../schema/defaults/getDefault.js";
 import { getGeneratedTypeName } from "../../../schema/utils/getSchemaName.js";
@@ -42,7 +42,10 @@ export function getVariableDefinitions(
                     }
                 ];
             } else {
-                throw new Error(`Variable ${variableName} has unsupported schema ${JSON.stringify(schema)}`);
+                throw new CliError({
+                    message: `Variable ${variableName} has unsupported schema ${JSON.stringify(schema)}`,
+                    code: CliError.Code.ValidationError
+                });
             }
         })
     );

--- a/packages/cli/api-importers/openapi/openapi-ir-parser/src/schema/convertSchemas.ts
+++ b/packages/cli/api-importers/openapi/openapi-ir-parser/src/schema/convertSchemas.ts
@@ -11,9 +11,9 @@ import {
     type SdkGroupName,
     type Source
 } from "@fern-api/openapi-ir";
+import { CliError } from "@fern-api/task-context";
 import { size } from "lodash-es";
 import type { OpenAPIV3 } from "openapi-types";
-
 import { getExtension } from "../getExtension.js";
 import { OpenAPIExtension } from "../openapi/v3/extensions/extensions.js";
 import { FernOpenAPIExtension } from "../openapi/v3/extensions/fernExtensions.js";
@@ -1574,7 +1574,10 @@ export function convertToReferencedSchema(
 
     const schemaId = getSchemaIdFromReference(schema);
     if (schemaId == null) {
-        throw new Error(`Invalid schema reference ${JSON.stringify(schema)}`);
+        throw new CliError({
+            message: `Invalid schema reference ${JSON.stringify(schema)}`,
+            code: CliError.Code.ReferenceError
+        });
     }
 
     return Schema.reference({

--- a/packages/cli/api-importers/openapi/openapi-ir-parser/src/schema/examples/ExampleTypeFactory.ts
+++ b/packages/cli/api-importers/openapi/openapi-ir-parser/src/schema/examples/ExampleTypeFactory.ts
@@ -11,7 +11,7 @@ import {
     SchemaId,
     SchemaWithExample
 } from "@fern-api/openapi-ir";
-
+import { CliError } from "@fern-api/task-context";
 import { SchemaParserContext } from "../SchemaParserContext.js";
 import { convertToFullExample } from "./convertToFullExample.js";
 import { getFullExampleAsArray, getFullExampleAsObject } from "./getFullExample.js";
@@ -894,7 +894,10 @@ export class ExampleTypeFactory {
         while (schema.type === "reference") {
             const resolvedSchema = this.schemas[schema.schema];
             if (resolvedSchema == null) {
-                throw new Error(`Unexpected error: Failed to resolve schema reference: ${schema.schema}`);
+                throw new CliError({
+                    message: `Unexpected error: Failed to resolve schema reference: ${schema.schema}`,
+                    code: CliError.Code.InternalError
+                });
             }
             schema = resolvedSchema;
         }

--- a/packages/cli/api-importers/openapi/openapi-ir-parser/src/schema/utils/getRequestBodyIdFromReference.ts
+++ b/packages/cli/api-importers/openapi/openapi-ir-parser/src/schema/utils/getRequestBodyIdFromReference.ts
@@ -1,10 +1,13 @@
+import { CliError } from "@fern-api/task-context";
 import { OpenAPIV3 } from "openapi-types";
-
 import { REQUEST_BODY_REFERENCE_PREFIX } from "../../openapi/v3/AbstractOpenAPIV3ParserContext.js";
 
 export function getRequestBodyIdFromReference(ref: OpenAPIV3.ReferenceObject): string {
     if (!ref.$ref.startsWith(REQUEST_BODY_REFERENCE_PREFIX)) {
-        throw new Error(`Cannot get request body id from reference: ${ref.$ref}`);
+        throw new CliError({
+            message: `Cannot get request body id from reference: ${ref.$ref}`,
+            code: CliError.Code.ReferenceError
+        });
     }
     return ref.$ref.replace(REQUEST_BODY_REFERENCE_PREFIX, "");
 }


### PR DESCRIPTION
## Description

Migrates `@fern-api/openapi-ir-parser` to use explicit `CliError` error codes on every `failAndThrow` / `failWithoutThrowing` call site.

This is one of the package migration PRs that follow the error classification system introduced in #14749.

## Changes Made

Assigned typed error codes across call sites in the OpenAPI IR parser package.

### Error codes used

| Code | Usage |
|------|-------|
| `PARSE_ERROR` | Malformed OpenAPI specs, invalid schema structures |
| `VALIDATION_ERROR` | Schema validation failures, unsupported OpenAPI features |
| `REFERENCE_ERROR` | Unresolvable `$ref` references in OpenAPI specs |

### Files touched (grouped by area)

- **OpenAPI parsing**: Various parser files in the openapi-ir-parser package

## Testing

- [x] Existing tests pass (`pnpm test`, excluding e2e and pre-existing environment failures)
