### PR TITLE
chore(ruby): add Severity to Naming/VariableNumber in rubocop config

### DIFF
--- a/generators/ruby-v2/ast/src/custom-config/BaseRubyCustomConfigSchema.ts
+++ b/generators/ruby-v2/ast/src/custom-config/BaseRubyCustomConfigSchema.ts
@@ -38,9 +38,10 @@ export const BaseRubyCustomConfigSchema = z.object({
     // - "disabled": disables the cop entirely
     rubocopVariableNumberStyle: z.enum(["snake_case", "normalcase", "disabled"]).optional(),
     // Severity level for the Naming/VariableNumber cop
+    // - "info": reports violations as informational notes
     // - "warning": reports violations as warnings (default for customer SDKs)
     // - "error": reports violations as errors (used in seed to enforce rubocop)
-    rubocopSeverity: z.enum(["warning", "error"]).optional(),
+    rubocopSeverity: z.enum(["info", "warning", "error"]).optional(),
     maxRetries: z.number().int().min(0).optional()
 });
 

--- a/generators/ruby-v2/ast/src/custom-config/BaseRubyCustomConfigSchema.ts
+++ b/generators/ruby-v2/ast/src/custom-config/BaseRubyCustomConfigSchema.ts
@@ -37,6 +37,10 @@ export const BaseRubyCustomConfigSchema = z.object({
     // - "normalcase": allows numbers without underscores (e.g., recaptcha_v2, office365)
     // - "disabled": disables the cop entirely
     rubocopVariableNumberStyle: z.enum(["snake_case", "normalcase", "disabled"]).optional(),
+    // Severity level for the Naming/VariableNumber cop
+    // - "warning": reports violations as warnings (default for customer SDKs)
+    // - "error": reports violations as errors (used in seed to enforce rubocop)
+    rubocopSeverity: z.enum(["warning", "error"]).optional(),
     maxRetries: z.number().int().min(0).optional()
 });
 

--- a/generators/ruby-v2/base/src/project/RubocopFile.ts
+++ b/generators/ruby-v2/base/src/project/RubocopFile.ts
@@ -24,7 +24,8 @@ export class RubocopFile {
         }
 
         return `Naming/VariableNumber:
-  EnforcedStyle: ${style}`;
+  EnforcedStyle: ${style}
+  Severity: warning`;
     }
 
     public async toString(): Promise<string> {

--- a/generators/ruby-v2/base/src/project/RubocopFile.ts
+++ b/generators/ruby-v2/base/src/project/RubocopFile.ts
@@ -23,9 +23,11 @@ export class RubocopFile {
   Enabled: false`;
         }
 
+        const severity = this.context.customConfig.rubocopSeverity ?? "warning";
+
         return `Naming/VariableNumber:
   EnforcedStyle: ${style}
-  Severity: warning`;
+  Severity: ${severity}`;
     }
 
     public async toString(): Promise<string> {

--- a/generators/ruby-v2/sdk/changes/unreleased/add-rubocop-severity-warning.yml
+++ b/generators/ruby-v2/sdk/changes/unreleased/add-rubocop-severity-warning.yml
@@ -1,0 +1,3 @@
+- summary: |
+    Add `Severity: warning` to `Naming/VariableNumber` in generated `.rubocop.yml` config.
+  type: chore

--- a/generators/ruby-v2/sdk/changes/unreleased/add-rubocop-severity-warning.yml
+++ b/generators/ruby-v2/sdk/changes/unreleased/add-rubocop-severity-warning.yml
@@ -1,3 +1,4 @@
 - summary: |
-    Add `Severity: warning` to `Naming/VariableNumber` in generated `.rubocop.yml` config.
+    Add `Severity` to `Naming/VariableNumber` in generated `.rubocop.yml` config.
+    Defaults to `warning` for customer SDKs. Configurable via `rubocopSeverity` custom config.
   type: chore

--- a/seed/ruby-sdk-v2/accept-header/.rubocop.yml
+++ b/seed/ruby-sdk-v2/accept-header/.rubocop.yml
@@ -46,7 +46,7 @@ Layout/LineLength:
 
 Naming/VariableNumber:
   EnforcedStyle: normalcase
-  Severity: warning
+  Severity: error
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/accept-header/.rubocop.yml
+++ b/seed/ruby-sdk-v2/accept-header/.rubocop.yml
@@ -46,6 +46,7 @@ Layout/LineLength:
 
 Naming/VariableNumber:
   EnforcedStyle: normalcase
+  Severity: warning
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/alias-extends/.rubocop.yml
+++ b/seed/ruby-sdk-v2/alias-extends/.rubocop.yml
@@ -46,7 +46,7 @@ Layout/LineLength:
 
 Naming/VariableNumber:
   EnforcedStyle: normalcase
-  Severity: warning
+  Severity: error
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/alias-extends/.rubocop.yml
+++ b/seed/ruby-sdk-v2/alias-extends/.rubocop.yml
@@ -46,6 +46,7 @@ Layout/LineLength:
 
 Naming/VariableNumber:
   EnforcedStyle: normalcase
+  Severity: warning
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/alias/.rubocop.yml
+++ b/seed/ruby-sdk-v2/alias/.rubocop.yml
@@ -46,7 +46,7 @@ Layout/LineLength:
 
 Naming/VariableNumber:
   EnforcedStyle: normalcase
-  Severity: warning
+  Severity: error
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/alias/.rubocop.yml
+++ b/seed/ruby-sdk-v2/alias/.rubocop.yml
@@ -46,6 +46,7 @@ Layout/LineLength:
 
 Naming/VariableNumber:
   EnforcedStyle: normalcase
+  Severity: warning
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/allof-inline/.rubocop.yml
+++ b/seed/ruby-sdk-v2/allof-inline/.rubocop.yml
@@ -46,7 +46,7 @@ Layout/LineLength:
 
 Naming/VariableNumber:
   EnforcedStyle: normalcase
-  Severity: warning
+  Severity: error
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/allof-inline/.rubocop.yml
+++ b/seed/ruby-sdk-v2/allof-inline/.rubocop.yml
@@ -46,6 +46,7 @@ Layout/LineLength:
 
 Naming/VariableNumber:
   EnforcedStyle: normalcase
+  Severity: warning
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/allof/.rubocop.yml
+++ b/seed/ruby-sdk-v2/allof/.rubocop.yml
@@ -46,7 +46,7 @@ Layout/LineLength:
 
 Naming/VariableNumber:
   EnforcedStyle: normalcase
-  Severity: warning
+  Severity: error
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/allof/.rubocop.yml
+++ b/seed/ruby-sdk-v2/allof/.rubocop.yml
@@ -46,6 +46,7 @@ Layout/LineLength:
 
 Naming/VariableNumber:
   EnforcedStyle: normalcase
+  Severity: warning
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/any-auth/.rubocop.yml
+++ b/seed/ruby-sdk-v2/any-auth/.rubocop.yml
@@ -46,7 +46,7 @@ Layout/LineLength:
 
 Naming/VariableNumber:
   EnforcedStyle: normalcase
-  Severity: warning
+  Severity: error
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/any-auth/.rubocop.yml
+++ b/seed/ruby-sdk-v2/any-auth/.rubocop.yml
@@ -46,6 +46,7 @@ Layout/LineLength:
 
 Naming/VariableNumber:
   EnforcedStyle: normalcase
+  Severity: warning
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/api-wide-base-path/.rubocop.yml
+++ b/seed/ruby-sdk-v2/api-wide-base-path/.rubocop.yml
@@ -46,7 +46,7 @@ Layout/LineLength:
 
 Naming/VariableNumber:
   EnforcedStyle: normalcase
-  Severity: warning
+  Severity: error
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/api-wide-base-path/.rubocop.yml
+++ b/seed/ruby-sdk-v2/api-wide-base-path/.rubocop.yml
@@ -46,6 +46,7 @@ Layout/LineLength:
 
 Naming/VariableNumber:
   EnforcedStyle: normalcase
+  Severity: warning
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/audiences/.rubocop.yml
+++ b/seed/ruby-sdk-v2/audiences/.rubocop.yml
@@ -46,7 +46,7 @@ Layout/LineLength:
 
 Naming/VariableNumber:
   EnforcedStyle: normalcase
-  Severity: warning
+  Severity: error
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/audiences/.rubocop.yml
+++ b/seed/ruby-sdk-v2/audiences/.rubocop.yml
@@ -46,6 +46,7 @@ Layout/LineLength:
 
 Naming/VariableNumber:
   EnforcedStyle: normalcase
+  Severity: warning
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/basic-auth-environment-variables/.rubocop.yml
+++ b/seed/ruby-sdk-v2/basic-auth-environment-variables/.rubocop.yml
@@ -46,7 +46,7 @@ Layout/LineLength:
 
 Naming/VariableNumber:
   EnforcedStyle: normalcase
-  Severity: warning
+  Severity: error
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/basic-auth-environment-variables/.rubocop.yml
+++ b/seed/ruby-sdk-v2/basic-auth-environment-variables/.rubocop.yml
@@ -46,6 +46,7 @@ Layout/LineLength:
 
 Naming/VariableNumber:
   EnforcedStyle: normalcase
+  Severity: warning
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/basic-auth-pw-omitted/.rubocop.yml
+++ b/seed/ruby-sdk-v2/basic-auth-pw-omitted/.rubocop.yml
@@ -46,7 +46,7 @@ Layout/LineLength:
 
 Naming/VariableNumber:
   EnforcedStyle: normalcase
-  Severity: warning
+  Severity: error
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/basic-auth-pw-omitted/.rubocop.yml
+++ b/seed/ruby-sdk-v2/basic-auth-pw-omitted/.rubocop.yml
@@ -46,6 +46,7 @@ Layout/LineLength:
 
 Naming/VariableNumber:
   EnforcedStyle: normalcase
+  Severity: warning
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/basic-auth-pw-omitted/wire-tests/.rubocop.yml
+++ b/seed/ruby-sdk-v2/basic-auth-pw-omitted/wire-tests/.rubocop.yml
@@ -46,7 +46,7 @@ Layout/LineLength:
 
 Naming/VariableNumber:
   EnforcedStyle: normalcase
-  Severity: warning
+  Severity: error
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/basic-auth-pw-omitted/wire-tests/.rubocop.yml
+++ b/seed/ruby-sdk-v2/basic-auth-pw-omitted/wire-tests/.rubocop.yml
@@ -46,6 +46,7 @@ Layout/LineLength:
 
 Naming/VariableNumber:
   EnforcedStyle: normalcase
+  Severity: warning
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/basic-auth/.rubocop.yml
+++ b/seed/ruby-sdk-v2/basic-auth/.rubocop.yml
@@ -46,7 +46,7 @@ Layout/LineLength:
 
 Naming/VariableNumber:
   EnforcedStyle: normalcase
-  Severity: warning
+  Severity: error
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/basic-auth/.rubocop.yml
+++ b/seed/ruby-sdk-v2/basic-auth/.rubocop.yml
@@ -46,6 +46,7 @@ Layout/LineLength:
 
 Naming/VariableNumber:
   EnforcedStyle: normalcase
+  Severity: warning
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/basic-auth/wire-tests/.rubocop.yml
+++ b/seed/ruby-sdk-v2/basic-auth/wire-tests/.rubocop.yml
@@ -46,7 +46,7 @@ Layout/LineLength:
 
 Naming/VariableNumber:
   EnforcedStyle: normalcase
-  Severity: warning
+  Severity: error
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/basic-auth/wire-tests/.rubocop.yml
+++ b/seed/ruby-sdk-v2/basic-auth/wire-tests/.rubocop.yml
@@ -46,6 +46,7 @@ Layout/LineLength:
 
 Naming/VariableNumber:
   EnforcedStyle: normalcase
+  Severity: warning
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/bearer-token-environment-variable/.rubocop.yml
+++ b/seed/ruby-sdk-v2/bearer-token-environment-variable/.rubocop.yml
@@ -46,7 +46,7 @@ Layout/LineLength:
 
 Naming/VariableNumber:
   EnforcedStyle: normalcase
-  Severity: warning
+  Severity: error
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/bearer-token-environment-variable/.rubocop.yml
+++ b/seed/ruby-sdk-v2/bearer-token-environment-variable/.rubocop.yml
@@ -46,6 +46,7 @@ Layout/LineLength:
 
 Naming/VariableNumber:
   EnforcedStyle: normalcase
+  Severity: warning
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/bytes-download/.rubocop.yml
+++ b/seed/ruby-sdk-v2/bytes-download/.rubocop.yml
@@ -46,7 +46,7 @@ Layout/LineLength:
 
 Naming/VariableNumber:
   EnforcedStyle: normalcase
-  Severity: warning
+  Severity: error
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/bytes-download/.rubocop.yml
+++ b/seed/ruby-sdk-v2/bytes-download/.rubocop.yml
@@ -46,6 +46,7 @@ Layout/LineLength:
 
 Naming/VariableNumber:
   EnforcedStyle: normalcase
+  Severity: warning
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/bytes-upload/.rubocop.yml
+++ b/seed/ruby-sdk-v2/bytes-upload/.rubocop.yml
@@ -46,7 +46,7 @@ Layout/LineLength:
 
 Naming/VariableNumber:
   EnforcedStyle: normalcase
-  Severity: warning
+  Severity: error
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/bytes-upload/.rubocop.yml
+++ b/seed/ruby-sdk-v2/bytes-upload/.rubocop.yml
@@ -46,6 +46,7 @@ Layout/LineLength:
 
 Naming/VariableNumber:
   EnforcedStyle: normalcase
+  Severity: warning
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/circular-references-advanced/.rubocop.yml
+++ b/seed/ruby-sdk-v2/circular-references-advanced/.rubocop.yml
@@ -46,7 +46,7 @@ Layout/LineLength:
 
 Naming/VariableNumber:
   EnforcedStyle: normalcase
-  Severity: warning
+  Severity: error
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/circular-references-advanced/.rubocop.yml
+++ b/seed/ruby-sdk-v2/circular-references-advanced/.rubocop.yml
@@ -46,6 +46,7 @@ Layout/LineLength:
 
 Naming/VariableNumber:
   EnforcedStyle: normalcase
+  Severity: warning
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/circular-references-extends/.rubocop.yml
+++ b/seed/ruby-sdk-v2/circular-references-extends/.rubocop.yml
@@ -46,7 +46,7 @@ Layout/LineLength:
 
 Naming/VariableNumber:
   EnforcedStyle: normalcase
-  Severity: warning
+  Severity: error
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/circular-references-extends/.rubocop.yml
+++ b/seed/ruby-sdk-v2/circular-references-extends/.rubocop.yml
@@ -46,6 +46,7 @@ Layout/LineLength:
 
 Naming/VariableNumber:
   EnforcedStyle: normalcase
+  Severity: warning
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/circular-references/.rubocop.yml
+++ b/seed/ruby-sdk-v2/circular-references/.rubocop.yml
@@ -46,7 +46,7 @@ Layout/LineLength:
 
 Naming/VariableNumber:
   EnforcedStyle: normalcase
-  Severity: warning
+  Severity: error
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/circular-references/.rubocop.yml
+++ b/seed/ruby-sdk-v2/circular-references/.rubocop.yml
@@ -46,6 +46,7 @@ Layout/LineLength:
 
 Naming/VariableNumber:
   EnforcedStyle: normalcase
+  Severity: warning
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/client-side-params/.rubocop.yml
+++ b/seed/ruby-sdk-v2/client-side-params/.rubocop.yml
@@ -46,7 +46,7 @@ Layout/LineLength:
 
 Naming/VariableNumber:
   EnforcedStyle: normalcase
-  Severity: warning
+  Severity: error
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/client-side-params/.rubocop.yml
+++ b/seed/ruby-sdk-v2/client-side-params/.rubocop.yml
@@ -46,6 +46,7 @@ Layout/LineLength:
 
 Naming/VariableNumber:
   EnforcedStyle: normalcase
+  Severity: warning
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/content-type/.rubocop.yml
+++ b/seed/ruby-sdk-v2/content-type/.rubocop.yml
@@ -46,7 +46,7 @@ Layout/LineLength:
 
 Naming/VariableNumber:
   EnforcedStyle: normalcase
-  Severity: warning
+  Severity: error
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/content-type/.rubocop.yml
+++ b/seed/ruby-sdk-v2/content-type/.rubocop.yml
@@ -46,6 +46,7 @@ Layout/LineLength:
 
 Naming/VariableNumber:
   EnforcedStyle: normalcase
+  Severity: warning
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/cross-package-type-names/.rubocop.yml
+++ b/seed/ruby-sdk-v2/cross-package-type-names/.rubocop.yml
@@ -46,7 +46,7 @@ Layout/LineLength:
 
 Naming/VariableNumber:
   EnforcedStyle: normalcase
-  Severity: warning
+  Severity: error
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/cross-package-type-names/.rubocop.yml
+++ b/seed/ruby-sdk-v2/cross-package-type-names/.rubocop.yml
@@ -46,6 +46,7 @@ Layout/LineLength:
 
 Naming/VariableNumber:
   EnforcedStyle: normalcase
+  Severity: warning
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/dollar-string-examples/.rubocop.yml
+++ b/seed/ruby-sdk-v2/dollar-string-examples/.rubocop.yml
@@ -46,7 +46,7 @@ Layout/LineLength:
 
 Naming/VariableNumber:
   EnforcedStyle: normalcase
-  Severity: warning
+  Severity: error
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/dollar-string-examples/.rubocop.yml
+++ b/seed/ruby-sdk-v2/dollar-string-examples/.rubocop.yml
@@ -46,6 +46,7 @@ Layout/LineLength:
 
 Naming/VariableNumber:
   EnforcedStyle: normalcase
+  Severity: warning
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/empty-clients/.rubocop.yml
+++ b/seed/ruby-sdk-v2/empty-clients/.rubocop.yml
@@ -46,7 +46,7 @@ Layout/LineLength:
 
 Naming/VariableNumber:
   EnforcedStyle: normalcase
-  Severity: warning
+  Severity: error
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/empty-clients/.rubocop.yml
+++ b/seed/ruby-sdk-v2/empty-clients/.rubocop.yml
@@ -46,6 +46,7 @@ Layout/LineLength:
 
 Naming/VariableNumber:
   EnforcedStyle: normalcase
+  Severity: warning
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/endpoint-security-auth/.rubocop.yml
+++ b/seed/ruby-sdk-v2/endpoint-security-auth/.rubocop.yml
@@ -46,7 +46,7 @@ Layout/LineLength:
 
 Naming/VariableNumber:
   EnforcedStyle: normalcase
-  Severity: warning
+  Severity: error
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/endpoint-security-auth/.rubocop.yml
+++ b/seed/ruby-sdk-v2/endpoint-security-auth/.rubocop.yml
@@ -46,6 +46,7 @@ Layout/LineLength:
 
 Naming/VariableNumber:
   EnforcedStyle: normalcase
+  Severity: warning
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/enum/.rubocop.yml
+++ b/seed/ruby-sdk-v2/enum/.rubocop.yml
@@ -46,7 +46,7 @@ Layout/LineLength:
 
 Naming/VariableNumber:
   EnforcedStyle: normalcase
-  Severity: warning
+  Severity: error
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/enum/.rubocop.yml
+++ b/seed/ruby-sdk-v2/enum/.rubocop.yml
@@ -46,6 +46,7 @@ Layout/LineLength:
 
 Naming/VariableNumber:
   EnforcedStyle: normalcase
+  Severity: warning
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/error-property/.rubocop.yml
+++ b/seed/ruby-sdk-v2/error-property/.rubocop.yml
@@ -46,7 +46,7 @@ Layout/LineLength:
 
 Naming/VariableNumber:
   EnforcedStyle: normalcase
-  Severity: warning
+  Severity: error
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/error-property/.rubocop.yml
+++ b/seed/ruby-sdk-v2/error-property/.rubocop.yml
@@ -46,6 +46,7 @@ Layout/LineLength:
 
 Naming/VariableNumber:
   EnforcedStyle: normalcase
+  Severity: warning
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/errors/.rubocop.yml
+++ b/seed/ruby-sdk-v2/errors/.rubocop.yml
@@ -46,7 +46,7 @@ Layout/LineLength:
 
 Naming/VariableNumber:
   EnforcedStyle: normalcase
-  Severity: warning
+  Severity: error
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/errors/.rubocop.yml
+++ b/seed/ruby-sdk-v2/errors/.rubocop.yml
@@ -46,6 +46,7 @@ Layout/LineLength:
 
 Naming/VariableNumber:
   EnforcedStyle: normalcase
+  Severity: warning
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/examples/no-custom-config/.rubocop.yml
+++ b/seed/ruby-sdk-v2/examples/no-custom-config/.rubocop.yml
@@ -46,7 +46,7 @@ Layout/LineLength:
 
 Naming/VariableNumber:
   EnforcedStyle: normalcase
-  Severity: warning
+  Severity: error
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/examples/no-custom-config/.rubocop.yml
+++ b/seed/ruby-sdk-v2/examples/no-custom-config/.rubocop.yml
@@ -46,6 +46,7 @@ Layout/LineLength:
 
 Naming/VariableNumber:
   EnforcedStyle: normalcase
+  Severity: warning
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/examples/omit-fern-headers/.rubocop.yml
+++ b/seed/ruby-sdk-v2/examples/omit-fern-headers/.rubocop.yml
@@ -46,7 +46,7 @@ Layout/LineLength:
 
 Naming/VariableNumber:
   EnforcedStyle: normalcase
-  Severity: warning
+  Severity: error
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/examples/omit-fern-headers/.rubocop.yml
+++ b/seed/ruby-sdk-v2/examples/omit-fern-headers/.rubocop.yml
@@ -46,6 +46,7 @@ Layout/LineLength:
 
 Naming/VariableNumber:
   EnforcedStyle: normalcase
+  Severity: warning
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/examples/readme-config/.rubocop.yml
+++ b/seed/ruby-sdk-v2/examples/readme-config/.rubocop.yml
@@ -46,7 +46,7 @@ Layout/LineLength:
 
 Naming/VariableNumber:
   EnforcedStyle: normalcase
-  Severity: warning
+  Severity: error
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/examples/readme-config/.rubocop.yml
+++ b/seed/ruby-sdk-v2/examples/readme-config/.rubocop.yml
@@ -46,6 +46,7 @@ Layout/LineLength:
 
 Naming/VariableNumber:
   EnforcedStyle: normalcase
+  Severity: warning
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/examples/require-paths/.rubocop.yml
+++ b/seed/ruby-sdk-v2/examples/require-paths/.rubocop.yml
@@ -46,7 +46,7 @@ Layout/LineLength:
 
 Naming/VariableNumber:
   EnforcedStyle: normalcase
-  Severity: warning
+  Severity: error
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/examples/require-paths/.rubocop.yml
+++ b/seed/ruby-sdk-v2/examples/require-paths/.rubocop.yml
@@ -46,6 +46,7 @@ Layout/LineLength:
 
 Naming/VariableNumber:
   EnforcedStyle: normalcase
+  Severity: warning
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/examples/wire-tests/.rubocop.yml
+++ b/seed/ruby-sdk-v2/examples/wire-tests/.rubocop.yml
@@ -46,7 +46,7 @@ Layout/LineLength:
 
 Naming/VariableNumber:
   EnforcedStyle: normalcase
-  Severity: warning
+  Severity: error
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/examples/wire-tests/.rubocop.yml
+++ b/seed/ruby-sdk-v2/examples/wire-tests/.rubocop.yml
@@ -46,6 +46,7 @@ Layout/LineLength:
 
 Naming/VariableNumber:
   EnforcedStyle: normalcase
+  Severity: warning
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/exhaustive/wire-tests/.rubocop.yml
+++ b/seed/ruby-sdk-v2/exhaustive/wire-tests/.rubocop.yml
@@ -46,7 +46,7 @@ Layout/LineLength:
 
 Naming/VariableNumber:
   EnforcedStyle: normalcase
-  Severity: warning
+  Severity: error
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/exhaustive/wire-tests/.rubocop.yml
+++ b/seed/ruby-sdk-v2/exhaustive/wire-tests/.rubocop.yml
@@ -46,6 +46,7 @@ Layout/LineLength:
 
 Naming/VariableNumber:
   EnforcedStyle: normalcase
+  Severity: warning
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/extends/.rubocop.yml
+++ b/seed/ruby-sdk-v2/extends/.rubocop.yml
@@ -46,7 +46,7 @@ Layout/LineLength:
 
 Naming/VariableNumber:
   EnforcedStyle: normalcase
-  Severity: warning
+  Severity: error
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/extends/.rubocop.yml
+++ b/seed/ruby-sdk-v2/extends/.rubocop.yml
@@ -46,6 +46,7 @@ Layout/LineLength:
 
 Naming/VariableNumber:
   EnforcedStyle: normalcase
+  Severity: warning
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/extra-properties/.rubocop.yml
+++ b/seed/ruby-sdk-v2/extra-properties/.rubocop.yml
@@ -46,7 +46,7 @@ Layout/LineLength:
 
 Naming/VariableNumber:
   EnforcedStyle: normalcase
-  Severity: warning
+  Severity: error
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/extra-properties/.rubocop.yml
+++ b/seed/ruby-sdk-v2/extra-properties/.rubocop.yml
@@ -46,6 +46,7 @@ Layout/LineLength:
 
 Naming/VariableNumber:
   EnforcedStyle: normalcase
+  Severity: warning
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/file-download/.rubocop.yml
+++ b/seed/ruby-sdk-v2/file-download/.rubocop.yml
@@ -46,7 +46,7 @@ Layout/LineLength:
 
 Naming/VariableNumber:
   EnforcedStyle: normalcase
-  Severity: warning
+  Severity: error
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/file-download/.rubocop.yml
+++ b/seed/ruby-sdk-v2/file-download/.rubocop.yml
@@ -46,6 +46,7 @@ Layout/LineLength:
 
 Naming/VariableNumber:
   EnforcedStyle: normalcase
+  Severity: warning
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/file-upload-openapi/.rubocop.yml
+++ b/seed/ruby-sdk-v2/file-upload-openapi/.rubocop.yml
@@ -46,7 +46,7 @@ Layout/LineLength:
 
 Naming/VariableNumber:
   EnforcedStyle: normalcase
-  Severity: warning
+  Severity: error
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/file-upload-openapi/.rubocop.yml
+++ b/seed/ruby-sdk-v2/file-upload-openapi/.rubocop.yml
@@ -46,6 +46,7 @@ Layout/LineLength:
 
 Naming/VariableNumber:
   EnforcedStyle: normalcase
+  Severity: warning
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/file-upload/.rubocop.yml
+++ b/seed/ruby-sdk-v2/file-upload/.rubocop.yml
@@ -46,7 +46,7 @@ Layout/LineLength:
 
 Naming/VariableNumber:
   EnforcedStyle: normalcase
-  Severity: warning
+  Severity: error
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/file-upload/.rubocop.yml
+++ b/seed/ruby-sdk-v2/file-upload/.rubocop.yml
@@ -46,6 +46,7 @@ Layout/LineLength:
 
 Naming/VariableNumber:
   EnforcedStyle: normalcase
+  Severity: warning
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/folders/.rubocop.yml
+++ b/seed/ruby-sdk-v2/folders/.rubocop.yml
@@ -46,7 +46,7 @@ Layout/LineLength:
 
 Naming/VariableNumber:
   EnforcedStyle: normalcase
-  Severity: warning
+  Severity: error
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/folders/.rubocop.yml
+++ b/seed/ruby-sdk-v2/folders/.rubocop.yml
@@ -46,6 +46,7 @@ Layout/LineLength:
 
 Naming/VariableNumber:
   EnforcedStyle: normalcase
+  Severity: warning
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/header-auth-environment-variable/.rubocop.yml
+++ b/seed/ruby-sdk-v2/header-auth-environment-variable/.rubocop.yml
@@ -46,7 +46,7 @@ Layout/LineLength:
 
 Naming/VariableNumber:
   EnforcedStyle: normalcase
-  Severity: warning
+  Severity: error
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/header-auth-environment-variable/.rubocop.yml
+++ b/seed/ruby-sdk-v2/header-auth-environment-variable/.rubocop.yml
@@ -46,6 +46,7 @@ Layout/LineLength:
 
 Naming/VariableNumber:
   EnforcedStyle: normalcase
+  Severity: warning
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/header-auth/.rubocop.yml
+++ b/seed/ruby-sdk-v2/header-auth/.rubocop.yml
@@ -46,7 +46,7 @@ Layout/LineLength:
 
 Naming/VariableNumber:
   EnforcedStyle: normalcase
-  Severity: warning
+  Severity: error
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/header-auth/.rubocop.yml
+++ b/seed/ruby-sdk-v2/header-auth/.rubocop.yml
@@ -46,6 +46,7 @@ Layout/LineLength:
 
 Naming/VariableNumber:
   EnforcedStyle: normalcase
+  Severity: warning
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/http-head/.rubocop.yml
+++ b/seed/ruby-sdk-v2/http-head/.rubocop.yml
@@ -46,7 +46,7 @@ Layout/LineLength:
 
 Naming/VariableNumber:
   EnforcedStyle: normalcase
-  Severity: warning
+  Severity: error
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/http-head/.rubocop.yml
+++ b/seed/ruby-sdk-v2/http-head/.rubocop.yml
@@ -46,6 +46,7 @@ Layout/LineLength:
 
 Naming/VariableNumber:
   EnforcedStyle: normalcase
+  Severity: warning
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/idempotency-headers/.rubocop.yml
+++ b/seed/ruby-sdk-v2/idempotency-headers/.rubocop.yml
@@ -46,7 +46,7 @@ Layout/LineLength:
 
 Naming/VariableNumber:
   EnforcedStyle: normalcase
-  Severity: warning
+  Severity: error
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/idempotency-headers/.rubocop.yml
+++ b/seed/ruby-sdk-v2/idempotency-headers/.rubocop.yml
@@ -46,6 +46,7 @@ Layout/LineLength:
 
 Naming/VariableNumber:
   EnforcedStyle: normalcase
+  Severity: warning
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/imdb/.rubocop.yml
+++ b/seed/ruby-sdk-v2/imdb/.rubocop.yml
@@ -46,7 +46,7 @@ Layout/LineLength:
 
 Naming/VariableNumber:
   EnforcedStyle: normalcase
-  Severity: warning
+  Severity: error
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/imdb/.rubocop.yml
+++ b/seed/ruby-sdk-v2/imdb/.rubocop.yml
@@ -46,6 +46,7 @@ Layout/LineLength:
 
 Naming/VariableNumber:
   EnforcedStyle: normalcase
+  Severity: warning
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/inferred-auth-explicit/.rubocop.yml
+++ b/seed/ruby-sdk-v2/inferred-auth-explicit/.rubocop.yml
@@ -46,7 +46,7 @@ Layout/LineLength:
 
 Naming/VariableNumber:
   EnforcedStyle: normalcase
-  Severity: warning
+  Severity: error
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/inferred-auth-explicit/.rubocop.yml
+++ b/seed/ruby-sdk-v2/inferred-auth-explicit/.rubocop.yml
@@ -46,6 +46,7 @@ Layout/LineLength:
 
 Naming/VariableNumber:
   EnforcedStyle: normalcase
+  Severity: warning
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/inferred-auth-implicit-api-key/.rubocop.yml
+++ b/seed/ruby-sdk-v2/inferred-auth-implicit-api-key/.rubocop.yml
@@ -46,7 +46,7 @@ Layout/LineLength:
 
 Naming/VariableNumber:
   EnforcedStyle: normalcase
-  Severity: warning
+  Severity: error
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/inferred-auth-implicit-api-key/.rubocop.yml
+++ b/seed/ruby-sdk-v2/inferred-auth-implicit-api-key/.rubocop.yml
@@ -46,6 +46,7 @@ Layout/LineLength:
 
 Naming/VariableNumber:
   EnforcedStyle: normalcase
+  Severity: warning
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/inferred-auth-implicit-no-expiry/.rubocop.yml
+++ b/seed/ruby-sdk-v2/inferred-auth-implicit-no-expiry/.rubocop.yml
@@ -46,7 +46,7 @@ Layout/LineLength:
 
 Naming/VariableNumber:
   EnforcedStyle: normalcase
-  Severity: warning
+  Severity: error
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/inferred-auth-implicit-no-expiry/.rubocop.yml
+++ b/seed/ruby-sdk-v2/inferred-auth-implicit-no-expiry/.rubocop.yml
@@ -46,6 +46,7 @@ Layout/LineLength:
 
 Naming/VariableNumber:
   EnforcedStyle: normalcase
+  Severity: warning
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/inferred-auth-implicit-reference/.rubocop.yml
+++ b/seed/ruby-sdk-v2/inferred-auth-implicit-reference/.rubocop.yml
@@ -46,7 +46,7 @@ Layout/LineLength:
 
 Naming/VariableNumber:
   EnforcedStyle: normalcase
-  Severity: warning
+  Severity: error
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/inferred-auth-implicit-reference/.rubocop.yml
+++ b/seed/ruby-sdk-v2/inferred-auth-implicit-reference/.rubocop.yml
@@ -46,6 +46,7 @@ Layout/LineLength:
 
 Naming/VariableNumber:
   EnforcedStyle: normalcase
+  Severity: warning
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/inferred-auth-implicit/.rubocop.yml
+++ b/seed/ruby-sdk-v2/inferred-auth-implicit/.rubocop.yml
@@ -46,7 +46,7 @@ Layout/LineLength:
 
 Naming/VariableNumber:
   EnforcedStyle: normalcase
-  Severity: warning
+  Severity: error
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/inferred-auth-implicit/.rubocop.yml
+++ b/seed/ruby-sdk-v2/inferred-auth-implicit/.rubocop.yml
@@ -46,6 +46,7 @@ Layout/LineLength:
 
 Naming/VariableNumber:
   EnforcedStyle: normalcase
+  Severity: warning
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/license/.rubocop.yml
+++ b/seed/ruby-sdk-v2/license/.rubocop.yml
@@ -46,7 +46,7 @@ Layout/LineLength:
 
 Naming/VariableNumber:
   EnforcedStyle: normalcase
-  Severity: warning
+  Severity: error
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/license/.rubocop.yml
+++ b/seed/ruby-sdk-v2/license/.rubocop.yml
@@ -46,6 +46,7 @@ Layout/LineLength:
 
 Naming/VariableNumber:
   EnforcedStyle: normalcase
+  Severity: warning
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/literal/.rubocop.yml
+++ b/seed/ruby-sdk-v2/literal/.rubocop.yml
@@ -46,7 +46,7 @@ Layout/LineLength:
 
 Naming/VariableNumber:
   EnforcedStyle: normalcase
-  Severity: warning
+  Severity: error
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/literal/.rubocop.yml
+++ b/seed/ruby-sdk-v2/literal/.rubocop.yml
@@ -46,6 +46,7 @@ Layout/LineLength:
 
 Naming/VariableNumber:
   EnforcedStyle: normalcase
+  Severity: warning
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/literals-unions/.rubocop.yml
+++ b/seed/ruby-sdk-v2/literals-unions/.rubocop.yml
@@ -46,7 +46,7 @@ Layout/LineLength:
 
 Naming/VariableNumber:
   EnforcedStyle: normalcase
-  Severity: warning
+  Severity: error
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/literals-unions/.rubocop.yml
+++ b/seed/ruby-sdk-v2/literals-unions/.rubocop.yml
@@ -46,6 +46,7 @@ Layout/LineLength:
 
 Naming/VariableNumber:
   EnforcedStyle: normalcase
+  Severity: warning
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/mixed-case/.rubocop.yml
+++ b/seed/ruby-sdk-v2/mixed-case/.rubocop.yml
@@ -46,7 +46,7 @@ Layout/LineLength:
 
 Naming/VariableNumber:
   EnforcedStyle: normalcase
-  Severity: warning
+  Severity: error
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/mixed-case/.rubocop.yml
+++ b/seed/ruby-sdk-v2/mixed-case/.rubocop.yml
@@ -46,6 +46,7 @@ Layout/LineLength:
 
 Naming/VariableNumber:
   EnforcedStyle: normalcase
+  Severity: warning
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/mixed-file-directory/.rubocop.yml
+++ b/seed/ruby-sdk-v2/mixed-file-directory/.rubocop.yml
@@ -46,7 +46,7 @@ Layout/LineLength:
 
 Naming/VariableNumber:
   EnforcedStyle: normalcase
-  Severity: warning
+  Severity: error
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/mixed-file-directory/.rubocop.yml
+++ b/seed/ruby-sdk-v2/mixed-file-directory/.rubocop.yml
@@ -46,6 +46,7 @@ Layout/LineLength:
 
 Naming/VariableNumber:
   EnforcedStyle: normalcase
+  Severity: warning
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/multi-line-docs/.rubocop.yml
+++ b/seed/ruby-sdk-v2/multi-line-docs/.rubocop.yml
@@ -46,7 +46,7 @@ Layout/LineLength:
 
 Naming/VariableNumber:
   EnforcedStyle: normalcase
-  Severity: warning
+  Severity: error
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/multi-line-docs/.rubocop.yml
+++ b/seed/ruby-sdk-v2/multi-line-docs/.rubocop.yml
@@ -46,6 +46,7 @@ Layout/LineLength:
 
 Naming/VariableNumber:
   EnforcedStyle: normalcase
+  Severity: warning
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/multi-url-environment-no-default/.rubocop.yml
+++ b/seed/ruby-sdk-v2/multi-url-environment-no-default/.rubocop.yml
@@ -46,7 +46,7 @@ Layout/LineLength:
 
 Naming/VariableNumber:
   EnforcedStyle: normalcase
-  Severity: warning
+  Severity: error
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/multi-url-environment-no-default/.rubocop.yml
+++ b/seed/ruby-sdk-v2/multi-url-environment-no-default/.rubocop.yml
@@ -46,6 +46,7 @@ Layout/LineLength:
 
 Naming/VariableNumber:
   EnforcedStyle: normalcase
+  Severity: warning
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/multi-url-environment/.rubocop.yml
+++ b/seed/ruby-sdk-v2/multi-url-environment/.rubocop.yml
@@ -46,7 +46,7 @@ Layout/LineLength:
 
 Naming/VariableNumber:
   EnforcedStyle: normalcase
-  Severity: warning
+  Severity: error
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/multi-url-environment/.rubocop.yml
+++ b/seed/ruby-sdk-v2/multi-url-environment/.rubocop.yml
@@ -46,6 +46,7 @@ Layout/LineLength:
 
 Naming/VariableNumber:
   EnforcedStyle: normalcase
+  Severity: warning
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/multiple-request-bodies/.rubocop.yml
+++ b/seed/ruby-sdk-v2/multiple-request-bodies/.rubocop.yml
@@ -46,7 +46,7 @@ Layout/LineLength:
 
 Naming/VariableNumber:
   EnforcedStyle: normalcase
-  Severity: warning
+  Severity: error
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/multiple-request-bodies/.rubocop.yml
+++ b/seed/ruby-sdk-v2/multiple-request-bodies/.rubocop.yml
@@ -46,6 +46,7 @@ Layout/LineLength:
 
 Naming/VariableNumber:
   EnforcedStyle: normalcase
+  Severity: warning
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/no-content-response/.rubocop.yml
+++ b/seed/ruby-sdk-v2/no-content-response/.rubocop.yml
@@ -46,7 +46,7 @@ Layout/LineLength:
 
 Naming/VariableNumber:
   EnforcedStyle: normalcase
-  Severity: warning
+  Severity: error
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/no-content-response/.rubocop.yml
+++ b/seed/ruby-sdk-v2/no-content-response/.rubocop.yml
@@ -46,6 +46,7 @@ Layout/LineLength:
 
 Naming/VariableNumber:
   EnforcedStyle: normalcase
+  Severity: warning
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/no-environment/.rubocop.yml
+++ b/seed/ruby-sdk-v2/no-environment/.rubocop.yml
@@ -46,7 +46,7 @@ Layout/LineLength:
 
 Naming/VariableNumber:
   EnforcedStyle: normalcase
-  Severity: warning
+  Severity: error
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/no-environment/.rubocop.yml
+++ b/seed/ruby-sdk-v2/no-environment/.rubocop.yml
@@ -46,6 +46,7 @@ Layout/LineLength:
 
 Naming/VariableNumber:
   EnforcedStyle: normalcase
+  Severity: warning
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/no-retries/.rubocop.yml
+++ b/seed/ruby-sdk-v2/no-retries/.rubocop.yml
@@ -46,7 +46,7 @@ Layout/LineLength:
 
 Naming/VariableNumber:
   EnforcedStyle: normalcase
-  Severity: warning
+  Severity: error
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/no-retries/.rubocop.yml
+++ b/seed/ruby-sdk-v2/no-retries/.rubocop.yml
@@ -46,6 +46,7 @@ Layout/LineLength:
 
 Naming/VariableNumber:
   EnforcedStyle: normalcase
+  Severity: warning
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/null-type/.rubocop.yml
+++ b/seed/ruby-sdk-v2/null-type/.rubocop.yml
@@ -46,7 +46,7 @@ Layout/LineLength:
 
 Naming/VariableNumber:
   EnforcedStyle: normalcase
-  Severity: warning
+  Severity: error
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/null-type/.rubocop.yml
+++ b/seed/ruby-sdk-v2/null-type/.rubocop.yml
@@ -46,6 +46,7 @@ Layout/LineLength:
 
 Naming/VariableNumber:
   EnforcedStyle: normalcase
+  Severity: warning
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/nullable-allof-extends/.rubocop.yml
+++ b/seed/ruby-sdk-v2/nullable-allof-extends/.rubocop.yml
@@ -46,7 +46,7 @@ Layout/LineLength:
 
 Naming/VariableNumber:
   EnforcedStyle: normalcase
-  Severity: warning
+  Severity: error
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/nullable-allof-extends/.rubocop.yml
+++ b/seed/ruby-sdk-v2/nullable-allof-extends/.rubocop.yml
@@ -46,6 +46,7 @@ Layout/LineLength:
 
 Naming/VariableNumber:
   EnforcedStyle: normalcase
+  Severity: warning
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/nullable-optional/.rubocop.yml
+++ b/seed/ruby-sdk-v2/nullable-optional/.rubocop.yml
@@ -46,7 +46,7 @@ Layout/LineLength:
 
 Naming/VariableNumber:
   EnforcedStyle: normalcase
-  Severity: warning
+  Severity: error
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/nullable-optional/.rubocop.yml
+++ b/seed/ruby-sdk-v2/nullable-optional/.rubocop.yml
@@ -46,6 +46,7 @@ Layout/LineLength:
 
 Naming/VariableNumber:
   EnforcedStyle: normalcase
+  Severity: warning
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/nullable-request-body/.rubocop.yml
+++ b/seed/ruby-sdk-v2/nullable-request-body/.rubocop.yml
@@ -46,7 +46,7 @@ Layout/LineLength:
 
 Naming/VariableNumber:
   EnforcedStyle: normalcase
-  Severity: warning
+  Severity: error
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/nullable-request-body/.rubocop.yml
+++ b/seed/ruby-sdk-v2/nullable-request-body/.rubocop.yml
@@ -46,6 +46,7 @@ Layout/LineLength:
 
 Naming/VariableNumber:
   EnforcedStyle: normalcase
+  Severity: warning
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/nullable/.rubocop.yml
+++ b/seed/ruby-sdk-v2/nullable/.rubocop.yml
@@ -46,7 +46,7 @@ Layout/LineLength:
 
 Naming/VariableNumber:
   EnforcedStyle: normalcase
-  Severity: warning
+  Severity: error
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/nullable/.rubocop.yml
+++ b/seed/ruby-sdk-v2/nullable/.rubocop.yml
@@ -46,6 +46,7 @@ Layout/LineLength:
 
 Naming/VariableNumber:
   EnforcedStyle: normalcase
+  Severity: warning
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/oauth-client-credentials-custom/.rubocop.yml
+++ b/seed/ruby-sdk-v2/oauth-client-credentials-custom/.rubocop.yml
@@ -46,7 +46,7 @@ Layout/LineLength:
 
 Naming/VariableNumber:
   EnforcedStyle: normalcase
-  Severity: warning
+  Severity: error
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/oauth-client-credentials-custom/.rubocop.yml
+++ b/seed/ruby-sdk-v2/oauth-client-credentials-custom/.rubocop.yml
@@ -46,6 +46,7 @@ Layout/LineLength:
 
 Naming/VariableNumber:
   EnforcedStyle: normalcase
+  Severity: warning
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/oauth-client-credentials-default/.rubocop.yml
+++ b/seed/ruby-sdk-v2/oauth-client-credentials-default/.rubocop.yml
@@ -46,7 +46,7 @@ Layout/LineLength:
 
 Naming/VariableNumber:
   EnforcedStyle: normalcase
-  Severity: warning
+  Severity: error
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/oauth-client-credentials-default/.rubocop.yml
+++ b/seed/ruby-sdk-v2/oauth-client-credentials-default/.rubocop.yml
@@ -46,6 +46,7 @@ Layout/LineLength:
 
 Naming/VariableNumber:
   EnforcedStyle: normalcase
+  Severity: warning
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/oauth-client-credentials-environment-variables/.rubocop.yml
+++ b/seed/ruby-sdk-v2/oauth-client-credentials-environment-variables/.rubocop.yml
@@ -46,7 +46,7 @@ Layout/LineLength:
 
 Naming/VariableNumber:
   EnforcedStyle: normalcase
-  Severity: warning
+  Severity: error
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/oauth-client-credentials-environment-variables/.rubocop.yml
+++ b/seed/ruby-sdk-v2/oauth-client-credentials-environment-variables/.rubocop.yml
@@ -46,6 +46,7 @@ Layout/LineLength:
 
 Naming/VariableNumber:
   EnforcedStyle: normalcase
+  Severity: warning
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/oauth-client-credentials-mandatory-auth/.rubocop.yml
+++ b/seed/ruby-sdk-v2/oauth-client-credentials-mandatory-auth/.rubocop.yml
@@ -46,7 +46,7 @@ Layout/LineLength:
 
 Naming/VariableNumber:
   EnforcedStyle: normalcase
-  Severity: warning
+  Severity: error
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/oauth-client-credentials-mandatory-auth/.rubocop.yml
+++ b/seed/ruby-sdk-v2/oauth-client-credentials-mandatory-auth/.rubocop.yml
@@ -46,6 +46,7 @@ Layout/LineLength:
 
 Naming/VariableNumber:
   EnforcedStyle: normalcase
+  Severity: warning
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/oauth-client-credentials-nested-root/.rubocop.yml
+++ b/seed/ruby-sdk-v2/oauth-client-credentials-nested-root/.rubocop.yml
@@ -46,7 +46,7 @@ Layout/LineLength:
 
 Naming/VariableNumber:
   EnforcedStyle: normalcase
-  Severity: warning
+  Severity: error
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/oauth-client-credentials-nested-root/.rubocop.yml
+++ b/seed/ruby-sdk-v2/oauth-client-credentials-nested-root/.rubocop.yml
@@ -46,6 +46,7 @@ Layout/LineLength:
 
 Naming/VariableNumber:
   EnforcedStyle: normalcase
+  Severity: warning
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/oauth-client-credentials-openapi/.rubocop.yml
+++ b/seed/ruby-sdk-v2/oauth-client-credentials-openapi/.rubocop.yml
@@ -46,7 +46,7 @@ Layout/LineLength:
 
 Naming/VariableNumber:
   EnforcedStyle: normalcase
-  Severity: warning
+  Severity: error
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/oauth-client-credentials-openapi/.rubocop.yml
+++ b/seed/ruby-sdk-v2/oauth-client-credentials-openapi/.rubocop.yml
@@ -46,6 +46,7 @@ Layout/LineLength:
 
 Naming/VariableNumber:
   EnforcedStyle: normalcase
+  Severity: warning
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/oauth-client-credentials-reference/.rubocop.yml
+++ b/seed/ruby-sdk-v2/oauth-client-credentials-reference/.rubocop.yml
@@ -46,7 +46,7 @@ Layout/LineLength:
 
 Naming/VariableNumber:
   EnforcedStyle: normalcase
-  Severity: warning
+  Severity: error
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/oauth-client-credentials-reference/.rubocop.yml
+++ b/seed/ruby-sdk-v2/oauth-client-credentials-reference/.rubocop.yml
@@ -46,6 +46,7 @@ Layout/LineLength:
 
 Naming/VariableNumber:
   EnforcedStyle: normalcase
+  Severity: warning
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/oauth-client-credentials-with-variables/.rubocop.yml
+++ b/seed/ruby-sdk-v2/oauth-client-credentials-with-variables/.rubocop.yml
@@ -46,7 +46,7 @@ Layout/LineLength:
 
 Naming/VariableNumber:
   EnforcedStyle: normalcase
-  Severity: warning
+  Severity: error
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/oauth-client-credentials-with-variables/.rubocop.yml
+++ b/seed/ruby-sdk-v2/oauth-client-credentials-with-variables/.rubocop.yml
@@ -46,6 +46,7 @@ Layout/LineLength:
 
 Naming/VariableNumber:
   EnforcedStyle: normalcase
+  Severity: warning
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/oauth-client-credentials/.rubocop.yml
+++ b/seed/ruby-sdk-v2/oauth-client-credentials/.rubocop.yml
@@ -46,7 +46,7 @@ Layout/LineLength:
 
 Naming/VariableNumber:
   EnforcedStyle: normalcase
-  Severity: warning
+  Severity: error
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/oauth-client-credentials/.rubocop.yml
+++ b/seed/ruby-sdk-v2/oauth-client-credentials/.rubocop.yml
@@ -46,6 +46,7 @@ Layout/LineLength:
 
 Naming/VariableNumber:
   EnforcedStyle: normalcase
+  Severity: warning
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/object/.rubocop.yml
+++ b/seed/ruby-sdk-v2/object/.rubocop.yml
@@ -46,7 +46,7 @@ Layout/LineLength:
 
 Naming/VariableNumber:
   EnforcedStyle: normalcase
-  Severity: warning
+  Severity: error
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/object/.rubocop.yml
+++ b/seed/ruby-sdk-v2/object/.rubocop.yml
@@ -46,6 +46,7 @@ Layout/LineLength:
 
 Naming/VariableNumber:
   EnforcedStyle: normalcase
+  Severity: warning
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/objects-with-imports/.rubocop.yml
+++ b/seed/ruby-sdk-v2/objects-with-imports/.rubocop.yml
@@ -46,7 +46,7 @@ Layout/LineLength:
 
 Naming/VariableNumber:
   EnforcedStyle: normalcase
-  Severity: warning
+  Severity: error
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/objects-with-imports/.rubocop.yml
+++ b/seed/ruby-sdk-v2/objects-with-imports/.rubocop.yml
@@ -46,6 +46,7 @@ Layout/LineLength:
 
 Naming/VariableNumber:
   EnforcedStyle: normalcase
+  Severity: warning
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/optional/.rubocop.yml
+++ b/seed/ruby-sdk-v2/optional/.rubocop.yml
@@ -46,7 +46,7 @@ Layout/LineLength:
 
 Naming/VariableNumber:
   EnforcedStyle: normalcase
-  Severity: warning
+  Severity: error
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/optional/.rubocop.yml
+++ b/seed/ruby-sdk-v2/optional/.rubocop.yml
@@ -46,6 +46,7 @@ Layout/LineLength:
 
 Naming/VariableNumber:
   EnforcedStyle: normalcase
+  Severity: warning
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/package-yml/.rubocop.yml
+++ b/seed/ruby-sdk-v2/package-yml/.rubocop.yml
@@ -46,7 +46,7 @@ Layout/LineLength:
 
 Naming/VariableNumber:
   EnforcedStyle: normalcase
-  Severity: warning
+  Severity: error
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/package-yml/.rubocop.yml
+++ b/seed/ruby-sdk-v2/package-yml/.rubocop.yml
@@ -46,6 +46,7 @@ Layout/LineLength:
 
 Naming/VariableNumber:
   EnforcedStyle: normalcase
+  Severity: warning
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/pagination-custom/.rubocop.yml
+++ b/seed/ruby-sdk-v2/pagination-custom/.rubocop.yml
@@ -46,7 +46,7 @@ Layout/LineLength:
 
 Naming/VariableNumber:
   EnforcedStyle: normalcase
-  Severity: warning
+  Severity: error
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/pagination-custom/.rubocop.yml
+++ b/seed/ruby-sdk-v2/pagination-custom/.rubocop.yml
@@ -46,6 +46,7 @@ Layout/LineLength:
 
 Naming/VariableNumber:
   EnforcedStyle: normalcase
+  Severity: warning
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/pagination-uri-path/.rubocop.yml
+++ b/seed/ruby-sdk-v2/pagination-uri-path/.rubocop.yml
@@ -46,7 +46,7 @@ Layout/LineLength:
 
 Naming/VariableNumber:
   EnforcedStyle: normalcase
-  Severity: warning
+  Severity: error
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/pagination-uri-path/.rubocop.yml
+++ b/seed/ruby-sdk-v2/pagination-uri-path/.rubocop.yml
@@ -46,6 +46,7 @@ Layout/LineLength:
 
 Naming/VariableNumber:
   EnforcedStyle: normalcase
+  Severity: warning
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/pagination/.rubocop.yml
+++ b/seed/ruby-sdk-v2/pagination/.rubocop.yml
@@ -46,7 +46,7 @@ Layout/LineLength:
 
 Naming/VariableNumber:
   EnforcedStyle: normalcase
-  Severity: warning
+  Severity: error
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/pagination/.rubocop.yml
+++ b/seed/ruby-sdk-v2/pagination/.rubocop.yml
@@ -46,6 +46,7 @@ Layout/LineLength:
 
 Naming/VariableNumber:
   EnforcedStyle: normalcase
+  Severity: warning
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/path-parameters/.rubocop.yml
+++ b/seed/ruby-sdk-v2/path-parameters/.rubocop.yml
@@ -46,7 +46,7 @@ Layout/LineLength:
 
 Naming/VariableNumber:
   EnforcedStyle: normalcase
-  Severity: warning
+  Severity: error
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/path-parameters/.rubocop.yml
+++ b/seed/ruby-sdk-v2/path-parameters/.rubocop.yml
@@ -46,6 +46,7 @@ Layout/LineLength:
 
 Naming/VariableNumber:
   EnforcedStyle: normalcase
+  Severity: warning
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/plain-text/.rubocop.yml
+++ b/seed/ruby-sdk-v2/plain-text/.rubocop.yml
@@ -46,7 +46,7 @@ Layout/LineLength:
 
 Naming/VariableNumber:
   EnforcedStyle: normalcase
-  Severity: warning
+  Severity: error
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/plain-text/.rubocop.yml
+++ b/seed/ruby-sdk-v2/plain-text/.rubocop.yml
@@ -46,6 +46,7 @@ Layout/LineLength:
 
 Naming/VariableNumber:
   EnforcedStyle: normalcase
+  Severity: warning
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/property-access/.rubocop.yml
+++ b/seed/ruby-sdk-v2/property-access/.rubocop.yml
@@ -46,7 +46,7 @@ Layout/LineLength:
 
 Naming/VariableNumber:
   EnforcedStyle: normalcase
-  Severity: warning
+  Severity: error
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/property-access/.rubocop.yml
+++ b/seed/ruby-sdk-v2/property-access/.rubocop.yml
@@ -46,6 +46,7 @@ Layout/LineLength:
 
 Naming/VariableNumber:
   EnforcedStyle: normalcase
+  Severity: warning
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/public-object/.rubocop.yml
+++ b/seed/ruby-sdk-v2/public-object/.rubocop.yml
@@ -46,7 +46,7 @@ Layout/LineLength:
 
 Naming/VariableNumber:
   EnforcedStyle: normalcase
-  Severity: warning
+  Severity: error
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/public-object/.rubocop.yml
+++ b/seed/ruby-sdk-v2/public-object/.rubocop.yml
@@ -46,6 +46,7 @@ Layout/LineLength:
 
 Naming/VariableNumber:
   EnforcedStyle: normalcase
+  Severity: warning
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/query-param-name-conflict/.rubocop.yml
+++ b/seed/ruby-sdk-v2/query-param-name-conflict/.rubocop.yml
@@ -46,7 +46,7 @@ Layout/LineLength:
 
 Naming/VariableNumber:
   EnforcedStyle: normalcase
-  Severity: warning
+  Severity: error
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/query-param-name-conflict/.rubocop.yml
+++ b/seed/ruby-sdk-v2/query-param-name-conflict/.rubocop.yml
@@ -46,6 +46,7 @@ Layout/LineLength:
 
 Naming/VariableNumber:
   EnforcedStyle: normalcase
+  Severity: warning
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/query-parameters-openapi-as-objects/.rubocop.yml
+++ b/seed/ruby-sdk-v2/query-parameters-openapi-as-objects/.rubocop.yml
@@ -46,7 +46,7 @@ Layout/LineLength:
 
 Naming/VariableNumber:
   EnforcedStyle: normalcase
-  Severity: warning
+  Severity: error
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/query-parameters-openapi-as-objects/.rubocop.yml
+++ b/seed/ruby-sdk-v2/query-parameters-openapi-as-objects/.rubocop.yml
@@ -46,6 +46,7 @@ Layout/LineLength:
 
 Naming/VariableNumber:
   EnforcedStyle: normalcase
+  Severity: warning
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/query-parameters-openapi/.rubocop.yml
+++ b/seed/ruby-sdk-v2/query-parameters-openapi/.rubocop.yml
@@ -46,7 +46,7 @@ Layout/LineLength:
 
 Naming/VariableNumber:
   EnforcedStyle: normalcase
-  Severity: warning
+  Severity: error
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/query-parameters-openapi/.rubocop.yml
+++ b/seed/ruby-sdk-v2/query-parameters-openapi/.rubocop.yml
@@ -46,6 +46,7 @@ Layout/LineLength:
 
 Naming/VariableNumber:
   EnforcedStyle: normalcase
+  Severity: warning
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/query-parameters/.rubocop.yml
+++ b/seed/ruby-sdk-v2/query-parameters/.rubocop.yml
@@ -46,7 +46,7 @@ Layout/LineLength:
 
 Naming/VariableNumber:
   EnforcedStyle: normalcase
-  Severity: warning
+  Severity: error
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/query-parameters/.rubocop.yml
+++ b/seed/ruby-sdk-v2/query-parameters/.rubocop.yml
@@ -46,6 +46,7 @@ Layout/LineLength:
 
 Naming/VariableNumber:
   EnforcedStyle: normalcase
+  Severity: warning
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/request-parameters/.rubocop.yml
+++ b/seed/ruby-sdk-v2/request-parameters/.rubocop.yml
@@ -46,7 +46,7 @@ Layout/LineLength:
 
 Naming/VariableNumber:
   EnforcedStyle: normalcase
-  Severity: warning
+  Severity: error
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/request-parameters/.rubocop.yml
+++ b/seed/ruby-sdk-v2/request-parameters/.rubocop.yml
@@ -46,6 +46,7 @@ Layout/LineLength:
 
 Naming/VariableNumber:
   EnforcedStyle: normalcase
+  Severity: warning
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/required-nullable/.rubocop.yml
+++ b/seed/ruby-sdk-v2/required-nullable/.rubocop.yml
@@ -46,7 +46,7 @@ Layout/LineLength:
 
 Naming/VariableNumber:
   EnforcedStyle: normalcase
-  Severity: warning
+  Severity: error
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/required-nullable/.rubocop.yml
+++ b/seed/ruby-sdk-v2/required-nullable/.rubocop.yml
@@ -46,6 +46,7 @@ Layout/LineLength:
 
 Naming/VariableNumber:
   EnforcedStyle: normalcase
+  Severity: warning
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/reserved-keywords/.rubocop.yml
+++ b/seed/ruby-sdk-v2/reserved-keywords/.rubocop.yml
@@ -46,7 +46,7 @@ Layout/LineLength:
 
 Naming/VariableNumber:
   EnforcedStyle: normalcase
-  Severity: warning
+  Severity: error
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/reserved-keywords/.rubocop.yml
+++ b/seed/ruby-sdk-v2/reserved-keywords/.rubocop.yml
@@ -46,6 +46,7 @@ Layout/LineLength:
 
 Naming/VariableNumber:
   EnforcedStyle: normalcase
+  Severity: warning
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/response-property/.rubocop.yml
+++ b/seed/ruby-sdk-v2/response-property/.rubocop.yml
@@ -46,7 +46,7 @@ Layout/LineLength:
 
 Naming/VariableNumber:
   EnforcedStyle: normalcase
-  Severity: warning
+  Severity: error
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/response-property/.rubocop.yml
+++ b/seed/ruby-sdk-v2/response-property/.rubocop.yml
@@ -46,6 +46,7 @@ Layout/LineLength:
 
 Naming/VariableNumber:
   EnforcedStyle: normalcase
+  Severity: warning
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/ruby-reserved-word-properties/.rubocop.yml
+++ b/seed/ruby-sdk-v2/ruby-reserved-word-properties/.rubocop.yml
@@ -46,7 +46,7 @@ Layout/LineLength:
 
 Naming/VariableNumber:
   EnforcedStyle: normalcase
-  Severity: warning
+  Severity: error
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/ruby-reserved-word-properties/.rubocop.yml
+++ b/seed/ruby-sdk-v2/ruby-reserved-word-properties/.rubocop.yml
@@ -46,6 +46,7 @@ Layout/LineLength:
 
 Naming/VariableNumber:
   EnforcedStyle: normalcase
+  Severity: warning
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/schemaless-request-body-examples/.rubocop.yml
+++ b/seed/ruby-sdk-v2/schemaless-request-body-examples/.rubocop.yml
@@ -46,7 +46,7 @@ Layout/LineLength:
 
 Naming/VariableNumber:
   EnforcedStyle: normalcase
-  Severity: warning
+  Severity: error
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/schemaless-request-body-examples/.rubocop.yml
+++ b/seed/ruby-sdk-v2/schemaless-request-body-examples/.rubocop.yml
@@ -46,6 +46,7 @@ Layout/LineLength:
 
 Naming/VariableNumber:
   EnforcedStyle: normalcase
+  Severity: warning
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/seed.yml
+++ b/seed/ruby-sdk-v2/seed.yml
@@ -3,6 +3,8 @@ displayName: Ruby SDK
 language: ruby
 generatorType: SDK
 defaultOutputMode: github
+defaultCustomConfig:
+  rubocopSeverity: error
 image: fernapi/fern-ruby-sdk-v2
 imageAliases: [fernapi/fern-ruby-sdk]
 changelogLocation: ../../generators/ruby-v2/sdk/versions.yml

--- a/seed/ruby-sdk-v2/server-sent-event-examples/.rubocop.yml
+++ b/seed/ruby-sdk-v2/server-sent-event-examples/.rubocop.yml
@@ -46,7 +46,7 @@ Layout/LineLength:
 
 Naming/VariableNumber:
   EnforcedStyle: normalcase
-  Severity: warning
+  Severity: error
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/server-sent-event-examples/.rubocop.yml
+++ b/seed/ruby-sdk-v2/server-sent-event-examples/.rubocop.yml
@@ -46,6 +46,7 @@ Layout/LineLength:
 
 Naming/VariableNumber:
   EnforcedStyle: normalcase
+  Severity: warning
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/server-sent-events-openapi/.rubocop.yml
+++ b/seed/ruby-sdk-v2/server-sent-events-openapi/.rubocop.yml
@@ -46,7 +46,7 @@ Layout/LineLength:
 
 Naming/VariableNumber:
   EnforcedStyle: normalcase
-  Severity: warning
+  Severity: error
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/server-sent-events-openapi/.rubocop.yml
+++ b/seed/ruby-sdk-v2/server-sent-events-openapi/.rubocop.yml
@@ -46,6 +46,7 @@ Layout/LineLength:
 
 Naming/VariableNumber:
   EnforcedStyle: normalcase
+  Severity: warning
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/server-sent-events/.rubocop.yml
+++ b/seed/ruby-sdk-v2/server-sent-events/.rubocop.yml
@@ -46,7 +46,7 @@ Layout/LineLength:
 
 Naming/VariableNumber:
   EnforcedStyle: normalcase
-  Severity: warning
+  Severity: error
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/server-sent-events/.rubocop.yml
+++ b/seed/ruby-sdk-v2/server-sent-events/.rubocop.yml
@@ -46,6 +46,7 @@ Layout/LineLength:
 
 Naming/VariableNumber:
   EnforcedStyle: normalcase
+  Severity: warning
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/server-url-templating/.rubocop.yml
+++ b/seed/ruby-sdk-v2/server-url-templating/.rubocop.yml
@@ -46,7 +46,7 @@ Layout/LineLength:
 
 Naming/VariableNumber:
   EnforcedStyle: normalcase
-  Severity: warning
+  Severity: error
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/server-url-templating/.rubocop.yml
+++ b/seed/ruby-sdk-v2/server-url-templating/.rubocop.yml
@@ -46,6 +46,7 @@ Layout/LineLength:
 
 Naming/VariableNumber:
   EnforcedStyle: normalcase
+  Severity: warning
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/simple-api/.rubocop.yml
+++ b/seed/ruby-sdk-v2/simple-api/.rubocop.yml
@@ -46,7 +46,7 @@ Layout/LineLength:
 
 Naming/VariableNumber:
   EnforcedStyle: normalcase
-  Severity: warning
+  Severity: error
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/simple-api/.rubocop.yml
+++ b/seed/ruby-sdk-v2/simple-api/.rubocop.yml
@@ -46,6 +46,7 @@ Layout/LineLength:
 
 Naming/VariableNumber:
   EnforcedStyle: normalcase
+  Severity: warning
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/simple-fhir/.rubocop.yml
+++ b/seed/ruby-sdk-v2/simple-fhir/.rubocop.yml
@@ -46,7 +46,7 @@ Layout/LineLength:
 
 Naming/VariableNumber:
   EnforcedStyle: normalcase
-  Severity: warning
+  Severity: error
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/simple-fhir/.rubocop.yml
+++ b/seed/ruby-sdk-v2/simple-fhir/.rubocop.yml
@@ -46,6 +46,7 @@ Layout/LineLength:
 
 Naming/VariableNumber:
   EnforcedStyle: normalcase
+  Severity: warning
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/single-url-environment-default/.rubocop.yml
+++ b/seed/ruby-sdk-v2/single-url-environment-default/.rubocop.yml
@@ -46,7 +46,7 @@ Layout/LineLength:
 
 Naming/VariableNumber:
   EnforcedStyle: normalcase
-  Severity: warning
+  Severity: error
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/single-url-environment-default/.rubocop.yml
+++ b/seed/ruby-sdk-v2/single-url-environment-default/.rubocop.yml
@@ -46,6 +46,7 @@ Layout/LineLength:
 
 Naming/VariableNumber:
   EnforcedStyle: normalcase
+  Severity: warning
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/single-url-environment-no-default/.rubocop.yml
+++ b/seed/ruby-sdk-v2/single-url-environment-no-default/.rubocop.yml
@@ -46,7 +46,7 @@ Layout/LineLength:
 
 Naming/VariableNumber:
   EnforcedStyle: normalcase
-  Severity: warning
+  Severity: error
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/single-url-environment-no-default/.rubocop.yml
+++ b/seed/ruby-sdk-v2/single-url-environment-no-default/.rubocop.yml
@@ -46,6 +46,7 @@ Layout/LineLength:
 
 Naming/VariableNumber:
   EnforcedStyle: normalcase
+  Severity: warning
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/streaming-parameter/.rubocop.yml
+++ b/seed/ruby-sdk-v2/streaming-parameter/.rubocop.yml
@@ -46,7 +46,7 @@ Layout/LineLength:
 
 Naming/VariableNumber:
   EnforcedStyle: normalcase
-  Severity: warning
+  Severity: error
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/streaming-parameter/.rubocop.yml
+++ b/seed/ruby-sdk-v2/streaming-parameter/.rubocop.yml
@@ -46,6 +46,7 @@ Layout/LineLength:
 
 Naming/VariableNumber:
   EnforcedStyle: normalcase
+  Severity: warning
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/streaming/.rubocop.yml
+++ b/seed/ruby-sdk-v2/streaming/.rubocop.yml
@@ -46,7 +46,7 @@ Layout/LineLength:
 
 Naming/VariableNumber:
   EnforcedStyle: normalcase
-  Severity: warning
+  Severity: error
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/streaming/.rubocop.yml
+++ b/seed/ruby-sdk-v2/streaming/.rubocop.yml
@@ -46,6 +46,7 @@ Layout/LineLength:
 
 Naming/VariableNumber:
   EnforcedStyle: normalcase
+  Severity: warning
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/trace/.rubocop.yml
+++ b/seed/ruby-sdk-v2/trace/.rubocop.yml
@@ -46,7 +46,7 @@ Layout/LineLength:
 
 Naming/VariableNumber:
   EnforcedStyle: normalcase
-  Severity: warning
+  Severity: error
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/trace/.rubocop.yml
+++ b/seed/ruby-sdk-v2/trace/.rubocop.yml
@@ -46,6 +46,7 @@ Layout/LineLength:
 
 Naming/VariableNumber:
   EnforcedStyle: normalcase
+  Severity: warning
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/undiscriminated-union-with-response-property/.rubocop.yml
+++ b/seed/ruby-sdk-v2/undiscriminated-union-with-response-property/.rubocop.yml
@@ -46,7 +46,7 @@ Layout/LineLength:
 
 Naming/VariableNumber:
   EnforcedStyle: normalcase
-  Severity: warning
+  Severity: error
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/undiscriminated-union-with-response-property/.rubocop.yml
+++ b/seed/ruby-sdk-v2/undiscriminated-union-with-response-property/.rubocop.yml
@@ -46,6 +46,7 @@ Layout/LineLength:
 
 Naming/VariableNumber:
   EnforcedStyle: normalcase
+  Severity: warning
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/undiscriminated-unions/.rubocop.yml
+++ b/seed/ruby-sdk-v2/undiscriminated-unions/.rubocop.yml
@@ -46,7 +46,7 @@ Layout/LineLength:
 
 Naming/VariableNumber:
   EnforcedStyle: normalcase
-  Severity: warning
+  Severity: error
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/undiscriminated-unions/.rubocop.yml
+++ b/seed/ruby-sdk-v2/undiscriminated-unions/.rubocop.yml
@@ -46,6 +46,7 @@ Layout/LineLength:
 
 Naming/VariableNumber:
   EnforcedStyle: normalcase
+  Severity: warning
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/unions-with-local-date/.rubocop.yml
+++ b/seed/ruby-sdk-v2/unions-with-local-date/.rubocop.yml
@@ -46,7 +46,7 @@ Layout/LineLength:
 
 Naming/VariableNumber:
   EnforcedStyle: normalcase
-  Severity: warning
+  Severity: error
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/unions-with-local-date/.rubocop.yml
+++ b/seed/ruby-sdk-v2/unions-with-local-date/.rubocop.yml
@@ -46,6 +46,7 @@ Layout/LineLength:
 
 Naming/VariableNumber:
   EnforcedStyle: normalcase
+  Severity: warning
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/unions/.rubocop.yml
+++ b/seed/ruby-sdk-v2/unions/.rubocop.yml
@@ -46,7 +46,7 @@ Layout/LineLength:
 
 Naming/VariableNumber:
   EnforcedStyle: normalcase
-  Severity: warning
+  Severity: error
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/unions/.rubocop.yml
+++ b/seed/ruby-sdk-v2/unions/.rubocop.yml
@@ -46,6 +46,7 @@ Layout/LineLength:
 
 Naming/VariableNumber:
   EnforcedStyle: normalcase
+  Severity: warning
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/unknown/.rubocop.yml
+++ b/seed/ruby-sdk-v2/unknown/.rubocop.yml
@@ -46,7 +46,7 @@ Layout/LineLength:
 
 Naming/VariableNumber:
   EnforcedStyle: normalcase
-  Severity: warning
+  Severity: error
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/unknown/.rubocop.yml
+++ b/seed/ruby-sdk-v2/unknown/.rubocop.yml
@@ -46,6 +46,7 @@ Layout/LineLength:
 
 Naming/VariableNumber:
   EnforcedStyle: normalcase
+  Severity: warning
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/url-form-encoded/.rubocop.yml
+++ b/seed/ruby-sdk-v2/url-form-encoded/.rubocop.yml
@@ -46,7 +46,7 @@ Layout/LineLength:
 
 Naming/VariableNumber:
   EnforcedStyle: normalcase
-  Severity: warning
+  Severity: error
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/url-form-encoded/.rubocop.yml
+++ b/seed/ruby-sdk-v2/url-form-encoded/.rubocop.yml
@@ -46,6 +46,7 @@ Layout/LineLength:
 
 Naming/VariableNumber:
   EnforcedStyle: normalcase
+  Severity: warning
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/validation/.rubocop.yml
+++ b/seed/ruby-sdk-v2/validation/.rubocop.yml
@@ -46,7 +46,7 @@ Layout/LineLength:
 
 Naming/VariableNumber:
   EnforcedStyle: normalcase
-  Severity: warning
+  Severity: error
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/validation/.rubocop.yml
+++ b/seed/ruby-sdk-v2/validation/.rubocop.yml
@@ -46,6 +46,7 @@ Layout/LineLength:
 
 Naming/VariableNumber:
   EnforcedStyle: normalcase
+  Severity: warning
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/variables/.rubocop.yml
+++ b/seed/ruby-sdk-v2/variables/.rubocop.yml
@@ -46,7 +46,7 @@ Layout/LineLength:
 
 Naming/VariableNumber:
   EnforcedStyle: normalcase
-  Severity: warning
+  Severity: error
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/variables/.rubocop.yml
+++ b/seed/ruby-sdk-v2/variables/.rubocop.yml
@@ -46,6 +46,7 @@ Layout/LineLength:
 
 Naming/VariableNumber:
   EnforcedStyle: normalcase
+  Severity: warning
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/version-no-default/.rubocop.yml
+++ b/seed/ruby-sdk-v2/version-no-default/.rubocop.yml
@@ -46,7 +46,7 @@ Layout/LineLength:
 
 Naming/VariableNumber:
   EnforcedStyle: normalcase
-  Severity: warning
+  Severity: error
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/version-no-default/.rubocop.yml
+++ b/seed/ruby-sdk-v2/version-no-default/.rubocop.yml
@@ -46,6 +46,7 @@ Layout/LineLength:
 
 Naming/VariableNumber:
   EnforcedStyle: normalcase
+  Severity: warning
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/version/.rubocop.yml
+++ b/seed/ruby-sdk-v2/version/.rubocop.yml
@@ -46,7 +46,7 @@ Layout/LineLength:
 
 Naming/VariableNumber:
   EnforcedStyle: normalcase
-  Severity: warning
+  Severity: error
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/version/.rubocop.yml
+++ b/seed/ruby-sdk-v2/version/.rubocop.yml
@@ -46,6 +46,7 @@ Layout/LineLength:
 
 Naming/VariableNumber:
   EnforcedStyle: normalcase
+  Severity: warning
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/webhook-audience/.rubocop.yml
+++ b/seed/ruby-sdk-v2/webhook-audience/.rubocop.yml
@@ -46,7 +46,7 @@ Layout/LineLength:
 
 Naming/VariableNumber:
   EnforcedStyle: normalcase
-  Severity: warning
+  Severity: error
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/webhook-audience/.rubocop.yml
+++ b/seed/ruby-sdk-v2/webhook-audience/.rubocop.yml
@@ -46,6 +46,7 @@ Layout/LineLength:
 
 Naming/VariableNumber:
   EnforcedStyle: normalcase
+  Severity: warning
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/webhooks/.rubocop.yml
+++ b/seed/ruby-sdk-v2/webhooks/.rubocop.yml
@@ -46,7 +46,7 @@ Layout/LineLength:
 
 Naming/VariableNumber:
   EnforcedStyle: normalcase
-  Severity: warning
+  Severity: error
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/webhooks/.rubocop.yml
+++ b/seed/ruby-sdk-v2/webhooks/.rubocop.yml
@@ -46,6 +46,7 @@ Layout/LineLength:
 
 Naming/VariableNumber:
   EnforcedStyle: normalcase
+  Severity: warning
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/websocket-bearer-auth/.rubocop.yml
+++ b/seed/ruby-sdk-v2/websocket-bearer-auth/.rubocop.yml
@@ -46,7 +46,7 @@ Layout/LineLength:
 
 Naming/VariableNumber:
   EnforcedStyle: normalcase
-  Severity: warning
+  Severity: error
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/websocket-bearer-auth/.rubocop.yml
+++ b/seed/ruby-sdk-v2/websocket-bearer-auth/.rubocop.yml
@@ -46,6 +46,7 @@ Layout/LineLength:
 
 Naming/VariableNumber:
   EnforcedStyle: normalcase
+  Severity: warning
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/websocket-inferred-auth/.rubocop.yml
+++ b/seed/ruby-sdk-v2/websocket-inferred-auth/.rubocop.yml
@@ -46,7 +46,7 @@ Layout/LineLength:
 
 Naming/VariableNumber:
   EnforcedStyle: normalcase
-  Severity: warning
+  Severity: error
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/websocket-inferred-auth/.rubocop.yml
+++ b/seed/ruby-sdk-v2/websocket-inferred-auth/.rubocop.yml
@@ -46,6 +46,7 @@ Layout/LineLength:
 
 Naming/VariableNumber:
   EnforcedStyle: normalcase
+  Severity: warning
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/websocket-multi-url/.rubocop.yml
+++ b/seed/ruby-sdk-v2/websocket-multi-url/.rubocop.yml
@@ -46,7 +46,7 @@ Layout/LineLength:
 
 Naming/VariableNumber:
   EnforcedStyle: normalcase
-  Severity: warning
+  Severity: error
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/websocket-multi-url/.rubocop.yml
+++ b/seed/ruby-sdk-v2/websocket-multi-url/.rubocop.yml
@@ -46,6 +46,7 @@ Layout/LineLength:
 
 Naming/VariableNumber:
   EnforcedStyle: normalcase
+  Severity: warning
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/websocket/.rubocop.yml
+++ b/seed/ruby-sdk-v2/websocket/.rubocop.yml
@@ -46,7 +46,7 @@ Layout/LineLength:
 
 Naming/VariableNumber:
   EnforcedStyle: normalcase
-  Severity: warning
+  Severity: error
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/websocket/.rubocop.yml
+++ b/seed/ruby-sdk-v2/websocket/.rubocop.yml
@@ -46,6 +46,7 @@ Layout/LineLength:
 
 Naming/VariableNumber:
   EnforcedStyle: normalcase
+  Severity: warning
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/x-fern-default/.rubocop.yml
+++ b/seed/ruby-sdk-v2/x-fern-default/.rubocop.yml
@@ -46,7 +46,7 @@ Layout/LineLength:
 
 Naming/VariableNumber:
   EnforcedStyle: normalcase
-  Severity: warning
+  Severity: error
 
 Style/Documentation:
   Enabled: false

--- a/seed/ruby-sdk-v2/x-fern-default/.rubocop.yml
+++ b/seed/ruby-sdk-v2/x-fern-default/.rubocop.yml
@@ -46,6 +46,7 @@ Layout/LineLength:
 
 Naming/VariableNumber:
   EnforcedStyle: normalcase
+  Severity: warning
 
 Style/Documentation:
   Enabled: false


### PR DESCRIPTION
## Description

Adds a configurable `Severity` to the `Naming/VariableNumber` cop in the generated `.rubocop.yml` config for Ruby SDKs.

- **Customer SDKs** default to `Severity: warning`
- **Seed tests** use `Severity: error` (via `defaultCustomConfig` in `seed.yml`) to enforce rubocop strictly

## Changes Made

- Added `rubocopSeverity` custom config option (`"warning"` | `"error"`, defaults to `"warning"`) to `BaseRubyCustomConfigSchema`
- Updated `RubocopFile.ts` to use the new config when rendering the `Naming/VariableNumber` section
- Set `defaultCustomConfig: { rubocopSeverity: error }` in `seed/ruby-sdk-v2/seed.yml` so all seed fixtures enforce `error`
- Updated all 125 seed fixture `.rubocop.yml` files to use `Severity: error`
- Added unreleased changelog entry

## Testing

- [x] Verified all 125 seed fixtures updated correctly
- [x] Formatting checks pass (`pnpm format`)

Link to Devin session: https://app.devin.ai/sessions/6f746fa42a0740b1ba68b806d5d6a790
Requested by: @iamnamananand996