### PR TITLE
fix(ci): fix Octokit response destructuring in seed PR comment workflow

### DIFF
--- a/.github/workflows/seed-pr-comment.yml
+++ b/.github/workflows/seed-pr-comment.yml
@@ -179,10 +179,10 @@ jobs:
             core.setOutput('generator-path-map', JSON.stringify(generatorPathMap));
             core.setOutput('comment-id', commentId);
             core.setOutput('pr-number', prNumber);
-            core.setOutput('pr-ref', pr.data.head.ref);
-            core.setOutput('pr-sha', pr.data.head.sha);
-            core.setOutput('pr-repo-full-name', pr.data.head.repo.full_name);
-            core.setOutput('base-repo-full-name', pr.data.base.repo.full_name);
+            core.setOutput('pr-ref', pr.head.ref);
+            core.setOutput('pr-sha', pr.head.sha);
+            core.setOutput('pr-repo-full-name', pr.head.repo.full_name);
+            core.setOutput('base-repo-full-name', pr.base.repo.full_name);
 
       - name: Check if we can push to PR branch
         id: check-push


### PR DESCRIPTION
## Summary
- Fix `TypeError` in the seed PR comment workflow caused by incorrect Octokit response destructuring
- `const { data: pr }` means `pr` is already the response body, so `pr.data.head.ref` is `undefined.head.ref` which crashes
- Changed to `pr.head.ref`, `pr.head.sha`, `pr.head.repo.full_name`, and `pr.base.repo.full_name`

## Test plan
- [x] Verified against real GitHub API: `pr.data` is `undefined`, `pr.head.ref` returns the correct branch name