### PR TITLE
fix(cli): remove leaked seed script containers with docker rm -f

### DIFF
--- a/packages/seed/src/commands/test/script-runner/ContainerScriptRunner.ts
+++ b/packages/seed/src/commands/test/script-runner/ContainerScriptRunner.ts
@@ -232,14 +232,19 @@ export class ContainerScriptRunner extends ScriptRunner {
 
     public async stop(): Promise<void> {
         const logger = this.shouldStreamOutput() ? this.context.logger : undefined;
-        const killPromises = this.allSlots.flatMap((slot) =>
+        // Use `rm -f` to both stop and remove the container in one step. `kill`
+        // alone leaves stopped containers behind, which accumulate in `docker ps -a`
+        // across repeated seed runs.
+        const removePromises = this.allSlots.flatMap((slot) =>
             slot.scripts.map((script) =>
-                loggingExeca(logger, this.runner, ["kill", script.containerId], {
+                loggingExeca(logger, this.runner, ["rm", "-f", script.containerId], {
                     doNotPipeOutput: !this.shouldStreamOutput()
                 })
             )
         );
-        await Promise.all(killPromises);
+        await Promise.all(removePromises);
+        this.allSlots = [];
+        this.availableSlots = [];
     }
 
     protected async initialize(): Promise<void> {
@@ -398,11 +403,11 @@ export class ContainerScriptRunner extends ScriptRunner {
             for (const result of settledPromises) {
                 if (result.status === "fulfilled") {
                     for (const script of result.value.scripts) {
-                        await loggingExeca(logger, this.runner, ["kill", script.containerId], {
+                        await loggingExeca(logger, this.runner, ["rm", "-f", script.containerId], {
                             doNotPipeOutput: true
-                        }).catch((killError: unknown) => {
+                        }).catch((removeError: unknown) => {
                             CONSOLE_LOGGER.warn(
-                                `Best-effort cleanup: failed to kill container ${script.containerId}: ${killError}`
+                                `Best-effort cleanup: failed to remove container ${script.containerId}: ${removeError}`
                             );
                         });
                     }
@@ -448,11 +453,11 @@ export class ContainerScriptRunner extends ScriptRunner {
         } catch (error) {
             // Clean up any containers that started before the failure in this slot
             for (const script of scripts) {
-                await loggingExeca(logger, this.runner, ["kill", script.containerId], {
+                await loggingExeca(logger, this.runner, ["rm", "-f", script.containerId], {
                     doNotPipeOutput: true
-                }).catch((killError: unknown) => {
+                }).catch((removeError: unknown) => {
                     CONSOLE_LOGGER.warn(
-                        `Failed to kill container ${script.containerId} during slot cleanup: ${killError}`
+                        `Failed to remove container ${script.containerId} during slot cleanup: ${removeError}`
                     );
                 });
             }


### PR DESCRIPTION
## Description

Seed script-runner containers were being stopped with `docker kill` (and `podman kill`), which leaves the containers in a stopped state rather than removing them. Since the initial `docker run` does not use `--rm`, these stopped containers accumulate in `docker ps -a` across seed runs.

This PR switches the script-runner cleanup paths to `rm -f`, which both stops and removes the container in one step (matching what `ReusableContainerExecutionEnvironment` already does via `stopContainer`).

## Changes Made

- In `ContainerScriptRunner`, replace `["kill", containerId]` with `["rm", "-f", containerId]` in three places:
  - `stop()` — normal teardown after a seed run
  - `startContainers()` error-recovery — when one slot fails to start, tear down any successfully-started slots
  - `startSlot()` error-recovery — when a slot partially starts and then fails, tear down the containers that did start
- Clear `allSlots` / `availableSlots` at the end of `stop()` so the runner cannot be reused against removed container IDs.
- Update warning messages/variable names from `kill` → `remove` to match the new behavior.

## Things to review carefully

- **Behavioral change:** `rm -f` on a running container sends SIGKILL and removes it. This is effectively what `kill` was doing plus the removal. No graceful shutdown was attempted before, so this should be equivalent in practice, but worth a sanity check for both `docker` and `podman` runners.
- **`stop()` clearing state:** new `this.allSlots = []` / `this.availableSlots = []` assignments are safe as long as `stop()` is only called at end-of-run (current behavior). If anything ever awaits on a slot after `stop()`, that waiter will hang — but that was already true with `kill`.
- Only the script-runner path was affected — `ContainerTestRunner` / `ReusableContainerExecutionEnvironment` already use `rm -f` via `stopContainer`.

## Testing

- [x] `pnpm run check` (biome) passes
- [ ] Unit tests added/updated — no tests exist for this runner; change is exercised by running seed tests (`pnpm seed:build && node packages/seed/dist/cli.cjs test ...`) and verifying `docker ps -a` is clean afterward.

Link to Devin session: https://app.devin.ai/sessions/122353610fb840f4824a24840d9e8f11
Requested by: @Swimburger
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/15091" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
