### PR TITLE
fix: pipe Next.js server stdout/stderr to debug log file

### DIFF
--- a/packages/cli/docs-preview/src/DebugLogger.ts
+++ b/packages/cli/docs-preview/src/DebugLogger.ts
@@ -93,7 +93,13 @@ export interface MetricsMessage {
  * CLI-side metric event
  */
 export interface CliMetricEvent {
-    type: "cli_reload_start" | "cli_reload_finish" | "cli_memory" | "cli_docs_generation" | "cli_validation";
+    type:
+        | "cli_reload_start"
+        | "cli_reload_finish"
+        | "cli_memory"
+        | "cli_docs_generation"
+        | "cli_validation"
+        | "nextjs_server_output";
     timestamp: string;
     durationMs?: number;
     metadata?: Record<string, unknown>;
@@ -299,6 +305,22 @@ export class DebugLogger {
         };
 
         await this.logCliMetric(event);
+    }
+
+    /**
+     * Log Next.js server output (stdout/stderr) to the debug file.
+     * This captures rendering errors, module-not-found errors, etc.
+     */
+    async logServerOutput(stream: "stdout" | "stderr", text: string): Promise<void> {
+        const entry: DebugLogEntry = {
+            timestamp: new Date().toISOString(),
+            source: "nextjs-server",
+            level: stream === "stderr" ? "error" : "debug",
+            eventType: "nextjs_server_output",
+            data: { stream, text: text.trimEnd() }
+        };
+
+        await this.writeEntry(entry);
     }
 
     /**

--- a/packages/cli/docs-preview/src/runAppPreviewServer.ts
+++ b/packages/cli/docs-preview/src/runAppPreviewServer.ts
@@ -866,6 +866,7 @@ export async function runAppPreviewServer({
             const checkReady = (data: Buffer) => {
                 const output = data.toString();
                 context.logger.debug(`[Next.js] ${output}`);
+                void debugLogger.logServerOutput("stdout", output);
 
                 const portMatch = output.match(/localhost:(\d+)/);
                 if (portMatch != null) {
@@ -878,9 +879,11 @@ export async function runAppPreviewServer({
             };
             serverProcess.stdout?.on("data", checkReady);
 
-            // Also log stderr but don't block on it
+            // Also log stderr to both the console logger and the debug log file
             serverProcess.stderr?.on("data", (data) => {
-                context.logger.debug(`[Next.js] ${data.toString()}`);
+                const text = data.toString();
+                context.logger.debug(`[Next.js stderr] ${text}`);
+                void debugLogger.logServerOutput("stderr", text);
             });
 
             context.logger.debug(`Next.js standalone server started with PID: ${serverProcess.pid}`);
@@ -888,17 +891,18 @@ export async function runAppPreviewServer({
             // eslint-disable-next-line @typescript-eslint/no-floating-promises
             serverProcess.on("error", (err) => {
                 context.logger.debug(`Server process error: ${err.message}`);
+                void debugLogger.logServerOutput("stderr", `[process error] ${err.message}`);
             });
 
             // eslint-disable-next-line @typescript-eslint/no-floating-promises
             serverProcess.on("exit", (code, signal) => {
-                if (code) {
-                    context.logger.debug(`Server process exited with code: ${code}`);
-                } else if (signal) {
-                    context.logger.debug(`Server process killed with signal: ${signal}`);
-                } else {
-                    context.logger.debug("Server process exited");
-                }
+                const msg = code
+                    ? `Server process exited with code: ${code}`
+                    : signal
+                      ? `Server process killed with signal: ${signal}`
+                      : "Server process exited";
+                context.logger.debug(msg);
+                void debugLogger.logServerOutput("stderr", `[process exit] ${msg}`);
             });
 
             // Fallback timeout in case we miss the ready message


### PR DESCRIPTION
## Description

Refs: Related to fern-api/fern-platform#9752

Previously, the Next.js standalone server's stdout/stderr was only sent to `context.logger.debug()`, which does **not** write to the `~/.fern/logs/*.debug.log` file. This made it impossible to diagnose server-side errors (e.g. 500 responses, module resolution failures) from the debug log — only CLI-level structured events (reload, validation, memory) appeared there.

## Changes Made

- Added `DebugLogger.logServerOutput(stream, text)` method that writes structured JSON entries with `source: "nextjs-server"` and appropriate log levels (`"error"` for stderr, `"debug"` for stdout)
- Wired up all four server output channels in `runAppPreviewServer.ts` to write to the debug log:
  - `stdout` data (the `checkReady` handler)
  - `stderr` data
  - Process `error` events
  - Process `exit` events
- Added `"nextjs_server_output"` to the `CliMetricEvent` type union

All calls use `void` (fire-and-forget) to avoid blocking server operation, matching the existing pattern for other debug logger calls.

## Review Checklist

- [ ] `"nextjs_server_output"` was added to `CliMetricEvent.type`, but `logServerOutput` writes directly via `writeEntry` rather than going through `logCliMetric` — the type union addition is not strictly necessary. Confirm this is acceptable or should be removed.
- [ ] Verify that high-volume stdout (e.g. during SSR of many pages) won't cause excessive disk writes or performance issues via the fire-and-forget `appendFile` calls.

## Testing

- [ ] Manual testing not feasible in this environment (requires Windows + `fern docs dev`)
- [ ] Lint passes (`pnpm run check`)
- [ ] No unit tests added — this is a logging-only change with no behavioral impact on the server itself

Link to Devin session: https://app.devin.ai/sessions/384de2d2e741453fa07377d662b6e2c2
Requested by: @thesandlord