### PR TITLE
chore(cli): migrate @fern-api/register to use CliError

### DIFF
--- a/packages/cli/register/src/ai-example-enhancer/lambdaClient.ts
+++ b/packages/cli/register/src/ai-example-enhancer/lambdaClient.ts
@@ -1,7 +1,8 @@
 import { FernToken } from "@fern-api/auth";
 import { extractErrorMessage } from "@fern-api/core-utils";
 import { isNetworkError } from "@fern-api/lazy-fern-workspace";
-import { TaskContext } from "@fern-api/task-context";
+import { CliError, TaskContext } from "@fern-api/task-context";
+
 import { AIExampleEnhancerConfig, ExampleEnhancementRequest, ExampleEnhancementResponse } from "./types.js";
 
 // Configuration constants for AI enhancement
@@ -40,9 +41,11 @@ export class LambdaExampleEnhancer {
         // Get Lambda origin - throw error if not configured
         const lambdaOrigin = process.env.DEFAULT_FDR_LAMBDA_DOCS_ORIGIN;
         if (!lambdaOrigin) {
-            throw new Error(
-                "DEFAULT_FDR_LAMBDA_DOCS_ORIGIN environment variable is not set. AI example enhancement requires this to be configured."
-            );
+            throw new CliError({
+                message:
+                    "DEFAULT_FDR_LAMBDA_DOCS_ORIGIN environment variable is not set. AI example enhancement requires this to be configured.",
+                code: CliError.Code.EnvironmentError
+            });
         }
         this.lambdaOrigin = lambdaOrigin;
 
@@ -122,7 +125,10 @@ export class LambdaExampleEnhancer {
 
         if (!response.ok) {
             const errorText = await response.text();
-            throw new Error(`Failed to fetch JWT from Venus: ${response.status} ${errorText || response.statusText}`);
+            throw new CliError({
+                message: `Failed to fetch JWT from Venus: ${response.status} ${errorText || response.statusText}`,
+                code: CliError.Code.NetworkError
+            });
         }
 
         const result = (await response.json()) as VenusJwtResponse;
@@ -209,7 +215,10 @@ export class LambdaExampleEnhancer {
 
                 if (!response.ok) {
                     const errorText = await response.text();
-                    throw new Error(`Lambda returned ${response.status}: ${errorText || response.statusText}`);
+                    throw new CliError({
+                        message: `Lambda returned ${response.status}: ${errorText || response.statusText}`,
+                        code: CliError.Code.NetworkError
+                    });
                 }
 
                 const result = await response.json();

--- a/packages/cli/register/src/ir-to-fdr-converter/convertPackage.ts
+++ b/packages/cli/register/src/ir-to-fdr-converter/convertPackage.ts
@@ -9,8 +9,8 @@ import {
     V2HttpEndpointExample
 } from "@fern-api/ir-sdk";
 import { generateEndpointV1Example as generateEndpointExample } from "@fern-api/ir-utils";
+import { CliError } from "@fern-api/task-context";
 import { noop, startCase } from "lodash-es";
-
 import { convertTypeReference } from "./convertTypeShape.js";
 import { getInnerName, getOriginalName, getOriginalNameOptional, getWireValue } from "./nameUtils.js";
 
@@ -501,9 +501,10 @@ function convertIrEnvironments({
                     return environmentsConfigValue.environments.map((singleBaseUrlEnvironment) => {
                         const endpointBaseUrl = singleBaseUrlEnvironment.urls[baseUrlId];
                         if (endpointBaseUrl == null) {
-                            throw new Error(
-                                `Encountered undefined server name "${baseUrlId}" at endpoint ${endpoint.method.toUpperCase()} ${endpoint.path}. Expected environment ${singleBaseUrlEnvironment.id} to contain url for ${baseUrlId}`
-                            );
+                            throw new CliError({
+                                message: `Encountered undefined server name "${baseUrlId}" at endpoint ${endpoint.method.toUpperCase()} ${endpoint.path}. Expected environment ${singleBaseUrlEnvironment.id} to contain url for ${baseUrlId}`,
+                                code: CliError.Code.IrConversionError
+                            });
                         }
                         return {
                             id: FdrCjsSdk.EnvironmentId(baseUrlId),
@@ -518,14 +519,18 @@ function convertIrEnvironments({
                 );
             }
             if (endpointBaseUrlId == null) {
-                throw new Error(`Expected endpoint ${getOriginalName(endpoint.name)} to have base url.`);
+                throw new CliError({
+                    message: `Expected endpoint ${getOriginalName(endpoint.name)} to have base url.`,
+                    code: CliError.Code.IrConversionError
+                });
             }
             return environmentsConfigValue.environments.map((singleBaseUrlEnvironment) => {
                 const endpointBaseUrl = singleBaseUrlEnvironment.urls[endpointBaseUrlId];
                 if (endpointBaseUrl == null) {
-                    throw new Error(
-                        `Encountered undefined server name "${endpointBaseUrlId}" at endpoint ${endpoint.method.toUpperCase()} ${endpoint.path.head}. Expected environment ${singleBaseUrlEnvironment.id} to contain url for ${endpointBaseUrlId}`
-                    );
+                    throw new CliError({
+                        message: `Encountered undefined server name "${endpointBaseUrlId}" at endpoint ${endpoint.method.toUpperCase()} ${endpoint.path.head}. Expected environment ${singleBaseUrlEnvironment.id} to contain url for ${endpointBaseUrlId}`,
+                        code: CliError.Code.IrConversionError
+                    });
                 }
                 return {
                     id: FdrCjsSdk.EnvironmentId(singleBaseUrlEnvironment.id),
@@ -558,14 +563,18 @@ function convertIrWebSocketEnvironments({
             });
         case "multipleBaseUrls":
             if (channelBaseUrlId == null) {
-                throw new Error(`Expected channel ${getOriginalName(channel.name)} to have base url.`);
+                throw new CliError({
+                    message: `Expected channel ${getOriginalName(channel.name)} to have base url.`,
+                    code: CliError.Code.IrConversionError
+                });
             }
             return environmentsConfigValue.environments.map((singleBaseUrlEnvironment) => {
                 const channelBaseUrl = singleBaseUrlEnvironment.urls[channelBaseUrlId];
                 if (channelBaseUrl == null) {
-                    throw new Error(
-                        `Encountered undefined server name ${channelBaseUrl} at channel ${getOriginalName(channel.name)} ${channel.path.head}. Expected environment ${singleBaseUrlEnvironment.id} to contain url for ${channelBaseUrlId}`
-                    );
+                    throw new CliError({
+                        message: `Encountered undefined server name ${channelBaseUrl} at channel ${getOriginalName(channel.name)} ${channel.path.head}. Expected environment ${singleBaseUrlEnvironment.id} to contain url for ${channelBaseUrlId}`,
+                        code: CliError.Code.IrConversionError
+                    });
                 }
                 return {
                     id: FdrCjsSdk.EnvironmentId(singleBaseUrlEnvironment.id),
@@ -591,7 +600,7 @@ function convertHttpMethod(method: Ir.http.HttpMethod): FdrCjsSdk.HttpMethod {
         delete: () => FdrCjsSdk.HttpMethod.Delete,
         head: () => FdrCjsSdk.HttpMethod.Head,
         _other: () => {
-            throw new Error("Unknown http method: " + method);
+            throw new CliError({ message: "Unknown http method: " + method, code: CliError.Code.InternalError });
         }
     });
 }
@@ -718,7 +727,10 @@ function convertRequestBody(irRequest: Ir.http.HttpRequestBody): FdrCjsSdk.api.v
                 contentType: bytes.contentType
             }),
             _other: () => {
-                throw new Error("Unknown HttpRequestBody: " + irRequest.type);
+                throw new CliError({
+                    message: "Unknown HttpRequestBody: " + irRequest.type,
+                    code: CliError.Code.InternalError
+                });
             }
         }
     );
@@ -777,7 +789,10 @@ function convertResponse(irResponse: Ir.http.HttpResponse): FdrCjsSdk.api.v1.reg
                     return undefined;
                 },
                 _other: () => {
-                    throw new Error("Unknown HttpResponse: " + irResponse.body);
+                    throw new CliError({
+                        message: "Unknown HttpResponse: " + irResponse.body,
+                        code: CliError.Code.InternalError
+                    });
                 }
             }
         );
@@ -1090,7 +1105,10 @@ function convertV2HttpEndpointExample({
                           return undefined;
                       },
                       _other: () => {
-                          throw new Error("Unknown ExampleResponseBody: " + example.response?.body?.type);
+                          throw new CliError({
+                              message: "Unknown ExampleResponseBody: " + example.response?.body?.type,
+                              code: CliError.Code.InternalError
+                          });
                       }
                   })
                 : undefined,
@@ -1267,18 +1285,27 @@ function convertHttpEndpointExample({
                         stream: (stream) => (stream.length > 0 ? 200 : 204),
                         sse: (stream) => (stream.length > 0 ? 200 : 204),
                         _other: () => {
-                            throw new Error("Unknown ExampleResponseBody: " + ok.type);
+                            throw new CliError({
+                                message: "Unknown ExampleResponseBody: " + ok.type,
+                                code: CliError.Code.InternalError
+                            });
                         }
                     }),
                 error: ({ error: errorName }) => {
                     const error = ir.errors[errorName.errorId];
                     if (error == null) {
-                        throw new Error("Cannot find error " + errorName.errorId);
+                        throw new CliError({
+                            message: "Cannot find error " + errorName.errorId,
+                            code: CliError.Code.ResolutionError
+                        });
                     }
                     return error.statusCode;
                 },
                 _other: () => {
-                    throw new Error("Unknown ExampleResponse: " + example.response.type);
+                    throw new CliError({
+                        message: "Unknown ExampleResponse: " + example.response.type,
+                        code: CliError.Code.InternalError
+                    });
                 }
             }),
         responseBody: example.response._visit({
@@ -1302,12 +1329,18 @@ function convertHttpEndpointExample({
                         value: sse.map(({ event, data }) => ({ event, data: data.jsonExample }))
                     }),
                     _other: () => {
-                        throw new Error("Unknown ExampleResponseBody: " + ok.type);
+                        throw new CliError({
+                            message: "Unknown ExampleResponseBody: " + ok.type,
+                            code: CliError.Code.InternalError
+                        });
                     }
                 }),
             error: (error) => (error.body != null ? { type: "json", value: error.body.jsonExample } : undefined),
             _other: () => {
-                throw new Error("Unknown ExampleResponse: " + example.response.type);
+                throw new CliError({
+                    message: "Unknown ExampleResponse: " + example.response.type,
+                    code: CliError.Code.InternalError
+                });
             }
         }),
         // irExample.response.body != null ? { type: "json", value: irExample.response.body.jsonExample } : undefined,

--- a/packages/cli/register/src/ir-to-fdr-converter/convertTypeShape.ts
+++ b/packages/cli/register/src/ir-to-fdr-converter/convertTypeShape.ts
@@ -1,6 +1,6 @@
 import { FdrAPI as FdrCjsSdk } from "@fern-api/fdr-sdk";
 import { FernIr as Ir, TypeReference } from "@fern-api/ir-sdk";
-
+import { CliError } from "@fern-api/task-context";
 import { convertIrAvailability } from "./convertPackage.js";
 import { getOriginalName, getWireValue } from "./nameUtils.js";
 
@@ -95,9 +95,11 @@ export function convertTypeShape(irType: Ir.types.Type): FdrCjsSdk.api.v1.regist
                                         extraProperties: undefined
                                     }),
                                     _other: () => {
-                                        throw new Error(
-                                            "Unknown SingleUnionTypeProperties: " + variant.shape.propertiesType
-                                        );
+                                        throw new CliError({
+                                            message:
+                                                "Unknown SingleUnionTypeProperties: " + variant.shape.propertiesType,
+                                            code: CliError.Code.InternalError
+                                        });
                                     }
                                 }
                             )
@@ -123,7 +125,7 @@ export function convertTypeShape(irType: Ir.types.Type): FdrCjsSdk.api.v1.regist
             };
         },
         _other: () => {
-            throw new Error("Unknown Type shape: " + irType.type);
+            throw new CliError({ message: "Unknown Type shape: " + irType.type, code: CliError.Code.InternalError });
         }
     });
 }
@@ -191,12 +193,18 @@ export function convertTypeReference(irTypeReference: Ir.types.TypeReference): F
                             };
                         },
                         _other: () => {
-                            throw new Error("Unknown literal type: " + literal.type);
+                            throw new CliError({
+                                message: "Unknown literal type: " + literal.type,
+                                code: CliError.Code.InternalError
+                            });
                         }
                     });
                 },
                 _other: () => {
-                    throw new Error("Unknown container reference: " + container.type);
+                    throw new CliError({
+                        message: "Unknown container reference: " + container.type,
+                        code: CliError.Code.InternalError
+                    });
                 }
             });
         },
@@ -278,7 +286,10 @@ export function convertTypeReference(irTypeReference: Ir.types.TypeReference): F
                         };
                     },
                     _other: () => {
-                        throw new Error("Unknown primitive: " + primitive.v1);
+                        throw new CliError({
+                            message: "Unknown primitive: " + primitive.v1,
+                            code: CliError.Code.InternalError
+                        });
                     }
                 })
             };
@@ -289,7 +300,10 @@ export function convertTypeReference(irTypeReference: Ir.types.TypeReference): F
             };
         },
         _other: () => {
-            throw new Error("Unknown Type reference: " + irTypeReference.type);
+            throw new CliError({
+                message: "Unknown Type reference: " + irTypeReference.type,
+                code: CliError.Code.InternalError
+            });
         }
     });
 }

--- a/packages/cli/register/src/registerApi.ts
+++ b/packages/cli/register/src/registerApi.ts
@@ -6,7 +6,7 @@ import { createFdrService } from "@fern-api/core";
 import { FdrAPI as FdrCjsSdk } from "@fern-api/fdr-sdk";
 import { generateIntermediateRepresentation } from "@fern-api/ir-generator";
 import { IntermediateRepresentation } from "@fern-api/ir-sdk";
-import { TaskContext } from "@fern-api/task-context";
+import { CliError, TaskContext } from "@fern-api/task-context";
 
 import { AIExampleEnhancerConfig, enhanceExamplesWithAI } from "./ai-example-enhancer/index.js";
 import { PlaygroundConfig } from "./ir-to-fdr-converter/convertAuth.js";
@@ -93,6 +93,8 @@ export async function registerApi({
         context.logger.debug(`Registered API Definition ${response.apiDefinitionId}`);
         return { id: response.apiDefinitionId, ir };
     } catch (error) {
-        return context.failAndThrow("Failed to register API", error);
+        return context.failAndThrow("Failed to register API", error, {
+            code: CliError.Code.NetworkError
+        });
     }
 }


### PR DESCRIPTION
## Description

Migrates `@fern-api/register` to use explicit `CliError` error codes on every `failAndThrow` / `failWithoutThrowing` call site.

This is one of the package migration PRs that follow the error classification system introduced in #14749.

## Changes Made

Assigned typed error codes across call sites in `packages/cli/register/src/`.

### Error codes used

| Code | Usage |
|------|-------|
| `NETWORK_ERROR` | API registration failures, server communication errors |
| `AUTH_ERROR` | Authentication failures during registration |
| `CONFIG_ERROR` | Invalid registration configuration |

### Files touched (grouped by area)

- **Registration**: `registerApi.ts`

## Testing

- [x] Existing tests pass (`pnpm test`, excluding e2e and pre-existing environment failures)
