### PR TITLE
chore(docs): codify breaking changes policy for generators

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -162,6 +162,26 @@ pnpm seed run --generator go-sdk --path /path/to/project --skip-scripts
 
 **Output**: Seed test overwrites `/seed/<generator>/<fixture>/`, seed run writes to temp directory
 
+### Breaking Changes Policy (Generators)
+
+**Generators MUST NOT ship breaking changes to existing users without a migration path.** Autorelease cannot succeed if a generator silently changes default behavior, and on-call will page.
+
+When you need to change a generator default or behavior in a way that is not backwards compatible:
+
+1. **Gate the new behavior behind a config flag and keep the old behavior as the default.** Users opt in to the new behavior by setting the flag.
+2. **When you are ready to flip the default (major version bump of the generator), add a generator migration** under `packages/generator-migrations/src/generators/<generator>/migrations/<next-major>.0.0.ts`. The migration must set the old value for users who had not explicitly configured the field, so their existing `generators.yml` continues to produce the same output.
+3. **Register the migration** in the generator's `migrations/index.ts` and publish `@fern-api/generator-migrations`. Migrations run automatically via `fern generator upgrade --include-major`.
+
+See `packages/generator-migrations/src/generators/typescript/migrations/3.0.0.ts` for a reference example (switching TypeScript SDK defaults from `yarn`/`jest` to `pnpm`/`vitest`). See `packages/generator-migrations/README.md` for the full authoring guide.
+
+**Checklist for any generator-defaults PR:**
+- [ ] Is the new behavior gated so existing users are unaffected until they opt in or a major version lands?
+- [ ] If this is the major version flip, is there a corresponding migration file under `packages/generator-migrations/`?
+- [ ] Is the migration registered in `src/generators/<generator>/migrations/index.ts`?
+- [ ] Are there tests for the migration (see `packages/generator-migrations/src/__test__/`)?
+
+Skipping this process breaks autorelease for every customer pinned to the old major and will cause an on-call incident.
+
 ### Feature Addition Workflow (Generated Code)
 
 Multi-stage process: API Schema → IR Updates → Generator Updates → Release

--- a/packages/generator-migrations/README.md
+++ b/packages/generator-migrations/README.md
@@ -6,6 +6,18 @@ Unified migration package for all Fern generator configurations.
 
 This package contains migrations for all Fern generators, organized by generator name. When users run `fern generator upgrade`, the CLI automatically downloads this package and applies relevant migrations to transform their `generators.yml` configuration.
 
+## Policy: Breaking Changes in Generators
+
+**Generators must never ship breaking changes to existing users without a migration path.** If a generator silently changes default behavior, autorelease will fail for every customer pinned to the previous major and the team will be paged.
+
+The required workflow is:
+
+1. **Add the new behavior behind a feature flag, and keep the old behavior as the default.** Users opt in explicitly.
+2. **When you are ready to flip the default, bump the generator's major version** and add a migration file in this package under `src/generators/<generator>/migrations/<next-major>.0.0.ts`. The migration uses `??=` to set the old default for any user who had not explicitly configured the field, so their `generators.yml` continues to produce the same output.
+3. **Register the migration** in `src/generators/<generator>/migrations/index.ts` and publish `@fern-api/generator-migrations`. The migration runs automatically when customers run `fern generator upgrade --include-major`.
+
+Reference example: [`src/generators/typescript/migrations/3.0.0.ts`](src/generators/typescript/migrations/3.0.0.ts) switched TypeScript SDK defaults from `yarn`/`jest` to `pnpm`/`vitest` while preserving the old defaults for existing users.
+
 ## Architecture
 
 ### Single Unified Package


### PR DESCRIPTION
## Description

Codifies the team's policy on shipping breaking changes in generators, per [Slack discussion](https://buildwithfern.slack.com/archives/C05J55L8JES/p1776353919978089). The rule: breaking changes must first ship behind a feature flag (old behavior remains the default), and when the default is flipped at the next major version, a migration must be added under `packages/generator-migrations/` so existing `generators.yml` configs continue to produce the same output. Skipping this breaks autorelease and causes on-call pages.

## Changes Made

- Added a new "Breaking Changes Policy (Generators)" section to the root `CLAUDE.md`, including a 3-step workflow and a PR checklist, with a pointer to `packages/generator-migrations/src/generators/typescript/migrations/3.0.0.ts` as the reference example.
- Added a "Policy: Breaking Changes in Generators" section near the top of `packages/generator-migrations/README.md` so contributors editing migrations directly see the policy (not just the authoring mechanics).

## Testing

Docs-only change; no code or tests affected.

## Review checklist

- Does the wording accurately reflect the team's intended policy (feature-flag-first, migration at next major, `--include-major` runs migrations)?
- Are the file paths and the reference example (`typescript/migrations/3.0.0.ts`) the right ones to point contributors at?
- Is the root `CLAUDE.md` the right home for this, or should it also be mirrored into each generator's `CLAUDE.md`? I kept it centralized to avoid duplication, but can fan it out if preferred.

Link to Devin session: https://app.devin.ai/sessions/a7c8aa76c5854e68a5a21f67e761f5da
Requested by: @Swimburger
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/15084" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
