### PR TITLE
fix: use commit SHA in changelog URL instead of PR branch name

### DIFF
--- a/packages/generator-cli/src/pipeline/steps/GithubStep.ts
+++ b/packages/generator-cli/src/pipeline/steps/GithubStep.ts
@@ -199,8 +199,9 @@ export class GithubStep extends BaseStep {
         }
 
         const finalCommitMessage = this.config.commitMessage ?? "SDK Generation";
+        const headSha = await repository.getHeadSha();
         const changelogUrl = this.config.changelogEntry
-            ? `https://github.com/${this.config.uri}/blob/${prBranch}/changelog.md`
+            ? `https://github.com/${this.config.uri}/blob/${headSha}/changelog.md`
             : undefined;
         const { prTitle, prBody } = parseCommitMessageForPR(
             finalCommitMessage,


### PR DESCRIPTION
## Description

Refs companion PR: fern-api/fiddle#700 (same fix for the fiddle coordinator path)

The "See full changelog" link in auto-versioned SDK PRs used the PR branch name (e.g. `fern-bot/2025-04-15T12-00Z`) in the GitHub blob URL. After the PR is merged and the branch is deleted, this URL returns a 404. This change uses the commit SHA instead, which is permanent.

## Changes Made

- Replaced `prBranch` with `repository.getHeadSha()` in the changelog URL construction in `GithubStep.executePullRequestMode`
- The resulting URL format changes from `.../blob/fern-bot/2025-.../changelog.md` to `.../blob/abc123def.../changelog.md`

## Testing

- [x] Existing tests pass (`pnpm run check` — 4316 files, no issues)
- [ ] No new unit tests — the changed line is deep inside a method that orchestrates git + GitHub API calls; the URL is passed through to `parseCommitMessageForPR` which is already tested independently

## Review Checklist

- Verify `getHeadSha()` returns the correct commit at this execution point (after `commitAllChanges` on L153 and `push`/`forcePush` on L179–181). It should, since HEAD tracks the latest local commit.
- Consider the `skipCommit` (replay) path: `commitAllChanges` is skipped but `createReplayBranch` (L128) has already committed, so HEAD should still be valid.
- Consider preview mode (`previewMode=true`): push is skipped, so the SHA won't exist on GitHub — but the old `prBranch` URL had the same problem (branch not pushed either), so this is not a regression.

Link to Devin session: https://app.devin.ai/sessions/46ab5d2460754756b7bce40428100c9b
Requested by: @Swimburger
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/15070" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
