### PR TITLE
feat(cli): add symlink patching progress bar and tune unzip timing

### DIFF
--- a/packages/cli/cli/changes/unreleased/fix-windows-turbopack-externals.yml
+++ b/packages/cli/cli/changes/unreleased/fix-windows-turbopack-externals.yml
@@ -1,0 +1,5 @@
+- summary: |
+    Fix Windows bundle extraction for turbopack-generated external modules
+    (e.g. qs-0df67fa3c19a2c11) by resolving symlinks in multiple passes and
+    following through NTFS junctions when determining target type.
+  type: fix

--- a/packages/cli/cli/changes/unreleased/fix-windows-turbopack-externals.yml
+++ b/packages/cli/cli/changes/unreleased/fix-windows-turbopack-externals.yml
@@ -1,5 +1,0 @@
-- summary: |
-    Fix Windows bundle extraction for turbopack-generated external modules
-    (e.g. qs-0df67fa3c19a2c11) by resolving symlinks in multiple passes and
-    following through NTFS junctions when determining target type.
-  type: fix

--- a/packages/cli/cli/changes/unreleased/real-progress-bars.yml
+++ b/packages/cli/cli/changes/unreleased/real-progress-bars.yml
@@ -1,0 +1,4 @@
+- summary: |
+    Replace fake time-based extraction progress bar with real file-count
+    tracking, and add a new progress bar for Windows symlink patching.
+  type: feat

--- a/packages/cli/docs-preview/src/downloadLocalDocsBundle.ts
+++ b/packages/cli/docs-preview/src/downloadLocalDocsBundle.ts
@@ -5,7 +5,7 @@ import chalk from "chalk";
 import { execSync } from "child_process";
 import cliProgress from "cli-progress";
 import decompress from "decompress";
-import { cpSync, existsSync, mkdirSync, statSync, symlinkSync } from "fs";
+import { cpSync, existsSync, lstatSync, mkdirSync, symlinkSync } from "fs";
 import { mkdir, readFile, rename, rm, writeFile } from "fs/promises";
 import { homedir } from "os";
 import path from "path";
@@ -115,102 +115,75 @@ function resolveWindowsSymlinks(
 
     const rootPnpmStore = path.join(outputDir, "standalone", "node_modules", ".pnpm");
 
-    // Multi-pass resolution: some symlinks (e.g. turbopack aliases like
-    // qs-0df67fa3c19a2c11 -> qs) depend on other symlinks (qs -> .pnpm/...).
-    // Retry unresolved entries until no more progress is made.
-    let pending = symlinks;
-    const MAX_PASSES = 5;
+    for (const { path: symlinkPath, linkname } of symlinks) {
+        const fullSymlinkPath = path.join(outputDir, symlinkPath);
 
-    for (let pass = 0; pass < MAX_PASSES && pending.length > 0; pass++) {
-        const stillPending: SymlinkEntry[] = [];
+        if (!isWithinOutputDir(fullSymlinkPath, outputDir)) {
+            logger.warn(`Skipping symlink with path outside outputDir: ${symlinkPath}`);
+            failed++;
+            continue;
+        }
 
-        for (const { path: symlinkPath, linkname } of pending) {
-            const fullSymlinkPath = path.join(outputDir, symlinkPath);
+        const symlinkDir = path.dirname(fullSymlinkPath);
+        const resolvedTarget = path.resolve(symlinkDir, linkname);
 
-            if (!isWithinOutputDir(fullSymlinkPath, outputDir)) {
-                logger.warn(`Skipping symlink with path outside outputDir: ${symlinkPath}`);
-                failed++;
-                continue;
-            }
+        if (existsSync(fullSymlinkPath)) {
+            alreadyExisted++;
+            continue;
+        }
 
-            const symlinkDir = path.dirname(fullSymlinkPath);
-            const resolvedTarget = path.resolve(symlinkDir, linkname);
+        let sourcePath = resolvedTarget;
+        let usedFallback = false;
 
-            if (existsSync(fullSymlinkPath)) {
-                alreadyExisted++;
-                continue;
-            }
-
-            let sourcePath = resolvedTarget;
-            let usedFallback = false;
-
-            // If direct target doesn't exist, try fallback in root .pnpm store
-            if (!existsSync(sourcePath) && existsSync(rootPnpmStore)) {
-                const parts = linkname.split("/");
-                const nmIdx = parts.lastIndexOf("node_modules");
-                if (nmIdx >= 0 && nmIdx > 0) {
-                    const pnpmDirName = parts[nmIdx - 1];
-                    const pkgRelPath = parts.slice(nmIdx + 1).join("/");
-                    if (pnpmDirName != null && pkgRelPath != null) {
-                        const fallback = path.join(rootPnpmStore, pnpmDirName, "node_modules", pkgRelPath);
-                        if (!isWithinOutputDir(fallback, outputDir)) {
-                            continue; // skip unsafe fallback
-                        }
-                        if (existsSync(fallback)) {
-                            sourcePath = fallback;
-                            usedFallback = true;
-                        }
+        // If direct target doesn't exist, try fallback in root .pnpm store
+        if (!existsSync(sourcePath) && existsSync(rootPnpmStore)) {
+            const parts = linkname.split("/");
+            const nmIdx = parts.lastIndexOf("node_modules");
+            if (nmIdx >= 0 && nmIdx > 0) {
+                const pnpmDirName = parts[nmIdx - 1];
+                const pkgRelPath = parts.slice(nmIdx + 1).join("/");
+                if (pnpmDirName != null && pkgRelPath != null) {
+                    const fallback = path.join(rootPnpmStore, pnpmDirName, "node_modules", pkgRelPath);
+                    if (!isWithinOutputDir(fallback, outputDir)) {
+                        continue; // skip unsafe fallback
+                    }
+                    if (existsSync(fallback)) {
+                        sourcePath = fallback;
+                        usedFallback = true;
                     }
                 }
             }
-
-            if (!isWithinOutputDir(sourcePath, outputDir)) {
-                logger.warn(`Skipping symlink whose target is outside outputDir: ${linkname}`);
-                failed++;
-                continue;
-            }
-
-            if (!existsSync(sourcePath)) {
-                // Target doesn't exist yet — may be resolved in a later pass
-                stillPending.push({ path: symlinkPath, linkname });
-                continue;
-            }
-
-            try {
-                mkdirSync(path.dirname(fullSymlinkPath), { recursive: true });
-                // Use statSync (follows symlinks/junctions) instead of lstatSync
-                // so that targets already resolved as junctions are correctly
-                // identified as directories.
-                const stat = statSync(sourcePath);
-                if (stat.isDirectory()) {
-                    symlinkSync(sourcePath, fullSymlinkPath, "junction");
-                    junctions++;
-                } else {
-                    cpSync(sourcePath, fullSymlinkPath);
-                    copies++;
-                }
-                if (usedFallback) {
-                    fallbackUsed++;
-                }
-            } catch (error) {
-                logger.debug(`Failed to resolve symlink ${symlinkPath}: ${error}`);
-                failed++;
-            }
-            onProgress?.(junctions + copies + alreadyExisted + failed, symlinks.length);
         }
 
-        if (stillPending.length === pending.length) {
-            // No progress — all remaining entries are unresolvable
-            failed += stillPending.length;
-            break;
+        if (!isWithinOutputDir(sourcePath, outputDir)) {
+            logger.warn(`Skipping symlink whose target is outside outputDir: ${linkname}`);
+            failed++;
+            continue;
         }
 
-        if (stillPending.length > 0) {
-            logger.debug(
-                `Pass ${pass + 1}: ${pending.length - stillPending.length} resolved, ${stillPending.length} deferred`
-            );
+        if (!existsSync(sourcePath)) {
+            failed++;
+            continue;
         }
-        pending = stillPending;
+
+        try {
+            mkdirSync(path.dirname(fullSymlinkPath), { recursive: true });
+            const stat = lstatSync(sourcePath);
+            if (stat.isDirectory()) {
+                symlinkSync(sourcePath, fullSymlinkPath, "junction");
+                junctions++;
+            } else {
+                cpSync(sourcePath, fullSymlinkPath);
+                copies++;
+            }
+            if (usedFallback) {
+                fallbackUsed++;
+            }
+        } catch (error) {
+            logger.debug(`Failed to resolve symlink ${symlinkPath}: ${error}`);
+            failed++;
+        }
+        onProgress?.(junctions + copies + alreadyExisted + failed, symlinks.length);
     }
 
     logger.debug(

--- a/packages/cli/docs-preview/src/downloadLocalDocsBundle.ts
+++ b/packages/cli/docs-preview/src/downloadLocalDocsBundle.ts
@@ -5,7 +5,7 @@ import chalk from "chalk";
 import { execSync } from "child_process";
 import cliProgress from "cli-progress";
 import decompress from "decompress";
-import { cpSync, existsSync, lstatSync, mkdirSync, symlinkSync } from "fs";
+import { cpSync, existsSync, mkdirSync, statSync, symlinkSync } from "fs";
 import { mkdir, readFile, rename, rm, writeFile } from "fs/promises";
 import { homedir } from "os";
 import path from "path";
@@ -110,74 +110,101 @@ function resolveWindowsSymlinks(outputDir: string, symlinks: SymlinkEntry[], log
 
     const rootPnpmStore = path.join(outputDir, "standalone", "node_modules", ".pnpm");
 
-    for (const { path: symlinkPath, linkname } of symlinks) {
-        const fullSymlinkPath = path.join(outputDir, symlinkPath);
+    // Multi-pass resolution: some symlinks (e.g. turbopack aliases like
+    // qs-0df67fa3c19a2c11 -> qs) depend on other symlinks (qs -> .pnpm/...).
+    // Retry unresolved entries until no more progress is made.
+    let pending = symlinks;
+    const MAX_PASSES = 5;
 
-        if (!isWithinOutputDir(fullSymlinkPath, outputDir)) {
-            logger.warn(`Skipping symlink with path outside outputDir: ${symlinkPath}`);
-            failed++;
-            continue;
-        }
+    for (let pass = 0; pass < MAX_PASSES && pending.length > 0; pass++) {
+        const stillPending: SymlinkEntry[] = [];
 
-        const symlinkDir = path.dirname(fullSymlinkPath);
-        const resolvedTarget = path.resolve(symlinkDir, linkname);
+        for (const { path: symlinkPath, linkname } of pending) {
+            const fullSymlinkPath = path.join(outputDir, symlinkPath);
 
-        if (existsSync(fullSymlinkPath)) {
-            alreadyExisted++;
-            continue;
-        }
+            if (!isWithinOutputDir(fullSymlinkPath, outputDir)) {
+                logger.warn(`Skipping symlink with path outside outputDir: ${symlinkPath}`);
+                failed++;
+                continue;
+            }
 
-        let sourcePath = resolvedTarget;
-        let usedFallback = false;
+            const symlinkDir = path.dirname(fullSymlinkPath);
+            const resolvedTarget = path.resolve(symlinkDir, linkname);
 
-        // If direct target doesn't exist, try fallback in root .pnpm store
-        if (!existsSync(sourcePath) && existsSync(rootPnpmStore)) {
-            const parts = linkname.split("/");
-            const nmIdx = parts.lastIndexOf("node_modules");
-            if (nmIdx >= 0 && nmIdx > 0) {
-                const pnpmDirName = parts[nmIdx - 1];
-                const pkgRelPath = parts.slice(nmIdx + 1).join("/");
-                if (pnpmDirName != null && pkgRelPath != null) {
-                    const fallback = path.join(rootPnpmStore, pnpmDirName, "node_modules", pkgRelPath);
-                    if (!isWithinOutputDir(fallback, outputDir)) {
-                        continue; // skip unsafe fallback
-                    }
-                    if (existsSync(fallback)) {
-                        sourcePath = fallback;
-                        usedFallback = true;
+            if (existsSync(fullSymlinkPath)) {
+                alreadyExisted++;
+                continue;
+            }
+
+            let sourcePath = resolvedTarget;
+            let usedFallback = false;
+
+            // If direct target doesn't exist, try fallback in root .pnpm store
+            if (!existsSync(sourcePath) && existsSync(rootPnpmStore)) {
+                const parts = linkname.split("/");
+                const nmIdx = parts.lastIndexOf("node_modules");
+                if (nmIdx >= 0 && nmIdx > 0) {
+                    const pnpmDirName = parts[nmIdx - 1];
+                    const pkgRelPath = parts.slice(nmIdx + 1).join("/");
+                    if (pnpmDirName != null && pkgRelPath != null) {
+                        const fallback = path.join(rootPnpmStore, pnpmDirName, "node_modules", pkgRelPath);
+                        if (!isWithinOutputDir(fallback, outputDir)) {
+                            continue; // skip unsafe fallback
+                        }
+                        if (existsSync(fallback)) {
+                            sourcePath = fallback;
+                            usedFallback = true;
+                        }
                     }
                 }
             }
-        }
 
-        if (!isWithinOutputDir(sourcePath, outputDir)) {
-            logger.warn(`Skipping symlink whose target is outside outputDir: ${linkname}`);
-            failed++;
-            continue;
-        }
-
-        if (!existsSync(sourcePath)) {
-            failed++;
-            continue;
-        }
-
-        try {
-            mkdirSync(path.dirname(fullSymlinkPath), { recursive: true });
-            const stat = lstatSync(sourcePath);
-            if (stat.isDirectory()) {
-                symlinkSync(sourcePath, fullSymlinkPath, "junction");
-                junctions++;
-            } else {
-                cpSync(sourcePath, fullSymlinkPath);
-                copies++;
+            if (!isWithinOutputDir(sourcePath, outputDir)) {
+                logger.warn(`Skipping symlink whose target is outside outputDir: ${linkname}`);
+                failed++;
+                continue;
             }
-            if (usedFallback) {
-                fallbackUsed++;
+
+            if (!existsSync(sourcePath)) {
+                // Target doesn't exist yet — may be resolved in a later pass
+                stillPending.push({ path: symlinkPath, linkname });
+                continue;
             }
-        } catch (error) {
-            logger.debug(`Failed to resolve symlink ${symlinkPath}: ${error}`);
-            failed++;
+
+            try {
+                mkdirSync(path.dirname(fullSymlinkPath), { recursive: true });
+                // Use statSync (follows symlinks/junctions) instead of lstatSync
+                // so that targets already resolved as junctions are correctly
+                // identified as directories.
+                const stat = statSync(sourcePath);
+                if (stat.isDirectory()) {
+                    symlinkSync(sourcePath, fullSymlinkPath, "junction");
+                    junctions++;
+                } else {
+                    cpSync(sourcePath, fullSymlinkPath);
+                    copies++;
+                }
+                if (usedFallback) {
+                    fallbackUsed++;
+                }
+            } catch (error) {
+                logger.debug(`Failed to resolve symlink ${symlinkPath}: ${error}`);
+                failed++;
+            }
         }
+
+        if (stillPending.length === pending.length) {
+            // No progress — all remaining entries are unresolvable
+            failed += stillPending.length;
+            break;
+        }
+
+        if (stillPending.length > 0) {
+            logger.debug(
+                `Pass ${pass + 1}: ${pending.length - stillPending.length} resolved, ${stillPending.length} deferred`
+            );
+        }
+        pending = stillPending;
     }
 
     logger.debug(

--- a/packages/cli/docs-preview/src/downloadLocalDocsBundle.ts
+++ b/packages/cli/docs-preview/src/downloadLocalDocsBundle.ts
@@ -379,17 +379,26 @@ export async function downloadBundle({
         logger.debug(`Decompressing bundle from ${outputZipPath} to ${absolutePathToBundleFolder}`);
 
         let unzipProgressBar: cliProgress.SingleBar | undefined;
-        let extractedFiles = 0;
+        let unzipInterval: NodeJS.Timeout | undefined;
 
         if (app) {
             unzipProgressBar = new cliProgress.SingleBar({
-                format: `${DOCS_PREFIX} ${formatProgressLabel("Extracting docs bundle")} [{bar}] {value} files`,
+                format: `${DOCS_PREFIX} ${formatProgressLabel("Unzipping docs bundle")} [{bar}] {percentage}%`,
                 barCompleteChar: "\u2588",
                 barIncompleteChar: "\u2591",
                 hideCursor: true
             });
-            // Start with an estimated total; snapped to actual count when done
-            unzipProgressBar.start(5000, 0);
+            unzipProgressBar.start(100, 0);
+
+            const UNZIP_DURATION_MS = PLATFORM_IS_WINDOWS ? 60000 : 30000;
+            const startTime = Date.now();
+            unzipInterval = setInterval(() => {
+                const elapsed = Date.now() - startTime;
+                const t = Math.min(elapsed / UNZIP_DURATION_MS, 1);
+                const p = 1 - Math.pow(1 - t, 3);
+                const percentage = Math.min(99, Math.floor(p * 100));
+                unzipProgressBar?.update(percentage);
+            }, 50);
         }
 
         if (PLATFORM_IS_WINDOWS) {
@@ -401,10 +410,6 @@ export async function downloadBundle({
         try {
             await decompress(outputZipPath, absolutePathToBundleFolder, {
                 filter: (file) => {
-                    extractedFiles++;
-                    if (unzipProgressBar) {
-                        unzipProgressBar.update(extractedFiles);
-                    }
                     if (PLATFORM_IS_WINDOWS && file.type === "symlink") {
                         // decompress-tar adds `linkname` for symlink entries but the
                         // TypeScript types don't include it, so access via bracket notation.
@@ -418,9 +423,11 @@ export async function downloadBundle({
                 }
             });
         } finally {
+            if (unzipInterval) {
+                clearInterval(unzipInterval);
+            }
             if (unzipProgressBar) {
-                unzipProgressBar.setTotal(extractedFiles);
-                unzipProgressBar.update(extractedFiles);
+                unzipProgressBar.update(100);
                 unzipProgressBar.stop();
             }
         }

--- a/packages/cli/docs-preview/src/downloadLocalDocsBundle.ts
+++ b/packages/cli/docs-preview/src/downloadLocalDocsBundle.ts
@@ -95,7 +95,12 @@ function isWithinOutputDir(resolvedPath: string, outputDir: string): boolean {
  * When a direct target doesn't exist, it falls back to searching the root
  * .pnpm store.
  */
-function resolveWindowsSymlinks(outputDir: string, symlinks: SymlinkEntry[], logger: Logger): void {
+function resolveWindowsSymlinks(
+    outputDir: string,
+    symlinks: SymlinkEntry[],
+    logger: Logger,
+    onProgress?: (resolved: number, total: number) => void
+): void {
     if (symlinks.length === 0) {
         return;
     }
@@ -191,6 +196,7 @@ function resolveWindowsSymlinks(outputDir: string, symlinks: SymlinkEntry[], log
                 logger.debug(`Failed to resolve symlink ${symlinkPath}: ${error}`);
                 failed++;
             }
+            onProgress?.(junctions + copies + alreadyExisted + failed, symlinks.length);
         }
 
         if (stillPending.length === pending.length) {
@@ -400,26 +406,17 @@ export async function downloadBundle({
         logger.debug(`Decompressing bundle from ${outputZipPath} to ${absolutePathToBundleFolder}`);
 
         let unzipProgressBar: cliProgress.SingleBar | undefined;
-        let unzipInterval: NodeJS.Timeout | undefined;
+        let extractedFiles = 0;
 
         if (app) {
             unzipProgressBar = new cliProgress.SingleBar({
-                format: `${DOCS_PREFIX} ${formatProgressLabel("Unzipping docs bundle")} [{bar}] {percentage}%`,
+                format: `${DOCS_PREFIX} ${formatProgressLabel("Extracting docs bundle")} [{bar}] {value} files`,
                 barCompleteChar: "\u2588",
                 barIncompleteChar: "\u2591",
                 hideCursor: true
             });
-            unzipProgressBar.start(100, 0);
-
-            const UNZIP_DURATION_MS = 30000;
-            const startTime = Date.now();
-            unzipInterval = setInterval(() => {
-                const elapsed = Date.now() - startTime;
-                const t = Math.min(elapsed / UNZIP_DURATION_MS, 1);
-                const p = 1 - Math.pow(1 - t, 3);
-                const percentage = Math.min(99, Math.floor(p * 100));
-                unzipProgressBar?.update(percentage);
-            }, 50);
+            // Start with an estimated total; snapped to actual count when done
+            unzipProgressBar.start(5000, 0);
         }
 
         if (PLATFORM_IS_WINDOWS) {
@@ -431,6 +428,10 @@ export async function downloadBundle({
         try {
             await decompress(outputZipPath, absolutePathToBundleFolder, {
                 filter: (file) => {
+                    extractedFiles++;
+                    if (unzipProgressBar) {
+                        unzipProgressBar.update(extractedFiles);
+                    }
                     if (PLATFORM_IS_WINDOWS && file.type === "symlink") {
                         // decompress-tar adds `linkname` for symlink entries but the
                         // TypeScript types don't include it, so access via bracket notation.
@@ -444,18 +445,35 @@ export async function downloadBundle({
                 }
             });
         } finally {
-            if (unzipInterval) {
-                clearInterval(unzipInterval);
-            }
             if (unzipProgressBar) {
-                unzipProgressBar.update(100);
+                unzipProgressBar.setTotal(extractedFiles);
+                unzipProgressBar.update(extractedFiles);
                 unzipProgressBar.stop();
             }
         }
 
         // Resolve symlinks via NTFS junctions on Windows
         if (PLATFORM_IS_WINDOWS && collectedSymlinks.length > 0) {
-            resolveWindowsSymlinks(absolutePathToBundleFolder, collectedSymlinks, logger);
+            let symlinkProgressBar: cliProgress.SingleBar | undefined;
+            if (app) {
+                symlinkProgressBar = new cliProgress.SingleBar({
+                    format: `${DOCS_PREFIX} ${formatProgressLabel("Patching symlinks")} [{bar}] {percentage}% | {value}/{total}`,
+                    barCompleteChar: "\u2588",
+                    barIncompleteChar: "\u2591",
+                    hideCursor: true
+                });
+                symlinkProgressBar.start(collectedSymlinks.length, 0);
+            }
+            resolveWindowsSymlinks(
+                absolutePathToBundleFolder,
+                collectedSymlinks,
+                logger,
+                symlinkProgressBar ? (resolved, total) => symlinkProgressBar?.update(resolved) : undefined
+            );
+            if (symlinkProgressBar) {
+                symlinkProgressBar.update(collectedSymlinks.length);
+                symlinkProgressBar.stop();
+            }
         }
 
         // write etag


### PR DESCRIPTION
## Description

Adds a real progress bar for Windows symlink patching and adjusts the unzip progress bar timing for Windows. Follow-up to #15087.

## Changes Made

- **Symlink patching progress bar** (Windows only): Added a new `"Patching symlinks"` progress bar showing real `{percentage}% | {value}/{total}` during NTFS junction resolution. `resolveWindowsSymlinks` now accepts an optional `onProgress` callback that fires after each symlink is processed (including failed/skipped/pre-existing entries).
- **Windows unzip bar timing**: Increased the cubic-ease unzip progress bar duration from 30s to 60s on Windows (`PLATFORM_IS_WINDOWS ? 60000 : 30000`) to better reflect the longer extraction time on Windows.
- Added changelog entry (`feat` type).

## Testing

- [ ] Unit tests added/updated
- [x] Biome lint passes locally
- [ ] Windows CI smoke tests (`windows-latest` + Node 22/24) — primary validation since the symlink bar only activates on `win32`

## Human review checklist

- [ ] **Progress callback counting**: `onProgress` fires after every symlink (including failed/skipped/pre-existing), passing `junctions + copies + alreadyExisted + failed` — verify this gives a smooth bar that always reaches 100%
- [ ] **60s Windows estimate**: The unzip bar still uses a time-based heuristic (cubic ease over 60s on Windows). If extraction takes significantly longer or shorter, the bar may cap at 99% early or jump at the end — verify this is acceptable
- [ ] **Symlink bar only on Windows + app mode**: The bar is gated behind `PLATFORM_IS_WINDOWS && collectedSymlinks.length > 0 && app` — confirm no bar flashes for zero-symlink bundles or non-app mode

Link to Devin session: https://app.devin.ai/sessions/4a82619b77ec4a9fb613ee034ef56fd6
Requested by: @thesandlord