### PR TITLE
fix(seed): ignore changelog/changes directories in affected detection

### DIFF
--- a/packages/seed/src/__test__/affected.test.ts
+++ b/packages/seed/src/__test__/affected.test.ts
@@ -86,6 +86,55 @@ describe("detectAffected", () => {
             expect(result.affectedFixtures).toEqual([]);
         });
 
+        it("skips all seed tests when only changelog template files change", () => {
+            const result = detectAffected(
+                [
+                    "generators/typescript/sdk/changes/unreleased/.template.yml",
+                    "generators/python/sdk/changes/unreleased/.template.yml",
+                    "generators/java/sdk/changes/unreleased/.template.yml",
+                    "generators/csharp/sdk/changes/unreleased/.template.yml",
+                    "generators/go/sdk/changes/unreleased/.template.yml"
+                ],
+                ALL_GENERATORS
+            );
+
+            expect(result.allGeneratorsAffected).toBe(false);
+            expect(result.allFixturesAffected).toBe(false);
+            expect(result.affectedGenerators).toEqual([]);
+            expect(result.generatorsWithAllFixtures).toEqual([]);
+            expect(result.affectedFixtures).toEqual([]);
+        });
+
+        it("skips all seed tests when only changelog entry files change", () => {
+            const result = detectAffected(
+                [
+                    "generators/typescript/sdk/changes/unreleased/add-new-feature.yml",
+                    "generators/python/sdk/changes/1.0.0/fix-bug.yml"
+                ],
+                ALL_GENERATORS
+            );
+
+            expect(result.allGeneratorsAffected).toBe(false);
+            expect(result.allFixturesAffected).toBe(false);
+            expect(result.affectedGenerators).toEqual([]);
+            expect(result.generatorsWithAllFixtures).toEqual([]);
+            expect(result.affectedFixtures).toEqual([]);
+        });
+
+        it("skips seed for changelog files but still detects other generator changes", () => {
+            const result = detectAffected(
+                [
+                    "generators/csharp/sdk/changes/unreleased/.template.yml",
+                    "generators/python/src/generator.ts"
+                ],
+                ALL_GENERATORS
+            );
+
+            expect(result.affectedGenerators).toContain("python-sdk");
+            expect(result.affectedGenerators).not.toContain("csharp-sdk");
+            expect(result.affectedGenerators).not.toContain("csharp-model");
+        });
+
         it("skips seed for versions.yml but still detects other generator changes", () => {
             const result = detectAffected(
                 ["generators/csharp/sdk/versions.yml", "generators/python/src/generator.ts"],
@@ -793,6 +842,34 @@ describe("end-to-end scenario tests", () => {
             "generators/csharp/sdk/versions.yml",
             "generators/csharp/model/versions.yml",
             "generators/python/sdk/versions.yml"
+        ];
+        const affected = detectAffected(changedFiles, ALL_GENERATORS);
+
+        // No generators should run
+        const generators = resolveAffectedGenerators(affected, ALL_GENERATORS);
+        expect(generators).toHaveLength(0);
+
+        // No fixtures should be resolved
+        for (const gen of ALL_GENERATORS) {
+            const fixtures = resolveAffectedFixtures(affected, ALL_FIXTURES, gen.workspaceName);
+            expect(fixtures).toEqual([]);
+        }
+    });
+
+    it("scenario: changelog and release metadata changes are fully ignored for seed detection", () => {
+        const changedFiles = [
+            "generators/csharp/sdk/changes/unreleased/.template.yml",
+            "generators/go/sdk/changes/unreleased/.template.yml",
+            "generators/java/sdk/changes/unreleased/.template.yml",
+            "generators/php/sdk/changes/unreleased/.template.yml",
+            "generators/python/sdk/changes/unreleased/.template.yml",
+            "generators/ruby-v2/sdk/changes/unreleased/.template.yml",
+            "generators/rust/sdk/changes/unreleased/.template.yml",
+            "generators/swift/sdk/changes/unreleased/.template.yml",
+            "generators/typescript/sdk/changes/unreleased/.template.yml",
+            "fern-changes-yml.schema.json",
+            "scripts/release.ts",
+            "packages/cli/cli/changes/unreleased/.template.yml"
         ];
         const affected = detectAffected(changedFiles, ALL_GENERATORS);
 

--- a/packages/seed/src/__test__/affected.test.ts
+++ b/packages/seed/src/__test__/affected.test.ts
@@ -132,6 +132,12 @@ describe("detectAffected", () => {
             expect(result.affectedGenerators).not.toContain("csharp-model");
         });
 
+        it("does not ignore non-changelog /changes/ paths under generator source", () => {
+            const result = detectAffected(["generators/python/src/changes/handler.ts"], ALL_GENERATORS);
+
+            expect(result.affectedGenerators).toContain("python-sdk");
+        });
+
         it("skips seed for versions.yml but still detects other generator changes", () => {
             const result = detectAffected(
                 ["generators/csharp/sdk/versions.yml", "generators/python/src/generator.ts"],

--- a/packages/seed/src/__test__/affected.test.ts
+++ b/packages/seed/src/__test__/affected.test.ts
@@ -123,10 +123,7 @@ describe("detectAffected", () => {
 
         it("skips seed for changelog files but still detects other generator changes", () => {
             const result = detectAffected(
-                [
-                    "generators/csharp/sdk/changes/unreleased/.template.yml",
-                    "generators/python/src/generator.ts"
-                ],
+                ["generators/csharp/sdk/changes/unreleased/.template.yml", "generators/python/src/generator.ts"],
                 ALL_GENERATORS
             );
 

--- a/packages/seed/src/commands/affected/getAffected.ts
+++ b/packages/seed/src/commands/affected/getAffected.ts
@@ -34,6 +34,14 @@ export interface AffectedResult {
 const IGNORED_FILENAMES = ["versions.yml"];
 
 /**
+ * Path segments that indicate changelog / release metadata directories.
+ * Files under paths containing these segments live under generator source
+ * paths but do not affect generated code (e.g.
+ * `generators/typescript/sdk/changes/unreleased/.template.yml`).
+ */
+const IGNORED_PATH_SEGMENTS = ["/changes/"];
+
+/**
  * Paths that, when changed, affect ALL generators and ALL fixtures.
  * These are infrastructure-level changes that feed into IR generation
  * or affect how seed tests execute. Includes:
@@ -214,6 +222,9 @@ export function detectAffected(changedFiles: string[], allGenerators: GeneratorW
         // Skip metadata files that live under generator paths but don't affect codegen
         const basename = file.split("/").pop() ?? "";
         if (IGNORED_FILENAMES.includes(basename)) {
+            continue;
+        }
+        if (IGNORED_PATH_SEGMENTS.some((segment) => file.includes(segment))) {
             continue;
         }
         for (const [generatorName, sourcePaths] of Object.entries(GENERATOR_SOURCE_PATHS)) {

--- a/packages/seed/src/commands/affected/getAffected.ts
+++ b/packages/seed/src/commands/affected/getAffected.ts
@@ -34,12 +34,11 @@ export interface AffectedResult {
 const IGNORED_FILENAMES = ["versions.yml"];
 
 /**
- * Path segments that indicate changelog / release metadata directories.
- * Files under paths containing these segments live under generator source
- * paths but do not affect generated code (e.g.
- * `generators/typescript/sdk/changes/unreleased/.template.yml`).
+ * Regex patterns for changelog / release metadata paths that live under
+ * generator source trees but do not affect generated code.
+ * Matches paths like `generators/typescript/sdk/changes/unreleased/.template.yml`.
  */
-const IGNORED_PATH_SEGMENTS = ["/changes/"];
+const IGNORED_PATH_PATTERNS = [/\/sdk\/changes\//];
 
 /**
  * Paths that, when changed, affect ALL generators and ALL fixtures.
@@ -224,7 +223,7 @@ export function detectAffected(changedFiles: string[], allGenerators: GeneratorW
         if (IGNORED_FILENAMES.includes(basename)) {
             continue;
         }
-        if (IGNORED_PATH_SEGMENTS.some((segment) => file.includes(segment))) {
+        if (IGNORED_PATH_PATTERNS.some((pattern) => pattern.test(file))) {
             continue;
         }
         for (const [generatorName, sourcePaths] of Object.entries(GENERATOR_SOURCE_PATHS)) {


### PR DESCRIPTION
## Description

Refs https://github.com/fern-api/fern/pull/15023

Changelog and release metadata files under `generators/*/sdk/changes/` (e.g. `.template.yml`, unreleased changelog entries) were incorrectly triggering seed tests because their paths match `GENERATOR_SOURCE_PATHS` prefixes like `generators/typescript/`. This caused PR #15023 (a release-script-only change) to run the full seed test matrix for every generator.

## Changes Made

- Added `IGNORED_PATH_PATTERNS = [/\/sdk\/changes\//]` in `getAffected.ts` — a regex that specifically targets the `generators/*/sdk/changes/` changelog directory structure, following the same skip pattern as `IGNORED_FILENAMES` for `versions.yml`
- Added a regex check in the generator detection loop to skip files matching these changelog paths
- Added unit tests covering: changelog templates only, changelog entries only, mixed changelog + real source changes, and an end-to-end scenario matching the exact file list from PR #15023
- Added a safety test verifying that a non-changelog path containing `/changes/` (e.g. `generators/python/src/changes/handler.ts`) is **not** incorrectly ignored

## Testing

- [x] Unit tests added (5 new test cases, all 67 tests passing)
- [x] Manual verification: the exact file list from PR #15023 now correctly produces zero affected generators

## Updates since last revision

- Tightened the match from a generic `/changes/` substring to a specific `/sdk/changes/` regex pattern (addresses [review feedback](https://github.com/fern-api/fern/pull/15028#discussion_r3087675518))
- Added test case ensuring hypothetical source files under non-changelog `/changes/` paths still correctly trigger seed tests

## Human Review Checklist

- **Regex specificity**: The pattern `/\/sdk\/changes\//` targets only the known changelog directory layout (`generators/*/sdk/changes/`). A source file at `generators/python/src/changes/handler.ts` would **not** be skipped (verified by test). A file at e.g. `generators/python/sdk/changes_util.ts` would also not match (the regex requires a trailing `/`).
- **Scope**: The filter only applies to the generator source detection loop. It does **not** suppress global infrastructure detection, fixture detection, Dockerfile detection, or seed.yml detection — those remain unaffected.

Link to Devin session: https://app.devin.ai/sessions/ee2ef92363ce43b6917e378ae667bdab
Requested by: @Swimburger
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/15028" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
