### PR TITLE
feat(ci): handle pre-release versions and add pre-release tag support to release script

### DIFF
--- a/fern-changes-yml.schema.json
+++ b/fern-changes-yml.schema.json
@@ -18,6 +18,10 @@
                 "type": {
                     "$ref": "#/definitions/ChangelogType",
                     "description": "Type of change determines version bump: fix/chore (patch), feat/internal (minor), break (major)"
+                },
+                "pre-release": {
+                    "$ref": "#/definitions/PreReleaseTag",
+                    "description": "Optional pre-release tag. When set, the release version includes this suffix (e.g., 1.2.0-rc.0)."
                 }
             },
             "required": [
@@ -37,6 +41,16 @@
             ],
             "title": "Changelog Type",
             "description": "The type of change: fix/chore → patch, feat/internal → minor, break → major"
+        },
+        "PreReleaseTag": {
+            "type": "string",
+            "enum": [
+                "alpha",
+                "beta",
+                "rc"
+            ],
+            "title": "Pre-Release Tag",
+            "description": "Pre-release identifier appended to the version (e.g., rc → 1.2.0-rc.0)"
         }
     }
 }

--- a/generators/csharp/sdk/changes/unreleased/.template.yml
+++ b/generators/csharp/sdk/changes/unreleased/.template.yml
@@ -6,3 +6,4 @@
     Brief description of your change.
     You can use multiple lines for longer descriptions.
   type: feat  # Options: fix/chore (patch), feat/internal (minor), break (major)
+  # pre-release: rc  # Optional: alpha, beta, or rc (e.g., produces 1.2.0-rc.0)

--- a/generators/go/sdk/changes/unreleased/.template.yml
+++ b/generators/go/sdk/changes/unreleased/.template.yml
@@ -6,3 +6,4 @@
     Brief description of your change.
     You can use multiple lines for longer descriptions.
   type: feat  # Options: fix/chore (patch), feat/internal (minor), break (major)
+  # pre-release: rc  # Optional: alpha, beta, or rc (e.g., produces 1.2.0-rc.0)

--- a/generators/java/sdk/changes/unreleased/.template.yml
+++ b/generators/java/sdk/changes/unreleased/.template.yml
@@ -6,3 +6,4 @@
     Brief description of your change.
     You can use multiple lines for longer descriptions.
   type: feat  # Options: fix/chore (patch), feat/internal (minor), break (major)
+  # pre-release: rc  # Optional: alpha, beta, or rc (e.g., produces 1.2.0-rc.0)

--- a/generators/php/sdk/changes/unreleased/.template.yml
+++ b/generators/php/sdk/changes/unreleased/.template.yml
@@ -6,3 +6,4 @@
     Brief description of your change.
     You can use multiple lines for longer descriptions.
   type: feat  # Options: fix/chore (patch), feat/internal (minor), break (major)
+  # pre-release: rc  # Optional: alpha, beta, or rc (e.g., produces 1.2.0-rc.0)

--- a/generators/python/sdk/changes/unreleased/.template.yml
+++ b/generators/python/sdk/changes/unreleased/.template.yml
@@ -6,3 +6,4 @@
     Brief description of your change.
     You can use multiple lines for longer descriptions.
   type: feat  # Options: fix/chore (patch), feat/internal (minor), break (major)
+  # pre-release: rc  # Optional: alpha, beta, or rc (e.g., produces 1.2.0-rc.0)

--- a/generators/ruby-v2/sdk/changes/unreleased/.template.yml
+++ b/generators/ruby-v2/sdk/changes/unreleased/.template.yml
@@ -6,3 +6,4 @@
     Brief description of your change.
     You can use multiple lines for longer descriptions.
   type: feat  # Options: fix/chore (patch), feat/internal (minor), break (major)
+  # pre-release: rc  # Optional: alpha, beta, or rc (e.g., produces 1.2.0-rc.0)

--- a/generators/ruby/sdk/changes/unreleased/.template.yml
+++ b/generators/ruby/sdk/changes/unreleased/.template.yml
@@ -6,3 +6,4 @@
     Brief description of your change.
     You can use multiple lines for longer descriptions.
   type: feat  # Options: fix/chore (patch), feat/internal (minor), break (major)
+  # pre-release: rc  # Optional: alpha, beta, or rc (e.g., produces 1.2.0-rc.0)

--- a/generators/rust/sdk/changes/unreleased/.template.yml
+++ b/generators/rust/sdk/changes/unreleased/.template.yml
@@ -6,3 +6,4 @@
     Brief description of your change.
     You can use multiple lines for longer descriptions.
   type: feat  # Options: fix/chore (patch), feat/internal (minor), break (major)
+  # pre-release: rc  # Optional: alpha, beta, or rc (e.g., produces 1.2.0-rc.0)

--- a/generators/swift/sdk/changes/unreleased/.template.yml
+++ b/generators/swift/sdk/changes/unreleased/.template.yml
@@ -6,3 +6,4 @@
     Brief description of your change.
     You can use multiple lines for longer descriptions.
   type: feat  # Options: fix/chore (patch), feat/internal (minor), break (major)
+  # pre-release: rc  # Optional: alpha, beta, or rc (e.g., produces 1.2.0-rc.0)

--- a/generators/typescript/sdk/changes/unreleased/.template.yml
+++ b/generators/typescript/sdk/changes/unreleased/.template.yml
@@ -6,3 +6,4 @@
     Brief description of your change.
     You can use multiple lines for longer descriptions.
   type: feat  # Options: fix/chore (patch), feat/internal (minor), break (major)
+  # pre-release: rc  # Optional: alpha, beta, or rc (e.g., produces 1.2.0-rc.0)

--- a/packages/cli/cli/changes/unreleased/.template.yml
+++ b/packages/cli/cli/changes/unreleased/.template.yml
@@ -6,3 +6,4 @@
     Brief description of your change.
     You can use multiple lines for longer descriptions.
   type: feat  # Options: fix/chore (patch), feat/internal (minor), break (major)
+  # pre-release: rc  # Optional: alpha, beta, or rc (e.g., produces 1.2.0-rc.0)

--- a/scripts/release.ts
+++ b/scripts/release.ts
@@ -17,9 +17,11 @@ import { setupSoftware } from "./release-setup.js";
 interface ChangelogEntry {
     summary: string;
     type: "fix" | "chore" | "feat" | "internal" | "break";
+    "pre-release"?: string;
 }
 
 const VALID_CHANGELOG_TYPES = new Set(["fix", "chore", "feat", "internal", "break"]);
+const VALID_PRE_RELEASE_TAGS = new Set(["alpha", "beta", "rc"]);
 
 type Severity = "major" | "minor" | "patch";
 
@@ -68,12 +70,22 @@ function validateChangelogEntry(entry: unknown, filename: string, index: number)
         process.exit(1);
     }
 
-    const allowedKeys = new Set(["summary", "type"]);
+    if (obj["pre-release"] !== undefined) {
+        if (typeof obj["pre-release"] !== "string" || !VALID_PRE_RELEASE_TAGS.has(obj["pre-release"])) {
+            console.error(
+                `Error in ${filename}, entry ${index + 1}: Invalid "pre-release" field: ${JSON.stringify(obj["pre-release"])}. ` +
+                    `Expected one of: ${[...VALID_PRE_RELEASE_TAGS].join(", ")}`
+            );
+            process.exit(1);
+        }
+    }
+
+    const allowedKeys = new Set(["summary", "type", "pre-release"]);
     for (const key of Object.keys(obj)) {
         if (!allowedKeys.has(key)) {
             console.error(
                 `Error in ${filename}, entry ${index + 1}: Unknown field "${key}". ` +
-                    `Only "summary" and "type" are allowed.`
+                    `Only "summary", "type", and "pre-release" are allowed.`
             );
             process.exit(1);
         }
@@ -130,6 +142,35 @@ function readUnreleasedChanges(unreleasedDir: string): UnreleasedChange[] {
     return changes;
 }
 
+function getPreReleaseTag(changes: UnreleasedChange[]): string | undefined {
+    for (const change of changes) {
+        for (const entry of change.entries) {
+            if (entry["pre-release"]) {
+                return entry["pre-release"];
+            }
+        }
+    }
+    return undefined;
+}
+
+/**
+ * Parses the pre-release counter from a version string.
+ * E.g., "4.2.0-rc.1" with tag "rc" returns 1; "4.2.0-rc0" with tag "rc" returns 0.
+ * Returns undefined if the current version doesn't use the same pre-release tag.
+ */
+function getPreReleaseCounter(currentVersion: string, tag: string): number | undefined {
+    // Match formats like "-rc.1" or "-rc1"
+    const dotMatch = currentVersion.match(new RegExp(`-${tag}\\.(\\d+)$`));
+    if (dotMatch?.[1] !== undefined) {
+        return Number(dotMatch[1]);
+    }
+    const noDotMatch = currentVersion.match(new RegExp(`-${tag}(\\d+)$`));
+    if (noDotMatch?.[1] !== undefined) {
+        return Number(noDotMatch[1]);
+    }
+    return undefined;
+}
+
 function determineNextVersion(currentVersion: string, changes: UnreleasedChange[]): string {
     let highestSeverity: Severity = "patch";
 
@@ -144,8 +185,10 @@ function determineNextVersion(currentVersion: string, changes: UnreleasedChange[
         }
     }
 
+    const preReleaseTag = getPreReleaseTag(changes);
+
     // Strip pre-release suffix (e.g., "4.2.0-rc.1" -> "4.2.0")
-    const isPreRelease = currentVersion.includes("-");
+    const isCurrentPreRelease = currentVersion.includes("-");
     const baseVersion = currentVersion.replace(/-.*$/, "");
     const [major, minor, patch] = baseVersion.split(".").map(Number);
 
@@ -161,17 +204,35 @@ function determineNextVersion(currentVersion: string, changes: UnreleasedChange[
         process.exit(1);
     }
 
-    // For pre-release versions, graduate to the base version for patch-level
-    // changes (e.g., 4.2.0-rc.1 -> 4.2.0), and bump from the base version
-    // for higher-severity changes (e.g., 4.2.0-rc.1 + minor -> 4.3.0).
+    // Compute the base next version from severity
+    let nextBase: string;
     switch (highestSeverity) {
         case "major":
-            return `${major + 1}.0.0`;
+            nextBase = `${major + 1}.0.0`;
+            break;
         case "minor":
-            return `${major}.${minor + 1}.0`;
+            nextBase = `${major}.${minor + 1}.0`;
+            break;
         case "patch":
-            return isPreRelease ? `${major}.${minor}.${patch}` : `${major}.${minor}.${patch + 1}`;
+            nextBase = isCurrentPreRelease ? `${major}.${minor}.${patch}` : `${major}.${minor}.${patch + 1}`;
+            break;
     }
+
+    // If no pre-release tag requested, return the stable version
+    if (!preReleaseTag) {
+        return nextBase;
+    }
+
+    // If the current version is already a pre-release with the same tag and same
+    // base version, increment the pre-release counter instead of resetting to 0.
+    if (isCurrentPreRelease) {
+        const counter = getPreReleaseCounter(currentVersion, preReleaseTag);
+        if (counter !== undefined && baseVersion === nextBase) {
+            return `${nextBase}-${preReleaseTag}.${counter + 1}`;
+        }
+    }
+
+    return `${nextBase}-${preReleaseTag}.0`;
 }
 
 function getCurrentVersion(versionsFile: string): string {

--- a/scripts/release.ts
+++ b/scripts/release.ts
@@ -144,7 +144,9 @@ function determineNextVersion(currentVersion: string, changes: UnreleasedChange[
         }
     }
 
-    const [major, minor, patch] = currentVersion.split(".").map(Number);
+    // Strip pre-release suffix (e.g., "4.2.0-rc.1" -> "4.2.0")
+    const baseVersion = currentVersion.replace(/-.*$/, "");
+    const [major, minor, patch] = baseVersion.split(".").map(Number);
 
     if (
         major === undefined ||

--- a/scripts/release.ts
+++ b/scripts/release.ts
@@ -145,6 +145,7 @@ function determineNextVersion(currentVersion: string, changes: UnreleasedChange[
     }
 
     // Strip pre-release suffix (e.g., "4.2.0-rc.1" -> "4.2.0")
+    const isPreRelease = currentVersion.includes("-");
     const baseVersion = currentVersion.replace(/-.*$/, "");
     const [major, minor, patch] = baseVersion.split(".").map(Number);
 
@@ -160,13 +161,16 @@ function determineNextVersion(currentVersion: string, changes: UnreleasedChange[
         process.exit(1);
     }
 
+    // For pre-release versions, graduate to the base version for patch-level
+    // changes (e.g., 4.2.0-rc.1 -> 4.2.0), and bump from the base version
+    // for higher-severity changes (e.g., 4.2.0-rc.1 + minor -> 4.3.0).
     switch (highestSeverity) {
         case "major":
             return `${major + 1}.0.0`;
         case "minor":
             return `${major}.${minor + 1}.0`;
         case "patch":
-            return `${major}.${minor}.${patch + 1}`;
+            return isPreRelease ? `${major}.${minor}.${patch}` : `${major}.${minor}.${patch + 1}`;
     }
 }
 


### PR DESCRIPTION
## Description

Fixes the failing [Release Software](https://github.com/fern-api/fern/actions/runs/24453090940) CI workflow and adds first-class pre-release version support to the changelog/release system.

The Java SDK generator release was failing because its current version (`4.2.0-rc.1`) contains a pre-release suffix that the version parser doesn't handle. Root cause: `"4.2.0-rc.1".split(".")` produces `["4", "2", "0-rc", "1"]`, and `Number("0-rc")` is `NaN`, triggering the `"currentVersion is invalid"` error.

Beyond fixing the parse error, this PR adds an optional `pre-release` field to changelog entries so authors can specify whether a release should be `alpha`, `beta`, or `rc`.

## Changes Made

- **Fix version parsing**: Strip pre-release suffix before parsing major/minor/patch components in `determineNextVersion()`
- **Graduation semantics**: When no `pre-release` tag is specified, pre-release versions graduate to their base version for patch-level changes (e.g., `4.2.0-rc.1` + `chore` → `4.2.0`)
- **New `pre-release` field**: Add optional `pre-release` property (`alpha` | `beta` | `rc`) to `ChangelogEntry`, validated in `validateChangelogEntry()`
- **Pre-release counter logic**: New `getPreReleaseTag()` and `getPreReleaseCounter()` helpers to determine and increment the pre-release suffix
- **Schema update**: `fern-changes-yml.schema.json` updated with `PreReleaseTag` definition
- **Template updates**: All 11 `.template.yml` files updated with a commented-out `pre-release` example

### Version bump examples

| Current version | Change type | `pre-release` field | Result |
|---|---|---|---|
| `4.2.0-rc.1` | `chore` | _(none)_ | `4.2.0` |
| `4.2.0-rc.1` | `feat` | _(none)_ | `4.3.0` |
| `4.2.0` | `feat` | `rc` | `4.3.0-rc.0` |
| `4.2.0-rc.1` | `chore` | `rc` | `4.2.0-rc.2` |
| `4.2.0-rc.1` | `feat` | `rc` | `4.3.0-rc.0` |
| `1.1.0-alpha.2` | `chore` | `beta` | `1.1.0-beta.0` |

## Testing

- [ ] Unit tests added/updated
- [x] Manually verified all version bump scenarios listed above via `node -e` script

## Human Review Checklist

- **Graduation semantics**: Patch-level changes on a pre-release _without_ `pre-release` field graduate to the base version (`4.2.0-rc.1` → `4.2.0`). Verify this is the desired behavior vs. producing `4.2.1`.
- **First-tag-wins**: If multiple changelog entries specify different `pre-release` tags, `getPreReleaseTag()` returns the first one found. Conflicting tags are not detected or rejected.
- **No automated tests**: The version logic is only manually verified. Regex edge cases (e.g., a tag name that is a substring of another) are mitigated by the fixed enum (`alpha`, `beta`, `rc`) but not tested.

Link to Devin session: https://app.devin.ai/sessions/bb80eb0bdd964805b998b6e287c0d597
Requested by: @Swimburger
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/15023" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
