### PR TITLE
chore(ci): migrate seed jobs to Seed runners and lightweight jobs to ubuntu-latest

### DIFF
--- a/.github/workflows/security-scanning-and-remediation.yml
+++ b/.github/workflows/security-scanning-and-remediation.yml
@@ -360,7 +360,7 @@ jobs:
 
   create-grype-pr-java-sdk:
     name: Run grype scan - java SDK
-    runs-on: Seed
+    runs-on: ubuntu-latest
     permissions:
       id-token: write
       contents: write

--- a/.github/workflows/seed.yml
+++ b/.github/workflows/seed.yml
@@ -324,7 +324,7 @@ jobs:
           fi
 
   ruby-sdk-v2:
-    runs-on: Seed
+    runs-on: ubuntu-latest-16-cores
     timeout-minutes: 20
     needs: [setup, get-all-test-matrices]
     if: >-
@@ -357,7 +357,7 @@ jobs:
           dockerhub-token: ${{ secrets.DOCKER_PASSWORD_PUBLIC_READONLY }}
 
   pydantic:
-    runs-on: Seed
+    runs-on: ubuntu-latest-16-cores
     timeout-minutes: 15
     needs: [setup, get-all-test-matrices]
     if: >-
@@ -389,7 +389,7 @@ jobs:
           dockerhub-token: ${{ secrets.DOCKER_PASSWORD_PUBLIC_READONLY }}
 
   python-sdk:
-    runs-on: Seed
+    runs-on: ubuntu-latest-16-cores
     timeout-minutes: 30
     needs: [setup, get-all-test-matrices]
     if: >-
@@ -454,7 +454,7 @@ jobs:
           dockerhub-token: ${{ secrets.DOCKER_PASSWORD_PUBLIC_READONLY }}
 
   java-sdk:
-    runs-on: Seed
+    runs-on: ubuntu-latest-16-cores
     timeout-minutes: 30
     needs: [setup, get-all-test-matrices]
     if: >-
@@ -486,7 +486,7 @@ jobs:
           dockerhub-token: ${{ secrets.DOCKER_PASSWORD_PUBLIC_READONLY }}
 
   java-model:
-    runs-on: Seed
+    runs-on: ubuntu-latest-16-cores
     timeout-minutes: 15
     needs: [setup, get-all-test-matrices]
     if: >-
@@ -518,7 +518,7 @@ jobs:
           dockerhub-token: ${{ secrets.DOCKER_PASSWORD_PUBLIC_READONLY }}
 
   ts-sdk:
-    runs-on: Seed
+    runs-on: ubuntu-latest-16-cores
     timeout-minutes: 15
     needs: [setup, get-all-test-matrices]
     if: >-
@@ -551,7 +551,7 @@ jobs:
           dockerhub-token: ${{ secrets.DOCKER_PASSWORD_PUBLIC_READONLY }}
 
   go-model:
-    runs-on: Seed
+    runs-on: ubuntu-latest-16-cores
     timeout-minutes: 20
     needs: [setup, get-all-test-matrices]
     if: >-
@@ -583,7 +583,7 @@ jobs:
           dockerhub-token: ${{ secrets.DOCKER_PASSWORD_PUBLIC_READONLY }}
 
   go-sdk:
-    runs-on: Seed
+    runs-on: ubuntu-latest-16-cores
     timeout-minutes: 20
     needs: [setup, get-all-test-matrices]
     if: >-
@@ -615,7 +615,7 @@ jobs:
           dockerhub-token: ${{ secrets.DOCKER_PASSWORD_PUBLIC_READONLY }}
 
   csharp-model:
-    runs-on: Seed
+    runs-on: ubuntu-latest-16-cores
     timeout-minutes: 15
     needs: [setup, get-all-test-matrices]
     if: >-
@@ -647,7 +647,7 @@ jobs:
           dockerhub-token: ${{ secrets.DOCKER_PASSWORD_PUBLIC_READONLY }}
 
   csharp-sdk:
-    runs-on: Seed
+    runs-on: ubuntu-latest-16-cores
     timeout-minutes: 20
     needs: [setup, get-all-test-matrices]
     if: >-
@@ -679,7 +679,7 @@ jobs:
           dockerhub-token: ${{ secrets.DOCKER_PASSWORD_PUBLIC_READONLY }}
 
   php-model:
-    runs-on: Seed
+    runs-on: ubuntu-latest-16-cores
     timeout-minutes: 15
     needs: [setup, get-all-test-matrices]
     if: >-
@@ -711,7 +711,7 @@ jobs:
           dockerhub-token: ${{ secrets.DOCKER_PASSWORD_PUBLIC_READONLY }}
 
   php-sdk:
-    runs-on: Seed
+    runs-on: ubuntu-latest-16-cores
     timeout-minutes: 15
     needs: [setup, get-all-test-matrices]
     if: >-
@@ -743,7 +743,7 @@ jobs:
           dockerhub-token: ${{ secrets.DOCKER_PASSWORD_PUBLIC_READONLY }}
 
   swift-sdk:
-    runs-on: Seed
+    runs-on: ubuntu-latest-16-cores
     timeout-minutes: 15
     needs: [setup, get-all-test-matrices]
     if: >-
@@ -775,7 +775,7 @@ jobs:
           dockerhub-token: ${{ secrets.DOCKER_PASSWORD_PUBLIC_READONLY }}
 
   rust-model:
-    runs-on: Seed
+    runs-on: ubuntu-latest-16-cores
     timeout-minutes: 15
     needs: [setup, get-all-test-matrices]
     if: >-
@@ -807,7 +807,7 @@ jobs:
           dockerhub-token: ${{ secrets.DOCKER_PASSWORD_PUBLIC_READONLY }}
 
   rust-sdk:
-    runs-on: Seed
+    runs-on: ubuntu-latest-16-cores
     timeout-minutes: 15
     needs: [setup, get-all-test-matrices]
     if: >-
@@ -873,7 +873,7 @@ jobs:
           retention-days: 1
 
   benchmark:
-    runs-on: Seed
+    runs-on: ubuntu-latest-16-cores
     timeout-minutes: 60
     needs: [get-all-test-matrices, benchmark-setup]
     if: >-
@@ -1159,7 +1159,7 @@ jobs:
   # Runs the real `fern generate --docs --preview` command against the benchmark
   # fixture and measures wall-clock time, same philosophy as SDK benchmarks.
   docs-benchmark:
-    runs-on: Seed
+    runs-on: ubuntu-latest-16-cores
     timeout-minutes: 45
     needs: [get-all-test-matrices, benchmark-setup]
     if: >-

--- a/.github/workflows/seed.yml
+++ b/.github/workflows/seed.yml
@@ -324,7 +324,7 @@ jobs:
           fi
 
   ruby-sdk-v2:
-    runs-on: ubuntu-latest
+    runs-on: Seed
     timeout-minutes: 20
     needs: [setup, get-all-test-matrices]
     if: >-
@@ -357,7 +357,7 @@ jobs:
           dockerhub-token: ${{ secrets.DOCKER_PASSWORD_PUBLIC_READONLY }}
 
   pydantic:
-    runs-on: ubuntu-latest
+    runs-on: Seed
     timeout-minutes: 15
     needs: [setup, get-all-test-matrices]
     if: >-
@@ -389,7 +389,7 @@ jobs:
           dockerhub-token: ${{ secrets.DOCKER_PASSWORD_PUBLIC_READONLY }}
 
   python-sdk:
-    runs-on: ubuntu-latest
+    runs-on: Seed
     timeout-minutes: 30
     needs: [setup, get-all-test-matrices]
     if: >-
@@ -454,7 +454,7 @@ jobs:
           dockerhub-token: ${{ secrets.DOCKER_PASSWORD_PUBLIC_READONLY }}
 
   java-sdk:
-    runs-on: ubuntu-latest
+    runs-on: Seed
     timeout-minutes: 30
     needs: [setup, get-all-test-matrices]
     if: >-
@@ -486,7 +486,7 @@ jobs:
           dockerhub-token: ${{ secrets.DOCKER_PASSWORD_PUBLIC_READONLY }}
 
   java-model:
-    runs-on: ubuntu-latest
+    runs-on: Seed
     timeout-minutes: 15
     needs: [setup, get-all-test-matrices]
     if: >-
@@ -518,7 +518,7 @@ jobs:
           dockerhub-token: ${{ secrets.DOCKER_PASSWORD_PUBLIC_READONLY }}
 
   ts-sdk:
-    runs-on: ubuntu-latest
+    runs-on: Seed
     timeout-minutes: 15
     needs: [setup, get-all-test-matrices]
     if: >-
@@ -551,7 +551,7 @@ jobs:
           dockerhub-token: ${{ secrets.DOCKER_PASSWORD_PUBLIC_READONLY }}
 
   go-model:
-    runs-on: ubuntu-latest
+    runs-on: Seed
     timeout-minutes: 20
     needs: [setup, get-all-test-matrices]
     if: >-
@@ -583,7 +583,7 @@ jobs:
           dockerhub-token: ${{ secrets.DOCKER_PASSWORD_PUBLIC_READONLY }}
 
   go-sdk:
-    runs-on: ubuntu-latest
+    runs-on: Seed
     timeout-minutes: 20
     needs: [setup, get-all-test-matrices]
     if: >-
@@ -615,7 +615,7 @@ jobs:
           dockerhub-token: ${{ secrets.DOCKER_PASSWORD_PUBLIC_READONLY }}
 
   csharp-model:
-    runs-on: ubuntu-latest
+    runs-on: Seed
     timeout-minutes: 15
     needs: [setup, get-all-test-matrices]
     if: >-
@@ -647,7 +647,7 @@ jobs:
           dockerhub-token: ${{ secrets.DOCKER_PASSWORD_PUBLIC_READONLY }}
 
   csharp-sdk:
-    runs-on: ubuntu-latest
+    runs-on: Seed
     timeout-minutes: 20
     needs: [setup, get-all-test-matrices]
     if: >-
@@ -679,7 +679,7 @@ jobs:
           dockerhub-token: ${{ secrets.DOCKER_PASSWORD_PUBLIC_READONLY }}
 
   php-model:
-    runs-on: ubuntu-latest
+    runs-on: Seed
     timeout-minutes: 15
     needs: [setup, get-all-test-matrices]
     if: >-
@@ -711,7 +711,7 @@ jobs:
           dockerhub-token: ${{ secrets.DOCKER_PASSWORD_PUBLIC_READONLY }}
 
   php-sdk:
-    runs-on: ubuntu-latest
+    runs-on: Seed
     timeout-minutes: 15
     needs: [setup, get-all-test-matrices]
     if: >-
@@ -743,7 +743,7 @@ jobs:
           dockerhub-token: ${{ secrets.DOCKER_PASSWORD_PUBLIC_READONLY }}
 
   swift-sdk:
-    runs-on: ubuntu-latest
+    runs-on: Seed
     timeout-minutes: 15
     needs: [setup, get-all-test-matrices]
     if: >-
@@ -775,7 +775,7 @@ jobs:
           dockerhub-token: ${{ secrets.DOCKER_PASSWORD_PUBLIC_READONLY }}
 
   rust-model:
-    runs-on: ubuntu-latest
+    runs-on: Seed
     timeout-minutes: 15
     needs: [setup, get-all-test-matrices]
     if: >-
@@ -807,7 +807,7 @@ jobs:
           dockerhub-token: ${{ secrets.DOCKER_PASSWORD_PUBLIC_READONLY }}
 
   rust-sdk:
-    runs-on: ubuntu-latest
+    runs-on: Seed
     timeout-minutes: 15
     needs: [setup, get-all-test-matrices]
     if: >-
@@ -873,7 +873,7 @@ jobs:
           retention-days: 1
 
   benchmark:
-    runs-on: ubuntu-latest
+    runs-on: Seed
     timeout-minutes: 60
     needs: [get-all-test-matrices, benchmark-setup]
     if: >-
@@ -1159,7 +1159,7 @@ jobs:
   # Runs the real `fern generate --docs --preview` command against the benchmark
   # fixture and measures wall-clock time, same philosophy as SDK benchmarks.
   docs-benchmark:
-    runs-on: ubuntu-latest
+    runs-on: Seed
     timeout-minutes: 45
     needs: [get-all-test-matrices, benchmark-setup]
     if: >-

--- a/.github/workflows/test-remote-vs-local-generation-parity.yml
+++ b/.github/workflows/test-remote-vs-local-generation-parity.yml
@@ -75,7 +75,7 @@ jobs:
 
   compile-and-build:
     needs: determine-generator
-    runs-on: Seed
+    runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
       - name: Checkout Repo

--- a/.github/workflows/update-seed.yml
+++ b/.github/workflows/update-seed.yml
@@ -271,7 +271,7 @@ jobs:
           echo "${{ matrix.generator-name }}-changes=${{ steps.get-generator-changes.outputs.any_changed }}" >> $GITHUB_OUTPUT
 
   get-all-test-matrices:
-    runs-on: Seed
+    runs-on: ubuntu-latest
     timeout-minutes: 10
     needs: [setup]
     outputs:
@@ -333,7 +333,7 @@ jobs:
           done
 
   ruby-sdk-v2-seed-update:
-    runs-on: ubuntu-latest
+    runs-on: Seed
     timeout-minutes: 60
     needs: [changes, setup, get-all-test-matrices]
     if: >-
@@ -369,7 +369,7 @@ jobs:
           dockerhub-token: ${{ secrets.DOCKER_PASSWORD_PUBLIC_READONLY }}
 
   pydantic-seed-update:
-    runs-on: ubuntu-latest
+    runs-on: Seed
     timeout-minutes: 60
     needs: [changes, setup, get-all-test-matrices]
     if: >-
@@ -513,7 +513,7 @@ jobs:
           dockerhub-token: ${{ secrets.DOCKER_PASSWORD_PUBLIC_READONLY }}
 
   java-model-seed-update:
-    runs-on: ubuntu-latest
+    runs-on: Seed
     timeout-minutes: 60
     needs: [changes, setup, get-all-test-matrices]
     if: >-
@@ -549,7 +549,7 @@ jobs:
           dockerhub-token: ${{ secrets.DOCKER_PASSWORD_PUBLIC_READONLY }}
 
   typescript-sdk-seed-update:
-    runs-on: ubuntu-latest
+    runs-on: Seed
     timeout-minutes: 60
     needs: [changes, setup, get-all-test-matrices]
     if: >-
@@ -585,7 +585,7 @@ jobs:
           dockerhub-token: ${{ secrets.DOCKER_PASSWORD_PUBLIC_READONLY }}
 
   go-model-seed-update:
-    runs-on: ubuntu-latest
+    runs-on: Seed
     timeout-minutes: 60
     needs: [changes, setup, get-all-test-matrices]
     if: >-
@@ -621,7 +621,7 @@ jobs:
           dockerhub-token: ${{ secrets.DOCKER_PASSWORD_PUBLIC_READONLY }}
 
   go-sdk-seed-update:
-    runs-on: ubuntu-latest
+    runs-on: Seed
     timeout-minutes: 60
     needs: [changes, setup, get-all-test-matrices]
     if: >-
@@ -657,7 +657,7 @@ jobs:
           dockerhub-token: ${{ secrets.DOCKER_PASSWORD_PUBLIC_READONLY }}
 
   csharp-model-seed-update:
-    runs-on: ubuntu-latest
+    runs-on: Seed
     timeout-minutes: 60
     needs: [changes, setup, get-all-test-matrices]
     if: >-
@@ -693,7 +693,7 @@ jobs:
           dockerhub-token: ${{ secrets.DOCKER_PASSWORD_PUBLIC_READONLY }}
 
   csharp-sdk-seed-update:
-    runs-on: ubuntu-latest
+    runs-on: Seed
     timeout-minutes: 60
     needs: [changes, setup, get-all-test-matrices]
     if: >-
@@ -729,7 +729,7 @@ jobs:
           dockerhub-token: ${{ secrets.DOCKER_PASSWORD_PUBLIC_READONLY }}
 
   php-model-seed-update:
-    runs-on: ubuntu-latest
+    runs-on: Seed
     timeout-minutes: 60
     needs: [changes, setup, get-all-test-matrices]
     if: >-
@@ -765,7 +765,7 @@ jobs:
           dockerhub-token: ${{ secrets.DOCKER_PASSWORD_PUBLIC_READONLY }}
 
   php-sdk-seed-update:
-    runs-on: ubuntu-latest
+    runs-on: Seed
     timeout-minutes: 60
     needs: [changes, setup, get-all-test-matrices]
     if: >-
@@ -801,7 +801,7 @@ jobs:
           dockerhub-token: ${{ secrets.DOCKER_PASSWORD_PUBLIC_READONLY }}
 
   swift-sdk-seed-update:
-    runs-on: ubuntu-latest
+    runs-on: Seed
     timeout-minutes: 60
     needs: [changes, setup, get-all-test-matrices]
     if: >-
@@ -837,7 +837,7 @@ jobs:
           dockerhub-token: ${{ secrets.DOCKER_PASSWORD_PUBLIC_READONLY }}
 
   rust-model-seed-update:
-    runs-on: ubuntu-latest
+    runs-on: Seed
     timeout-minutes: 60
     needs: [changes, setup, get-all-test-matrices]
     if: >-
@@ -873,7 +873,7 @@ jobs:
           dockerhub-token: ${{ secrets.DOCKER_PASSWORD_PUBLIC_READONLY }}
 
   rust-sdk-seed-update:
-    runs-on: ubuntu-latest
+    runs-on: Seed
     timeout-minutes: 60
     needs: [changes, setup, get-all-test-matrices]
     if: >-

--- a/.github/workflows/update-seed.yml
+++ b/.github/workflows/update-seed.yml
@@ -333,7 +333,7 @@ jobs:
           done
 
   ruby-sdk-v2-seed-update:
-    runs-on: Seed
+    runs-on: ubuntu-latest
     timeout-minutes: 60
     needs: [changes, setup, get-all-test-matrices]
     if: >-
@@ -369,7 +369,7 @@ jobs:
           dockerhub-token: ${{ secrets.DOCKER_PASSWORD_PUBLIC_READONLY }}
 
   pydantic-seed-update:
-    runs-on: Seed
+    runs-on: ubuntu-latest
     timeout-minutes: 60
     needs: [changes, setup, get-all-test-matrices]
     if: >-
@@ -405,7 +405,7 @@ jobs:
           dockerhub-token: ${{ secrets.DOCKER_PASSWORD_PUBLIC_READONLY }}
 
   python-sdk-seed-update:
-    runs-on: Seed
+    runs-on: ubuntu-latest
     timeout-minutes: 60
     needs: [changes, setup, get-all-test-matrices]
     if: >-
@@ -477,7 +477,7 @@ jobs:
           dockerhub-token: ${{ secrets.DOCKER_PASSWORD_PUBLIC_READONLY }}
 
   java-sdk-seed-update:
-    runs-on: Seed
+    runs-on: ubuntu-latest
     timeout-minutes: 60
     needs: [changes, setup, get-all-test-matrices]
     if: >-
@@ -513,7 +513,7 @@ jobs:
           dockerhub-token: ${{ secrets.DOCKER_PASSWORD_PUBLIC_READONLY }}
 
   java-model-seed-update:
-    runs-on: Seed
+    runs-on: ubuntu-latest
     timeout-minutes: 60
     needs: [changes, setup, get-all-test-matrices]
     if: >-
@@ -549,7 +549,7 @@ jobs:
           dockerhub-token: ${{ secrets.DOCKER_PASSWORD_PUBLIC_READONLY }}
 
   typescript-sdk-seed-update:
-    runs-on: Seed
+    runs-on: ubuntu-latest
     timeout-minutes: 60
     needs: [changes, setup, get-all-test-matrices]
     if: >-
@@ -585,7 +585,7 @@ jobs:
           dockerhub-token: ${{ secrets.DOCKER_PASSWORD_PUBLIC_READONLY }}
 
   go-model-seed-update:
-    runs-on: Seed
+    runs-on: ubuntu-latest
     timeout-minutes: 60
     needs: [changes, setup, get-all-test-matrices]
     if: >-
@@ -621,7 +621,7 @@ jobs:
           dockerhub-token: ${{ secrets.DOCKER_PASSWORD_PUBLIC_READONLY }}
 
   go-sdk-seed-update:
-    runs-on: Seed
+    runs-on: ubuntu-latest
     timeout-minutes: 60
     needs: [changes, setup, get-all-test-matrices]
     if: >-
@@ -657,7 +657,7 @@ jobs:
           dockerhub-token: ${{ secrets.DOCKER_PASSWORD_PUBLIC_READONLY }}
 
   csharp-model-seed-update:
-    runs-on: Seed
+    runs-on: ubuntu-latest
     timeout-minutes: 60
     needs: [changes, setup, get-all-test-matrices]
     if: >-
@@ -693,7 +693,7 @@ jobs:
           dockerhub-token: ${{ secrets.DOCKER_PASSWORD_PUBLIC_READONLY }}
 
   csharp-sdk-seed-update:
-    runs-on: Seed
+    runs-on: ubuntu-latest
     timeout-minutes: 60
     needs: [changes, setup, get-all-test-matrices]
     if: >-
@@ -729,7 +729,7 @@ jobs:
           dockerhub-token: ${{ secrets.DOCKER_PASSWORD_PUBLIC_READONLY }}
 
   php-model-seed-update:
-    runs-on: Seed
+    runs-on: ubuntu-latest
     timeout-minutes: 60
     needs: [changes, setup, get-all-test-matrices]
     if: >-
@@ -765,7 +765,7 @@ jobs:
           dockerhub-token: ${{ secrets.DOCKER_PASSWORD_PUBLIC_READONLY }}
 
   php-sdk-seed-update:
-    runs-on: Seed
+    runs-on: ubuntu-latest
     timeout-minutes: 60
     needs: [changes, setup, get-all-test-matrices]
     if: >-
@@ -801,7 +801,7 @@ jobs:
           dockerhub-token: ${{ secrets.DOCKER_PASSWORD_PUBLIC_READONLY }}
 
   swift-sdk-seed-update:
-    runs-on: Seed
+    runs-on: ubuntu-latest
     timeout-minutes: 60
     needs: [changes, setup, get-all-test-matrices]
     if: >-
@@ -837,7 +837,7 @@ jobs:
           dockerhub-token: ${{ secrets.DOCKER_PASSWORD_PUBLIC_READONLY }}
 
   rust-model-seed-update:
-    runs-on: Seed
+    runs-on: ubuntu-latest
     timeout-minutes: 60
     needs: [changes, setup, get-all-test-matrices]
     if: >-
@@ -873,7 +873,7 @@ jobs:
           dockerhub-token: ${{ secrets.DOCKER_PASSWORD_PUBLIC_READONLY }}
 
   rust-sdk-seed-update:
-    runs-on: Seed
+    runs-on: ubuntu-latest
     timeout-minutes: 60
     needs: [changes, setup, get-all-test-matrices]
     if: >-


### PR DESCRIPTION
## Summary
- Moves compute-heavy seed test and seed update jobs to self-hosted `Seed` runners across `seed.yml` and `update-seed.yml` (ruby, pydantic, python, java, typescript, go, csharp, php, swift, rust, benchmark, docs-benchmark)
- Moves lightweight jobs to `ubuntu-latest`: grype java SDK scan (`security-scanning-and-remediation.yml`), compile-and-build (`test-remote-vs-local-generation-parity.yml`), get-all-test-matrices (`update-seed.yml`)

## Test plan
- [x] Verify seed test jobs run successfully on `Seed` runners
- [x] Verify lightweight jobs run on `ubuntu-latest`
- [x] Check no jobs are stuck waiting for runner availability

🤖 Generated with [Claude Code](https://claude.com/claude-code)