### PR TITLE
fix(python): handle OAuth and header auth simultaneously

### DIFF
--- a/generators/python/sdk/changes/unreleased/fix-header-auth-with-oauth.yml
+++ b/generators/python/sdk/changes/unreleased/fix-header-auth-with-oauth.yml
@@ -1,0 +1,7 @@
+- summary: |
+    Fix `auth: any` with OAuth + header auth schemes (e.g. API key):
+    - Header auth parameters are now included in the generated client constructor (previously silently dropped when OAuth was present)
+    - Header auth parameters are passed through to the client wrapper (previously missing, causing a runtime `TypeError`)
+    - Header auth types are made optional when alongside OAuth, with conditional header setting
+    - The client can now be instantiated with just a header auth credential (e.g. `api_key`) without requiring OAuth credentials or a bearer token
+  type: fix

--- a/generators/python/sdk/changes/unreleased/fix-header-auth-with-oauth.yml
+++ b/generators/python/sdk/changes/unreleased/fix-header-auth-with-oauth.yml
@@ -1,7 +1,0 @@
-- summary: |
-    Fix `auth: any` with OAuth + header auth schemes (e.g. API key):
-    - Header auth parameters are now included in the generated client constructor (previously silently dropped when OAuth was present)
-    - Header auth parameters are passed through to the client wrapper (previously missing, causing a runtime `TypeError`)
-    - Header auth types are made optional when alongside OAuth, with conditional header setting
-    - The client can now be instantiated with just a header auth credential (e.g. `api_key`) without requiring OAuth credentials or a bearer token
-  type: fix

--- a/generators/python/sdk/versions.yml
+++ b/generators/python/sdk/versions.yml
@@ -1,4 +1,16 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 5.4.0-rc.1
+  changelogEntry:
+    - summary: |
+        Fix `auth: any` with OAuth + header auth schemes (e.g. API key):
+        - Header auth parameters are now included in the generated client constructor (previously silently dropped when OAuth was present)
+        - Header auth parameters are passed through to the client wrapper (previously missing, causing a runtime `TypeError`)
+        - Header auth types are made optional when alongside OAuth, with conditional header setting
+        - The client can now be instantiated with just a header auth credential (e.g. `api_key`) without requiring OAuth credentials or a bearer token
+      type: fix
+  createdAt: "2026-04-15"
+  irVersion: 66
+
 - version: 5.4.0-rc.0
   changelogEntry:
     - summary: |

--- a/generators/python/src/fern_python/generators/sdk/client_generator/root_client_generator.py
+++ b/generators/python/src/fern_python/generators/sdk/client_generator/root_client_generator.py
@@ -1298,20 +1298,41 @@ class RootClientGenerator(BaseWrappedClientGenerator[RootClientConstructorParame
             )
             writer.write_newline_if_last_line_not()
 
-        # else: raise error
+        # else: fall back to header-auth-only or raise error
+        has_header_auth_schemes = len(client_wrapper_generator._get_header_auth_schemes()) > 0
         writer.write_line("else:")
         with writer.indent():
-            writer.write("raise ")
-            writer.write_node(
-                self._context.core_utilities.instantiate_api_error(
-                    headers=None,
-                    status_code=None,
-                    body=AST.Expression(
-                        "\"The client must be instantiated with either 'token' or both 'client_id' and 'client_secret'\""
-                    ),
+            if has_header_auth_schemes:
+                # When header auth schemes exist (e.g. api_key via auth: any), allow constructing
+                # the client without a bearer token — the header auth alone is sufficient.
+                header_only_kwargs = self._get_client_wrapper_kwargs(
+                    client_wrapper_generator=client_wrapper_generator,
+                    environments_config=self._environments_config,
+                    timeout_local_variable=timeout_local_variable,
+                    is_async=is_async,
+                    exclude_auth=True,
+                    transport_variable_name=transport_variable_name,
                 )
-            )
-            writer.write_newline_if_last_line_not()
+                writer.write(f"self.{self._get_client_wrapper_member_name()} = ")
+                writer.write_node(
+                    AST.ClassInstantiation(
+                        self._context.core_utilities.get_reference_to_client_wrapper(is_async=is_async),
+                        kwargs=header_only_kwargs,
+                    )
+                )
+                writer.write_newline_if_last_line_not()
+            else:
+                writer.write("raise ")
+                writer.write_node(
+                    self._context.core_utilities.instantiate_api_error(
+                        headers=None,
+                        status_code=None,
+                        body=AST.Expression(
+                            "\"The client must be instantiated with either 'token' or both 'client_id' and 'client_secret'\""
+                        ),
+                    )
+                )
+                writer.write_newline_if_last_line_not()
 
     def _get_client_wrapper_kwargs(
         self,

--- a/generators/python/src/fern_python/generators/sdk/core_utilities/client_wrapper_generator.py
+++ b/generators/python/src/fern_python/generators/sdk/core_utilities/client_wrapper_generator.py
@@ -699,6 +699,34 @@ class ClientWrapperGenerator:
                 )
             )
 
+        # Header auth schemes (e.g. X-API-Key) are independent of bearer/basic/OAuth auth
+        # and must always be included — even when exclude_auth is True (OAuth token override mode).
+        # When OAuth is also present (auth: any), make them optional so users can authenticate
+        # with either OAuth or the header auth scheme alone.
+        # TODO(dsinghvi): Support suppliers for header auth schemes
+        for header_auth_scheme in self._get_header_auth_schemes():
+            constructor_parameter_name = names.get_auth_scheme_header_constructor_parameter_name(header_auth_scheme)
+            type_hint = self._context.pydantic_generator_context.get_type_hint_for_type_reference(
+                header_auth_scheme.value_type
+            )
+            if self._has_oauth() and not type_hint.is_optional:
+                type_hint = AST.TypeHint.optional(type_hint)
+            parameters.append(
+                ConstructorParameter(
+                    constructor_parameter_name=constructor_parameter_name,
+                    private_member_name=names.get_auth_scheme_header_private_member_name(header_auth_scheme),
+                    type_hint=type_hint,
+                    initializer=AST.Expression(
+                        f'{constructor_parameter_name}="YOUR_{resolve_name(get_name_from_wire_value(header_auth_scheme.name)).screaming_snake_case.safe_name}"',
+                    ),
+                    header_key=get_wire_value(header_auth_scheme.name),
+                    header_prefix=header_auth_scheme.prefix,
+                    environment_variable=(
+                        header_auth_scheme.header_env_var if header_auth_scheme.header_env_var is not None else None
+                    ),
+                )
+            )
+
         if exclude_auth:
             # Add generic headers parameter even when excluding auth
             parameters.append(headers_constructor_parameter)
@@ -720,27 +748,6 @@ class ClientWrapperGenerator:
                     private_member_name=ClientWrapperGenerator.AUTH_HEADERS_MEMBER_NAME,
                     initializer=AST.Expression(AST.TypeHint.none()),
                     docs="A callable that returns auth headers to send with every request. Used for inferred authentication.",
-                )
-            )
-
-        # TODO(dsinghvi): Support suppliers for header auth schemes
-        for header_auth_scheme in self._get_header_auth_schemes():
-            constructor_parameter_name = names.get_auth_scheme_header_constructor_parameter_name(header_auth_scheme)
-            parameters.append(
-                ConstructorParameter(
-                    constructor_parameter_name=constructor_parameter_name,
-                    private_member_name=names.get_auth_scheme_header_private_member_name(header_auth_scheme),
-                    type_hint=self._context.pydantic_generator_context.get_type_hint_for_type_reference(
-                        header_auth_scheme.value_type
-                    ),
-                    initializer=AST.Expression(
-                        f'{constructor_parameter_name}="YOUR_{resolve_name(get_name_from_wire_value(header_auth_scheme.name)).screaming_snake_case.safe_name}"',
-                    ),
-                    header_key=get_wire_value(header_auth_scheme.name),
-                    header_prefix=header_auth_scheme.prefix,
-                    environment_variable=(
-                        header_auth_scheme.header_env_var if header_auth_scheme.header_env_var is not None else None
-                    ),
                 )
             )
 

--- a/seed/python-sdk/any-auth/src/seed/client.py
+++ b/seed/python-sdk/any-auth/src/seed/client.py
@@ -6,7 +6,6 @@ import os
 import typing
 
 import httpx
-from .core.api_error import ApiError
 from .core.client_wrapper import AsyncClientWrapper, SyncClientWrapper
 from .core.logging import LogConfig, Logger
 from .core.oauth_token_provider import AsyncOAuthTokenProvider, OAuthTokenProvider
@@ -83,6 +82,7 @@ class SeedAnyAuth:
         self,
         *,
         base_url: str,
+        api_key: typing.Optional[str] = os.getenv("MY_API_KEY"),
         headers: typing.Optional[typing.Dict[str, str]] = None,
         timeout: typing.Optional[float] = None,
         follow_redirects: typing.Optional[bool] = True,
@@ -96,6 +96,7 @@ class SeedAnyAuth:
         self,
         *,
         base_url: str,
+        api_key: typing.Optional[str] = os.getenv("MY_API_KEY"),
         headers: typing.Optional[typing.Dict[str, str]] = None,
         timeout: typing.Optional[float] = None,
         follow_redirects: typing.Optional[bool] = True,
@@ -107,6 +108,7 @@ class SeedAnyAuth:
         self,
         *,
         base_url: str,
+        api_key: typing.Optional[str] = os.getenv("MY_API_KEY"),
         headers: typing.Optional[typing.Dict[str, str]] = None,
         client_id: typing.Optional[str] = os.getenv("MY_CLIENT_ID"),
         client_secret: typing.Optional[str] = os.getenv("MY_CLIENT_SECRET"),
@@ -123,6 +125,7 @@ class SeedAnyAuth:
         if token is not None:
             self._client_wrapper = SyncClientWrapper(
                 base_url=base_url,
+                api_key=api_key,
                 headers=headers,
                 httpx_client=httpx_client
                 if httpx_client is not None
@@ -139,6 +142,7 @@ class SeedAnyAuth:
                 client_secret=client_secret,
                 client_wrapper=SyncClientWrapper(
                     base_url=base_url,
+                    api_key=api_key,
                     headers=headers,
                     httpx_client=httpx_client
                     if httpx_client is not None
@@ -151,6 +155,7 @@ class SeedAnyAuth:
             )
             self._client_wrapper = SyncClientWrapper(
                 base_url=base_url,
+                api_key=api_key,
                 headers=headers,
                 token=_token_getter_override if _token_getter_override is not None else oauth_token_provider.get_token,
                 httpx_client=httpx_client
@@ -162,8 +167,17 @@ class SeedAnyAuth:
                 logging=logging,
             )
         else:
-            raise ApiError(
-                body="The client must be instantiated with either 'token' or both 'client_id' and 'client_secret'"
+            self._client_wrapper = SyncClientWrapper(
+                base_url=base_url,
+                api_key=api_key,
+                headers=headers,
+                httpx_client=httpx_client
+                if httpx_client is not None
+                else httpx.Client(timeout=_defaulted_timeout, follow_redirects=follow_redirects)
+                if follow_redirects is not None
+                else httpx.Client(timeout=_defaulted_timeout),
+                timeout=_defaulted_timeout,
+                logging=logging,
             )
         self._auth: typing.Optional[AuthClient] = None
         self._user: typing.Optional[UserClient] = None
@@ -270,6 +284,7 @@ class AsyncSeedAnyAuth:
         self,
         *,
         base_url: str,
+        api_key: typing.Optional[str] = os.getenv("MY_API_KEY"),
         headers: typing.Optional[typing.Dict[str, str]] = None,
         timeout: typing.Optional[float] = None,
         follow_redirects: typing.Optional[bool] = True,
@@ -283,6 +298,7 @@ class AsyncSeedAnyAuth:
         self,
         *,
         base_url: str,
+        api_key: typing.Optional[str] = os.getenv("MY_API_KEY"),
         headers: typing.Optional[typing.Dict[str, str]] = None,
         timeout: typing.Optional[float] = None,
         follow_redirects: typing.Optional[bool] = True,
@@ -294,6 +310,7 @@ class AsyncSeedAnyAuth:
         self,
         *,
         base_url: str,
+        api_key: typing.Optional[str] = os.getenv("MY_API_KEY"),
         headers: typing.Optional[typing.Dict[str, str]] = None,
         client_id: typing.Optional[str] = os.getenv("MY_CLIENT_ID"),
         client_secret: typing.Optional[str] = os.getenv("MY_CLIENT_SECRET"),
@@ -310,6 +327,7 @@ class AsyncSeedAnyAuth:
         if token is not None:
             self._client_wrapper = AsyncClientWrapper(
                 base_url=base_url,
+                api_key=api_key,
                 headers=headers,
                 httpx_client=httpx_client
                 if httpx_client is not None
@@ -324,6 +342,7 @@ class AsyncSeedAnyAuth:
                 client_secret=client_secret,
                 client_wrapper=AsyncClientWrapper(
                     base_url=base_url,
+                    api_key=api_key,
                     headers=headers,
                     httpx_client=httpx_client
                     if httpx_client is not None
@@ -336,6 +355,7 @@ class AsyncSeedAnyAuth:
             )
             self._client_wrapper = AsyncClientWrapper(
                 base_url=base_url,
+                api_key=api_key,
                 headers=headers,
                 token=_token_getter_override,
                 async_token=oauth_token_provider.get_token,
@@ -346,8 +366,15 @@ class AsyncSeedAnyAuth:
                 logging=logging,
             )
         else:
-            raise ApiError(
-                body="The client must be instantiated with either 'token' or both 'client_id' and 'client_secret'"
+            self._client_wrapper = AsyncClientWrapper(
+                base_url=base_url,
+                api_key=api_key,
+                headers=headers,
+                httpx_client=httpx_client
+                if httpx_client is not None
+                else _make_default_async_client(timeout=_defaulted_timeout, follow_redirects=follow_redirects),
+                timeout=_defaulted_timeout,
+                logging=logging,
             )
         self._auth: typing.Optional[AsyncAuthClient] = None
         self._user: typing.Optional[AsyncUserClient] = None

--- a/seed/python-sdk/any-auth/src/seed/core/client_wrapper.py
+++ b/seed/python-sdk/any-auth/src/seed/core/client_wrapper.py
@@ -11,8 +11,8 @@ class BaseClientWrapper:
     def __init__(
         self,
         *,
+        api_key: typing.Optional[str] = None,
         auth_headers: typing.Optional[typing.Callable[[], typing.Dict[str, str]]] = None,
-        api_key: str,
         token: typing.Optional[typing.Union[str, typing.Callable[[], str]]] = None,
         username: typing.Optional[typing.Union[str, typing.Callable[[], str]]] = None,
         password: typing.Optional[typing.Union[str, typing.Callable[[], str]]] = None,
@@ -21,8 +21,8 @@ class BaseClientWrapper:
         timeout: typing.Optional[float] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        self._auth_headers = auth_headers
         self.api_key = api_key
+        self._auth_headers = auth_headers
         self._token = token
         self._username = username
         self._password = password
@@ -47,7 +47,8 @@ class BaseClientWrapper:
         password = self._get_password()
         if username is not None and password is not None:
             headers["Authorization"] = httpx.BasicAuth(username, password)._auth_header
-        headers["X-API-Key"] = self.api_key
+        if self.api_key is not None:
+            headers["X-API-Key"] = self.api_key
         token = self._get_token()
         if token is not None:
             headers["Authorization"] = f"Bearer {token}"
@@ -87,8 +88,8 @@ class SyncClientWrapper(BaseClientWrapper):
     def __init__(
         self,
         *,
+        api_key: typing.Optional[str] = None,
         auth_headers: typing.Optional[typing.Callable[[], typing.Dict[str, str]]] = None,
-        api_key: str,
         token: typing.Optional[typing.Union[str, typing.Callable[[], str]]] = None,
         username: typing.Optional[typing.Union[str, typing.Callable[[], str]]] = None,
         password: typing.Optional[typing.Union[str, typing.Callable[[], str]]] = None,
@@ -99,8 +100,8 @@ class SyncClientWrapper(BaseClientWrapper):
         httpx_client: httpx.Client,
     ):
         super().__init__(
-            auth_headers=auth_headers,
             api_key=api_key,
+            auth_headers=auth_headers,
             token=token,
             username=username,
             password=password,
@@ -122,8 +123,8 @@ class AsyncClientWrapper(BaseClientWrapper):
     def __init__(
         self,
         *,
+        api_key: typing.Optional[str] = None,
         auth_headers: typing.Optional[typing.Callable[[], typing.Dict[str, str]]] = None,
-        api_key: str,
         token: typing.Optional[typing.Union[str, typing.Callable[[], str]]] = None,
         username: typing.Optional[typing.Union[str, typing.Callable[[], str]]] = None,
         password: typing.Optional[typing.Union[str, typing.Callable[[], str]]] = None,
@@ -136,8 +137,8 @@ class AsyncClientWrapper(BaseClientWrapper):
         httpx_client: httpx.AsyncClient,
     ):
         super().__init__(
-            auth_headers=auth_headers,
             api_key=api_key,
+            auth_headers=auth_headers,
             token=token,
             username=username,
             password=password,

--- a/seed/python-sdk/endpoint-security-auth/src/seed/client.py
+++ b/seed/python-sdk/endpoint-security-auth/src/seed/client.py
@@ -6,7 +6,6 @@ import os
 import typing
 
 import httpx
-from .core.api_error import ApiError
 from .core.client_wrapper import AsyncClientWrapper, SyncClientWrapper
 from .core.logging import LogConfig, Logger
 from .core.oauth_token_provider import AsyncOAuthTokenProvider, OAuthTokenProvider
@@ -83,6 +82,7 @@ class SeedEndpointSecurityAuth:
         self,
         *,
         base_url: str,
+        api_key: typing.Optional[str] = os.getenv("MY_API_KEY"),
         headers: typing.Optional[typing.Dict[str, str]] = None,
         timeout: typing.Optional[float] = None,
         follow_redirects: typing.Optional[bool] = True,
@@ -96,6 +96,7 @@ class SeedEndpointSecurityAuth:
         self,
         *,
         base_url: str,
+        api_key: typing.Optional[str] = os.getenv("MY_API_KEY"),
         headers: typing.Optional[typing.Dict[str, str]] = None,
         timeout: typing.Optional[float] = None,
         follow_redirects: typing.Optional[bool] = True,
@@ -107,6 +108,7 @@ class SeedEndpointSecurityAuth:
         self,
         *,
         base_url: str,
+        api_key: typing.Optional[str] = os.getenv("MY_API_KEY"),
         headers: typing.Optional[typing.Dict[str, str]] = None,
         client_id: typing.Optional[str] = os.getenv("MY_CLIENT_ID"),
         client_secret: typing.Optional[str] = os.getenv("MY_CLIENT_SECRET"),
@@ -123,6 +125,7 @@ class SeedEndpointSecurityAuth:
         if token is not None:
             self._client_wrapper = SyncClientWrapper(
                 base_url=base_url,
+                api_key=api_key,
                 headers=headers,
                 httpx_client=httpx_client
                 if httpx_client is not None
@@ -139,6 +142,7 @@ class SeedEndpointSecurityAuth:
                 client_secret=client_secret,
                 client_wrapper=SyncClientWrapper(
                     base_url=base_url,
+                    api_key=api_key,
                     headers=headers,
                     httpx_client=httpx_client
                     if httpx_client is not None
@@ -151,6 +155,7 @@ class SeedEndpointSecurityAuth:
             )
             self._client_wrapper = SyncClientWrapper(
                 base_url=base_url,
+                api_key=api_key,
                 headers=headers,
                 token=_token_getter_override if _token_getter_override is not None else oauth_token_provider.get_token,
                 httpx_client=httpx_client
@@ -162,8 +167,17 @@ class SeedEndpointSecurityAuth:
                 logging=logging,
             )
         else:
-            raise ApiError(
-                body="The client must be instantiated with either 'token' or both 'client_id' and 'client_secret'"
+            self._client_wrapper = SyncClientWrapper(
+                base_url=base_url,
+                api_key=api_key,
+                headers=headers,
+                httpx_client=httpx_client
+                if httpx_client is not None
+                else httpx.Client(timeout=_defaulted_timeout, follow_redirects=follow_redirects)
+                if follow_redirects is not None
+                else httpx.Client(timeout=_defaulted_timeout),
+                timeout=_defaulted_timeout,
+                logging=logging,
             )
         self._auth: typing.Optional[AuthClient] = None
         self._user: typing.Optional[UserClient] = None
@@ -270,6 +284,7 @@ class AsyncSeedEndpointSecurityAuth:
         self,
         *,
         base_url: str,
+        api_key: typing.Optional[str] = os.getenv("MY_API_KEY"),
         headers: typing.Optional[typing.Dict[str, str]] = None,
         timeout: typing.Optional[float] = None,
         follow_redirects: typing.Optional[bool] = True,
@@ -283,6 +298,7 @@ class AsyncSeedEndpointSecurityAuth:
         self,
         *,
         base_url: str,
+        api_key: typing.Optional[str] = os.getenv("MY_API_KEY"),
         headers: typing.Optional[typing.Dict[str, str]] = None,
         timeout: typing.Optional[float] = None,
         follow_redirects: typing.Optional[bool] = True,
@@ -294,6 +310,7 @@ class AsyncSeedEndpointSecurityAuth:
         self,
         *,
         base_url: str,
+        api_key: typing.Optional[str] = os.getenv("MY_API_KEY"),
         headers: typing.Optional[typing.Dict[str, str]] = None,
         client_id: typing.Optional[str] = os.getenv("MY_CLIENT_ID"),
         client_secret: typing.Optional[str] = os.getenv("MY_CLIENT_SECRET"),
@@ -310,6 +327,7 @@ class AsyncSeedEndpointSecurityAuth:
         if token is not None:
             self._client_wrapper = AsyncClientWrapper(
                 base_url=base_url,
+                api_key=api_key,
                 headers=headers,
                 httpx_client=httpx_client
                 if httpx_client is not None
@@ -324,6 +342,7 @@ class AsyncSeedEndpointSecurityAuth:
                 client_secret=client_secret,
                 client_wrapper=AsyncClientWrapper(
                     base_url=base_url,
+                    api_key=api_key,
                     headers=headers,
                     httpx_client=httpx_client
                     if httpx_client is not None
@@ -336,6 +355,7 @@ class AsyncSeedEndpointSecurityAuth:
             )
             self._client_wrapper = AsyncClientWrapper(
                 base_url=base_url,
+                api_key=api_key,
                 headers=headers,
                 token=_token_getter_override,
                 async_token=oauth_token_provider.get_token,
@@ -346,8 +366,15 @@ class AsyncSeedEndpointSecurityAuth:
                 logging=logging,
             )
         else:
-            raise ApiError(
-                body="The client must be instantiated with either 'token' or both 'client_id' and 'client_secret'"
+            self._client_wrapper = AsyncClientWrapper(
+                base_url=base_url,
+                api_key=api_key,
+                headers=headers,
+                httpx_client=httpx_client
+                if httpx_client is not None
+                else _make_default_async_client(timeout=_defaulted_timeout, follow_redirects=follow_redirects),
+                timeout=_defaulted_timeout,
+                logging=logging,
             )
         self._auth: typing.Optional[AsyncAuthClient] = None
         self._user: typing.Optional[AsyncUserClient] = None

--- a/seed/python-sdk/endpoint-security-auth/src/seed/core/client_wrapper.py
+++ b/seed/python-sdk/endpoint-security-auth/src/seed/core/client_wrapper.py
@@ -11,8 +11,8 @@ class BaseClientWrapper:
     def __init__(
         self,
         *,
+        api_key: typing.Optional[str] = None,
         auth_headers: typing.Optional[typing.Callable[[], typing.Dict[str, str]]] = None,
-        api_key: str,
         token: typing.Optional[typing.Union[str, typing.Callable[[], str]]] = None,
         username: typing.Optional[typing.Union[str, typing.Callable[[], str]]] = None,
         password: typing.Optional[typing.Union[str, typing.Callable[[], str]]] = None,
@@ -21,8 +21,8 @@ class BaseClientWrapper:
         timeout: typing.Optional[float] = None,
         logging: typing.Optional[typing.Union[LogConfig, Logger]] = None,
     ):
-        self._auth_headers = auth_headers
         self.api_key = api_key
+        self._auth_headers = auth_headers
         self._token = token
         self._username = username
         self._password = password
@@ -47,7 +47,8 @@ class BaseClientWrapper:
         password = self._get_password()
         if username is not None and password is not None:
             headers["Authorization"] = httpx.BasicAuth(username, password)._auth_header
-        headers["X-API-Key"] = self.api_key
+        if self.api_key is not None:
+            headers["X-API-Key"] = self.api_key
         token = self._get_token()
         if token is not None:
             headers["Authorization"] = f"Bearer {token}"
@@ -87,8 +88,8 @@ class SyncClientWrapper(BaseClientWrapper):
     def __init__(
         self,
         *,
+        api_key: typing.Optional[str] = None,
         auth_headers: typing.Optional[typing.Callable[[], typing.Dict[str, str]]] = None,
-        api_key: str,
         token: typing.Optional[typing.Union[str, typing.Callable[[], str]]] = None,
         username: typing.Optional[typing.Union[str, typing.Callable[[], str]]] = None,
         password: typing.Optional[typing.Union[str, typing.Callable[[], str]]] = None,
@@ -99,8 +100,8 @@ class SyncClientWrapper(BaseClientWrapper):
         httpx_client: httpx.Client,
     ):
         super().__init__(
-            auth_headers=auth_headers,
             api_key=api_key,
+            auth_headers=auth_headers,
             token=token,
             username=username,
             password=password,
@@ -122,8 +123,8 @@ class AsyncClientWrapper(BaseClientWrapper):
     def __init__(
         self,
         *,
+        api_key: typing.Optional[str] = None,
         auth_headers: typing.Optional[typing.Callable[[], typing.Dict[str, str]]] = None,
-        api_key: str,
         token: typing.Optional[typing.Union[str, typing.Callable[[], str]]] = None,
         username: typing.Optional[typing.Union[str, typing.Callable[[], str]]] = None,
         password: typing.Optional[typing.Union[str, typing.Callable[[], str]]] = None,
@@ -136,8 +137,8 @@ class AsyncClientWrapper(BaseClientWrapper):
         httpx_client: httpx.AsyncClient,
     ):
         super().__init__(
-            auth_headers=auth_headers,
             api_key=api_key,
+            auth_headers=auth_headers,
             token=token,
             username=username,
             password=password,


### PR DESCRIPTION
## Description

Fix `auth: any` with OAuth + header auth schemes (e.g. API key). Previously, when a Fern config declared `auth: any: [OAuthScheme, ApiKey]`, the generated Python SDK silently dropped the header-auth credential, forcing downstream teams (e.g. Vectara) to manually patch `base_client.py` to accept an `api_key`-only constructor call.

## Changes Made

### Generator fixes
- **`core_utilities/client_wrapper_generator.py`** — Header auth parameters were silently dropped when OAuth was present because the `exclude_auth` early-return happened before header auth schemes were appended. Moved header-auth parameter handling ahead of the early return, and made the header auth type optional when OAuth coexists (so callers can supply just one).
- **`client_generator/root_client_generator.py`** (`_write_oauth_token_override_constructor_body`) — Even with the parameter wired through, `Client(api_key="...")` with no token fell into an `else` branch that raised `ApiError`. Added a branch that constructs the client wrapper with `exclude_auth=True` when header auth schemes exist, so the header-only path is valid.

### Release
- Added `5.4.0-rc.1` entry at the top of `generators/python/sdk/versions.yml` (IR 66) with a bullet-list summary of the fix.

### Seed fixtures regenerated
- `seed/python-sdk/any-auth/` — root client now accepts `api_key`, constructor forwards it to the wrapper (previously required but unused → runtime `TypeError`).
- `seed/python-sdk/endpoint-security-auth/` — reflects the same header + OAuth interaction fix.
- Other auth fixtures (`header-auth`, `oauth-client-credentials`) show no functional changes, confirming non-breaking.

## Testing
- [x] `pnpm seed run --generator python-sdk --path /Users/Patrick/configs/vectara-fern-config/fern --log-level debug --skipScripts` reproduces the customer setup and generates a client that accepts `api_key` alone.
- [x] `pnpm seed test --generator python-sdk` — `any-auth` and `endpoint-security-auth` fixtures regenerate cleanly; unrelated fixtures unchanged.
- [x] Manual verification: `Vectara(api_key="...")`, `Vectara(token="...")`, and `Vectara(client_id=..., client_secret=...)` all instantiate successfully.
- [ ] Unit tests added/updated

Linear ticket: Refs