### PR TITLE
chore(generator-cli): upgrade @fern-api/replay to 0.11.0

### DIFF
--- a/packages/generator-cli/package.json
+++ b/packages/generator-cli/package.json
@@ -24,7 +24,7 @@
   "files": ["bin", "dist", "lib"],
   "dependencies": {
     "@fern-api/core-utils": "workspace:*",
-    "@fern-api/replay": "0.10.4",
+    "@fern-api/replay": "0.11.0",
     "@octokit/rest": "catalog:",
     "es-toolkit": "catalog:",
     "tmp-promise": "catalog:"

--- a/packages/generator-cli/versions.yml
+++ b/packages/generator-cli/versions.yml
@@ -1,6 +1,13 @@
 # yaml-language-server: $schema=../../versions-yml.schema.json
 - changelogEntry:
     - summary: |
+        Upgrade @fern-api/replay to 0.11.0.
+      type: chore
+  createdAt: "2026-04-16"
+  version: 0.9.9
+
+- changelogEntry:
+    - summary: |
         Use commit SHA instead of branch name in changelog URL so the link
         remains valid after the PR branch is deleted or squash-merged.
       type: fix

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7814,8 +7814,8 @@ importers:
         specifier: workspace:*
         version: link:../commons/core-utils
       '@fern-api/replay':
-        specifier: 0.10.4
-        version: 0.10.4
+        specifier: 0.11.0
+        version: 0.11.0
       '@octokit/rest':
         specifier: 'catalog:'
         version: 22.0.1
@@ -9334,6 +9334,11 @@ packages:
 
   '@fern-api/replay@0.10.4':
     resolution: {integrity: sha512-j/stjn9QMrFPnuLy0KNCwb4rM8ruq7nPtem1ZD5d8E+T7q+yxx1R3QsIaKZcKwFp/LFoyf8PPLhOAa6H8il8WQ==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  '@fern-api/replay@0.11.0':
+    resolution: {integrity: sha512-RdJMZc3zpmYVHH5UM7ogstG28wycS74Vw8lInT4YD70bJ2LhjgmEnntWLtpHOBAaEhw3nCz8aTk8KUkTXTp4SA==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -16355,6 +16360,15 @@ snapshots:
       chalk: 5.6.2
 
   '@fern-api/replay@0.10.4':
+    dependencies:
+      minimatch: 10.2.5
+      node-diff3: 3.2.0
+      simple-git: 3.35.2
+      yaml: 2.8.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@fern-api/replay@0.11.0':
     dependencies:
       minimatch: 10.2.5
       node-diff3: 3.2.0


### PR DESCRIPTION
## Description

Bumps `@fern-api/replay` from `0.10.4` to `0.11.0` in `@fern-api/generator-cli`. This is the latest published release of [fern-replay](https://github.com/fern-api/fern-replay/releases/tag/0.11.0) and includes several replay fixes (accumulator populations in new-file-both clean merge path, accumulator truthiness, adversarial test fixes, credential filter in detector + lockfile save, rename detection, etc.).

Once this PR merges and a new `generator-cli` version is published, a follow-up PR will bump fiddle to consume the new `generator-cli`.

## Changes Made

- `packages/generator-cli/package.json`: bump `@fern-api/replay` from `0.10.4` → `0.11.0`.
- `packages/generator-cli/versions.yml`: add a new `0.9.9` changelog entry (`chore`) documenting the replay upgrade, following the convention used by previous replay bumps (`0.9.7`, `0.9.6`, `0.9.5`, `0.9.4`).
- `pnpm-lock.yaml`: regenerated to resolve `@fern-api/replay@0.11.0`.

## Testing

- [x] `pnpm run check` (biome) passes.
- [x] `pnpm install --filter @fern-api/generator-cli` succeeds and resolves `0.11.0`.
- Relying on CI to run the generator-cli test suite.

## Reviewer checklist

- Confirm the version-bump convention in `packages/generator-cli/versions.yml` is correct (manually adding `0.9.9`, consistent with prior replay upgrade entries — this package is not listed in `release-config.json`, so versioning automation does not apply here).
- Sanity-check there are no API-level breakages between replay `0.10.4` and `0.11.0` that would require code changes in `packages/generator-cli/src/replay/*` or `src/api.ts`.

Link to Devin session: https://app.devin.ai/sessions/6661ab7c8ddf4cd3be515b905a6a307a
Requested by: @tstanmay13