### PR TITLE
fix(go): `go-v2` demands a `strictObject`, fail fast on mismatched casing

### DIFF
--- a/generators/go-v2/ast/src/custom-config/BaseGoCustomConfigSchema.ts
+++ b/generators/go-v2/ast/src/custom-config/BaseGoCustomConfigSchema.ts
@@ -3,7 +3,7 @@ import { CustomReadmeSectionSchema } from "./CustomReadmeSectionSchema.js";
 import { moduleConfigSchema } from "./ModuleConfigSchema.js";
 import { relativePathSchema } from "./RelativePathSchema.js";
 
-export const baseGoCustomConfigSchema = z.object({
+export const baseGoCustomConfigSchema = z.strictObject({
     module: moduleConfigSchema.optional(),
     packageName: z.string().optional(),
     packagePath: relativePathSchema.optional(),
@@ -18,6 +18,7 @@ export const baseGoCustomConfigSchema = z.object({
     includeLegacyClientOptions: z.boolean().optional(),
     inlinePathParameters: z.boolean().optional(),
     inlineFileProperties: z.boolean().optional(),
+    omitEmptyRequestWrappers: z.boolean().optional(),
     union: z.enum(["v0", "v1"]).optional(),
     useReaderForBytesRequest: z.boolean().optional(),
     useDefaultRequestParameterValues: z.boolean().optional(),

--- a/generators/go/sdk/changes/unreleased/strict-config-key-casing.yml
+++ b/generators/go/sdk/changes/unreleased/strict-config-key-casing.yml
@@ -1,0 +1,9 @@
+# yaml-language-server: $schema=../../../../../fern-changes-yml.schema.json
+
+- summary: |
+    Enforce strict config key casing in the Go SDK generator. Config keys in
+    `generators.yml` must now use exact camelCase (e.g., `importPath`, not
+    `importpath`). Previously, miscased keys were silently accepted by the v1
+    generator but ignored by the v2 generator, causing confusing `go mod tidy`
+    failures.
+  type: fix


### PR DESCRIPTION
## Description
`go-v2` now demands a `strictObject` for Zod, so any config flags that aren't genuine cause a hard failure, as we do in TS. This proves important since go-v1's config parser is case-insensitive, so a config flag like `importpath` (which should be `importPath`) would parse in v1 but get ignored in v2, causing all sorts of weird errors since the two sides of the generator would then be configured differently.

We also bring any lingering v1-only flags to the v2 Zod schema, of which there was only one (`omitEmptyRequestWrappers`). There's an argument to be made that this is an inconvenience, since now any v1-only flags must be included in the v2 schema to work; but since there's precedent in TS and we're looking to port to v2 anyway, this doesn't seem like the worst thing in the world.

## Testing
Manual testing on the MethodSecurity API; passes seed.