### PR TITLE
fix(ci): correct docs rsync paths and drop stale ruby release entry

### DIFF
--- a/.github/workflows/release-software.yml
+++ b/.github/workflows/release-software.yml
@@ -12,7 +12,6 @@ on:
       - "generators/java/sdk/changes/**"
       - "generators/php/sdk/changes/**"
       - "generators/python/sdk/changes/**"
-      - "generators/ruby/sdk/changes/**"
       - "generators/ruby-v2/sdk/changes/**"
       - "generators/rust/sdk/changes/**"
       - "generators/swift/sdk/changes/**"
@@ -33,7 +32,6 @@ on:
           - java
           - php
           - python
-          - ruby
           - ruby-v2
           - rust
           - swift

--- a/.github/workflows/write-changelogs-to-docs.yml
+++ b/.github/workflows/write-changelogs-to-docs.yml
@@ -47,31 +47,31 @@ jobs:
           path: docs
 
       - name: update csharp-sdk changelog
-        run: rsync -av --delete "changelogs/csharp-sdk/" "docs/fern/products/sdks/overview/csharp/changelog"
+        run: rsync -av --delete "changelogs/csharp-sdk/" "docs/fern/products/sdks/generators/csharp/changelog"
 
       - name: update go-sdk changelog
-        run: rsync -av --delete "changelogs/go-sdk/" "docs/fern/products/sdks/overview/go/changelog"
+        run: rsync -av --delete "changelogs/go-sdk/" "docs/fern/products/sdks/generators/go/changelog"
 
       - name: update java-sdk changelog
-        run: rsync -av --delete "changelogs/java-sdk/" "docs/fern/products/sdks/overview/java/changelog"
+        run: rsync -av --delete "changelogs/java-sdk/" "docs/fern/products/sdks/generators/java/changelog"
 
       - name: update php-sdk changelog
-        run: rsync -av --delete "changelogs/php-sdk/" "docs/fern/products/sdks/overview/php/changelog"
+        run: rsync -av --delete "changelogs/php-sdk/" "docs/fern/products/sdks/generators/php/changelog"
 
       - name: update python-sdk changelog
-        run: rsync -av --delete "changelogs/python-sdk/" "docs/fern/products/sdks/overview/python/changelog"
+        run: rsync -av --delete "changelogs/python-sdk/" "docs/fern/products/sdks/generators/python/changelog"
 
       - name: update ruby-sdk changelog
-        run: rsync -av --delete "changelogs/ruby-sdk-v2/" "docs/fern/products/sdks/overview/ruby/changelog"
+        run: rsync -av --delete "changelogs/ruby-sdk-v2/" "docs/fern/products/sdks/generators/ruby/changelog"
 
       - name: update ts-sdk changelog
-        run: rsync -av --delete "changelogs/ts-sdk/" "docs/fern/products/sdks/overview/typescript/changelog"
+        run: rsync -av --delete "changelogs/ts-sdk/" "docs/fern/products/sdks/generators/typescript/changelog"
 
       - name: update rust-sdk changelog
-        run: rsync -av --delete "changelogs/rust-sdk/" "docs/fern/products/sdks/overview/rust/changelog"
+        run: rsync -av --delete "changelogs/rust-sdk/" "docs/fern/products/sdks/generators/rust/changelog"
 
       - name: update swift-sdk changelog
-        run: rsync -av --delete "changelogs/swift-sdk/" "docs/fern/products/sdks/overview/swift/changelog"
+        run: rsync -av --delete "changelogs/swift-sdk/" "docs/fern/products/sdks/generators/swift/changelog"
 
       - name: update cli changelog
         run: rsync -av --delete "changelogs/cli/" "docs/fern/products/cli-api-reference/cli-changelog"

--- a/release-config.json
+++ b/release-config.json
@@ -37,12 +37,6 @@
       "changelogFolder": "generators/python/sdk/changes",
       "softwareDirectory": "generators/python"
     },
-    "ruby": {
-      "name": "Ruby SDK Generator",
-      "versionsFile": "generators/ruby/sdk/versions.yml",
-      "changelogFolder": "generators/ruby/sdk/changes",
-      "softwareDirectory": "generators/ruby"
-    },
     "ruby-v2": {
       "name": "Ruby v2 SDK Generator",
       "versionsFile": "generators/ruby-v2/sdk/versions.yml",


### PR DESCRIPTION
## Description
Two unrelated CI workflows have been failing on every push to `main`:

1. **Write Changelogs to Docs** — failing with `rsync: mkdir ".../docs/fern/products/sdks/overview/<lang>/changelog" failed: No such file or directory`. The `fern-api/docs` repo was restructured so SDK changelogs now live under `fern/products/sdks/generators/<lang>/changelog` (confirmed via the GitHub contents API for all 9 languages). The workflow was still pointing at the old `overview/` path.
2. **Release Software** — failing with `ENOENT: no such file or directory, open '.../generators/ruby/sdk/versions.yml'`. The v1 Ruby SDK generator was migrated to `ruby-v2`, so `generators/ruby/sdk/versions.yml` no longer exists, but `release-config.json` still had a `"ruby"` entry pointing at it.

## Changes Made
- Update all 9 per-language rsync destinations in `.github/workflows/write-changelogs-to-docs.yml` from `docs/fern/products/sdks/overview/<lang>/changelog` → `docs/fern/products/sdks/generators/<lang>/changelog`. The `ruby-sdk` step still sources from `changelogs/ruby-sdk-v2/` (unchanged) and targets `generators/ruby/changelog` in the docs repo. The `cli` changelog path is unchanged.
- Remove the `"ruby"` entry from `release-config.json`. `"ruby-v2"` remains and continues to produce Ruby releases.

## Testing
- Verified all 9 target directories exist in `fern-api/docs` on `main` via the GH contents API (csharp, go, java, php, python, ruby, typescript, rust, swift).
- Verified `generators/ruby/sdk/` in this repo no longer contains `versions.yml` (only `changes/`), confirming the v1 Ruby release path is dead.
- No unit tests cover these workflow/config files; validation will come from the next push to `main` successfully running both workflows.

## Review checklist
- [ ] Confirm `fern/products/sdks/generators/<lang>/changelog` is the intended final home for these changelogs in `fern-api/docs` (i.e., no further restructuring planned).
- [ ] Confirm dropping the `"ruby"` software entry is the desired fix (vs. pointing it at a new location or keeping it as a no-op). Nothing else in the repo is expected to key on `software.ruby`, but worth a sanity check.

Link to Devin session: https://app.devin.ai/sessions/670ef276e18545f5a871dcc8a21bbdf5
Requested by: @Swimburger
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/15098" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
