### PR TITLE
fix(ci): revert seed jobs from ubuntu-latest-16-cores to ubuntu-latest

### DIFF
--- a/.github/workflows/seed.yml
+++ b/.github/workflows/seed.yml
@@ -324,7 +324,7 @@ jobs:
           fi
 
   ruby-sdk-v2:
-    runs-on: ubuntu-latest-16-cores
+    runs-on: ubuntu-latest
     timeout-minutes: 20
     needs: [setup, get-all-test-matrices]
     if: >-
@@ -357,7 +357,7 @@ jobs:
           dockerhub-token: ${{ secrets.DOCKER_PASSWORD_PUBLIC_READONLY }}
 
   pydantic:
-    runs-on: ubuntu-latest-16-cores
+    runs-on: ubuntu-latest
     timeout-minutes: 15
     needs: [setup, get-all-test-matrices]
     # if: >-
@@ -390,7 +390,7 @@ jobs:
           dockerhub-token: ${{ secrets.DOCKER_PASSWORD_PUBLIC_READONLY }}
 
   python-sdk:
-    runs-on: ubuntu-latest-16-cores
+    runs-on: ubuntu-latest
     timeout-minutes: 30
     needs: [setup, get-all-test-matrices]
     if: >-
@@ -455,7 +455,7 @@ jobs:
           dockerhub-token: ${{ secrets.DOCKER_PASSWORD_PUBLIC_READONLY }}
 
   java-sdk:
-    runs-on: ubuntu-latest-16-cores
+    runs-on: ubuntu-latest
     timeout-minutes: 30
     needs: [setup, get-all-test-matrices]
     if: >-
@@ -487,7 +487,7 @@ jobs:
           dockerhub-token: ${{ secrets.DOCKER_PASSWORD_PUBLIC_READONLY }}
 
   java-model:
-    runs-on: ubuntu-latest-16-cores
+    runs-on: ubuntu-latest
     timeout-minutes: 15
     needs: [setup, get-all-test-matrices]
     # if: >-
@@ -520,7 +520,7 @@ jobs:
           dockerhub-token: ${{ secrets.DOCKER_PASSWORD_PUBLIC_READONLY }}
 
   ts-sdk:
-    runs-on: ubuntu-latest-16-cores
+    runs-on: ubuntu-latest
     timeout-minutes: 15
     needs: [setup, get-all-test-matrices]
     if: >-
@@ -553,7 +553,7 @@ jobs:
           dockerhub-token: ${{ secrets.DOCKER_PASSWORD_PUBLIC_READONLY }}
 
   go-model:
-    runs-on: ubuntu-latest-16-cores
+    runs-on: ubuntu-latest
     timeout-minutes: 20
     needs: [setup, get-all-test-matrices]
     # if: >-
@@ -586,7 +586,7 @@ jobs:
           dockerhub-token: ${{ secrets.DOCKER_PASSWORD_PUBLIC_READONLY }}
 
   go-sdk:
-    runs-on: ubuntu-latest-16-cores
+    runs-on: ubuntu-latest
     timeout-minutes: 20
     needs: [setup, get-all-test-matrices]
     if: >-
@@ -618,7 +618,7 @@ jobs:
           dockerhub-token: ${{ secrets.DOCKER_PASSWORD_PUBLIC_READONLY }}
 
   csharp-model:
-    runs-on: ubuntu-latest-16-cores
+    runs-on: ubuntu-latest
     timeout-minutes: 15
     needs: [setup, get-all-test-matrices]
     # if: >-
@@ -651,7 +651,7 @@ jobs:
           dockerhub-token: ${{ secrets.DOCKER_PASSWORD_PUBLIC_READONLY }}
 
   csharp-sdk:
-    runs-on: ubuntu-latest-16-cores
+    runs-on: ubuntu-latest
     timeout-minutes: 20
     needs: [setup, get-all-test-matrices]
     if: >-
@@ -683,7 +683,7 @@ jobs:
           dockerhub-token: ${{ secrets.DOCKER_PASSWORD_PUBLIC_READONLY }}
 
   php-model:
-    runs-on: ubuntu-latest-16-cores
+    runs-on: ubuntu-latest
     timeout-minutes: 15
     needs: [setup, get-all-test-matrices]
     # if: >-
@@ -716,7 +716,7 @@ jobs:
           dockerhub-token: ${{ secrets.DOCKER_PASSWORD_PUBLIC_READONLY }}
 
   php-sdk:
-    runs-on: ubuntu-latest-16-cores
+    runs-on: ubuntu-latest
     timeout-minutes: 15
     needs: [setup, get-all-test-matrices]
     if: >-
@@ -748,7 +748,7 @@ jobs:
           dockerhub-token: ${{ secrets.DOCKER_PASSWORD_PUBLIC_READONLY }}
 
   swift-sdk:
-    runs-on: ubuntu-latest-16-cores
+    runs-on: ubuntu-latest
     timeout-minutes: 15
     needs: [setup, get-all-test-matrices]
     if: >-
@@ -780,7 +780,7 @@ jobs:
           dockerhub-token: ${{ secrets.DOCKER_PASSWORD_PUBLIC_READONLY }}
 
   rust-model:
-    runs-on: ubuntu-latest-16-cores
+    runs-on: ubuntu-latest
     timeout-minutes: 15
     needs: [setup, get-all-test-matrices]
     # if: >-
@@ -813,7 +813,7 @@ jobs:
           dockerhub-token: ${{ secrets.DOCKER_PASSWORD_PUBLIC_READONLY }}
 
   rust-sdk:
-    runs-on: ubuntu-latest-16-cores
+    runs-on: ubuntu-latest
     timeout-minutes: 15
     needs: [setup, get-all-test-matrices]
     if: >-
@@ -879,7 +879,7 @@ jobs:
           retention-days: 1
 
   benchmark:
-    runs-on: ubuntu-latest-16-cores
+    runs-on: ubuntu-latest
     timeout-minutes: 60
     needs: [get-all-test-matrices, benchmark-setup]
     if: >-
@@ -1165,7 +1165,7 @@ jobs:
   # Runs the real `fern generate --docs --preview` command against the benchmark
   # fixture and measures wall-clock time, same philosophy as SDK benchmarks.
   docs-benchmark:
-    runs-on: ubuntu-latest-16-cores
+    runs-on: ubuntu-latest
     timeout-minutes: 45
     needs: [get-all-test-matrices, benchmark-setup]
     if: >-

--- a/.github/workflows/seed.yml
+++ b/.github/workflows/seed.yml
@@ -324,7 +324,7 @@ jobs:
           fi
 
   ruby-sdk-v2:
-    runs-on: ubuntu-latest
+    runs-on: Seed
     timeout-minutes: 20
     needs: [setup, get-all-test-matrices]
     if: >-
@@ -357,7 +357,7 @@ jobs:
           dockerhub-token: ${{ secrets.DOCKER_PASSWORD_PUBLIC_READONLY }}
 
   pydantic:
-    runs-on: ubuntu-latest
+    runs-on: Seed
     timeout-minutes: 15
     needs: [setup, get-all-test-matrices]
     # if: >-
@@ -390,7 +390,7 @@ jobs:
           dockerhub-token: ${{ secrets.DOCKER_PASSWORD_PUBLIC_READONLY }}
 
   python-sdk:
-    runs-on: ubuntu-latest
+    runs-on: Seed
     timeout-minutes: 30
     needs: [setup, get-all-test-matrices]
     if: >-
@@ -455,7 +455,7 @@ jobs:
           dockerhub-token: ${{ secrets.DOCKER_PASSWORD_PUBLIC_READONLY }}
 
   java-sdk:
-    runs-on: ubuntu-latest
+    runs-on: Seed
     timeout-minutes: 30
     needs: [setup, get-all-test-matrices]
     if: >-
@@ -487,7 +487,7 @@ jobs:
           dockerhub-token: ${{ secrets.DOCKER_PASSWORD_PUBLIC_READONLY }}
 
   java-model:
-    runs-on: ubuntu-latest
+    runs-on: Seed
     timeout-minutes: 15
     needs: [setup, get-all-test-matrices]
     # if: >-
@@ -520,7 +520,7 @@ jobs:
           dockerhub-token: ${{ secrets.DOCKER_PASSWORD_PUBLIC_READONLY }}
 
   ts-sdk:
-    runs-on: ubuntu-latest
+    runs-on: Seed
     timeout-minutes: 15
     needs: [setup, get-all-test-matrices]
     if: >-
@@ -553,7 +553,7 @@ jobs:
           dockerhub-token: ${{ secrets.DOCKER_PASSWORD_PUBLIC_READONLY }}
 
   go-model:
-    runs-on: ubuntu-latest
+    runs-on: Seed
     timeout-minutes: 20
     needs: [setup, get-all-test-matrices]
     # if: >-
@@ -586,7 +586,7 @@ jobs:
           dockerhub-token: ${{ secrets.DOCKER_PASSWORD_PUBLIC_READONLY }}
 
   go-sdk:
-    runs-on: ubuntu-latest
+    runs-on: Seed
     timeout-minutes: 20
     needs: [setup, get-all-test-matrices]
     if: >-
@@ -618,7 +618,7 @@ jobs:
           dockerhub-token: ${{ secrets.DOCKER_PASSWORD_PUBLIC_READONLY }}
 
   csharp-model:
-    runs-on: ubuntu-latest
+    runs-on: Seed
     timeout-minutes: 15
     needs: [setup, get-all-test-matrices]
     # if: >-
@@ -651,7 +651,7 @@ jobs:
           dockerhub-token: ${{ secrets.DOCKER_PASSWORD_PUBLIC_READONLY }}
 
   csharp-sdk:
-    runs-on: ubuntu-latest
+    runs-on: Seed
     timeout-minutes: 20
     needs: [setup, get-all-test-matrices]
     if: >-
@@ -683,7 +683,7 @@ jobs:
           dockerhub-token: ${{ secrets.DOCKER_PASSWORD_PUBLIC_READONLY }}
 
   php-model:
-    runs-on: ubuntu-latest
+    runs-on: Seed
     timeout-minutes: 15
     needs: [setup, get-all-test-matrices]
     # if: >-
@@ -716,7 +716,7 @@ jobs:
           dockerhub-token: ${{ secrets.DOCKER_PASSWORD_PUBLIC_READONLY }}
 
   php-sdk:
-    runs-on: ubuntu-latest
+    runs-on: Seed
     timeout-minutes: 15
     needs: [setup, get-all-test-matrices]
     if: >-
@@ -748,7 +748,7 @@ jobs:
           dockerhub-token: ${{ secrets.DOCKER_PASSWORD_PUBLIC_READONLY }}
 
   swift-sdk:
-    runs-on: ubuntu-latest
+    runs-on: Seed
     timeout-minutes: 15
     needs: [setup, get-all-test-matrices]
     if: >-
@@ -780,7 +780,7 @@ jobs:
           dockerhub-token: ${{ secrets.DOCKER_PASSWORD_PUBLIC_READONLY }}
 
   rust-model:
-    runs-on: ubuntu-latest
+    runs-on: Seed
     timeout-minutes: 15
     needs: [setup, get-all-test-matrices]
     # if: >-
@@ -813,7 +813,7 @@ jobs:
           dockerhub-token: ${{ secrets.DOCKER_PASSWORD_PUBLIC_READONLY }}
 
   rust-sdk:
-    runs-on: ubuntu-latest
+    runs-on: Seed
     timeout-minutes: 15
     needs: [setup, get-all-test-matrices]
     if: >-
@@ -879,7 +879,7 @@ jobs:
           retention-days: 1
 
   benchmark:
-    runs-on: ubuntu-latest
+    runs-on: Seed
     timeout-minutes: 60
     needs: [get-all-test-matrices, benchmark-setup]
     if: >-
@@ -1165,7 +1165,7 @@ jobs:
   # Runs the real `fern generate --docs --preview` command against the benchmark
   # fixture and measures wall-clock time, same philosophy as SDK benchmarks.
   docs-benchmark:
-    runs-on: ubuntu-latest
+    runs-on: Seed
     timeout-minutes: 45
     needs: [get-all-test-matrices, benchmark-setup]
     if: >-


### PR DESCRIPTION
## Description

Fixes seed test jobs that were queuing indefinitely waiting for a runner. PR #15096 changed 17 seed jobs in `.github/workflows/seed.yml` to `runs-on: ubuntu-latest-16-cores`, but that runner label is not provisioned in the fern-api org, so jobs sit in "Waiting for a runner to pick up this job..." forever (example: https://github.com/fern-api/fern/actions/runs/24531883451/job/71721802896?pr=15094).

This PR reverts those 17 jobs back to `ubuntu-latest` to restore seed CI.

## Changes Made

- Revert `runs-on: ubuntu-latest-16-cores` → `runs-on: ubuntu-latest` in `.github/workflows/seed.yml` for: `ruby-sdk-v2`, `pydantic`, `python-sdk`, `java-sdk`, `java-model`, `ts-sdk`, `go-model`, `go-sdk`, `csharp-model`, `csharp-sdk`, `php-model`, `php-sdk`, `swift-sdk`, `rust-model`, `rust-sdk`, `benchmark`, `docs-benchmark`.

## Reviewer checklist

- Confirm `ubuntu-latest-16-cores` is indeed not a valid/provisioned runner label in the org (vs. a transient capacity issue). If it is supposed to exist, the correct fix is to provision the runner rather than revert.
- If larger runners are still desired for these jobs, a follow-up should use a label that actually exists (e.g. `Seed`, or a properly-provisioned larger runner label).

## Testing

- [ ] Verify seed jobs start running on a PR after merge (no more "Waiting for a runner" hangs).

Link to Devin session: https://app.devin.ai/sessions/de7a0a5b4cf54d18a5b7ed53fe38a54b
Requested by: @Swimburger
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/15101" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
