### PR TITLE
fix(typescript): support inferred OAuth auth with form-encoded token endpoints

### DIFF
--- a/generators/typescript/sdk/changes/unreleased/fix-inferred-auth-form-encoded.yml
+++ b/generators/typescript/sdk/changes/unreleased/fix-inferred-auth-form-encoded.yml
@@ -1,0 +1,5 @@
+- summary: |
+    Support inferred OAuth auth with form-encoded (application/x-www-form-urlencoded) token endpoints.
+    Previously, the generator crashed with "Cannot get exported name for request wrapper" when the
+    token endpoint used a justRequestBody shape instead of a wrapper shape.
+  type: fix

--- a/generators/typescript/sdk/client-class-generator/src/auth-provider/InferredAuthProviderGenerator.ts
+++ b/generators/typescript/sdk/client-class-generator/src/auth-provider/InferredAuthProviderGenerator.ts
@@ -398,7 +398,7 @@ export class InferredAuthProviderGenerator implements AuthProviderGenerator {
         context: FileContext;
         requestWrapper: GeneratedRequestWrapper | undefined;
     }): MethodDeclarationStructure {
-        const requestProperties = requestWrapper?.getRequestProperties(context) ?? [];
+        const requestProperties = this.getRequestProperties({ context, requestWrapper });
 
         // Generate variable declarations and validation checks for each parameter
         const parameterStatements: (string | WriterFunction | StatementStructures)[] = [];
@@ -551,7 +551,7 @@ export class InferredAuthProviderGenerator implements AuthProviderGenerator {
         context: FileContext;
         requestWrapper: GeneratedRequestWrapper | undefined;
     }): ts.Expression[] {
-        const requestProperties = requestWrapper?.getRequestProperties(context) ?? [];
+        const requestProperties = this.getRequestProperties({ context, requestWrapper });
 
         // Build the request object
         const propertyAssignments = requestProperties.map((p) => {
@@ -596,6 +596,34 @@ export class InferredAuthProviderGenerator implements AuthProviderGenerator {
         }
 
         return `return ${checks};`;
+    }
+
+    /**
+     * Gets request properties from the wrapper if available, otherwise falls back
+     * to extracting properties from the endpoint's request body (for justRequestBody endpoints).
+     */
+    private getRequestProperties({
+        context,
+        requestWrapper
+    }: {
+        context: FileContext;
+        requestWrapper: GeneratedRequestWrapper | undefined;
+    }): GeneratedRequestWrapper.Property[] {
+        if (requestWrapper != null) {
+            return requestWrapper.getRequestProperties(context);
+        }
+        // For justRequestBody endpoints (e.g. form-encoded token endpoints),
+        // extract properties from AuthProviderContext which handles both cases.
+        const authTokenParams = context.authProvider.getPropertiesForAuthTokenParams(
+            FernIr.AuthScheme.inferred(this.authScheme)
+        );
+        return authTokenParams.map((param) => ({
+            name: param.name,
+            safeName: param.name,
+            type: param.type,
+            isOptional: param.isOptional,
+            docs: param.docs
+        }));
     }
 
     private getAuthClientTypeNode(context: FileContext): ts.TypeNode {

--- a/generators/typescript/utils/contexts/src/sdk-context/auth-provider/AuthProviderContext.ts
+++ b/generators/typescript/utils/contexts/src/sdk-context/auth-provider/AuthProviderContext.ts
@@ -98,31 +98,72 @@ export class AuthProviderContext {
         }
 
         const endpoint = this.getInferredAuthTokenEndpoint(authScheme);
-        const generatedRequestWrapper = this.context.requestWrapper.getGeneratedRequestWrapper(
-            authScheme.tokenEndpoint.endpoint.subpackageId
-                ? {
-                      isRoot: false,
-                      subpackageId: authScheme.tokenEndpoint.endpoint.subpackageId
-                  }
-                : {
-                      isRoot: true
-                  },
-            endpoint.name
-        );
-        const requestProperties = generatedRequestWrapper.getRequestProperties(this.context);
+        const hasWrappedRequest = endpoint.sdkRequest != null && endpoint.sdkRequest.shape.type === "wrapper";
+
+        if (hasWrappedRequest) {
+            const generatedRequestWrapper = this.context.requestWrapper.getGeneratedRequestWrapper(
+                authScheme.tokenEndpoint.endpoint.subpackageId
+                    ? {
+                          isRoot: false,
+                          subpackageId: authScheme.tokenEndpoint.endpoint.subpackageId
+                      }
+                    : {
+                          isRoot: true
+                      },
+                endpoint.name
+            );
+            const requestProperties = generatedRequestWrapper.getRequestProperties(this.context);
+            return requestProperties.map((property) => ({
+                name: property.safeName,
+                type: property.type,
+                isOptional: property.isOptional,
+                docs: property.docs
+            }));
+        }
+
+        // For justRequestBody endpoints (e.g. form-encoded token endpoints),
+        // extract properties directly from the request body type.
+        return this.getPropertiesFromRequestBody(endpoint);
+    }
+
+    private getPropertiesFromRequestBody(
+        endpoint: FernIr.HttpEndpoint
+    ): Array<{ name: string; type: ts.TypeNode; isOptional: boolean; docs: string[] | undefined }> {
+        const requestBody = endpoint.requestBody;
+        if (requestBody == null) {
+            return [];
+        }
+
         const properties: Array<{
             name: string;
             type: ts.TypeNode;
             isOptional: boolean;
             docs: string[] | undefined;
         }> = [];
-        for (const property of requestProperties) {
-            properties.push({
-                name: property.safeName,
-                type: property.type,
-                isOptional: property.isOptional,
-                docs: property.docs
-            });
+
+        if (requestBody.type === "inlinedRequestBody") {
+            for (const prop of requestBody.properties) {
+                const typeRef = this.context.type.getReferenceToType(prop.valueType);
+                properties.push({
+                    name: this.context.case.camelSafe(prop.name),
+                    type: typeRef.typeNodeWithoutUndefined,
+                    isOptional: typeRef.isOptional,
+                    docs: prop.docs ? [prop.docs] : undefined
+                });
+            }
+        } else if (requestBody.type === "reference" && requestBody.requestBodyType.type === "named") {
+            const typeDeclaration = this.context.type.getTypeDeclaration(requestBody.requestBodyType);
+            if (typeDeclaration.shape.type === "object") {
+                for (const prop of typeDeclaration.shape.properties) {
+                    const typeRef = this.context.type.getReferenceToType(prop.valueType);
+                    properties.push({
+                        name: this.context.case.camelSafe(prop.name),
+                        type: typeRef.typeNodeWithoutUndefined,
+                        isOptional: typeRef.isOptional,
+                        docs: prop.docs ? [prop.docs] : undefined
+                    });
+                }
+            }
         }
 
         return properties;


### PR DESCRIPTION
## Description

Fixes a crash in the TypeScript SDK generator when an inferred auth scheme points to a token endpoint that uses `application/x-www-form-urlencoded` content type (e.g. Box API's `POST /oauth2/token`).

**Error:** `Cannot get exported name for request wrapper, because endpoint request is not wrapped`

**Root cause:** Form-encoded endpoints produce a `justRequestBody` shape in the IR, not a `wrapper` shape. The inferred auth code unconditionally called `getGeneratedRequestWrapper()`, which calls `RequestWrapperDeclarationReferencer.getExportedName()` — that method throws for non-wrapper endpoints.

## Changes Made

- **`AuthProviderContext.ts`**: `getPropertiesForAuthTokenParams()` now checks whether the endpoint has a wrapped request before calling `getGeneratedRequestWrapper()`. For `justRequestBody` endpoints, a new `getPropertiesFromRequestBody()` method extracts properties directly from the endpoint's request body (supports both `inlinedRequestBody` and named `reference` types).

- **`InferredAuthProviderGenerator.ts`**: Added a `getRequestProperties()` helper that delegates to the wrapper when available, and falls back to `AuthProviderContext.getPropertiesForAuthTokenParams()` when not. Updated `generateGetAuthRequestFromTokenEndpointMethod` and `authTokenParametersToAuthTokenRequest` to use this helper instead of directly accessing `requestWrapper?.getRequestProperties()`.

- Added unreleased changelog entry.

## Testing
- [ ] Unit tests added/updated
- [x] Lint/type checks pass (`pnpm run check`)

### Key areas for human review
1. **Property name mapping in the fallback path**: `getPropertiesFromRequestBody` uses `this.context.case.camelSafe(prop.name)` — verify this produces names consistent with what the generated client method signature expects for `justRequestBody` endpoints.
2. **`name`/`safeName` equivalence**: In `InferredAuthProviderGenerator.getRequestProperties`, when falling back, both `name` and `safeName` are set to `param.name`. In the wrapper path these can differ — verify this doesn't cause mismatches in the generated property assignments.
3. **Unhandled body types**: `getPropertiesFromRequestBody` only handles `inlinedRequestBody` and `reference` (named) — `fileUpload`, `bytes`, and non-named references return empty properties. This seems correct for OAuth token endpoints but worth confirming.

Link to Devin session: https://app.devin.ai/sessions/ad12296f2ce342ada8a91a3f5a6ff99a
Requested by: @Swimburger
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/15048" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
