### PR TITLE
fix(cli-v2): fix CliError imports in org member/token commands

### DIFF
--- a/packages/cli/cli-v2/src/commands/org/member/add/__test__/command.test.ts
+++ b/packages/cli/cli-v2/src/commands/org/member/add/__test__/command.test.ts
@@ -1,7 +1,7 @@
 import type { Logger } from "@fern-api/logger";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-import { CliError } from "../../../../../errors/CliError.js";
+import { CliError } from "@fern-api/task-context";
 import { InviteMemberCommand } from "../command.js";
 
 vi.mock("@fern-api/core", () => ({

--- a/packages/cli/cli-v2/src/commands/org/member/add/__test__/command.test.ts
+++ b/packages/cli/cli-v2/src/commands/org/member/add/__test__/command.test.ts
@@ -1,7 +1,6 @@
 import type { Logger } from "@fern-api/logger";
-import { beforeEach, describe, expect, it, vi } from "vitest";
-
 import { CliError } from "@fern-api/task-context";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { InviteMemberCommand } from "../command.js";
 
 vi.mock("@fern-api/core", () => ({

--- a/packages/cli/cli-v2/src/commands/org/member/add/command.ts
+++ b/packages/cli/cli-v2/src/commands/org/member/add/command.ts
@@ -1,9 +1,8 @@
 import { createVenusService } from "@fern-api/core";
+import { CliError } from "@fern-api/task-context";
 import type { Argv } from "yargs";
-
 import type { Context } from "../../../../context/Context.js";
 import type { GlobalArgs } from "../../../../context/GlobalArgs.js";
-import { CliError } from "@fern-api/task-context";
 import { Icons } from "../../../../ui/format.js";
 import { withSpinner } from "../../../../ui/withSpinner.js";
 import { command } from "../../../_internal/command.js";

--- a/packages/cli/cli-v2/src/commands/org/member/add/command.ts
+++ b/packages/cli/cli-v2/src/commands/org/member/add/command.ts
@@ -3,7 +3,7 @@ import type { Argv } from "yargs";
 
 import type { Context } from "../../../../context/Context.js";
 import type { GlobalArgs } from "../../../../context/GlobalArgs.js";
-import { CliError } from "../../../../errors/CliError.js";
+import { CliError } from "@fern-api/task-context";
 import { Icons } from "../../../../ui/format.js";
 import { withSpinner } from "../../../../ui/withSpinner.js";
 import { command } from "../../../_internal/command.js";
@@ -24,7 +24,7 @@ export class InviteMemberCommand {
             context.stderr.error(
                 `${Icons.error} Organization tokens cannot manage members. Unset the FERN_TOKEN environment variable and run 'fern auth login' to manage members.`
             );
-            throw CliError.exit();
+            throw new CliError({ code: CliError.Code.AuthError });
         }
 
         const venus = createVenusService({ token: token.value });
@@ -34,11 +34,11 @@ export class InviteMemberCommand {
             orgLookup.error._visit({
                 unauthorizedError: () => {
                     context.stderr.error(`${Icons.error} You do not have access to organization "${args.org}".`);
-                    throw CliError.exit();
+                    throw new CliError({ code: CliError.Code.AuthError });
                 },
                 _other: () => {
                     context.stderr.error(`${Icons.error} Organization "${args.org}" was not found.`);
-                    throw CliError.exit();
+                    throw CliError.notFound();
                 }
             });
             return;
@@ -68,18 +68,18 @@ export class InviteMemberCommand {
                 context.stderr.error(
                     `${Icons.error} You do not have permission to invite members to organization "${args.org}".`
                 );
-                throw CliError.exit();
+                throw new CliError({ code: CliError.Code.AuthError });
             },
             userIdDoesNotExistError: () => {
                 context.stderr.error(`${Icons.error} No user found with email "${args.email}".`);
-                throw CliError.exit();
+                throw CliError.notFound();
             },
             _other: () => {
                 context.stderr.error(
                     `${Icons.error} Failed to invite member.\n` +
                         `\n  Please contact support@buildwithfern.com for assistance.`
                 );
-                throw CliError.exit();
+                throw CliError.internalError();
             }
         });
     }

--- a/packages/cli/cli-v2/src/commands/org/member/list/__test__/command.test.ts
+++ b/packages/cli/cli-v2/src/commands/org/member/list/__test__/command.test.ts
@@ -1,7 +1,7 @@
 import type { Logger } from "@fern-api/logger";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-import { CliError } from "../../../../../errors/CliError.js";
+import { CliError } from "@fern-api/task-context";
 import { ListMembersCommand } from "../command.js";
 
 vi.mock("@fern-api/core", () => ({

--- a/packages/cli/cli-v2/src/commands/org/member/list/__test__/command.test.ts
+++ b/packages/cli/cli-v2/src/commands/org/member/list/__test__/command.test.ts
@@ -1,7 +1,6 @@
 import type { Logger } from "@fern-api/logger";
-import { beforeEach, describe, expect, it, vi } from "vitest";
-
 import { CliError } from "@fern-api/task-context";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { ListMembersCommand } from "../command.js";
 
 vi.mock("@fern-api/core", () => ({

--- a/packages/cli/cli-v2/src/commands/org/member/list/command.ts
+++ b/packages/cli/cli-v2/src/commands/org/member/list/command.ts
@@ -3,7 +3,7 @@ import type { Argv } from "yargs";
 
 import type { Context } from "../../../../context/Context.js";
 import type { GlobalArgs } from "../../../../context/GlobalArgs.js";
-import { CliError } from "../../../../errors/CliError.js";
+import { CliError } from "@fern-api/task-context";
 import { Colors, Icons } from "../../../../ui/format.js";
 import { withSpinner } from "../../../../ui/withSpinner.js";
 import { command } from "../../../_internal/command.js";
@@ -23,7 +23,7 @@ export class ListMembersCommand {
             context.stderr.error(
                 `${Icons.error} Organization tokens cannot list members. Unset the FERN_TOKEN environment variable and run 'fern auth login' to list members.`
             );
-            throw CliError.exit();
+            throw new CliError({ code: CliError.Code.AuthError });
         }
 
         const venus = createVenusService({ token: token.value });
@@ -37,14 +37,14 @@ export class ListMembersCommand {
             response.error._visit({
                 unauthorizedError: () => {
                     context.stderr.error(`${Icons.error} You do not have access to organization "${args.org}".`);
-                    throw CliError.exit();
+                    throw new CliError({ code: CliError.Code.AuthError });
                 },
                 _other: () => {
                     context.stderr.error(
                         `${Icons.error} Failed to list members.\n` +
                             `\n  Please contact support@buildwithfern.com for assistance.`
                     );
-                    throw CliError.exit();
+                    throw CliError.internalError();
                 }
             });
             return;

--- a/packages/cli/cli-v2/src/commands/org/member/list/command.ts
+++ b/packages/cli/cli-v2/src/commands/org/member/list/command.ts
@@ -1,9 +1,8 @@
 import { createVenusService } from "@fern-api/core";
+import { CliError } from "@fern-api/task-context";
 import type { Argv } from "yargs";
-
 import type { Context } from "../../../../context/Context.js";
 import type { GlobalArgs } from "../../../../context/GlobalArgs.js";
-import { CliError } from "@fern-api/task-context";
 import { Colors, Icons } from "../../../../ui/format.js";
 import { withSpinner } from "../../../../ui/withSpinner.js";
 import { command } from "../../../_internal/command.js";

--- a/packages/cli/cli-v2/src/commands/org/member/remove/__test__/command.test.ts
+++ b/packages/cli/cli-v2/src/commands/org/member/remove/__test__/command.test.ts
@@ -1,7 +1,7 @@
 import type { Logger } from "@fern-api/logger";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-import { CliError } from "../../../../../errors/CliError.js";
+import { CliError } from "@fern-api/task-context";
 import { RemoveMemberCommand } from "../command.js";
 
 vi.mock("@fern-api/core", () => ({

--- a/packages/cli/cli-v2/src/commands/org/member/remove/__test__/command.test.ts
+++ b/packages/cli/cli-v2/src/commands/org/member/remove/__test__/command.test.ts
@@ -1,7 +1,6 @@
 import type { Logger } from "@fern-api/logger";
-import { beforeEach, describe, expect, it, vi } from "vitest";
-
 import { CliError } from "@fern-api/task-context";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { RemoveMemberCommand } from "../command.js";
 
 vi.mock("@fern-api/core", () => ({

--- a/packages/cli/cli-v2/src/commands/org/member/remove/command.ts
+++ b/packages/cli/cli-v2/src/commands/org/member/remove/command.ts
@@ -3,7 +3,7 @@ import type { Argv } from "yargs";
 
 import type { Context } from "../../../../context/Context.js";
 import type { GlobalArgs } from "../../../../context/GlobalArgs.js";
-import { CliError } from "../../../../errors/CliError.js";
+import { CliError } from "@fern-api/task-context";
 import { Icons } from "../../../../ui/format.js";
 import { withSpinner } from "../../../../ui/withSpinner.js";
 import { command } from "../../../_internal/command.js";
@@ -24,7 +24,7 @@ export class RemoveMemberCommand {
             context.stderr.error(
                 `${Icons.error} Organization tokens cannot remove members. Unset the FERN_TOKEN environment variable and run 'fern auth login' to remove members.`
             );
-            throw CliError.exit();
+            throw new CliError({ code: CliError.Code.AuthError });
         }
 
         const venus = createVenusService({ token: token.value });
@@ -34,11 +34,11 @@ export class RemoveMemberCommand {
             orgLookup.error._visit({
                 unauthorizedError: () => {
                     context.stderr.error(`${Icons.error} You do not have access to organization "${args.org}".`);
-                    throw CliError.exit();
+                    throw new CliError({ code: CliError.Code.AuthError });
                 },
                 _other: () => {
                     context.stderr.error(`${Icons.error} Organization "${args.org}" was not found.`);
-                    throw CliError.exit();
+                    throw CliError.notFound();
                 }
             });
             return;
@@ -69,18 +69,18 @@ export class RemoveMemberCommand {
                 context.stderr.error(
                     `${Icons.error} You do not have permission to remove members from organization "${args.org}".`
                 );
-                throw CliError.exit();
+                throw new CliError({ code: CliError.Code.AuthError });
             },
             userIdDoesNotExistError: () => {
                 context.stderr.error(`${Icons.error} User "${userId}" was not found.`);
-                throw CliError.exit();
+                throw CliError.notFound();
             },
             _other: () => {
                 context.stderr.error(
                     `${Icons.error} Failed to remove member.\n` +
                         `\n  Please contact support@buildwithfern.com for assistance.`
                 );
-                throw CliError.exit();
+                throw CliError.internalError();
             }
         });
     }

--- a/packages/cli/cli-v2/src/commands/org/member/remove/command.ts
+++ b/packages/cli/cli-v2/src/commands/org/member/remove/command.ts
@@ -1,9 +1,8 @@
 import { createVenusService } from "@fern-api/core";
+import { CliError } from "@fern-api/task-context";
 import type { Argv } from "yargs";
-
 import type { Context } from "../../../../context/Context.js";
 import type { GlobalArgs } from "../../../../context/GlobalArgs.js";
-import { CliError } from "@fern-api/task-context";
 import { Icons } from "../../../../ui/format.js";
 import { withSpinner } from "../../../../ui/withSpinner.js";
 import { command } from "../../../_internal/command.js";

--- a/packages/cli/cli-v2/src/commands/org/token/create/__test__/command.test.ts
+++ b/packages/cli/cli-v2/src/commands/org/token/create/__test__/command.test.ts
@@ -1,7 +1,7 @@
 import type { Logger } from "@fern-api/logger";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-import { CliError } from "../../../../../errors/CliError.js";
+import { CliError } from "@fern-api/task-context";
 import { CreateTokenCommand } from "../command.js";
 
 vi.mock("@fern-api/core", () => ({

--- a/packages/cli/cli-v2/src/commands/org/token/create/__test__/command.test.ts
+++ b/packages/cli/cli-v2/src/commands/org/token/create/__test__/command.test.ts
@@ -1,7 +1,6 @@
 import type { Logger } from "@fern-api/logger";
-import { beforeEach, describe, expect, it, vi } from "vitest";
-
 import { CliError } from "@fern-api/task-context";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { CreateTokenCommand } from "../command.js";
 
 vi.mock("@fern-api/core", () => ({

--- a/packages/cli/cli-v2/src/commands/org/token/create/command.ts
+++ b/packages/cli/cli-v2/src/commands/org/token/create/command.ts
@@ -3,7 +3,7 @@ import type { Argv } from "yargs";
 
 import type { Context } from "../../../../context/Context.js";
 import type { GlobalArgs } from "../../../../context/GlobalArgs.js";
-import { CliError } from "../../../../errors/CliError.js";
+import { CliError } from "@fern-api/task-context";
 import { Icons } from "../../../../ui/format.js";
 import { withSpinner } from "../../../../ui/withSpinner.js";
 import { command } from "../../../_internal/command.js";
@@ -24,7 +24,7 @@ export class CreateTokenCommand {
             context.stderr.error(
                 `${Icons.error} Organization tokens cannot manage API tokens. Unset the FERN_TOKEN environment variable and run 'fern auth login' to manage tokens.`
             );
-            throw CliError.exit();
+            throw new CliError({ code: CliError.Code.AuthError });
         }
 
         const venus = createVenusService({ token: token.value });
@@ -34,11 +34,11 @@ export class CreateTokenCommand {
             orgLookup.error._visit({
                 unauthorizedError: () => {
                     context.stderr.error(`${Icons.error} You do not have access to organization "${args.org}".`);
-                    throw CliError.exit();
+                    throw new CliError({ code: CliError.Code.AuthError });
                 },
                 _other: () => {
                     context.stderr.error(`${Icons.error} Organization "${args.org}" was not found.`);
-                    throw CliError.exit();
+                    throw CliError.notFound();
                 }
             });
             return;
@@ -73,18 +73,18 @@ export class CreateTokenCommand {
         response.error._visit({
             unauthorizedError: () => {
                 context.stderr.error(`${Icons.error} You do not have access to organization "${args.org}".`);
-                throw CliError.exit();
+                throw new CliError({ code: CliError.Code.AuthError });
             },
             organizationNotFoundError: () => {
                 context.stderr.error(`${Icons.error} Organization "${args.org}" was not found.`);
-                throw CliError.exit();
+                throw CliError.notFound();
             },
             _other: () => {
                 context.stderr.error(
                     `${Icons.error} Failed to create token.\n` +
                         `\n  Please contact support@buildwithfern.com for assistance.`
                 );
-                throw CliError.exit();
+                throw CliError.internalError();
             }
         });
     }

--- a/packages/cli/cli-v2/src/commands/org/token/create/command.ts
+++ b/packages/cli/cli-v2/src/commands/org/token/create/command.ts
@@ -1,9 +1,8 @@
 import { createVenusService } from "@fern-api/core";
+import { CliError } from "@fern-api/task-context";
 import type { Argv } from "yargs";
-
 import type { Context } from "../../../../context/Context.js";
 import type { GlobalArgs } from "../../../../context/GlobalArgs.js";
-import { CliError } from "@fern-api/task-context";
 import { Icons } from "../../../../ui/format.js";
 import { withSpinner } from "../../../../ui/withSpinner.js";
 import { command } from "../../../_internal/command.js";

--- a/packages/cli/cli-v2/src/commands/org/token/list/__test__/command.test.ts
+++ b/packages/cli/cli-v2/src/commands/org/token/list/__test__/command.test.ts
@@ -1,7 +1,6 @@
 import type { Logger } from "@fern-api/logger";
-import { beforeEach, describe, expect, it, vi } from "vitest";
-
 import { CliError } from "@fern-api/task-context";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { ListTokensCommand } from "../command.js";
 
 vi.mock("@fern-api/core", () => ({

--- a/packages/cli/cli-v2/src/commands/org/token/list/__test__/command.test.ts
+++ b/packages/cli/cli-v2/src/commands/org/token/list/__test__/command.test.ts
@@ -1,7 +1,7 @@
 import type { Logger } from "@fern-api/logger";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-import { CliError } from "../../../../../errors/CliError.js";
+import { CliError } from "@fern-api/task-context";
 import { ListTokensCommand } from "../command.js";
 
 vi.mock("@fern-api/core", () => ({

--- a/packages/cli/cli-v2/src/commands/org/token/list/command.ts
+++ b/packages/cli/cli-v2/src/commands/org/token/list/command.ts
@@ -4,7 +4,7 @@ import type { Argv } from "yargs";
 
 import type { Context } from "../../../../context/Context.js";
 import type { GlobalArgs } from "../../../../context/GlobalArgs.js";
-import { CliError } from "../../../../errors/CliError.js";
+import { CliError } from "@fern-api/task-context";
 import { Colors, Icons } from "../../../../ui/format.js";
 import { withSpinner } from "../../../../ui/withSpinner.js";
 import { command } from "../../../_internal/command.js";
@@ -24,7 +24,7 @@ export class ListTokensCommand {
             context.stderr.error(
                 `${Icons.error} Organization tokens cannot list API tokens. Unset the FERN_TOKEN environment variable and run 'fern auth login' to list tokens.`
             );
-            throw CliError.exit();
+            throw new CliError({ code: CliError.Code.AuthError });
         }
 
         const venus = createVenusService({ token: token.value });
@@ -34,11 +34,11 @@ export class ListTokensCommand {
             orgLookup.error._visit({
                 unauthorizedError: () => {
                     context.stderr.error(`${Icons.error} You do not have access to organization "${args.org}".`);
-                    throw CliError.exit();
+                    throw new CliError({ code: CliError.Code.AuthError });
                 },
                 _other: () => {
                     context.stderr.error(`${Icons.error} Organization "${args.org}" was not found.`);
-                    throw CliError.exit();
+                    throw CliError.notFound();
                 }
             });
             return;
@@ -54,18 +54,18 @@ export class ListTokensCommand {
             response.error._visit({
                 unauthorizedError: () => {
                     context.stderr.error(`${Icons.error} You do not have access to organization "${args.org}".`);
-                    throw CliError.exit();
+                    throw new CliError({ code: CliError.Code.AuthError });
                 },
                 organizationNotFoundError: () => {
                     context.stderr.error(`${Icons.error} Organization "${args.org}" was not found.`);
-                    throw CliError.exit();
+                    throw CliError.notFound();
                 },
                 _other: () => {
                     context.stderr.error(
                         `${Icons.error} Failed to list tokens.\n` +
                             `\n  Please contact support@buildwithfern.com for assistance.`
                     );
-                    throw CliError.exit();
+                    throw CliError.internalError();
                 }
             });
             return;

--- a/packages/cli/cli-v2/src/commands/org/token/list/command.ts
+++ b/packages/cli/cli-v2/src/commands/org/token/list/command.ts
@@ -1,10 +1,9 @@
 import { createVenusService } from "@fern-api/core";
 import { assertNever } from "@fern-api/core-utils";
+import { CliError } from "@fern-api/task-context";
 import type { Argv } from "yargs";
-
 import type { Context } from "../../../../context/Context.js";
 import type { GlobalArgs } from "../../../../context/GlobalArgs.js";
-import { CliError } from "@fern-api/task-context";
 import { Colors, Icons } from "../../../../ui/format.js";
 import { withSpinner } from "../../../../ui/withSpinner.js";
 import { command } from "../../../_internal/command.js";

--- a/packages/cli/cli-v2/src/commands/org/token/revoke/__test__/command.test.ts
+++ b/packages/cli/cli-v2/src/commands/org/token/revoke/__test__/command.test.ts
@@ -1,7 +1,7 @@
 import type { Logger } from "@fern-api/logger";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-import { CliError } from "../../../../../errors/CliError.js";
+import { CliError } from "@fern-api/task-context";
 import { RevokeTokenCommand } from "../command.js";
 
 vi.mock("@fern-api/core", () => ({

--- a/packages/cli/cli-v2/src/commands/org/token/revoke/__test__/command.test.ts
+++ b/packages/cli/cli-v2/src/commands/org/token/revoke/__test__/command.test.ts
@@ -1,7 +1,6 @@
 import type { Logger } from "@fern-api/logger";
-import { beforeEach, describe, expect, it, vi } from "vitest";
-
 import { CliError } from "@fern-api/task-context";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { RevokeTokenCommand } from "../command.js";
 
 vi.mock("@fern-api/core", () => ({

--- a/packages/cli/cli-v2/src/commands/org/token/revoke/command.ts
+++ b/packages/cli/cli-v2/src/commands/org/token/revoke/command.ts
@@ -1,9 +1,8 @@
 import { createVenusService } from "@fern-api/core";
+import { CliError } from "@fern-api/task-context";
 import type { Argv } from "yargs";
-
 import type { Context } from "../../../../context/Context.js";
 import type { GlobalArgs } from "../../../../context/GlobalArgs.js";
-import { CliError } from "@fern-api/task-context";
 import { Icons } from "../../../../ui/format.js";
 import { withSpinner } from "../../../../ui/withSpinner.js";
 import { command } from "../../../_internal/command.js";

--- a/packages/cli/cli-v2/src/commands/org/token/revoke/command.ts
+++ b/packages/cli/cli-v2/src/commands/org/token/revoke/command.ts
@@ -3,7 +3,7 @@ import type { Argv } from "yargs";
 
 import type { Context } from "../../../../context/Context.js";
 import type { GlobalArgs } from "../../../../context/GlobalArgs.js";
-import { CliError } from "../../../../errors/CliError.js";
+import { CliError } from "@fern-api/task-context";
 import { Icons } from "../../../../ui/format.js";
 import { withSpinner } from "../../../../ui/withSpinner.js";
 import { command } from "../../../_internal/command.js";
@@ -23,7 +23,7 @@ export class RevokeTokenCommand {
             context.stderr.error(
                 `${Icons.error} Organization tokens cannot revoke API tokens. Unset the FERN_TOKEN environment variable and run 'fern auth login' to revoke tokens.`
             );
-            throw CliError.exit();
+            throw new CliError({ code: CliError.Code.AuthError });
         }
 
         const venus = createVenusService({ token: token.value });
@@ -47,18 +47,18 @@ export class RevokeTokenCommand {
         response.error._visit({
             unauthorizedError: () => {
                 context.stderr.error(`${Icons.error} You are not authorized to revoke this token.`);
-                throw CliError.exit();
+                throw new CliError({ code: CliError.Code.AuthError });
             },
             tokenNotFoundError: () => {
                 context.stderr.error(`${Icons.error} Token "${tokenId}" was not found.`);
-                throw CliError.exit();
+                throw CliError.notFound();
             },
             _other: () => {
                 context.stderr.error(
                     `${Icons.error} Failed to revoke token.\n` +
                         `\n  Please contact support@buildwithfern.com for assistance.`
                 );
-                throw CliError.exit();
+                throw CliError.internalError();
             }
         });
     }


### PR DESCRIPTION
## Description
Refs #14884

Fixes CI compilation failure on `main` introduced by #14884 (`feat(cli-v2): add org token and member sub-commands`). All 12 new files referenced a nonexistent `CliError` module and a nonexistent `.exit()` static method.

## Changes Made
- **Fixed imports (12 files):** Replaced `import { CliError } from "../../../../errors/CliError.js"` (and `../../../../../` variant in tests) with `import { CliError } from "@fern-api/task-context"`, matching the existing `org create` and `org list` commands.
- **Replaced `CliError.exit()` calls (6 command files):** `CliError.exit()` does not exist on the `@fern-api/task-context` `CliError` class. Replaced with the appropriate constructors following existing patterns:
  - Unauthorized / auth errors → `new CliError({ code: CliError.Code.AuthError })`
  - Not-found errors → `CliError.notFound()`
  - Generic / unknown failures → `CliError.internalError()`

## Human Review Checklist
- [ ] **Error code mapping**: Verify the chosen error codes (`AuthError`, `notFound`, `internalError`) are semantically correct for each throw site. The existing tests only assert on stderr message content, not on error codes, so a wrong code would not be caught by tests.

## Testing
- [x] `pnpm compile --filter=@fern-api/cli-v2` passes (was failing with 12 TS2307/TS2339 errors before this fix)
- [x] `pnpm format` — no changes needed

Link to Devin session: https://app.devin.ai/sessions/7a6f99d9f0e94dbb9eca084d4490c833
Requested by: @Swimburger
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/15014" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
