### PR TITLE
fix(cli): do not default editThisPageLaunch to "dashboard" when edit-this-page is unconfigured

### DIFF
--- a/packages/cli/cli/changes/unreleased/fix-edit-this-page-default.yml
+++ b/packages/cli/cli/changes/unreleased/fix-edit-this-page-default.yml
@@ -1,0 +1,5 @@
+- summary: |
+    Fix "Edit this page" button appearing on docs sites that never configured it.
+    The default `editThisPageLaunch` is now `undefined` instead of `"dashboard"`,
+    so the button only renders when explicitly configured.
+  type: fix

--- a/packages/cli/cli/versions.yml
+++ b/packages/cli/cli/versions.yml
@@ -1,4 +1,13 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 4.70.1
+  changelogEntry:
+    - summary: |
+        Fix "Edit this page" button appearing on docs sites that never configured it.
+        The default `editThisPageLaunch` is now `undefined` instead of `"dashboard"`,
+        so the button only renders when explicitly configured.
+      type: fix
+  createdAt: "2026-04-15"
+  irVersion: 66
 - version: 4.70.0
   changelogEntry:
     - summary: |

--- a/packages/cli/docs-resolver/src/DocsDefinitionResolver.ts
+++ b/packages/cli/docs-resolver/src/DocsDefinitionResolver.ts
@@ -521,7 +521,7 @@ export class DocsDefinitionResolver {
             pages[DocsV1Write.PageId(relativePageFilepath)] = {
                 markdown: stripMdxComments(markdown),
                 editThisPageUrl: editThisPageUrl ? DocsV1Write.Url(editThisPageUrl) : undefined,
-                editThisPageLaunch: editThisPageLaunch as DocsV1Write.EditThisPageLaunch,
+                editThisPageLaunch: editThisPageLaunch as DocsV1Write.EditThisPageLaunch | undefined,
                 rawMarkdown: rawMarkdown
             };
         });
@@ -873,7 +873,7 @@ export class DocsDefinitionResolver {
                 this.parsedDocsConfig.announcement != null
                     ? { text: this.parsedDocsConfig.announcement.message }
                     : undefined,
-            editThisPageLaunch: (this.editThisPage?.launch ?? "dashboard") as DocsV1Write.EditThisPageLaunch,
+            editThisPageLaunch: this.editThisPage?.launch as DocsV1Write.EditThisPageLaunch | undefined,
             pageActions: this.convertPageActions(),
             theme:
                 this.parsedDocsConfig.theme != null
@@ -2287,8 +2287,8 @@ export class DocsDefinitionResolver {
 function createEditThisPageUrl(
     editThisPage: docsYml.RawSchemas.FernDocsConfig.EditThisPageConfig | undefined,
     pageFilepath: string
-): { url: string | undefined; launch: string } {
-    const launch = editThisPage?.launch ?? "dashboard";
+): { url: string | undefined; launch: string | undefined } {
+    const launch = editThisPage?.launch;
 
     if (editThisPage?.github == null) {
         return { url: undefined, launch };


### PR DESCRIPTION
## Description

Fixes the "Edit this page" button appearing on all docs sites even when the customer never configured `edit-this-page` in their `docs.yml`. This was a regression introduced in #14380 (v4.51.0), which changed the default `editThisPageLaunch` from `undefined` to `"dashboard"`.

The rendering side (`AbstractFooterLayout.tsx` in fern-platform) shows the dashboard edit button whenever `editThisPageLaunch === "dashboard"` and `docsUrl`/`slug`/`orgName` are present — those three are always available, so the button appeared unconditionally.

## Changes Made

- Removed the `?? "dashboard"` fallback in `DocsDefinitionResolver.ts` at both the config-level (line 876) and the `createEditThisPageUrl` helper (line 2291)
- Updated type annotations to allow `undefined` (`DocsV1Write.EditThisPageLaunch | undefined`) at both assignment sites
- Added unreleased changelog entry
- Added `versions.yml` entry for 4.70.1

## Testing

- [ ] Unit tests added/updated
- [x] Lint/typecheck passes (`pnpm run check`)

## Review Checklist

- [ ] Verify the FDR write API schema accepts `editThisPageLaunch` as optional/nullable — if it's required, this will break registration
- [ ] Confirm no regression for customers who *do* explicitly set `launch: dashboard` in their `edit-this-page` config (those should still work since `editThisPage?.launch` returns `"dashboard"`)
- [ ] Rendering side in `fern-platform` (`AbstractFooterLayout.tsx`) already returns `null` when `editThisPageLaunch` is not `"dashboard"`, so no changes needed there — but worth a quick sanity check

Link to Devin session: https://app.devin.ai/sessions/2403b6456b4d42bb9a5a11958e0b425e
Requested by: @thesandlord