### PR TITLE
fix(python): wrap non-string global header values with str()

### DIFF
--- a/generators/python/sdk/versions.yml
+++ b/generators/python/sdk/versions.yml
@@ -1,4 +1,16 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
+- version: 5.4.0-rc.2
+  changelogEntry:
+    - summary: |
+        Fix `mypy` error in generated client wrapper when a non-string global header is
+        declared (e.g. `Request-Timeout: integer`). The generator emits `headers: Dict[str, str]`
+        but previously assigned the raw typed member (e.g. `int`) directly, causing
+        `Incompatible types in assignment`. Non-string global header values are now wrapped
+        with `str(...)` when assigned. String-typed headers are unchanged.
+      type: fix
+  createdAt: "2026-04-15"
+  irVersion: 66
+
 - version: 5.4.0-rc.1
   changelogEntry:
     - summary: |

--- a/generators/python/src/fern_python/generators/sdk/client_generator/type_utilities.py
+++ b/generators/python/src/fern_python/generators/sdk/client_generator/type_utilities.py
@@ -25,6 +25,44 @@ HTTPX_PRIMITIVE_DATA_TYPES: Set[ir_types.PrimitiveTypeV1] = {
 }
 
 
+def is_type_reference_string(
+    type_reference: ir_types.TypeReference,
+    get_type_declaration: Callable[[ir_types.TypeId], ir_types.TypeDeclaration],
+) -> bool:
+    """
+    Check if a type reference resolves to a string primitive.
+
+    Unwraps Optional, nullable, and alias types to find the underlying type.
+    Literal string types are also considered strings.
+    """
+
+    def check_type(tr: ir_types.TypeReference) -> bool:
+        type_union = tr.get_as_union()
+
+        if type_union.type == "primitive":
+            return type_union.primitive.v_1 == ir_types.PrimitiveTypeV1.STRING
+
+        if type_union.type == "container":
+            container = type_union.container.get_as_union()
+            if container.type == "optional":
+                return check_type(container.optional)
+            if container.type == "nullable":
+                return check_type(container.nullable)
+            if container.type == "literal":
+                return container.literal.get_as_union().type == "string"
+            return False
+
+        if type_union.type == "named":
+            shape = get_type_declaration(type_union.type_id).shape.get_as_union()
+            if shape.type == "alias":
+                return check_type(shape.alias_of)
+            return False
+
+        return False
+
+    return check_type(type_reference)
+
+
 def is_type_primitive_for_multipart(
     type_reference: ir_types.TypeReference,
     get_type_declaration: Callable[[ir_types.TypeId], ir_types.TypeDeclaration],

--- a/generators/python/src/fern_python/generators/sdk/core_utilities/client_wrapper_generator.py
+++ b/generators/python/src/fern_python/generators/sdk/core_utilities/client_wrapper_generator.py
@@ -13,6 +13,7 @@ from fern_python.external_dependencies import httpx
 from fern_python.generators.sdk.client_generator.base_client_generator import (
     ConstructorParameter as BaseClientGeneratorConstructorParameter,
 )
+from fern_python.generators.sdk.client_generator.type_utilities import is_type_reference_string
 from fern_python.generators.sdk.core_utilities.core_utilities import CoreUtilities
 from fern_python.snippet.template_utils import TemplateGenerator
 from fern_python.utils import get_name_from_wire_value, get_wire_value, resolve_name
@@ -29,6 +30,9 @@ class ConstructorParameter(BaseClientGeneratorConstructorParameter):
     is_basic: bool = False
     docs: typing.Optional[str] = None
     template: typing.Optional[Template] = None
+    # True when the underlying fern type is not a string and the value must be
+    # wrapped with str(...) to satisfy the Dict[str, str] headers type.
+    needs_str_conversion: bool = False
 
 
 @dataclass
@@ -592,16 +596,23 @@ class ClientWrapperGenerator:
                                 )
                                 writer.write_line(f"if {param.constructor_parameter_name} is not None:")
                                 with writer.indent():
-                                    writer.write_line(
-                                        f'headers["{param.header_key}"] = {param.constructor_parameter_name}'
+                                    value_expr = (
+                                        f"str({param.constructor_parameter_name})"
+                                        if param.needs_str_conversion
+                                        else param.constructor_parameter_name
                                     )
+                                    writer.write_line(f'headers["{param.header_key}"] = {value_expr}')
                             else:
-                                writer.write_line(f'headers["{param.header_key}"] = self.{param.getter_method.name}()')
+                                getter_call = f"self.{param.getter_method.name}()"
+                                value_expr = f"str({getter_call})" if param.needs_str_conversion else getter_call
+                                writer.write_line(f'headers["{param.header_key}"] = {value_expr}')
                         elif param.private_member_name is not None:
                             if param.type_hint.is_optional:
                                 writer.write_line(f"if self.{param.private_member_name} is not None:")
                                 writer.indent()
-                            writer.write_line(f'headers["{param.header_key}"] = self.{param.private_member_name}')
+                            member_access = f"self.{param.private_member_name}"
+                            value_expr = f"str({member_access})" if param.needs_str_conversion else member_access
+                            writer.write_line(f'headers["{param.header_key}"] = {value_expr}')
                             if param.type_hint.is_optional:
                                 writer.outdent()
             for literal_header in literal_headers:
@@ -686,6 +697,10 @@ class ClientWrapperGenerator:
                 )
                 continue
             constructor_parameter_name = names.get_header_constructor_parameter_name(header)
+            needs_str_conversion = not is_type_reference_string(
+                header.value_type,
+                self._context.pydantic_generator_context.get_declaration_for_type_id,
+            )
             parameters.append(
                 ConstructorParameter(
                     constructor_parameter_name=constructor_parameter_name,
@@ -696,6 +711,7 @@ class ClientWrapperGenerator:
                     ),
                     header_key=get_wire_value(header.name),
                     environment_variable=header.env,
+                    needs_str_conversion=needs_str_conversion,
                 )
             )
 


### PR DESCRIPTION
## Description
<!-- Linear ticket: Closes  -->

Fixes a `mypy` failure in the generated Python SDK when an API declares a non-string global header (e.g. `Request-Timeout: integer`, as used by Vectara).

The generator emits `headers: Dict[str, str]` but previously assigned the raw typed member directly, producing:

```
src/vectara/core/client_wrapper.py:46: error: Incompatible types in assignment
    (expression has type "int", target has type "str")  [assignment]
headers["Request-Timeout"] = self._request_timeout
```

No existing seed fixture declared a non-string global header, so the code path was never exercised.

## Changes Made
- Added `is_type_reference_string` helper in `client_generator/type_utilities.py` that unwraps `Optional`/`nullable`/alias to detect the underlying primitive.
- Added a `needs_str_conversion` flag on `ConstructorParameter` in `core_utilities/client_wrapper_generator.py`, set when the header's Fern IR type is not a string.
- Updated `_get_write_get_headers_body` to wrap the RHS with `str(...)` only when `needs_str_conversion` is True — string-typed headers are emitted unchanged to avoid snapshot churn across existing fixtures.
- Recorded the fix in `generators/python/sdk/versions.yml` as `5.4.0-rc.2`.

Generated code now produces:
```python
if self._request_timeout is not None:
    headers["Request-Timeout"] = str(self._request_timeout)
```

- [ ] Updated README.md generator (if applicable)

## Testing
Regenerated the Vectara SDK against `/Users/Patrick/configs/vectara-fern-config/fern` using `pnpm seed run --generator python-sdk --skipScripts`, then ran the generated project's CI workflow locally:

- `poetry run mypy .` — Success: no issues found in 906 source files
- `poetry run pytest -rP -n auto .` — 49 passed, 4 skipped
- `poetry install --extras aiohttp && poetry run pytest -rP -n auto -m aiohttp .` — 3 passed

- [ ] Unit tests added/updated
- [x] Manual testing completed