### PR TITLE
fix(ci): add missing generator property to docs benchmark PostHog events

### DIFF
--- a/.github/workflows/seed.yml
+++ b/.github/workflows/seed.yml
@@ -1327,6 +1327,7 @@ jobs:
                 --arg event "benchmark-pr-result" \
                 --arg distinct_id "fern-ci-benchmark" \
                 --arg timestamp "$TIMESTAMP" \
+                --arg generator "docs" \
                 --arg spec "$spec" \
                 --argjson duration_seconds "$dur" \
                 --argjson exit_code "$ec" \
@@ -1343,6 +1344,7 @@ jobs:
                   distinct_id: $distinct_id,
                   timestamp: $timestamp,
                   properties: {
+                    generator: $generator,
                     spec: $spec,
                     duration_seconds: $duration_seconds,
                     exit_code: $exit_code,


### PR DESCRIPTION
## Description

The PostHog benchmark report tracking generator performance against Square's spec started showing `null` for the generator field on docs benchmark events.

## Changes Made

- Added the missing `generator` property (set to `"docs"`) to the PR docs benchmark PostHog event payload in `seed.yml`

**Root cause:** The "Send PR docs benchmark events to PostHog" step in `seed.yml` (the `docs-benchmark-report` job) constructs a `jq` payload but omits the `generator` property entirely. The parallel SDK benchmark step in the same file correctly includes `generator`, and the nightly baseline workflow (`benchmark-baseline.yml`) also correctly passes `"docs"` as the generator for docs events. This was simply an omission in this one code path, causing PostHog to receive events with a `null` generator.

## Testing

- [ ] Cannot be tested locally — this runs in GitHub Actions and sends events to PostHog
- [x] Verified the fix is consistent with how the same event is constructed in the SDK benchmark step (lines 1110-1144) and in `benchmark-baseline.yml` (line 283)

## Human Review Checklist

- [ ] Confirm `"docs"` is the intended generator value (matches `benchmark-baseline.yml` line 283: `send_event "docs" "docs" ...`)
- [ ] Verify no other PostHog event payloads in the file have the same omission

Link to Devin session: https://app.devin.ai/sessions/bc79e70c60a840fe86f0fc78667ec438
Requested by: @Swimburger
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/15080" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
