### PR TITLE
fix(cli): `fern automations list generate` skips local-file-system and autorelease-disabled generators

### DIFF
--- a/packages/cli/cli/changes/unreleased/automations-list-skip-generators.yml
+++ b/packages/cli/cli/changes/unreleased/automations-list-skip-generators.yml
@@ -1,0 +1,4 @@
+- summary: |
+    `fern automations list generate` now skips generators with local-file-system output
+    or autorelease disabled, matching the behavior of autopilot.
+  type: fix

--- a/packages/cli/cli/src/__test__/shouldSkipGenerator.test.ts
+++ b/packages/cli/cli/src/__test__/shouldSkipGenerator.test.ts
@@ -1,0 +1,83 @@
+import type { generatorsYml } from "@fern-api/configuration-loader";
+import { describe, expect, it } from "vitest";
+import { shouldSkipGenerator } from "../commands/generate/shouldSkipGenerator.js";
+
+function makeGenerator(
+    overrides: Partial<Pick<generatorsYml.GeneratorInvocation, "automation" | "absolutePathToLocalOutput" | "raw">> = {}
+): generatorsYml.GeneratorInvocation {
+    return {
+        automation: { generate: true, upgrade: true, preview: true, verify: true },
+        absolutePathToLocalOutput: undefined,
+        raw: undefined,
+        ...overrides
+    } as unknown as generatorsYml.GeneratorInvocation;
+}
+
+describe("shouldSkipGenerator", () => {
+    describe("automation.generate", () => {
+        it("does not skip when automation.generate is true", () => {
+            const generator = makeGenerator();
+            expect(shouldSkipGenerator({ generator, rootAutorelease: undefined })).toBe(false);
+        });
+
+        it("skips when automation.generate is false", () => {
+            const generator = makeGenerator({
+                automation: { generate: false, upgrade: true, preview: true, verify: true }
+            });
+            expect(shouldSkipGenerator({ generator, rootAutorelease: undefined })).toBe(true);
+        });
+    });
+
+    describe("local-file-system output", () => {
+        it("skips when absolutePathToLocalOutput is set", () => {
+            const generator = makeGenerator({
+                absolutePathToLocalOutput:
+                    "/tmp/output" as unknown as generatorsYml.GeneratorInvocation["absolutePathToLocalOutput"]
+            });
+            expect(shouldSkipGenerator({ generator, rootAutorelease: undefined })).toBe(true);
+        });
+
+        it("does not skip when absolutePathToLocalOutput is undefined", () => {
+            const generator = makeGenerator({ absolutePathToLocalOutput: undefined });
+            expect(shouldSkipGenerator({ generator, rootAutorelease: undefined })).toBe(false);
+        });
+    });
+
+    describe("autorelease", () => {
+        it("skips when generator-level autorelease is false", () => {
+            const generator = makeGenerator({
+                raw: { autorelease: false } as generatorsYml.GeneratorInvocation["raw"]
+            });
+            expect(shouldSkipGenerator({ generator, rootAutorelease: undefined })).toBe(true);
+        });
+
+        it("does not skip when generator-level autorelease is true", () => {
+            const generator = makeGenerator({
+                raw: { autorelease: true } as generatorsYml.GeneratorInvocation["raw"]
+            });
+            expect(shouldSkipGenerator({ generator, rootAutorelease: undefined })).toBe(false);
+        });
+
+        it("skips when root autorelease is false and generator has no override", () => {
+            const generator = makeGenerator();
+            expect(shouldSkipGenerator({ generator, rootAutorelease: false })).toBe(true);
+        });
+
+        it("does not skip when root autorelease is false but generator overrides to true", () => {
+            const generator = makeGenerator({
+                raw: { autorelease: true } as generatorsYml.GeneratorInvocation["raw"]
+            });
+            expect(shouldSkipGenerator({ generator, rootAutorelease: false })).toBe(false);
+        });
+
+        it("does not skip when root autorelease is true and generator has no override", () => {
+            const generator = makeGenerator();
+            expect(shouldSkipGenerator({ generator, rootAutorelease: true })).toBe(false);
+        });
+
+        it("does not skip when root autorelease is undefined and generator has no override", () => {
+            const generator = makeGenerator();
+            expect(shouldSkipGenerator({ generator, rootAutorelease: undefined })).toBe(false);
+        });
+    });
+});

--- a/packages/cli/cli/src/cli.ts
+++ b/packages/cli/cli/src/cli.ts
@@ -2240,7 +2240,10 @@ function addAutomationsCommand(cli: Argv<GlobalCliOptions>, cliContext: CliConte
  * `fern automations generate` commands — one per generator. Designed to be
  * consumed by a GitHub Actions matrix strategy to fan out generation jobs.
  *
- * Generators with `automation.generate: false` in generators.yml are excluded.
+ * Generators are excluded when any of the following is true:
+ * - `automation.generate: false` in generators.yml
+ * - Output is configured for `local-file-system` (cannot run remotely)
+ * - `autorelease: false` at the generator or root level
  *
  * Arguments passed to `list` (--version, --auto-merge) are forwarded into
  * each generated command, so the caller doesn't need to re-specify them.
@@ -2323,7 +2326,9 @@ function addAutomationsListGenerateCommand(cli: Argv<GlobalCliOptions>, cliConte
             const commands: string[] = [];
 
             for (const workspace of project.apiWorkspaces) {
-                const groups = workspace.generatorsConfiguration?.groups ?? [];
+                const generatorsConfiguration = workspace.generatorsConfiguration;
+                const groups = generatorsConfiguration?.groups ?? [];
+                const rootAutorelease = generatorsConfiguration?.rawConfiguration.autorelease;
                 for (const group of groups) {
                     if (argv.group != null && group.groupName !== argv.group) {
                         continue;
@@ -2331,6 +2336,19 @@ function addAutomationsListGenerateCommand(cli: Argv<GlobalCliOptions>, cliConte
                     for (let i = 0; i < group.generators.length; i++) {
                         const generator = group.generators[i];
                         if (generator == null || !generator.automation.generate) {
+                            continue;
+                        }
+
+                        // Skip generators that output to local file system (cannot run remotely)
+                        if (generator.absolutePathToLocalOutput != null) {
+                            continue;
+                        }
+
+                        // Skip generators with autorelease disabled (generator-level overrides root-level)
+                        const autoreleaseDisabled =
+                            generator.raw?.autorelease === false ||
+                            (generator.raw?.autorelease == null && rootAutorelease === false);
+                        if (autoreleaseDisabled) {
                             continue;
                         }
 

--- a/packages/cli/cli/src/cli.ts
+++ b/packages/cli/cli/src/cli.ts
@@ -56,6 +56,7 @@ import { formatWorkspaces } from "./commands/format/formatWorkspaces.js";
 import { parseGeneratorArg } from "./commands/generate/filterGenerators.js";
 import { GenerationMode, generateAPIWorkspaces } from "./commands/generate/generateAPIWorkspaces.js";
 import { generateDocsWorkspace } from "./commands/generate/generateDocsWorkspace.js";
+import { shouldSkipGenerator } from "./commands/generate/shouldSkipGenerator.js";
 import { generateDynamicIrForWorkspaces } from "./commands/generate-dynamic-ir/generateDynamicIrForWorkspaces.js";
 import { generateFdrApiDefinitionForWorkspaces } from "./commands/generate-fdr/generateFdrApiDefinitionForWorkspaces.js";
 import { generateIrForWorkspaces } from "./commands/generate-ir/generateIrForWorkspaces.js";
@@ -2335,20 +2336,7 @@ function addAutomationsListGenerateCommand(cli: Argv<GlobalCliOptions>, cliConte
                     }
                     for (let i = 0; i < group.generators.length; i++) {
                         const generator = group.generators[i];
-                        if (generator == null || !generator.automation.generate) {
-                            continue;
-                        }
-
-                        // Skip generators that output to local file system (cannot run remotely)
-                        if (generator.absolutePathToLocalOutput != null) {
-                            continue;
-                        }
-
-                        // Skip generators with autorelease disabled (generator-level overrides root-level)
-                        const autoreleaseDisabled =
-                            generator.raw?.autorelease === false ||
-                            (generator.raw?.autorelease == null && rootAutorelease === false);
-                        if (autoreleaseDisabled) {
+                        if (generator == null || shouldSkipGenerator({ generator, rootAutorelease })) {
                             continue;
                         }
 

--- a/packages/cli/cli/src/commands/generate/shouldSkipGenerator.ts
+++ b/packages/cli/cli/src/commands/generate/shouldSkipGenerator.ts
@@ -1,0 +1,37 @@
+import type { generatorsYml } from "@fern-api/configuration-loader";
+
+/**
+ * Determines whether a generator should be skipped for remote automation.
+ *
+ * A generator is skipped when any of the following is true:
+ * - `automation.generate` is false
+ * - Output is configured for `local-file-system` (cannot run remotely)
+ * - `autorelease` is disabled at the generator level, or at the root level
+ *   when the generator does not specify its own override
+ */
+export function shouldSkipGenerator({
+    generator,
+    rootAutorelease
+}: {
+    generator: generatorsYml.GeneratorInvocation;
+    rootAutorelease: boolean | undefined;
+}): boolean {
+    if (!generator.automation.generate) {
+        return true;
+    }
+
+    // Local-file-system output cannot run remotely
+    if (generator.absolutePathToLocalOutput != null) {
+        return true;
+    }
+
+    // Generator-level autorelease overrides root-level
+    if (generator.raw?.autorelease === false) {
+        return true;
+    }
+    if (generator.raw?.autorelease == null && rootAutorelease === false) {
+        return true;
+    }
+
+    return false;
+}


### PR DESCRIPTION
## Description

Aligns `fern automations list generate` with the generators that autopilot already skips during SDK generation. Previously, the command only excluded generators with `automation.generate: false`. Generators that autopilot would never run (local-file-system output, autorelease disabled) were still listed, producing commands that would be no-ops or failures.

## Changes Made

- Extracted skip logic into a standalone `shouldSkipGenerator` utility (`packages/cli/cli/src/commands/generate/shouldSkipGenerator.ts`) for testability
- Skip generators with `output.location: local-file-system` — these cannot run remotely
- Skip generators with `autorelease: false` (checked at generator level, falling back to root level)
- Updated JSDoc to document all three exclusion conditions
- Added 10 unit tests covering all skip conditions and autorelease precedence

## Key Review Points

- **Autorelease precedence**: Generator-level `autorelease` overrides root-level. The CLI schema doesn't support group-level `autorelease` (unlike the raw YAML autopilot parses), so group-level is intentionally omitted. Verify this matches expectations.
- **`autorelease: true` override**: If root is `false` but generator is `true`, the generator is correctly **not** skipped (the `generator.raw?.autorelease == null` guard prevents the root fallback).
- **Behavioral change**: This is a narrowing change — generators previously listed will now be excluded. This is intentional since autopilot already skips them, but could affect existing workflows that relied on these generators appearing in the output.

## Testing

- [x] Unit tests added/updated (10 tests in `shouldSkipGenerator.test.ts`)
- [x] Lint passes (`pnpm run check`)

Link to Devin session: https://app.devin.ai/sessions/0e6dce4338184f63ac3cecef8bd84809
Requested by: @Swimburger
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/15075" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
