### PR TITLE
chore(ci): disable unsupported model generators

### DIFF
--- a/.github/workflows/publish-generator-csharp-model.yml
+++ b/.github/workflows/publish-generator-csharp-model.yml
@@ -23,6 +23,7 @@ env:
 
 jobs:
   publish:
+    if: false # generator not actively supported
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo at current ref

--- a/.github/workflows/publish-generator-go-model.yml
+++ b/.github/workflows/publish-generator-go-model.yml
@@ -23,6 +23,7 @@ env:
 
 jobs:
   publish:
+    if: false # generator not actively supported
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo at current ref

--- a/.github/workflows/publish-generator-java-model.yml
+++ b/.github/workflows/publish-generator-java-model.yml
@@ -23,6 +23,7 @@ env:
 
 jobs:
   publish:
+    if: false # generator not actively supported
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo at current ref

--- a/.github/workflows/publish-generator-php-model.yml
+++ b/.github/workflows/publish-generator-php-model.yml
@@ -23,6 +23,7 @@ env:
 
 jobs:
   publish:
+    if: false # generator not actively supported
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo at current ref

--- a/.github/workflows/publish-generator-python-pydantic.yml
+++ b/.github/workflows/publish-generator-python-pydantic.yml
@@ -23,6 +23,7 @@ env:
 
 jobs:
   publish:
+    if: false # generator not actively supported
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo at current ref

--- a/.github/workflows/publish-generator-rust-model.yml
+++ b/.github/workflows/publish-generator-rust-model.yml
@@ -23,6 +23,7 @@ env:
 
 jobs:
   publish:
+    if: false # generator not actively supported
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo at current ref

--- a/.github/workflows/seed-pr-comment.yml
+++ b/.github/workflows/seed-pr-comment.yml
@@ -112,38 +112,66 @@ jobs:
 
             // Language to generators mapping
             const languageMap = {
-              'Python': ['python-sdk', 'pydantic', 'pydantic-v2'],
+              'Python': ['python-sdk'],
               'TypeScript': ['ts-sdk'],
-              'Java': ['java-sdk', 'java-model'],
-              'Go': ['go-sdk', 'go-model'],
+              'Java': ['java-sdk'],
+              'Go': ['go-sdk'],
               'Ruby': ['ruby-sdk-v2'],
-              'C#': ['csharp-sdk', 'csharp-model'],
-              'PHP': ['php-sdk', 'php-model'],
+              'C#': ['csharp-sdk'],
+              'PHP': ['php-sdk'],
               'Swift': ['swift-sdk'],
-              'Rust': ['rust-sdk', 'rust-model'],
+              'Rust': ['rust-sdk'],
               'OpenAPI': ['openapi'],
             };
 
             // Generator to path mapping
             const generatorPathMap = {
               'python-sdk': 'generators/python',
-              'pydantic': 'generators/python',
-              'pydantic-v2': 'generators/python-v2',
               'ts-sdk': 'generators/typescript',
               'java-sdk': 'generators/java',
-              'java-model': 'generators/java',
               'go-sdk': 'generators/go',
-              'go-model': 'generators/go',
               'ruby-sdk-v2': 'generators/ruby-v2',
               'csharp-sdk': 'generators/csharp',
-              'csharp-model': 'generators/csharp',
               'php-sdk': 'generators/php',
-              'php-model': 'generators/php',
               'swift-sdk': 'generators/swift',
               'rust-sdk': 'generators/rust',
-              'rust-model': 'generators/rust',
               'openapi': 'generators/openapi',
             };
+
+            // // Language to generators mapping
+            // const languageMap = {
+            //   'Python': ['python-sdk', 'pydantic', 'pydantic-v2'],
+            //   'TypeScript': ['ts-sdk'],
+            //   'Java': ['java-sdk', 'java-model'],
+            //   'Go': ['go-sdk', 'go-model'],
+            //   'Ruby': ['ruby-sdk-v2'],
+            //   'C#': ['csharp-sdk', 'csharp-model'],
+            //   'PHP': ['php-sdk', 'php-model'],
+            //   'Swift': ['swift-sdk'],
+            //   'Rust': ['rust-sdk', 'rust-model'],
+            //   'OpenAPI': ['openapi'],
+            // };
+            // 
+            // // Generator to path mapping
+            // const generatorPathMap = {
+            //   'python-sdk': 'generators/python',
+            //   'pydantic': 'generators/python',
+            //   'pydantic-v2': 'generators/python-v2',
+            //   'ts-sdk': 'generators/typescript',
+            //   'java-sdk': 'generators/java',
+            //   'java-model': 'generators/java',
+            //   'go-sdk': 'generators/go',
+            //   'go-model': 'generators/go',
+            //   'ruby-sdk-v2': 'generators/ruby-v2',
+            //   'csharp-sdk': 'generators/csharp',
+            //   'csharp-model': 'generators/csharp',
+            //   'php-sdk': 'generators/php',
+            //   'php-model': 'generators/php',
+            //   'swift-sdk': 'generators/swift',
+            //   'rust-sdk': 'generators/rust',
+            //   'rust-model': 'generators/rust',
+            //   'openapi': 'generators/openapi',
+            // };
 
             // Parse checked languages
             const lines = commentBody.split('\n');

--- a/.github/workflows/seed.yml
+++ b/.github/workflows/seed.yml
@@ -360,11 +360,12 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     needs: [setup, get-all-test-matrices]
-    if: >-
-      ${{
-        (needs.get-all-test-matrices.outputs.pydantic != ''
-        && github.event.pull_request.draft == false) || github.event_name == 'workflow_dispatch'
-      }}
+    # if: >-
+    #   ${{
+    #     (needs.get-all-test-matrices.outputs.pydantic != ''
+    #     && github.event.pull_request.draft == false) || github.event_name == 'workflow_dispatch'
+    #   }}
+    if: false # generator not actively supported
     strategy:
       fail-fast: false # Let all tests run, even if some fail
       max-parallel: 15 # Limit the number of runners for this job
@@ -489,11 +490,12 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     needs: [setup, get-all-test-matrices]
-    if: >-
-      ${{
-        (needs.get-all-test-matrices.outputs.java-model != ''
-        && github.event.pull_request.draft == false) || github.event_name == 'workflow_dispatch'
-      }}
+    # if: >-
+    #   ${{
+    #     (needs.get-all-test-matrices.outputs.java-model != ''
+    #     && github.event.pull_request.draft == false) || github.event_name == 'workflow_dispatch'
+    #   }}
+    if: false # generator not actively supported
     strategy:
       fail-fast: false # Let all tests run, even if some fail
       max-parallel: 15 # Limit the number of runners for this job
@@ -554,11 +556,12 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     needs: [setup, get-all-test-matrices]
-    if: >-
-      ${{
-        (needs.get-all-test-matrices.outputs.go-model != ''
-        && github.event.pull_request.draft == false) || github.event_name == 'workflow_dispatch'
-      }}
+    # if: >-
+    #   ${{
+    #     (needs.get-all-test-matrices.outputs.go-model != ''
+    #     && github.event.pull_request.draft == false) || github.event_name == 'workflow_dispatch'
+    #   }}
+    if: false # generator not actively supported
     strategy:
       fail-fast: false # Let all tests run, even if some fail
       max-parallel: 15 # Limit the number of runners for this job
@@ -618,11 +621,12 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     needs: [setup, get-all-test-matrices]
-    if: >-
-      ${{
-        (needs.get-all-test-matrices.outputs.csharp-model != ''
-        && github.event.pull_request.draft == false) || github.event_name == 'workflow_dispatch'
-      }}
+    # if: >-
+    #   ${{
+    #     (needs.get-all-test-matrices.outputs.csharp-model != ''
+    #     && github.event.pull_request.draft == false) || github.event_name == 'workflow_dispatch'
+    #   }}
+    if: false # generator not actively supported
     strategy:
       fail-fast: false # Let all tests run, even if some fail
       max-parallel: 15 # Limit the number of runners for this job
@@ -682,11 +686,12 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     needs: [setup, get-all-test-matrices]
-    if: >-
-      ${{
-        (needs.get-all-test-matrices.outputs.php-model != ''
-        && github.event.pull_request.draft == false) || github.event_name == 'workflow_dispatch'
-      }}
+    # if: >-
+    #   ${{
+    #     (needs.get-all-test-matrices.outputs.php-model != ''
+    #     && github.event.pull_request.draft == false) || github.event_name == 'workflow_dispatch'
+    #   }}
+    if: false # generator not actively supported
     strategy:
       fail-fast: false # Let all tests run, even if some fail
       max-parallel: 15 # Limit the number of runners for this job
@@ -778,11 +783,12 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     needs: [setup, get-all-test-matrices]
-    if: >-
-      ${{
-        (needs.get-all-test-matrices.outputs.rust-model != ''
-        && github.event.pull_request.draft == false) || github.event_name == 'workflow_dispatch'
-      }}
+    # if: >-
+    #   ${{
+    #     (needs.get-all-test-matrices.outputs.rust-model != ''
+    #     && github.event.pull_request.draft == false) || github.event_name == 'workflow_dispatch'
+    #   }}
+    if: false # generator not actively supported
     strategy:
       fail-fast: false # Let all tests run, even if some fail
       max-parallel: 15 # Limit the number of runners for this job

--- a/.github/workflows/update-seed.yml
+++ b/.github/workflows/update-seed.yml
@@ -372,13 +372,14 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 60
     needs: [changes, setup, get-all-test-matrices]
-    if: >-
-      ${{ 
-        always() && !cancelled() &&
-        (needs.setup.outputs.selected-language == 'all' || needs.setup.outputs.selected-language == 'python') &&
-        (github.event_name == 'workflow_dispatch' || needs.changes.outputs.python == 'true' || needs.changes.outputs.seed == 'true') &&
-        needs.get-all-test-matrices.outputs.pydantic != ''
-      }}
+    # if: >-
+    #   ${{ 
+    #     always() && !cancelled() &&
+    #     (needs.setup.outputs.selected-language == 'all' || needs.setup.outputs.selected-language == 'python') &&
+    #     (github.event_name == 'workflow_dispatch' || needs.changes.outputs.python == 'true' || needs.changes.outputs.seed == 'true') &&
+    #     needs.get-all-test-matrices.outputs.pydantic != ''
+    #   }}
+    if: false # generator not actively supported
     strategy:
       fail-fast: false # Let all tests run for debug, won't end up applying changes with a failure
       max-parallel: 15 # Limit the number of runners for this job
@@ -516,13 +517,14 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 60
     needs: [changes, setup, get-all-test-matrices]
-    if: >-
-      ${{ 
-        always() && !cancelled() &&
-        (needs.setup.outputs.selected-language == 'all' || needs.setup.outputs.selected-language == 'java') &&
-        (github.event_name == 'workflow_dispatch' || needs.changes.outputs.java == 'true' || needs.changes.outputs.seed == 'true') &&
-        needs.get-all-test-matrices.outputs.java-model != ''
-      }}
+    # if: >-
+    #   ${{ 
+    #     always() && !cancelled() &&
+    #     (needs.setup.outputs.selected-language == 'all' || needs.setup.outputs.selected-language == 'java') &&
+    #     (github.event_name == 'workflow_dispatch' || needs.changes.outputs.java == 'true' || needs.changes.outputs.seed == 'true') &&
+    #     needs.get-all-test-matrices.outputs.java-model != ''
+    #   }}
+    if: false # generator not actively supported
     strategy:
       fail-fast: false # Let all tests run for debug, won't end up applying changes with a failure
       max-parallel: 15 # Limit the number of runners for this job
@@ -588,13 +590,14 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 60
     needs: [changes, setup, get-all-test-matrices]
-    if: >-
-      ${{ 
-        always() && !cancelled() &&
-        (needs.setup.outputs.selected-language == 'all' || needs.setup.outputs.selected-language == 'go') &&
-        (github.event_name == 'workflow_dispatch' || needs.changes.outputs.go == 'true' || needs.changes.outputs.seed == 'true') &&
-        needs.get-all-test-matrices.outputs.go-model != ''
-      }}
+    # if: >-
+    #   ${{ 
+    #     always() && !cancelled() &&
+    #     (needs.setup.outputs.selected-language == 'all' || needs.setup.outputs.selected-language == 'go') &&
+    #     (github.event_name == 'workflow_dispatch' || needs.changes.outputs.go == 'true' || needs.changes.outputs.seed == 'true') &&
+    #     needs.get-all-test-matrices.outputs.go-model != ''
+    #   }}
+    if: false # generator not actively supported
     strategy:
       fail-fast: false # Let all tests run for debug, won't end up applying changes with a failure
       max-parallel: 15 # Limit the number of runners for this job
@@ -660,13 +663,14 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 60
     needs: [changes, setup, get-all-test-matrices]
-    if: >-
-      ${{ 
-        always() && !cancelled() &&
-        (needs.setup.outputs.selected-language == 'all' || needs.setup.outputs.selected-language == 'csharp') &&
-        (github.event_name == 'workflow_dispatch' || needs.changes.outputs.csharp == 'true' || needs.changes.outputs.seed == 'true') &&
-        needs.get-all-test-matrices.outputs.csharp-model != ''
-      }}
+    # if: >-
+    #   ${{ 
+    #     always() && !cancelled() &&
+    #     (needs.setup.outputs.selected-language == 'all' || needs.setup.outputs.selected-language == 'csharp') &&
+    #     (github.event_name == 'workflow_dispatch' || needs.changes.outputs.csharp == 'true' || needs.changes.outputs.seed == 'true') &&
+    #     needs.get-all-test-matrices.outputs.csharp-model != ''
+    #   }}
+    if: false # generator not actively supported
     strategy:
       fail-fast: false # Let all tests run for debug, won't end up applying changes with a failure
       max-parallel: 15 # Limit the number of runners for this job
@@ -732,13 +736,14 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 60
     needs: [changes, setup, get-all-test-matrices]
-    if: >-
-      ${{ 
-        always() && !cancelled() &&
-        (needs.setup.outputs.selected-language == 'all' || needs.setup.outputs.selected-language == 'php') &&
-        (github.event_name == 'workflow_dispatch' || needs.changes.outputs.php == 'true' || needs.changes.outputs.seed == 'true') &&
-        needs.get-all-test-matrices.outputs.php-model != ''
-      }}
+    # if: >-
+    #   ${{ 
+    #     always() && !cancelled() &&
+    #     (needs.setup.outputs.selected-language == 'all' || needs.setup.outputs.selected-language == 'php') &&
+    #     (github.event_name == 'workflow_dispatch' || needs.changes.outputs.php == 'true' || needs.changes.outputs.seed == 'true') &&
+    #     needs.get-all-test-matrices.outputs.php-model != ''
+    #   }}
+    if: false # generator not actively supported
     strategy:
       fail-fast: false # Let all tests run for debug, won't end up applying changes with a failure
       max-parallel: 15 # Limit the number of runners for this job
@@ -840,13 +845,14 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 60
     needs: [changes, setup, get-all-test-matrices]
-    if: >-
-      ${{ 
-        always() && !cancelled() &&
-        (needs.setup.outputs.selected-language == 'all' || needs.setup.outputs.selected-language == 'rust') &&
-        (github.event_name == 'workflow_dispatch' || needs.changes.outputs.rust == 'true' || needs.changes.outputs.seed == 'true') &&
-        needs.get-all-test-matrices.outputs.rust-model != ''
-      }}
+    # if: >-
+    #   ${{ 
+    #     always() && !cancelled() &&
+    #     (needs.setup.outputs.selected-language == 'all' || needs.setup.outputs.selected-language == 'rust') &&
+    #     (github.event_name == 'workflow_dispatch' || needs.changes.outputs.rust == 'true' || needs.changes.outputs.seed == 'true') &&
+    #     needs.get-all-test-matrices.outputs.rust-model != ''
+    #   }}
+    if: false # generator not actively supported
     strategy:
       fail-fast: false # Let all tests run for debug, won't end up applying changes with a failure
       max-parallel: 15 # Limit the number of runners for this job


### PR DESCRIPTION
## Summary
- Disable CI for unsupported model generators: `java-model`, `go-model`, `csharp-model`, `php-model`, `rust-model`, and `pydantic`
- Add `if: false` to seed test jobs in `seed.yml` and `update-seed.yml` (original conditions preserved as comments)
- Add `if: false` to publish workflows for all 6 generators
- Remove model generators from `seed-pr-comment.yml` language/generator mappings

These generators are not actively supported based on their `versions.yml` — they have few or no real releases and are lingering afterthoughts. Disabling rather than deleting so they can be re-enabled if needed.

## Test plan
- [x] Verify `seed.yml` workflow parses correctly (skipped jobs should show as "skipped" not "failed")
- [x] Verify `update-seed.yml` workflow parses correctly
- [x] Verify publish workflows are effectively disabled