### PR TITLE
fix(ci): scope hashFiles glob in cached-seed to avoid timeout

### DIFF
--- a/.github/actions/cached-seed/action.yaml
+++ b/.github/actions/cached-seed/action.yaml
@@ -74,7 +74,7 @@ runs:
       uses: actions/cache@v4
       with:
         path: /tmp/docker-cache
-        key: ${{ runner.os }}-docker-${{ inputs.generator-name }}-${{ hashFiles('**/Dockerfile*') }}
+        key: ${{ runner.os }}-docker-${{ inputs.generator-name }}-${{ hashFiles('generators/**/Dockerfile*', 'docker/**/Dockerfile*', 'packages/**/Dockerfile*') }}
         restore-keys: |
           ${{ runner.os }}-docker-${{ inputs.generator-name }}-
 


### PR DESCRIPTION
## Description

Fixes a consistent CI failure where the `hashFiles('**/Dockerfile*')` call in the `cached-seed` action times out after 120 seconds during the post-job cache save step.

Error: `hashFiles('**/Dockerfile*') couldn't finish within 120 seconds.`

## Changes Made

- Scoped the `hashFiles` glob from `**/Dockerfile*` (entire workspace) to `generators/**/Dockerfile*`, `docker/**/Dockerfile*`, `packages/**/Dockerfile*` (only directories containing Dockerfiles)

**Root cause:** The `**` glob scans the entire workspace, including the `seed/` output directory which grows to 900MB+ with hundreds of thousands of generated files during seed tests. This causes `hashFiles` to exceed its 120-second timeout.

## Testing

- [ ] Manual testing completed — this can only be validated by CI running the `cached-seed` action successfully
- Verified all Dockerfiles in the repo exist under `generators/`, `docker/`, or `packages/` — no Dockerfiles are missed by the scoped globs

## Review Checklist

- [ ] Confirm the three directory prefixes cover all Dockerfile locations (verified via `find` — they do)
- [ ] Note: this changes the cache key, so there will be a one-time cache miss after merge

Link to Devin session: https://app.devin.ai/sessions/48ea5e97c4284bdcbd4b66a2b6accb3b
Requested by: @davidkonigsberg
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/15022" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
