### PR TITLE
feat(cli): enable Windows docs bundle smoke tests with NTFS junction symlink resolution

### DIFF
--- a/.github/workflows/docs-bundle-smoke-test.yml
+++ b/.github/workflows/docs-bundle-smoke-test.yml
@@ -247,8 +247,6 @@ jobs:
       - name: Start server and run Playwright smoke tests (Windows)
         if: steps.node-check.outputs.available == 'true' && runner.os == 'Windows'
         shell: bash
-        env:
-          WATCHPACK_POLLING: "true"
         run: |
           cd docs-preview-smoke-test/fern
           FERN_NO_VERSION_REDIRECTION=true fern docs dev \

--- a/.github/workflows/docs-bundle-smoke-test.yml
+++ b/.github/workflows/docs-bundle-smoke-test.yml
@@ -78,13 +78,25 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest]
-        # TODO: re-enable windows-latest once bundle download speed is resolved
+        os: [ubuntu-latest, macos-latest, windows-latest]
         node-version: [20, 22, 24]
+        exclude:
+          # Node 20 lacks the `navigator` global (added in Node 21/22),
+          # which causes ReferenceError during SSR on Windows.
+          - os: windows-latest
+            node-version: 20
     runs-on: ${{ matrix.os }}
     timeout-minutes: 30
 
     steps:
+      - name: Enable long paths (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          New-ItemProperty -Path "HKLM:\SYSTEM\CurrentControlSet\Control\FileSystem" -Name "LongPathsEnabled" -Value 1 -PropertyType DWORD -Force
+          git config --system core.longpaths true
+          echo "Long paths enabled (LongPathsEnabled=1, git core.longpaths=true)"
+
       - name: Check Node.js version availability
         id: node-check
         shell: bash
@@ -145,6 +157,7 @@ jobs:
       # Playwright in a separate step.
       - name: Start fern docs dev server (Unix)
         if: steps.node-check.outputs.available == 'true' && runner.os != 'Windows'
+        shell: bash
         run: |
           cd docs-preview-smoke-test/fern
           FERN_NO_VERSION_REDIRECTION=true fern docs dev \
@@ -234,6 +247,8 @@ jobs:
       - name: Start server and run Playwright smoke tests (Windows)
         if: steps.node-check.outputs.available == 'true' && runner.os == 'Windows'
         shell: bash
+        env:
+          WATCHPACK_POLLING: "true"
         run: |
           cd docs-preview-smoke-test/fern
           FERN_NO_VERSION_REDIRECTION=true fern docs dev \
@@ -323,7 +338,7 @@ jobs:
           retention-days: 7
 
       - name: Print fern docs dev logs
-        if: always() && steps.node-check.outputs.available == 'true'
+        if: failure() && steps.node-check.outputs.available == 'true'
         shell: bash
         run: cat /tmp/fern-docs-dev.log 2>/dev/null || echo "No dev server log found"
 

--- a/packages/cli/cli/changes/unreleased/windows-symlink-resolution.yml
+++ b/packages/cli/cli/changes/unreleased/windows-symlink-resolution.yml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=../../../../../fern-changes-yml.schema.json
+
+- summary: |
+    Resolve Windows symlinks via NTFS junctions during bundle extraction instead
+    of running pnpm install in standalone. This enables docs preview on Windows
+    without elevated privileges.
+  type: feat

--- a/packages/cli/docs-preview/src/downloadLocalDocsBundle.ts
+++ b/packages/cli/docs-preview/src/downloadLocalDocsBundle.ts
@@ -330,7 +330,7 @@ export async function downloadBundle({
             await decompress(outputZipPath, absolutePathToBundleFolder, {
                 filter: (file) => {
                     if (PLATFORM_IS_WINDOWS && file.type === "symlink") {
-                        const linkname = (file as Record<string, unknown>).linkname;
+                        const linkname = (file as unknown as Record<string, unknown>).linkname;
                         if (typeof linkname === "string") {
                             collectedSymlinks.push({ path: file.path, linkname });
                         }

--- a/packages/cli/docs-preview/src/downloadLocalDocsBundle.ts
+++ b/packages/cli/docs-preview/src/downloadLocalDocsBundle.ts
@@ -82,6 +82,12 @@ function warnIfLongPathsDisabled(logger: Logger): void {
     );
 }
 
+function isWithinOutputDir(resolvedPath: string, outputDir: string): boolean {
+    const rel = path.relative(outputDir, resolvedPath);
+    // rel must not start with ".." and must not be an absolute path
+    return !rel.startsWith("..") && !path.isAbsolute(rel);
+}
+
 /**
  * On Windows, tar symlinks are filtered out during extraction (fs.symlink
  * requires elevated privileges). This function resolves each collected symlink
@@ -106,6 +112,13 @@ function resolveWindowsSymlinks(outputDir: string, symlinks: SymlinkEntry[], log
 
     for (const { path: symlinkPath, linkname } of symlinks) {
         const fullSymlinkPath = path.join(outputDir, symlinkPath);
+
+        if (!isWithinOutputDir(fullSymlinkPath, outputDir)) {
+            logger.warn(`Skipping symlink with path outside outputDir: ${symlinkPath}`);
+            failed++;
+            continue;
+        }
+
         const symlinkDir = path.dirname(fullSymlinkPath);
         const resolvedTarget = path.resolve(symlinkDir, linkname);
 
@@ -126,12 +139,21 @@ function resolveWindowsSymlinks(outputDir: string, symlinks: SymlinkEntry[], log
                 const pkgRelPath = parts.slice(nmIdx + 1).join("/");
                 if (pnpmDirName != null && pkgRelPath != null) {
                     const fallback = path.join(rootPnpmStore, pnpmDirName, "node_modules", pkgRelPath);
+                    if (!isWithinOutputDir(fallback, outputDir)) {
+                        continue; // skip unsafe fallback
+                    }
                     if (existsSync(fallback)) {
                         sourcePath = fallback;
                         usedFallback = true;
                     }
                 }
             }
+        }
+
+        if (!isWithinOutputDir(sourcePath, outputDir)) {
+            logger.warn(`Skipping symlink whose target is outside outputDir: ${linkname}`);
+            failed++;
+            continue;
         }
 
         if (!existsSync(sourcePath)) {

--- a/packages/cli/docs-preview/src/downloadLocalDocsBundle.ts
+++ b/packages/cli/docs-preview/src/downloadLocalDocsBundle.ts
@@ -2,10 +2,10 @@ import { AbsoluteFilePath, doesPathExist, join, RelativeFilePath } from "@fern-a
 import { Logger } from "@fern-api/logger";
 import { loggingExeca } from "@fern-api/logging-execa";
 import chalk from "chalk";
+import { execSync } from "child_process";
 import cliProgress from "cli-progress";
 import decompress from "decompress";
 import { cpSync, existsSync, lstatSync, mkdirSync, symlinkSync } from "fs";
-import { execSync } from "child_process";
 import { mkdir, readFile, rename, rm, writeFile } from "fs/promises";
 import { homedir } from "os";
 import path from "path";
@@ -56,23 +56,28 @@ function warnIfLongPathsDisabled(logger: Logger): void {
     }
 
     logger.warn(
-        chalk.yellow.bold("\n" +
-            "WARNING: Windows long path support is NOT enabled.\n" +
+        chalk.yellow.bold(
             "\n" +
-            "The docs bundle contains deeply nested .pnpm paths that may\n" +
-            "exceed the 260-character MAX_PATH limit. Without long path\n" +
-            "support, extraction may silently truncate paths and produce\n" +
-            "a broken bundle.\n" +
-            "\n" +
-            "To enable long paths, run this in an elevated PowerShell:\n" +
-            "\n" +
-            "  New-ItemProperty -Path 'HKLM:\\SYSTEM\\CurrentControlSet\\Control\\FileSystem' `\n" +
-            "    -Name 'LongPathsEnabled' -Value 1 -PropertyType DWORD -Force\n" +
-            "\n" +
-            "Then restart your terminal.\n" +
-            "\n" +
-            "For more details, see:\n" +
-            "  https://learn.microsoft.com/en-us/windows/win32/fileio/maximum-file-path-limitation\n")
+                "╔══════════════════════════════════════════════════════════════════════════╗\n" +
+                "║  WARNING: Windows long path support is NOT enabled.                     ║\n" +
+                "║                                                                         ║\n" +
+                "║  The docs bundle contains deeply nested .pnpm paths that may exceed     ║\n" +
+                "║  the 260-character MAX_PATH limit. Extraction may silently truncate     ║\n" +
+                "║  paths and produce a broken bundle.                                     ║\n" +
+                "║                                                                         ║\n" +
+                "║  To fix, run this in an elevated PowerShell:                             ║\n" +
+                "║                                                                         ║\n" +
+                "║    New-ItemProperty -Path                                                ║\n" +
+                "║      'HKLM:\\SYSTEM\\CurrentControlSet\\Control\\FileSystem'           ║\n" +
+                "║      -Name 'LongPathsEnabled' -Value 1 -PropertyType DWORD -Force       ║\n" +
+                "║                                                                         ║\n" +
+                "║  Then restart your terminal.                                             ║\n" +
+                "║                                                                         ║\n" +
+                "║  For more details, see:                                                  ║\n" +
+                "║  https://learn.microsoft.com/en-us/windows/win32/fileio/                 ║\n" +
+                "║  maximum-file-path-limitation                                            ║\n" +
+                "╚══════════════════════════════════════════════════════════════════════════╝\n"
+        )
     );
 }
 

--- a/packages/cli/docs-preview/src/downloadLocalDocsBundle.ts
+++ b/packages/cli/docs-preview/src/downloadLocalDocsBundle.ts
@@ -5,6 +5,7 @@ import chalk from "chalk";
 import cliProgress from "cli-progress";
 import decompress from "decompress";
 import { cpSync, existsSync, lstatSync, mkdirSync, symlinkSync } from "fs";
+import { execSync } from "child_process";
 import { mkdir, readFile, rename, rm, writeFile } from "fs/promises";
 import { homedir } from "os";
 import path from "path";
@@ -32,6 +33,47 @@ const COREPACK_MISSING_KEYID_ERROR_MESSAGE = 'Cannot find matching keyid: {"sign
 interface SymlinkEntry {
     path: string;
     linkname: string;
+}
+
+/**
+ * Checks the Windows registry for LongPathsEnabled and prints a prominent
+ * warning if long paths are not enabled. Long paths are required because
+ * .pnpm directory names inside the bundle can exceed the 260-char MAX_PATH.
+ */
+function warnIfLongPathsDisabled(logger: Logger): void {
+    try {
+        const output = execSync(
+            'reg query "HKLM\\SYSTEM\\CurrentControlSet\\Control\\FileSystem" /v LongPathsEnabled',
+            { encoding: "utf-8", timeout: 5000 }
+        );
+        // Output looks like: "LongPathsEnabled    REG_DWORD    0x1"
+        const match = output.match(/LongPathsEnabled\s+REG_DWORD\s+0x(\d+)/i);
+        if (match != null && match[1] === "1") {
+            return;
+        }
+    } catch {
+        // reg query failed — key may not exist, which means long paths are disabled
+    }
+
+    logger.warn(
+        chalk.yellow.bold("\n" +
+            "WARNING: Windows long path support is NOT enabled.\n" +
+            "\n" +
+            "The docs bundle contains deeply nested .pnpm paths that may\n" +
+            "exceed the 260-character MAX_PATH limit. Without long path\n" +
+            "support, extraction may silently truncate paths and produce\n" +
+            "a broken bundle.\n" +
+            "\n" +
+            "To enable long paths, run this in an elevated PowerShell:\n" +
+            "\n" +
+            "  New-ItemProperty -Path 'HKLM:\\SYSTEM\\CurrentControlSet\\Control\\FileSystem' `\n" +
+            "    -Name 'LongPathsEnabled' -Value 1 -PropertyType DWORD -Force\n" +
+            "\n" +
+            "Then restart your terminal.\n" +
+            "\n" +
+            "For more details, see:\n" +
+            "  https://learn.microsoft.com/en-us/windows/win32/fileio/maximum-file-path-limitation\n")
+    );
 }
 
 /**
@@ -322,6 +364,10 @@ export async function downloadBundle({
                 const percentage = Math.min(99, Math.floor(p * 100));
                 unzipProgressBar?.update(percentage);
             }, 50);
+        }
+
+        if (PLATFORM_IS_WINDOWS) {
+            warnIfLongPathsDisabled(logger);
         }
 
         const collectedSymlinks: SymlinkEntry[] = [];

--- a/packages/cli/docs-preview/src/downloadLocalDocsBundle.ts
+++ b/packages/cli/docs-preview/src/downloadLocalDocsBundle.ts
@@ -51,8 +51,9 @@ function warnIfLongPathsDisabled(logger: Logger): void {
         if (match != null && match[1] === "1") {
             return;
         }
-    } catch {
+    } catch (error) {
         // reg query failed — key may not exist, which means long paths are disabled
+        logger.debug(`Registry query for LongPathsEnabled failed: ${error}`);
     }
 
     logger.warn(
@@ -151,7 +152,8 @@ function resolveWindowsSymlinks(outputDir: string, symlinks: SymlinkEntry[], log
             if (usedFallback) {
                 fallbackUsed++;
             }
-        } catch {
+        } catch (error) {
+            logger.debug(`Failed to resolve symlink ${symlinkPath}: ${error}`);
             failed++;
         }
     }
@@ -381,7 +383,9 @@ export async function downloadBundle({
             await decompress(outputZipPath, absolutePathToBundleFolder, {
                 filter: (file) => {
                     if (PLATFORM_IS_WINDOWS && file.type === "symlink") {
-                        const linkname = (file as unknown as Record<string, unknown>).linkname;
+                        // decompress-tar adds `linkname` for symlink entries but the
+                        // TypeScript types don't include it, so access via bracket notation.
+                        const linkname = (file as unknown as Record<string, unknown>)["linkname"];
                         if (typeof linkname === "string") {
                             collectedSymlinks.push({ path: file.path, linkname });
                         }

--- a/packages/cli/docs-preview/src/downloadLocalDocsBundle.ts
+++ b/packages/cli/docs-preview/src/downloadLocalDocsBundle.ts
@@ -4,8 +4,10 @@ import { loggingExeca } from "@fern-api/logging-execa";
 import chalk from "chalk";
 import cliProgress from "cli-progress";
 import decompress from "decompress";
+import { cpSync, existsSync, lstatSync, mkdirSync, symlinkSync } from "fs";
 import { mkdir, readFile, rename, rm, writeFile } from "fs/promises";
 import { homedir } from "os";
+import path from "path";
 import tmp from "tmp-promise";
 import xml2js from "xml2js";
 
@@ -25,10 +27,102 @@ const LOCAL_STORAGE_FOLDER = process.env.LOCAL_STORAGE_FOLDER ?? ".fern";
 
 // Const for windows post-processing
 const INSTRUMENTATION_PATH = "packages/fern-docs/bundle/.next/server/instrumentation.js";
-const NPMRC_NAME = ".npmrc";
-const PNPMFILE_CJS_NAME = ".pnpmfile.cjs";
-const PNPM_WORKSPACE_YAML_NAME = "pnpm-workspace.yaml";
 const COREPACK_MISSING_KEYID_ERROR_MESSAGE = 'Cannot find matching keyid: {"signatures":';
+
+interface SymlinkEntry {
+    path: string;
+    linkname: string;
+}
+
+/**
+ * On Windows, tar symlinks are filtered out during extraction (fs.symlink
+ * requires elevated privileges). This function resolves each collected symlink
+ * by creating an NTFS junction (for directories) or copying the file.
+ * When a direct target doesn't exist, it falls back to searching the root
+ * .pnpm store.
+ */
+function resolveWindowsSymlinks(outputDir: string, symlinks: SymlinkEntry[], logger: Logger): void {
+    if (symlinks.length === 0) {
+        return;
+    }
+
+    logger.debug(`Resolving ${symlinks.length} symlinks via NTFS junctions/copies...`);
+
+    let junctions = 0;
+    let copies = 0;
+    let failed = 0;
+    let fallbackUsed = 0;
+    let alreadyExisted = 0;
+
+    const rootPnpmStore = path.join(outputDir, "standalone", "node_modules", ".pnpm");
+
+    for (const { path: symlinkPath, linkname } of symlinks) {
+        const fullSymlinkPath = path.join(outputDir, symlinkPath);
+        const symlinkDir = path.dirname(fullSymlinkPath);
+        const resolvedTarget = path.resolve(symlinkDir, linkname);
+
+        if (existsSync(fullSymlinkPath)) {
+            alreadyExisted++;
+            continue;
+        }
+
+        let sourcePath = resolvedTarget;
+        let usedFallback = false;
+
+        // If direct target doesn't exist, try fallback in root .pnpm store
+        if (!existsSync(sourcePath) && existsSync(rootPnpmStore)) {
+            const parts = linkname.split("/");
+            const nmIdx = parts.lastIndexOf("node_modules");
+            if (nmIdx >= 0 && nmIdx > 0) {
+                const pnpmDirName = parts[nmIdx - 1];
+                const pkgRelPath = parts.slice(nmIdx + 1).join("/");
+                if (pnpmDirName != null && pkgRelPath != null) {
+                    const fallback = path.join(rootPnpmStore, pnpmDirName, "node_modules", pkgRelPath);
+                    if (existsSync(fallback)) {
+                        sourcePath = fallback;
+                        usedFallback = true;
+                    }
+                }
+            }
+        }
+
+        if (!existsSync(sourcePath)) {
+            failed++;
+            continue;
+        }
+
+        try {
+            mkdirSync(path.dirname(fullSymlinkPath), { recursive: true });
+            const stat = lstatSync(sourcePath);
+            if (stat.isDirectory()) {
+                symlinkSync(sourcePath, fullSymlinkPath, "junction");
+                junctions++;
+            } else {
+                cpSync(sourcePath, fullSymlinkPath);
+                copies++;
+            }
+            if (usedFallback) {
+                fallbackUsed++;
+            }
+        } catch {
+            failed++;
+        }
+    }
+
+    logger.debug(
+        `Symlink resolution: ${junctions} junctions, ${copies} file copies, ` +
+            `${alreadyExisted} pre-existing, ${failed} failed (${fallbackUsed} via fallback) ` +
+            `out of ${symlinks.length}`
+    );
+
+    // Verify critical top-level packages
+    const standaloneNM = path.join(outputDir, "standalone", "node_modules");
+    for (const dep of ["next", "react", "react-dom", "styled-jsx"]) {
+        if (!existsSync(path.join(standaloneNM, dep))) {
+            logger.warn(`${dep} is MISSING from standalone/node_modules/`);
+        }
+    }
+}
 
 export function getLocalStorageFolder(): AbsoluteFilePath {
     return join(AbsoluteFilePath.of(homedir()), RelativeFilePath.of(LOCAL_STORAGE_FOLDER));
@@ -53,18 +147,6 @@ export function getPathToInstrumentationJs({ app = false }: { app?: boolean }): 
     return join(getPathToStandaloneFolder({ app }), RelativeFilePath.of(INSTRUMENTATION_PATH));
 }
 
-function getPathToPnpmWorkspaceYaml({ app = false }: { app?: boolean }): AbsoluteFilePath {
-    return join(getPathToStandaloneFolder({ app }), RelativeFilePath.of(PNPM_WORKSPACE_YAML_NAME));
-}
-
-function getPathToPnpmfileCjs({ app = false }: { app?: boolean }): AbsoluteFilePath {
-    return join(getPathToStandaloneFolder({ app }), RelativeFilePath.of(PNPMFILE_CJS_NAME));
-}
-
-function getPathToNpmrc({ app = false }: { app?: boolean }): AbsoluteFilePath {
-    return join(getPathToStandaloneFolder({ app }), RelativeFilePath.of(NPMRC_NAME));
-}
-
 function contactFernSupportError(errorMessage: string): Error {
     return new Error(`${errorMessage}. Please reach out to support@buildwithfern.com.`);
 }
@@ -84,27 +166,6 @@ export declare namespace DownloadLocalBundle {
         type: "failure";
     }
 }
-
-const PNPMFILE_CJS_CONTENTS = `module.exports = {
-    hooks: {
-        readPackage(pkg) {
-            // Remove all workspace:* dependencies
-            if (pkg.dependencies) {
-                Object.keys(pkg.dependencies).forEach(dep => {
-                    if (pkg.dependencies[dep] === 'workspace:*') {
-                        delete pkg.dependencies[dep]; } });
-                    }
-            if (pkg.devDependencies) {
-                Object.keys(pkg.devDependencies).forEach(dep => {
-                    if (pkg.devDependencies[dep] === 'workspace:*') {
-                        delete pkg.devDependencies[dep]; } });
-            } return pkg;
-        }
-    }
-};
-`;
-
-const NPMRC_CONTENTS = "@fern-fern:registry=https://npm.buildwithfern.com\n";
 
 export async function downloadBundle({
     bucketUrl,
@@ -263,9 +324,20 @@ export async function downloadBundle({
             }, 50);
         }
 
+        const collectedSymlinks: SymlinkEntry[] = [];
+
         try {
             await decompress(outputZipPath, absolutePathToBundleFolder, {
-                filter: (file) => !(PLATFORM_IS_WINDOWS && file.type === "symlink")
+                filter: (file) => {
+                    if (PLATFORM_IS_WINDOWS && file.type === "symlink") {
+                        const linkname = (file as Record<string, unknown>).linkname;
+                        if (typeof linkname === "string") {
+                            collectedSymlinks.push({ path: file.path, linkname });
+                        }
+                        return false;
+                    }
+                    return true;
+                }
             });
         } finally {
             if (unzipInterval) {
@@ -275,6 +347,11 @@ export async function downloadBundle({
                 unzipProgressBar.update(100);
                 unzipProgressBar.stop();
             }
+        }
+
+        // Resolve symlinks via NTFS junctions on Windows
+        if (PLATFORM_IS_WINDOWS && collectedSymlinks.length > 0) {
+            resolveWindowsSymlinks(absolutePathToBundleFolder, collectedSymlinks, logger);
         }
 
         // write etag
@@ -362,52 +439,10 @@ export async function downloadBundle({
             }
 
             if (PLATFORM_IS_WINDOWS) {
-                const absPathToStandalone = getPathToStandaloneFolder({ app });
                 const absPathToInstrumentationJs = getPathToInstrumentationJs({ app });
-                const pnpmWorkspacePath = getPathToPnpmWorkspaceYaml({ app });
-                const pnpmfilePath = getPathToPnpmfileCjs({ app });
-                const npmrcPath = getPathToNpmrc({ app });
-
-                // Check all paths in parallel
-                const [pnpmWorkspaceExists, pnpmfileExists, npmrcExists, instrumentationJsExists] = await Promise.all([
-                    doesPathExist(pnpmWorkspacePath),
-                    doesPathExist(pnpmfilePath),
-                    doesPathExist(npmrcPath),
-                    doesPathExist(absPathToInstrumentationJs)
-                ]);
-
-                // Warn if pnpm-workspace.yaml does not exist
-                if (!pnpmWorkspaceExists) {
-                    logger.warn(
-                        `Expected pnpm-workspace.yaml at ${pnpmWorkspacePath} but it does not exist. If you are experiencing issues, please contact support@buildwithfern.com.`
-                    );
-                }
-
-                // Write pnpmfile.cjs if it does not exist
-                if (!pnpmfileExists) {
-                    logger.debug(`Writing pnpmfile.cjs at ${pnpmfilePath}`);
-                    await writeFile(pnpmfilePath, PNPMFILE_CJS_CONTENTS);
-                }
-                // Write .npmrc if it does not exist
-                if (!npmrcExists) {
-                    logger.debug(`Writing .npmrc at ${npmrcPath}`);
-                    await writeFile(npmrcPath, NPMRC_CONTENTS);
-                }
-                // Remove instrumentation.js if it exists
-                if (instrumentationJsExists) {
+                if (await doesPathExist(absPathToInstrumentationJs)) {
                     logger.debug(`Removing instrumentation.js at ${absPathToInstrumentationJs}`);
                     await rm(absPathToInstrumentationJs);
-                }
-
-                try {
-                    // pnpm install within standalone
-                    logger.debug("Running pnpm install within standalone");
-                    await loggingExeca(logger, "pnpm", ["install"], {
-                        cwd: absPathToStandalone,
-                        doNotPipeOutput: true
-                    });
-                } catch (error) {
-                    throw contactFernSupportError(`Failed to install required package due to error: ${error}`);
                 }
             }
         }


### PR DESCRIPTION
## Description

Refs https://github.com/fern-api/fern-platform/pull/9752

Integrates Windows-compatible bundle extraction directly into the CLI (rather than using a separate CI-only script) and re-enables Windows in the docs bundle smoke test matrix.

## Changes Made

### CLI: `downloadLocalDocsBundle.ts`
- **New `warnIfLongPathsDisabled` function**: On Windows, queries the registry for `LongPathsEnabled` before extraction begins. If long paths are not enabled, prints a bordered warning box with a PowerShell command to enable it and a link to [Microsoft's long path docs](https://learn.microsoft.com/en-us/windows/win32/fileio/maximum-file-path-limitation).
- **New `isWithinOutputDir` path traversal guard**: Validates that both the symlink destination and resolved source stay inside `outputDir` before performing any filesystem operations (junctions, copies). Also applied to fallback paths constructed from `.pnpm` store lookups.
- **New `resolveWindowsSymlinks` function**: After extraction, resolves each filtered-out symlink by creating an NTFS junction (directories) or copying the file (regular files). Falls back to searching the root `.pnpm` store when a direct target doesn't exist.
- **Collects symlink metadata during decompress**: The existing `filter` callback now captures `path` and `linkname` from each symlink entry before filtering it out, instead of silently discarding them.
- **Removes the old `pnpm install` workaround**: The previous Windows path wrote `.pnpmfile.cjs`, `.npmrc`, and ran `pnpm install` in `standalone/` to recreate dependencies. NTFS junctions replace all of that — no elevated privileges or pnpm needed.
- **Retains `instrumentation.js` removal** on Windows (prevents OpenTelemetry native binding crashes).

### Workflow: `docs-bundle-smoke-test.yml`
- Adds `windows-latest` to the OS matrix
- Excludes `windows-latest` + Node 20 (Node 20 lacks the `navigator` global, causing SSR `ReferenceError`)
- Adds `LongPathsEnabled` registry step so deeply-nested `.pnpm` paths aren't truncated during extraction
- Adds explicit `shell: bash` to Unix server start step
- Changes dev server log printing from `always()` to `failure()` only

## Human review checklist
- [ ] **`linkname` access via type cast**: The `decompress` TypeScript types don't include `linkname`, but the underlying `decompress-tar` plugin [adds it for symlink entries](https://github.com/kevva/decompress-tar/blob/master/index.js#L31-L33). The code casts through `unknown` to `Record<string, unknown>` and checks `typeof linkname === "string"` before using it. Direct cast (`as Record<string, unknown>`) fails with TS2352, so the double cast is necessary. Is this acceptable, or should we consider using the `tar` npm package directly?
- [ ] **`isWithinOutputDir` guard**: Uses `path.relative()` to verify paths don't escape `outputDir`. Applied to the symlink destination, the resolved source, and fallback paths. Worth verifying the logic handles edge cases (e.g., `..` segments in `linkname`).
- [ ] **Removal of `pnpm install` fallback**: If junction resolution partially fails (some symlinks unresolved), those dependencies will be missing with no fallback. The function logs a warning for critical packages (`next`, `react`, `react-dom`, `styled-jsx`) but doesn't fail. Verify this is acceptable.
- [ ] **`LongPathsEnabled` is required**: Extraction depends on this registry setting. If the CI step is removed or fails, long `.pnpm` paths will be silently truncated. The CLI now warns about this at runtime via `warnIfLongPathsDisabled`.
- [ ] **Warning box alignment**: The bordered warning uses box drawing characters (`╔═║╚╝`). The escaped backslashes in the PowerShell path (`HKLM:\\SYSTEM\\...`) are shorter when rendered (single `\`), so the right-side `║` borders may not perfectly align with the top/bottom borders in all terminals.
- [ ] **`reg query` locale sensitivity**: The regex `LongPathsEnabled\s+REG_DWORD\s+0x(\d+)` parses English-format registry output. Verify this works on non-English Windows locales.

## Testing
- [x] `pnpm run check` (biome) passes locally
- [x] All required CI checks pass (compile, lint, biome, depcheck, test, test-ete)
- [x] Windows smoke tests pass in CI (`windows-latest` + Node 22 and 24)
- [x] macOS and Ubuntu smoke tests continue to pass
- [ ] Windows-specific code paths (NTFS junctions, registry queries) cannot be tested locally on Linux — CI is the only validation

Link to Devin session: https://app.devin.ai/sessions/4a82619b77ec4a9fb613ee034ef56fd6
Requested by: @thesandlord
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/15087" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
