### PR TITLE
fix(go): use go `1.26.2` in dockerfiles

### DIFF
--- a/generators/go/model/Dockerfile
+++ b/generators/go/model/Dockerfile
@@ -1,6 +1,6 @@
 FROM node:22.12-alpine3.20 AS node
 
-FROM golang:1.23.8-alpine3.20
+FROM golang:1.26.2-alpine3.23
 
 ENV YARN_CACHE_FOLDER=/.yarn
 

--- a/generators/go/sdk/Dockerfile
+++ b/generators/go/sdk/Dockerfile
@@ -8,7 +8,7 @@ RUN git config --global user.email "115122769+fern-api[bot]@users.noreply.github
 COPY generators/go-v2/sdk/dist/ /dist/
 
 # Stage 2: Final Go image
-FROM golang:1.23.8-alpine3.20
+FROM golang:1.26.2-alpine3.23
 
 WORKDIR /workspace
 

--- a/generators/go/sdk/changes/unreleased/bump-go-toolchain-to-1.26.2.yml
+++ b/generators/go/sdk/changes/unreleased/bump-go-toolchain-to-1.26.2.yml
@@ -1,0 +1,8 @@
+# yaml-language-server: $schema=../../../../../fern-changes-yml.schema.json
+
+- summary: |
+    Bump the Go toolchain in the generator Docker image from 1.23.8 to 1.26.2
+    (alpine3.23). This unblocks `go mod tidy` for generated SDKs whose modules
+    (or transitive dependencies) require a newer Go version, which previously
+    failed with `go.mod requires go >= X (running go 1.23.8; GOTOOLCHAIN=local)`.
+  type: fix


### PR DESCRIPTION
## Description

Bumps the Go toolchain in the Go generator Docker images from `golang:1.23.8-alpine3.20` to `golang:1.26.2-alpine3.23`.

## Changes Made

- `generators/go/sdk/Dockerfile`, `generators/go/model/Dockerfile`: base image `golang:1.23.8-alpine3.20` → `golang:1.26.2-alpine3.23`

## Testing

- [x] Reproduced the customer's exact error against the old image:
  ```
  $ docker run --rm golang:1.23.8-alpine3.20 sh -c 'echo "module t\ngo 1.26" > go.mod && go mod tidy'
  go: go.mod requires go >= 1.26 (running go 1.23.8; GOTOOLCHAIN=local)
  ```
- [x] Confirmed the fix on the new image — `go mod tidy` succeeds against a module declaring `go 1.26`
- [x] Built both `generators/go/sdk/Dockerfile` and `generators/go/model/Dockerfile` locally — clean builds, `go version` inside both images reports `go1.26.2 linux/arm64`
- [x] Seed test passed end-to-end against the rebuilt SDK image:
  ```
  $ pnpm seed test --generator go-sdk --fixture simple-fhir --skip-scripts
  1/1 test cases passed
  ```

## Notes

Considered also setting `GOTOOLCHAIN=auto` (which would let the generator auto-download any required toolchain at runtime, per the customer's alternative suggestion), but kept `GOTOOLCHAIN=local` to preserve deterministic, network-independent generation. If this class of issue recurs with future Go versions we can revisit.