### PR TITLE
fix(cli): use commit SHA in changelog URL for permanent links

### DIFF
--- a/packages/generator-cli/src/pipeline/steps/GithubStep.ts
+++ b/packages/generator-cli/src/pipeline/steps/GithubStep.ts
@@ -199,8 +199,9 @@ export class GithubStep extends BaseStep {
         }
 
         const finalCommitMessage = this.config.commitMessage ?? "SDK Generation";
+        const headSha = await repository.getHeadSha();
         const changelogUrl = this.config.changelogEntry
-            ? `https://github.com/${this.config.uri}/blob/${prBranch}/changelog.md`
+            ? `https://github.com/${this.config.uri}/blob/${headSha}/changelog.md`
             : undefined;
         const { prTitle, prBody } = parseCommitMessageForPR(
             finalCommitMessage,

--- a/packages/generator-cli/versions.yml
+++ b/packages/generator-cli/versions.yml
@@ -1,6 +1,14 @@
 # yaml-language-server: $schema=../../versions-yml.schema.json
 - changelogEntry:
     - summary: |
+        Use commit SHA instead of branch name in changelog URL so the link
+        remains valid after the PR branch is deleted or squash-merged.
+      type: fix
+  createdAt: "2026-04-15"
+  version: 0.9.8
+
+- changelogEntry:
+    - summary: |
         Upgrade @fern-api/replay to 0.10.4 (pinned).
       type: chore
   createdAt: "2026-04-12"


### PR DESCRIPTION
## Description

Refs companion PR: fern-api/fiddle#703 (same fix for the fiddle coordinator path)

The "See full changelog" link in auto-versioned SDK PRs used the PR branch name (`prBranch`) in the GitHub blob URL. After the PR is merged and the branch is deleted, this URL returns a 404. This change uses the commit SHA instead, which is permanent — it survives branch deletion and squash merges.

## Changes Made

- Replaced `prBranch` with `repository.getHeadSha()` in the changelog URL construction in `GithubStep.executePullRequestMode`
- The resulting URL format changes from `.../blob/fern-bot/2025-04-15T12-00Z/changelog.md` to `.../blob/<commit-sha>/changelog.md`
- Added version `0.9.8` entry in `versions.yml` for this fix

## Testing

- [x] `pnpm run check` passes
- [ ] No new unit tests — the changed line is deep inside a method that orchestrates git + GitHub API calls; the URL is passed through to `parseCommitMessageForPR` which is already tested independently
- [ ] End-to-end validation requires deploying and triggering a real SDK generation

## Review Checklist for Humans

- [ ] **Verify `getHeadSha()` timing**: Called at line 202, after `push()`/`forcePush()` (lines 179–181) but before PR creation. HEAD should match the remote commit. Does this hold in all paths?
- [ ] **`skipCommit` (replay) path**: When `skipCommit=true`, `commitAllChanges` is skipped but `createReplayBranch` has already committed, so HEAD should still be valid — but worth confirming.
- [ ] **Preview mode**: When `previewMode=true`, push is skipped, so the SHA won't exist on GitHub. The old `prBranch` URL had the same problem (branch not pushed either), so this is not a regression — but the link will 404 in either case.
- [ ] **Local HEAD vs remote**: Unlike the fiddle path (which creates a signed commit via GitHub API with a new SHA), this path uses standard `git push`, so local HEAD should always match the remote after push. Confirm no edge case breaks this assumption.

Link to Devin session: https://app.devin.ai/sessions/46ab5d2460754756b7bce40428100c9b
Requested by: @Swimburger
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/15071" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
