### PR TITLE
fix(cli): avoid missing-redirect warnings when old URLs are served by other pages

### DIFF
--- a/packages/cli/cli/changes/unreleased/fix-missing-redirects-changelog-false-positives.yml
+++ b/packages/cli/cli/changes/unreleased/fix-missing-redirects-changelog-false-positives.yml
@@ -1,0 +1,5 @@
+- summary: |
+    Fix false positive warnings in the `missing-redirects` check. Pages are no
+    longer flagged as removed or moved when their old URL is still actively
+    served by another page in the local docs config.
+  type: fix

--- a/packages/cli/yaml/docs-validator/src/rules/missing-redirects/__test__/missing-redirects.test.ts
+++ b/packages/cli/yaml/docs-validator/src/rules/missing-redirects/__test__/missing-redirects.test.ts
@@ -61,6 +61,50 @@ describe("findRemovedSlugs", () => {
         const local = new Map([["docs/welcome.mdx", "welcome"]]);
         expect(findRemovedSlugs([], local)).toEqual([]);
     });
+
+    it("skips removed page when another local page still serves the same slug", () => {
+        const published: MarkdownEntry[] = [
+            { pageId: "docs/welcome.mdx", slug: "welcome" },
+            { pageId: "changelog/2024-01-15.mdx", slug: "changelog" }
+        ];
+        const local = new Map([
+            ["docs/welcome.mdx", "welcome"],
+            ["changelog/overview.mdx", "changelog"]
+        ]);
+        expect(findRemovedSlugs(published, local)).toEqual([]);
+    });
+
+    it("skips moved page when another local page still serves the old slug", () => {
+        const published: MarkdownEntry[] = [{ pageId: "docs/guide.mdx", slug: "shared-slug" }];
+        const local = new Map([
+            ["docs/guide.mdx", "new-slug"],
+            ["docs/other.mdx", "shared-slug"]
+        ]);
+        expect(findRemovedSlugs(published, local)).toEqual([]);
+    });
+
+    it("skips changelog entries that share their parent slug when entry is removed", () => {
+        const published: MarkdownEntry[] = [
+            { pageId: "changelog/2024-01-15.mdx", slug: "whats-new/changelog" },
+            { pageId: "changelog/2024-01-15-hotfix.mdx", slug: "whats-new/changelog" },
+            { pageId: "changelog/2024-02-01.mdx", slug: "whats-new/changelog" }
+        ];
+        const local = new Map([["changelog/2024-02-01.mdx", "whats-new/changelog"]]);
+        expect(findRemovedSlugs(published, local)).toEqual([]);
+    });
+
+    it("skips published entries with empty slug when landing page serves root", () => {
+        const published: MarkdownEntry[] = [{ pageId: "changelog/2024-01-15.mdx", slug: "" }];
+        const local = new Map([["pages/landing.mdx", ""]]);
+        expect(findRemovedSlugs(published, local)).toEqual([]);
+    });
+
+    it("still flags removed page when no local page serves the old slug", () => {
+        const published: MarkdownEntry[] = [{ pageId: "docs/old.mdx", slug: "unique-old-slug" }];
+        const local = new Map([["docs/new.mdx", "different-slug"]]);
+        const removed = findRemovedSlugs(published, local);
+        expect(removed).toEqual([{ pageId: "docs/old.mdx", oldSlug: "unique-old-slug", newSlug: undefined }]);
+    });
 });
 
 describe("checkMissingRedirects", () => {

--- a/packages/cli/yaml/docs-validator/src/rules/missing-redirects/missing-redirects-logic.ts
+++ b/packages/cli/yaml/docs-validator/src/rules/missing-redirects/missing-redirects-logic.ts
@@ -56,18 +56,30 @@ function isSlugCoveredByRedirect(oldSlug: string, redirects: Redirect[], basePat
 /**
  * Compares published slug table entries against the local pageId->slug map
  * and returns entries whose slug disappeared or changed.
+ *
+ * Skips entries whose old slug is still actively served by another page in
+ * the local config. This prevents false positives for changelog entries
+ * (which share their parent changelog page's slug) and other cases where
+ * the URL remains alive despite a specific pageId being removed or moved.
  */
 export function findRemovedSlugs(
     publishedEntries: MarkdownEntry[],
     localPageIdToSlug: Map<string, string>
 ): RemovedSlug[] {
+    const activeSlugs = new Set(localPageIdToSlug.values());
     const removed: RemovedSlug[] = [];
-    for (const entry of publishedEntries) {
-        const newSlug = localPageIdToSlug.get(entry.pageId);
+    for (const publishedEntry of publishedEntries) {
+        const newSlug = localPageIdToSlug.get(publishedEntry.pageId);
         if (newSlug === undefined) {
-            removed.push({ pageId: entry.pageId, oldSlug: entry.slug, newSlug: undefined });
-        } else if (newSlug !== entry.slug) {
-            removed.push({ pageId: entry.pageId, oldSlug: entry.slug, newSlug });
+            if (activeSlugs.has(publishedEntry.slug)) {
+                continue;
+            }
+            removed.push({ pageId: publishedEntry.pageId, oldSlug: publishedEntry.slug, newSlug: undefined });
+        } else if (newSlug !== publishedEntry.slug) {
+            if (activeSlugs.has(publishedEntry.slug)) {
+                continue;
+            }
+            removed.push({ pageId: publishedEntry.pageId, oldSlug: publishedEntry.slug, newSlug });
         }
     }
     return removed;


### PR DESCRIPTION
## Description
Linear ticket: Closes FER-9764
<!-- Use "Closes" to automatically close the ticket when PR merges, or "Refs" to link without closing -->

This PR fixes false positives in the `missing-redirects` check. The validator now only reports a removed or moved page when its previously published URL is no longer served by any page in the current docs config.

## Changes Made
- Updated `missing-redirects` logic to treat a URL as valid when it is still actively served by another local page
- Added test coverage for shared-slug and still-live URL scenarios, including the cases that triggered the customer report

## Testing
- [x] Unit tests added/updated
- [x] Manual testing completed