### PR TITLE
fix(ci): move parity test to daily cron and add both-fail-as-parity logic

### DIFF
--- a/.github/workflows/test-remote-vs-local-generation-parity.yml
+++ b/.github/workflows/test-remote-vs-local-generation-parity.yml
@@ -1,10 +1,9 @@
 name: Test Remote vs Local Generation Parity
 
 on:
-  # Runs on every commit to main
-  push:
-    branches:
-      - main
+  # Runs on a daily schedule
+  schedule:
+    - cron: '0 6 * * *' # daily at 6:00 AM UTC
 
   # Runs when triggered manually (supports testing from any branch)
   workflow_dispatch:
@@ -70,7 +69,7 @@ jobs:
                 ;;
             esac
           else
-            # For push and workflow_dispatch, test all generators
+            # For schedule and workflow_dispatch, test all generators
             echo 'generators=["ts-sdk", "java-sdk", "go-sdk", "python-sdk"]' >> $GITHUB_OUTPUT
           fi
 

--- a/packages/seed/src/commands/test-remote-local/testExecution.ts
+++ b/packages/seed/src/commands/test-remote-local/testExecution.ts
@@ -131,6 +131,12 @@ export async function runTestCase(testCase: RemoteVsLocalTestCase): Promise<Test
 
         // Check for generation failures
         if (!localResult.success || !remoteResult.success) {
+            // Both failed with the exact same error — that's parity.
+            if (!localResult.success && !remoteResult.success && localResult.error === remoteResult.error) {
+                logger.warn(`Both local and remote generation failed with the same error — treating as parity`);
+                logger.warn(`  Error: ${localResult.error}`);
+                return { success: true };
+            }
             const errors: string[] = [];
             if (!localResult.success) {
                 errors.push(`Local generation failed: ${localResult.error}`);

--- a/packages/seed/src/commands/test-remote-local/testExecution.ts
+++ b/packages/seed/src/commands/test-remote-local/testExecution.ts
@@ -132,7 +132,15 @@ export async function runTestCase(testCase: RemoteVsLocalTestCase): Promise<Test
         // Check for generation failures
         if (!localResult.success || !remoteResult.success) {
             // Both failed with the exact same error — that's parity.
-            if (!localResult.success && !remoteResult.success && localResult.error === remoteResult.error) {
+            // Guard against false matches on generic fallback strings (e.g. "Unknown error"
+            // from generation.ts when stderr is empty).
+            const GENERIC_ERRORS = new Set(["Unknown error", ""]);
+            if (
+                !localResult.success &&
+                !remoteResult.success &&
+                localResult.error === remoteResult.error &&
+                !GENERIC_ERRORS.has(localResult.error)
+            ) {
                 logger.warn(`Both local and remote generation failed with the same error — treating as parity`);
                 logger.warn(`  Error: ${localResult.error}`);
                 return { success: true };

--- a/packages/seed/src/commands/test-remote-local/testExecution.ts
+++ b/packages/seed/src/commands/test-remote-local/testExecution.ts
@@ -131,20 +131,6 @@ export async function runTestCase(testCase: RemoteVsLocalTestCase): Promise<Test
 
         // Check for generation failures
         if (!localResult.success || !remoteResult.success) {
-            // Both failed with the exact same error — that's parity.
-            // Guard against false matches on generic fallback strings (e.g. "Unknown error"
-            // from generation.ts when stderr is empty).
-            const GENERIC_ERRORS = new Set(["Unknown error", ""]);
-            if (
-                !localResult.success &&
-                !remoteResult.success &&
-                localResult.error === remoteResult.error &&
-                !GENERIC_ERRORS.has(localResult.error)
-            ) {
-                logger.warn(`Both local and remote generation failed with the same error — treating as parity`);
-                logger.warn(`  Error: ${localResult.error}`);
-                return { success: true };
-            }
             const errors: string[] = [];
             if (!localResult.success) {
                 errors.push(`Local generation failed: ${localResult.error}`);


### PR DESCRIPTION
## Description

Refs: companion generator fix in #15009

The `test-remote-local-parity` workflow tests whether the latest **published** Docker image produces identical output when run locally vs remotely (via Fiddle). Since it validates the published artifact — not the PR code — running it on every push to `main` creates noise and blocks unrelated work when a generator has a known issue.

This PR moves the trigger from `push` to a daily cron schedule.

## Changes Made

- **Replaced `push` trigger with `schedule`**: Daily cron at 6:00 AM UTC. The `workflow_run` (post-publish) and `workflow_dispatch` (manual) triggers are unchanged, so immediate parity checks still happen after every generator release.
- Updated inline comment from "push" to "schedule" to match the new trigger.

## Testing

- [x] Workflow YAML syntax reviewed
- [x] Existing seed tests unaffected — change is scoped to workflow triggers only

## Things for reviewers to check

- [ ] Is daily cron (+ post-publish via `workflow_run`) sufficient coverage, or should `push` be retained?
- [ ] Cron runs against the default branch — confirm this is the intended behavior for this workflow.

Link to Devin session: https://app.devin.ai/sessions/67aa61c55d6a427d90a284cf7cf9a852
Requested by: @Swimburger
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/15011" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
