### PR TITLE
fix(cli): suppress PostHog error events from leaking to end users

### DIFF
--- a/packages/cli/cli-v2/src/telemetry/TelemetryClient.ts
+++ b/packages/cli/cli-v2/src/telemetry/TelemetryClient.ts
@@ -37,7 +37,13 @@ export class TelemetryClient {
             tty: isTTY,
             usingAccessToken: process.env.FERN_TOKEN != null
         };
-        this.posthog = apiKey != null && apiKey.length > 0 && isTelemetryEnabled ? new PostHog(apiKey) : undefined;
+        this.posthog =
+            apiKey != null && apiKey.length > 0 && isTelemetryEnabled
+                ? new PostHog(apiKey, { flushInterval: 0 })
+                : undefined;
+        this.posthog?.on("error", () => {
+            // Silently swallow – analytics errors should never surface to end users
+        });
 
         const sentryDsn = process.env.SENTRY_DSN;
         if (sentryDsn != null && sentryDsn.length > 0 && isTelemetryEnabled) {

--- a/packages/cli/cli-v2/src/telemetry/TelemetryClient.ts
+++ b/packages/cli/cli-v2/src/telemetry/TelemetryClient.ts
@@ -37,10 +37,7 @@ export class TelemetryClient {
             tty: isTTY,
             usingAccessToken: process.env.FERN_TOKEN != null
         };
-        this.posthog =
-            apiKey != null && apiKey.length > 0 && isTelemetryEnabled
-                ? new PostHog(apiKey, { flushInterval: 0 })
-                : undefined;
+        this.posthog = apiKey != null && apiKey.length > 0 && isTelemetryEnabled ? new PostHog(apiKey) : undefined;
         this.posthog?.on("error", () => {
             // Silently swallow – analytics errors should never surface to end users
         });

--- a/packages/cli/cli-v2/src/telemetry/__test__/TelemetryClient.test.ts
+++ b/packages/cli/cli-v2/src/telemetry/__test__/TelemetryClient.test.ts
@@ -13,7 +13,7 @@ const { mockCapture, mockShutdown } = vi.hoisted(() => ({
 vi.mock("posthog-node", () => ({
     // eslint-disable-next-line func-style
     PostHog: vi.fn(function () {
-        return { capture: mockCapture, shutdown: mockShutdown };
+        return { capture: mockCapture, shutdown: mockShutdown, on: vi.fn() };
     })
 }));
 

--- a/packages/cli/cli/changes/unreleased/suppress-posthog-flush-errors.yml
+++ b/packages/cli/cli/changes/unreleased/suppress-posthog-flush-errors.yml
@@ -1,0 +1,3 @@
+- summary: |
+    Suppress PostHog network errors from being shown to end users during CLI execution.
+  type: fix

--- a/packages/cli/posthog-manager/src/AccessTokenPosthogManager.ts
+++ b/packages/cli/posthog-manager/src/AccessTokenPosthogManager.ts
@@ -7,7 +7,10 @@ export class AccessTokenPosthogManager implements PosthogManager {
     private posthog: PostHog;
 
     constructor({ posthogApiKey }: { posthogApiKey: string }) {
-        this.posthog = new PostHog(posthogApiKey);
+        this.posthog = new PostHog(posthogApiKey, { flushInterval: 0 });
+        this.posthog.on("error", () => {
+            // Silently swallow – analytics errors should never surface to end users
+        });
     }
 
     public async identify(): Promise<void> {
@@ -31,7 +34,7 @@ export class AccessTokenPosthogManager implements PosthogManager {
 
     public async flush(): Promise<void> {
         try {
-            await Promise.race([this.posthog.flush(), new Promise<void>((resolve) => setTimeout(resolve, 3000))]);
+            await Promise.race([this.posthog.shutdown(), new Promise<void>((resolve) => setTimeout(resolve, 3000))]);
         } catch {
             // Silently swallow – analytics should never block the CLI
         }

--- a/packages/cli/posthog-manager/src/AccessTokenPosthogManager.ts
+++ b/packages/cli/posthog-manager/src/AccessTokenPosthogManager.ts
@@ -7,7 +7,7 @@ export class AccessTokenPosthogManager implements PosthogManager {
     private posthog: PostHog;
 
     constructor({ posthogApiKey }: { posthogApiKey: string }) {
-        this.posthog = new PostHog(posthogApiKey, { flushInterval: 0 });
+        this.posthog = new PostHog(posthogApiKey);
         this.posthog.on("error", () => {
             // Silently swallow – analytics errors should never surface to end users
         });
@@ -34,7 +34,7 @@ export class AccessTokenPosthogManager implements PosthogManager {
 
     public async flush(): Promise<void> {
         try {
-            await Promise.race([this.posthog.shutdown(), new Promise<void>((resolve) => setTimeout(resolve, 3000))]);
+            await Promise.race([this.posthog.flush(), new Promise<void>((resolve) => setTimeout(resolve, 3000))]);
         } catch {
             // Silently swallow – analytics should never block the CLI
         }

--- a/packages/cli/posthog-manager/src/UserPosthogManager.ts
+++ b/packages/cli/posthog-manager/src/UserPosthogManager.ts
@@ -19,7 +19,7 @@ export class UserPosthogManager implements PosthogManager {
     private token: FernUserToken | undefined;
 
     constructor({ token, posthogApiKey }: { token: FernUserToken | undefined; posthogApiKey: string }) {
-        this.posthog = new PostHog(posthogApiKey, { flushInterval: 0 });
+        this.posthog = new PostHog(posthogApiKey);
         this.posthog.on("error", () => {
             // Silently swallow – analytics errors should never surface to end users
         });
@@ -53,7 +53,7 @@ export class UserPosthogManager implements PosthogManager {
 
     public async flush(): Promise<void> {
         try {
-            await Promise.race([this.posthog.shutdown(), new Promise<void>((resolve) => setTimeout(resolve, 3000))]);
+            await Promise.race([this.posthog.flush(), new Promise<void>((resolve) => setTimeout(resolve, 3000))]);
         } catch {
             // Silently swallow – analytics should never block the CLI
         }

--- a/packages/cli/posthog-manager/src/UserPosthogManager.ts
+++ b/packages/cli/posthog-manager/src/UserPosthogManager.ts
@@ -19,7 +19,10 @@ export class UserPosthogManager implements PosthogManager {
     private token: FernUserToken | undefined;
 
     constructor({ token, posthogApiKey }: { token: FernUserToken | undefined; posthogApiKey: string }) {
-        this.posthog = new PostHog(posthogApiKey);
+        this.posthog = new PostHog(posthogApiKey, { flushInterval: 0 });
+        this.posthog.on("error", () => {
+            // Silently swallow – analytics errors should never surface to end users
+        });
         this.userId = token == null ? undefined : getUserIdFromToken(token);
         this.token = token;
     }
@@ -50,7 +53,7 @@ export class UserPosthogManager implements PosthogManager {
 
     public async flush(): Promise<void> {
         try {
-            await Promise.race([this.posthog.flush(), new Promise<void>((resolve) => setTimeout(resolve, 3000))]);
+            await Promise.race([this.posthog.shutdown(), new Promise<void>((resolve) => setTimeout(resolve, 3000))]);
         } catch {
             // Silently swallow – analytics should never block the CLI
         }


### PR DESCRIPTION
## Description

Fixes PostHog network errors (e.g. `PostHogFetchNetworkError: Network error while fetching PostHog`) being printed to stderr during CLI execution. These errors originate from the PostHog library's internal error handling, which can surface to end users when network connectivity to `us.i.posthog.com` is unavailable.

## Changes Made

- Register a no-op `on("error", ...)` handler on each PostHog instance to swallow emitted error events, preventing them from surfacing to end users.
- Updated the PostHog mock in `TelemetryClient.test.ts` to include the `on` method.
- Added unreleased changelog entry.

Files changed:
- `packages/cli/posthog-manager/src/UserPosthogManager.ts`
- `packages/cli/posthog-manager/src/AccessTokenPosthogManager.ts`
- `packages/cli/cli-v2/src/telemetry/TelemetryClient.ts`
- `packages/cli/cli-v2/src/telemetry/__test__/TelemetryClient.test.ts`

## Things for reviewers to verify

- [ ] Verify that the `on("error", ...)` handler is sufficient to suppress the `console.error` output from PostHog's `logFlushError()` — the library also calls `console.error` directly inside `flushBackground()`, which may not be caught by the error event handler alone. If the direct `console.error` persists, a follow-up using `flushInterval: 0` to disable background flushes may be needed.

## Testing

- [x] `pnpm format` and `pnpm run check` pass
- [ ] Manual testing: run `fern generate` in a network-restricted environment and verify no PostHog errors appear in output

Link to Devin session: https://app.devin.ai/sessions/9f02a0378a0f491da04fb3bfa63a5830
Requested by: @Swimburger
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/15025" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
