### PR TITLE
fix(go): remove unused wiremock/containerd deps from default go.mod imports

### DIFF
--- a/generators/go-v2/base/src/module/ModuleConfig.ts
+++ b/generators/go-v2/base/src/module/ModuleConfig.ts
@@ -3,17 +3,21 @@ export namespace ModuleConfig {
 
     export const DEFAULT: ModuleConfig = {
         path: "sdk",
-        version: "1.18",
+        version: "1.21",
         imports: {
             "github.com/google/uuid": "v1.4.0",
             "github.com/stretchr/testify": "v1.7.0",
-            "gopkg.in/yaml.v3": "v3.0.1",
-            // must pin wiremock dependencies to versions that still support go 1.23
-            "github.com/wiremock/wiremock-testcontainers-go": "v1.0.0-alpha-9",
-            "github.com/wiremock/go-wiremock": "v1.14.0",
-            // must pin go-wiremock indirect dependencies to later fixed versions
-            "github.com/containerd/containerd": "v1.7.27"
+            "gopkg.in/yaml.v3": "v3.0.1"
         }
+    };
+
+    // Wiremock dependencies pinned to versions that still support go 1.23.
+    // Only include these in go.mod when wire test Go files that import them are generated.
+    export const WIREMOCK_IMPORTS: Record<string, string> = {
+        "github.com/wiremock/wiremock-testcontainers-go": "v1.0.0-alpha-9",
+        "github.com/wiremock/go-wiremock": "v1.14.0",
+        // must pin go-wiremock indirect dependencies to later fixed versions
+        "github.com/containerd/containerd": "v1.7.27"
     };
 }
 

--- a/generators/go/sdk/changes/unreleased/fix-remove-unused-wiremock-deps.yml
+++ b/generators/go/sdk/changes/unreleased/fix-remove-unused-wiremock-deps.yml
@@ -1,0 +1,6 @@
+- summary: |
+    Remove unused wiremock and containerd dependencies from the default go.mod
+    imports. These packages were never imported by generated Go code, but
+    go mod tidy had to download hundreds of transitive dependencies to discover
+    they were unused, causing failures in CI environments.
+  type: fix


### PR DESCRIPTION
## Description

Fixes the consistently failing `test-remote-local-parity (go-sdk)` CI job ([example run](https://github.com/fern-api/fern/actions/runs/24366413892/job/71159463269)).

The go-v2 generator's `ModuleConfig.DEFAULT.imports` included `wiremock-testcontainers-go`, `go-wiremock`, and `containerd` in every generated `go.mod`, but **no generated Go source files ever import these packages**. This forced `go mod tidy` to download hundreds of transitive dependencies (especially from containerd) only to discover they were unused. In CI environments, this download frequently timed out or failed, crashing the generator.

## Changes Made

- **Removed** `wiremock-testcontainers-go`, `go-wiremock`, and `containerd` from `ModuleConfig.DEFAULT.imports`
- **Moved** them to a new `WIREMOCK_IMPORTS` constant for future use when wire test Go files that actually import these packages are generated
- **Bumped** `DEFAULT.version` from `1.18` to `1.21` — generated Go code uses the `min()` builtin (requires go 1.21); previously containerd's transitive deps forced `go mod tidy` to bump the version implicitly
- Added changelog entry

## Testing

- [x] Root cause confirmed by tracing CI logs showing `go mod tidy` downloading containerd transitive deps and failing
- [x] Verified via grep across all seed go-sdk fixtures that no generated `.go` files import wiremock libraries
- [ ] Full end-to-end verification requires publishing a new go-sdk Docker image with this fix

## Things for reviewers to check

- [ ] `WIREMOCK_IMPORTS` is exported but **not yet consumed** anywhere — it's effectively dead code. Should it be kept (for when wire test generation adds it) or removed?
- [ ] The version bump `1.18` → `1.21` is correct for current generated code, but verify no downstream users depend on the `go 1.18` directive (unlikely since `go mod tidy` was already bumping it)
- [ ] Seed test snapshots may need regeneration if any fixtures reference the old go version or the removed deps

Link to Devin session: https://app.devin.ai/sessions/67aa61c55d6a427d90a284cf7cf9a852
Requested by: @Swimburger
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/15009" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
