### PR TITLE
feat(docs): add mobile-toc option to docs.yml layout config

### DIFF
--- a/docs-yml.schema.json
+++ b/docs-yml.schema.json
@@ -5429,6 +5429,16 @@
               "type": "null"
             }
           ]
+        },
+        "mobile-toc": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ]
         }
       },
       "additionalProperties": false

--- a/fern/apis/docs-yml/definition/docs.yml
+++ b/fern/apis/docs-yml/definition/docs.yml
@@ -823,6 +823,12 @@ types:
         docs: |
           If `hide-feedback` is set to true, the feedback button will not be rendered. This can be overridden for a specific page using the frontmatter.
 
+      mobile-toc:
+        type: optional<boolean>
+        availability: in-development
+        docs: |
+          If `mobile-toc` is set to true, a sticky collapsible table of contents bar will be shown on mobile viewports for guide and overview layout pages.
+
   DocsSettingsConfig:
     properties:
       search-text:

--- a/packages/cli/configuration-loader/src/docs-yml/parseDocsConfiguration.ts
+++ b/packages/cli/configuration-loader/src/docs-yml/parseDocsConfiguration.ts
@@ -586,6 +586,7 @@ function convertLayoutConfig(
         disableHeader: layout.disableHeader ?? false,
         hideNavLinks: layout.hideNavLinks ?? false,
         hideFeedback: layout.hideFeedback ?? false,
+        mobileToc: layout.mobileToc ?? false,
         tabsAlignment: resolvedTabsAlignment
     } as unknown as docsYml.ParsedDocsConfiguration["layout"];
 }

--- a/packages/cli/configuration/src/docs-yml/DocsYmlSchemas.ts
+++ b/packages/cli/configuration/src/docs-yml/DocsYmlSchemas.ts
@@ -307,7 +307,8 @@ export const LayoutConfig = z.object({
     "header-position": HeaderPosition.optional(),
     "disable-header": z.boolean().optional(),
     "hide-nav-links": z.boolean().optional(),
-    "hide-feedback": z.boolean().optional()
+    "hide-feedback": z.boolean().optional(),
+    "mobile-toc": z.boolean().optional()
 });
 
 // ===== Settings =====

--- a/packages/cli/configuration/src/docs-yml/schemas/sdk/api/resources/docs/types/LayoutConfig.ts
+++ b/packages/cli/configuration/src/docs-yml/schemas/sdk/api/resources/docs/types/LayoutConfig.ts
@@ -94,4 +94,6 @@ export interface LayoutConfig {
     hideNavLinks?: boolean;
     /** If `hide-feedback` is set to true, the feedback button will not be rendered. This can be overridden for a specific page using the frontmatter. */
     hideFeedback?: boolean;
+    /** If `mobile-toc` is set to true, a sticky collapsible table of contents bar will be shown on mobile viewports for guide and overview layout pages. */
+    mobileToc?: boolean;
 }

--- a/packages/cli/configuration/src/docs-yml/schemas/sdk/serialization/resources/docs/types/LayoutConfig.ts
+++ b/packages/cli/configuration/src/docs-yml/schemas/sdk/serialization/resources/docs/types/LayoutConfig.ts
@@ -23,6 +23,7 @@ export const LayoutConfig: core.serialization.ObjectSchema<serializers.LayoutCon
         disableHeader: core.serialization.property("disable-header", core.serialization.boolean().optional()),
         hideNavLinks: core.serialization.property("hide-nav-links", core.serialization.boolean().optional()),
         hideFeedback: core.serialization.property("hide-feedback", core.serialization.boolean().optional()),
+        mobileToc: core.serialization.property("mobile-toc", core.serialization.boolean().optional()),
     });
 
 export declare namespace LayoutConfig {
@@ -39,5 +40,6 @@ export declare namespace LayoutConfig {
         "disable-header"?: boolean | null;
         "hide-nav-links"?: boolean | null;
         "hide-feedback"?: boolean | null;
+        "mobile-toc"?: boolean | null;
     }
 }

--- a/packages/cli/workspace/loader/src/docs-yml.schema.json
+++ b/packages/cli/workspace/loader/src/docs-yml.schema.json
@@ -5429,6 +5429,16 @@
               "type": "null"
             }
           ]
+        },
+        "mobile-toc": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ]
         }
       },
       "additionalProperties": false


### PR DESCRIPTION
## Summary
- Adds an opt-in `mobile-toc` boolean to the `layout` section of `docs.yml`, enabling a sticky collapsible table of contents bar on mobile viewports for guide and overview layout pages.
- Accompanies https://github.com/fern-api/fern-platform/pull/9736

## Changes Made
- Added `mobile-toc: optional<boolean>` to `LayoutConfig` in the Fern API definition
- Added `mobile-toc` to the zod schema in `DocsYmlSchemas.ts`
- Added `mobileToc` to the API type interface and serialization layer
- Mapped `mobileToc` in `parseDocsConfiguration.ts` (defaults to `false`)
- Updated both JSON schema files with the new field

## Test plan
- [ ] Verify `layout: { mobile-toc: true }` in docs.yml is parsed correctly
- [ ] Verify the field flows through to the write shape as `mobileToc: true`
- [ ] Verify omitting the field defaults to `false`

🤖 Generated with [Claude Code](https://claude.com/claude-code)