### PR TITLE
chore(ci): update GitHub Actions to Node.js 24 compatible versions

### DIFF
--- a/.github/actions/cached-seed/action.yaml
+++ b/.github/actions/cached-seed/action.yaml
@@ -38,7 +38,7 @@ runs:
     - name: Log in to Docker Hub
       id: docker-login
       if: ${{ inputs.dockerhub-username != '' }}
-      uses: docker/login-action@v3
+      uses: docker/login-action@v4
       continue-on-error: true
       with:
         username: ${{ inputs.dockerhub-username }}
@@ -47,7 +47,7 @@ runs:
     - name: Retry Docker Hub login
       id: docker-login-retry
       if: ${{ inputs.dockerhub-username != '' && steps.docker-login.outcome == 'failure' }}
-      uses: docker/login-action@v3
+      uses: docker/login-action@v4
       continue-on-error: true
       with:
         username: ${{ inputs.dockerhub-username }}
@@ -71,7 +71,7 @@ runs:
 
     - name: Cache Docker images
       id: docker-cache
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: /tmp/docker-cache
         key: ${{ runner.os }}-docker-${{ inputs.generator-name }}-${{ hashFiles('**/Dockerfile*') }}

--- a/.github/workflows/benchmark-baseline.yml
+++ b/.github/workflows/benchmark-baseline.yml
@@ -37,7 +37,7 @@ jobs:
         uses: ./.github/actions/fetch-benchmark-specs
 
       - name: Upload specs as shared artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: benchmark-specs
           path: benchmarks/fern/apis/*/openapi.json
@@ -63,7 +63,7 @@ jobs:
         uses: ./.github/actions/install
 
       - name: Download shared specs
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: benchmark-specs
           path: benchmarks/fern/apis
@@ -75,7 +75,7 @@ jobs:
           skip-scripts: "true"
 
       - name: Upload baseline results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: benchmark-baseline-${{ matrix.generator }}
           path: benchmark-results/
@@ -102,7 +102,7 @@ jobs:
         uses: ./.github/actions/install
 
       - name: Download shared specs
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: benchmark-specs
           path: benchmarks/fern/apis
@@ -113,7 +113,7 @@ jobs:
           generator: ${{ matrix.generator }}
 
       - name: Upload E2E results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: benchmark-e2e-${{ matrix.generator }}
           path: benchmark-results/
@@ -134,7 +134,7 @@ jobs:
         uses: ./.github/actions/install
 
       - name: Download shared specs
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: benchmark-specs
           path: benchmarks/fern/apis
@@ -145,7 +145,7 @@ jobs:
           fern-token: ${{ secrets.FERN_FERN_TOKEN }}
 
       - name: Upload docs baseline results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: benchmark-docs-baseline
           path: benchmark-results/
@@ -163,21 +163,21 @@ jobs:
     permissions: {}
     steps:
       - name: Download generator-only baseline artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           pattern: benchmark-baseline-*
           path: baseline-results
           merge-multiple: true
 
       - name: Download E2E baseline artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           pattern: benchmark-e2e-*
           path: e2e-results
           merge-multiple: true
 
       - name: Download docs baseline artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           pattern: benchmark-docs-baseline
           path: docs-results

--- a/.github/workflows/ci-dynamic-snippets.yml
+++ b/.github/workflows/ci-dynamic-snippets.yml
@@ -34,7 +34,7 @@ jobs:
         uses: ./.github/actions/install
 
       - name: Cache Fern bin dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.fern/bin
           key: ${{ runner.os }}-fern-bin-${{ hashFiles('packages/cli/workspace/lazy-fern-workspace/src/protobuf/BufDownloader.ts', 'packages/cli/workspace/lazy-fern-workspace/src/protobuf/ProtocGenOpenAPIDownloader.ts') }}
@@ -66,7 +66,7 @@ jobs:
         uses: ./.github/actions/install
 
       - name: Cache Fern bin dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.fern/bin
           key: ${{ runner.os }}-fern-bin-${{ hashFiles('packages/cli/workspace/lazy-fern-workspace/src/protobuf/BufDownloader.ts', 'packages/cli/workspace/lazy-fern-workspace/src/protobuf/ProtocGenOpenAPIDownloader.ts') }}
@@ -98,7 +98,7 @@ jobs:
         uses: ./.github/actions/install
 
       - name: Cache Fern bin dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.fern/bin
           key: ${{ runner.os }}-fern-bin-${{ hashFiles('packages/cli/workspace/lazy-fern-workspace/src/protobuf/BufDownloader.ts', 'packages/cli/workspace/lazy-fern-workspace/src/protobuf/ProtocGenOpenAPIDownloader.ts') }}
@@ -130,7 +130,7 @@ jobs:
         uses: ./.github/actions/install
 
       - name: Cache Fern bin dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.fern/bin
           key: ${{ runner.os }}-fern-bin-${{ hashFiles('packages/cli/workspace/lazy-fern-workspace/src/protobuf/BufDownloader.ts', 'packages/cli/workspace/lazy-fern-workspace/src/protobuf/ProtocGenOpenAPIDownloader.ts') }}
@@ -162,7 +162,7 @@ jobs:
         uses: ./.github/actions/install
 
       - name: Cache Fern bin dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.fern/bin
           key: ${{ runner.os }}-fern-bin-${{ hashFiles('packages/cli/workspace/lazy-fern-workspace/src/protobuf/BufDownloader.ts', 'packages/cli/workspace/lazy-fern-workspace/src/protobuf/ProtocGenOpenAPIDownloader.ts') }}
@@ -194,7 +194,7 @@ jobs:
         uses: ./.github/actions/install
 
       - name: Cache Fern bin dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.fern/bin
           key: ${{ runner.os }}-fern-bin-${{ hashFiles('packages/cli/workspace/lazy-fern-workspace/src/protobuf/BufDownloader.ts', 'packages/cli/workspace/lazy-fern-workspace/src/protobuf/ProtocGenOpenAPIDownloader.ts') }}
@@ -226,7 +226,7 @@ jobs:
         uses: ./.github/actions/install
 
       - name: Cache Fern bin dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.fern/bin
           key: ${{ runner.os }}-fern-bin-${{ hashFiles('packages/cli/workspace/lazy-fern-workspace/src/protobuf/BufDownloader.ts', 'packages/cli/workspace/lazy-fern-workspace/src/protobuf/ProtocGenOpenAPIDownloader.ts') }}
@@ -258,7 +258,7 @@ jobs:
         uses: ./.github/actions/install
 
       - name: Cache Fern bin dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.fern/bin
           key: ${{ runner.os }}-fern-bin-${{ hashFiles('packages/cli/workspace/lazy-fern-workspace/src/protobuf/BufDownloader.ts', 'packages/cli/workspace/lazy-fern-workspace/src/protobuf/ProtocGenOpenAPIDownloader.ts') }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,7 +123,7 @@ jobs:
         uses: ./.github/actions/install
 
       - name: Cache Fern bin dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.fern/bin
           key: ${{ runner.os }}-fern-bin-${{ hashFiles('packages/cli/workspace/lazy-fern-workspace/src/protobuf/BufDownloader.ts', 'packages/cli/workspace/lazy-fern-workspace/src/protobuf/ProtocGenOpenAPIDownloader.ts') }}
@@ -181,7 +181,7 @@ jobs:
 
       - name: Log in to Docker Hub
         if: ${{ env.DOCKERHUB_USERNAME != '' }}
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         env:
           DOCKERHUB_USERNAME: ${{ secrets.DOCKER_USERNAME_PUBLIC_READONLY }}
         with:
@@ -193,7 +193,7 @@ jobs:
 
       - name: Cache Docker images
         id: docker-cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: /tmp/docker-cache
           key: ${{ runner.os }}-docker-ete-${{ hashFiles('**/Dockerfile*') }}
@@ -210,7 +210,7 @@ jobs:
         run: docker images -q | sort -u > /tmp/docker-images-before.txt
 
       - name: Cache Fern bin dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.fern/bin
           key: ${{ runner.os }}-fern-bin-${{ hashFiles('packages/cli/workspace/lazy-fern-workspace/src/protobuf/BufDownloader.ts', 'packages/cli/workspace/lazy-fern-workspace/src/protobuf/ProtocGenOpenAPIDownloader.ts') }}

--- a/.github/workflows/cli-release.yml
+++ b/.github/workflows/cli-release.yml
@@ -69,7 +69,7 @@ jobs:
 
       - name: Create Release
         id: create_release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         if: steps.get_version.outputs.HAS_NEW_VERSION == 'true'
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish-snippets-core.yml
+++ b/.github/workflows/publish-snippets-core.yml
@@ -31,7 +31,7 @@ jobs:
         uses: ./.github/actions/install
 
       - name: Cache Fern bin dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.fern/bin
           key: ${{ runner.os }}-fern-bin-${{ hashFiles('packages/cli/workspace/lazy-fern-workspace/src/protobuf/BufDownloader.ts', 'packages/cli/workspace/lazy-fern-workspace/src/protobuf/ProtocGenOpenAPIDownloader.ts') }}

--- a/.github/workflows/release-software.yml
+++ b/.github/workflows/release-software.yml
@@ -53,7 +53,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           token: ${{ secrets.ACTIONS_PAT }}
           ref: main

--- a/.github/workflows/seed.yml
+++ b/.github/workflows/seed.yml
@@ -872,7 +872,7 @@ jobs:
         uses: ./.github/actions/fetch-benchmark-specs
 
       - name: Upload specs as shared artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: benchmark-specs
           path: benchmarks/fern/apis/*/openapi.json
@@ -901,7 +901,7 @@ jobs:
 
       - name: Log in to Docker Hub
         if: ${{ env.DOCKERHUB_USERNAME != '' }}
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         env:
           DOCKERHUB_USERNAME: ${{ secrets.DOCKER_USERNAME_PUBLIC_READONLY }}
         with:
@@ -913,7 +913,7 @@ jobs:
 
       - name: Cache Docker images
         id: docker-cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: /tmp/docker-cache
           key: ${{ runner.os }}-docker-${{ matrix.generator }}-${{ hashFiles('**/Dockerfile*') }}
@@ -930,7 +930,7 @@ jobs:
         run: docker images -q | sort -u > /tmp/docker-images-before.txt
 
       - name: Download shared specs
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: benchmark-specs
           path: benchmarks/fern/apis
@@ -957,7 +957,7 @@ jobs:
           done
 
       - name: Upload PR results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: benchmark-pr-${{ matrix.generator }}
           path: benchmark-results/
@@ -983,7 +983,7 @@ jobs:
           sparse-checkout: .github/scripts
 
       - name: Download all PR benchmark artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           pattern: benchmark-pr-*
           path: benchmark-pr-results
@@ -1182,7 +1182,7 @@ jobs:
         uses: ./.github/actions/install
 
       - name: Download shared specs
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: benchmark-specs
           path: benchmarks/fern/apis
@@ -1193,7 +1193,7 @@ jobs:
           fern-token: ${{ secrets.FERN_FERN_TOKEN }}
 
       - name: Upload PR docs benchmark results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: benchmark-pr-docs
           path: benchmark-results/
@@ -1219,7 +1219,7 @@ jobs:
           sparse-checkout: .github/scripts
 
       - name: Download PR docs benchmark artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           pattern: benchmark-pr-docs
           path: docs-pr-results

--- a/.github/workflows/test-definitions.yml
+++ b/.github/workflows/test-definitions.yml
@@ -39,7 +39,7 @@ jobs:
         uses: ./.github/actions/install
 
       - name: Cache Fern bin dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.fern/bin
           key: ${{ runner.os }}-fern-bin-${{ hashFiles('packages/cli/workspace/lazy-fern-workspace/src/protobuf/BufDownloader.ts', 'packages/cli/workspace/lazy-fern-workspace/src/protobuf/ProtocGenOpenAPIDownloader.ts') }}

--- a/.github/workflows/update-test.yml
+++ b/.github/workflows/update-test.yml
@@ -30,7 +30,7 @@ jobs:
         uses: ./.github/actions/install
 
       - name: Cache Fern bin dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.fern/bin
           key: ${{ runner.os }}-fern-bin-${{ hashFiles('packages/cli/workspace/lazy-fern-workspace/src/protobuf/BufDownloader.ts', 'packages/cli/workspace/lazy-fern-workspace/src/protobuf/ProtocGenOpenAPIDownloader.ts') }}


### PR DESCRIPTION
## Description

Addresses the Node.js 20 deprecation warnings surfaced in [this CI run](https://github.com/fern-api/fern/actions/runs/24548504615). GitHub is forcing JavaScript actions onto Node 24 on June 2, 2026, and Node 20 reaches EOL in April 2026 — this PR bumps every action in `.github/` that has a Node 24–compatible release available.

## Changes Made

Bumped the following actions across `.github/workflows/*.yml` and `.github/actions/cached-seed/action.yaml`:

- `actions/cache@v4` → `@v5`
- `actions/checkout@v4` → `@v6` (in `release-software.yml`)
- `actions/upload-artifact@v4` → `@v6`
- `actions/download-artifact@v4` → `@v7`
- `docker/login-action@v3` → `@v4`
- `softprops/action-gh-release@v2` → `@v3`

Files touched: `ci.yml`, `ci-dynamic-snippets.yml`, `benchmark-baseline.yml`, `seed.yml`, `cli-release.yml`, `publish-snippets-core.yml`, `release-software.yml`, `test-definitions.yml`, `update-test.yml`, `cached-seed/action.yaml`.

## Actions intentionally not bumped

These actions are still in use but have no Node 24 release yet, so their deprecation warnings will persist until upstream ships an update:

- `bufbuild/buf-setup-action@v1.50.0` (latest, still node20)
- `crs-k/stale-branches@v8.2.2` (latest, still node20)

`tj-actions/changed-files@v47` is already on Node 24 (migrated in v47.0.0), so no change needed there.

## Review checklist

- [ ] **Major version bumps** — `upload-artifact` v4→v6, `download-artifact` v4→v7, `cache` v4→v5, `checkout` v4→v6, `docker/login-action` v3→v4, `softprops/action-gh-release` v2→v3 are all major bumps. Confirm no breaking input/output changes affect our usage. Notably, `upload-artifact` v5+ produces immutable artifacts; matched with `download-artifact@v7` they should interop correctly.
- [ ] **Self-hosted runner** — `update-test.yml` uses `runs-on: Test`. Node 24 requires Actions Runner ≥ 2.327.1 — confirm the self-hosted runner is updated (GitHub-hosted runners are fine).
- [ ] Tested via CI only (YAML-only change).

Link to Devin session: https://app.devin.ai/sessions/b24269a1f97f43f9ae84b9029af20dd9
Requested by: @davidkonigsberg