### PR TITLE
feat(cli): add `docs.yml` setting to disable environment editing

### DIFF
--- a/docs-yml.schema.json
+++ b/docs-yml.schema.json
@@ -5544,6 +5544,16 @@
             }
           ]
         },
+        "disable-environment-editing": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
         "disable-analytics": {
           "oneOf": [
             {

--- a/fern/apis/docs-yml/definition/docs.yml
+++ b/fern/apis/docs-yml/definition/docs.yml
@@ -879,6 +879,15 @@ types:
           When this feature is enabled, your API must have Cross-Origin Resource Sharing (CORS) enabled to allow requests from the documentation domain.
 
           @default: false
+      disable-environment-editing:
+        type: optional<boolean>
+        docs: |
+          If set to true, the base URL (environment) shown in the endpoint header on API reference
+          docs pages will no longer be editable. Users will still be able to switch between configured
+          environments via the dropdown, but will not be able to double-click and type in a custom
+          URL. This does not affect the API Playground.
+
+          @default: false
       disable-analytics: optional<boolean>
       language: optional<Language>
       folder-title-source:

--- a/packages/cli/cli/changes/unreleased/disable-environment-editing-docs-yml.yml
+++ b/packages/cli/cli/changes/unreleased/disable-environment-editing-docs-yml.yml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=../../../../../fern-changes-yml.schema.json
+
+- summary: |
+    Add a docs.yml setting to disable editing the API reference environment URL.
+    This preserves the default editable behavior while allowing docs sites to lock the
+    displayed base URL when desired.
+  type: feat

--- a/packages/cli/configuration-loader/src/docs-yml/parseDocsConfiguration.ts
+++ b/packages/cli/configuration-loader/src/docs-yml/parseDocsConfiguration.ts
@@ -475,6 +475,7 @@ function convertSettingsConfig(
         searchText: settings.searchText ?? undefined,
         useJavascriptAsTypescript: settings.useJavascriptAsTypescript ?? false,
         disableExplorerProxy: settings.disableExplorerProxy ?? false,
+        disableEnvironmentEditing: settings.disableEnvironmentEditing ?? false,
         disableAnalytics: settings.disableAnalytics ?? false
     };
 }

--- a/packages/cli/configuration/src/docs-yml/ParsedDocsConfiguration.ts
+++ b/packages/cli/configuration/src/docs-yml/ParsedDocsConfiguration.ts
@@ -39,6 +39,11 @@ export interface ParsedPageActionsConfig {
     };
 }
 
+// TODO(kafkas): Remove this when we upgrade the fdr-sdk to latest
+interface ParsedDocsSettingsConfig extends CjsFdrSdk.docs.v1.commons.DocsSettingsConfig {
+    disableEnvironmentEditing: boolean | undefined;
+}
+
 export interface ParsedDocsConfiguration {
     instances: DocsInstance[];
     title: string | undefined;
@@ -69,7 +74,7 @@ export interface ParsedDocsConfiguration {
     colors: CjsFdrSdk.docs.v1.write.ColorsConfigV3 | undefined;
     typography: TypographyConfig | undefined;
     layout: CjsFdrSdk.docs.v1.commons.DocsLayoutConfig | undefined;
-    settings: CjsFdrSdk.docs.v1.commons.DocsSettingsConfig | undefined;
+    settings: ParsedDocsSettingsConfig | undefined;
     context7File: AbsoluteFilePath | undefined;
     llmsTxtFile: AbsoluteFilePath | undefined;
     llmsFullTxtFile: AbsoluteFilePath | undefined;

--- a/packages/cli/configuration/src/docs-yml/schemas/sdk/api/resources/docs/types/DocsSettingsConfig.ts
+++ b/packages/cli/configuration/src/docs-yml/schemas/sdk/api/resources/docs/types/DocsSettingsConfig.ts
@@ -57,6 +57,15 @@ export interface DocsSettingsConfig {
      * @default: false
      */
     disableExplorerProxy?: boolean;
+    /**
+     * If set to true, the base URL (environment) shown in the endpoint header on API reference
+     * docs pages will no longer be editable. Users will still be able to switch between configured
+     * environments via the dropdown, but will not be able to double-click and type in a custom
+     * URL. This does not affect the API Playground.
+     *
+     * @default: false
+     */
+    disableEnvironmentEditing?: boolean;
     disableAnalytics?: boolean;
     language?: FernDocsConfig.Language;
     /**

--- a/packages/cli/configuration/src/docs-yml/schemas/sdk/serialization/resources/docs/types/DocsSettingsConfig.ts
+++ b/packages/cli/configuration/src/docs-yml/schemas/sdk/serialization/resources/docs/types/DocsSettingsConfig.ts
@@ -28,6 +28,10 @@ export const DocsSettingsConfig: core.serialization.ObjectSchema<
         "disable-explorer-proxy",
         core.serialization.boolean().optional(),
     ),
+    disableEnvironmentEditing: core.serialization.property(
+        "disable-environment-editing",
+        core.serialization.boolean().optional(),
+    ),
     disableAnalytics: core.serialization.property("disable-analytics", core.serialization.boolean().optional()),
     language: Language.optional(),
     folderTitleSource: core.serialization.property("folder-title-source", TitleSource.optional()),
@@ -44,6 +48,7 @@ export declare namespace DocsSettingsConfig {
         "hide-404-page"?: boolean | null;
         "use-javascript-as-typescript"?: boolean | null;
         "disable-explorer-proxy"?: boolean | null;
+        "disable-environment-editing"?: boolean | null;
         "disable-analytics"?: boolean | null;
         language?: Language.Raw | null;
         "folder-title-source"?: TitleSource.Raw | null;

--- a/packages/cli/workspace/loader/src/docs-yml.schema.json
+++ b/packages/cli/workspace/loader/src/docs-yml.schema.json
@@ -5544,6 +5544,16 @@
             }
           ]
         },
+        "disable-environment-editing": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
         "disable-analytics": {
           "oneOf": [
             {


### PR DESCRIPTION
## Description
Linear ticket: Refs FER-9706
<!-- Use "Closes" to automatically close the ticket when PR merges, or "Refs" to link without closing -->
<!-- Provide a clear and concise description of the changes made in this PR -->

Adds a new `settings.disable-environment-editing` option to `docs.yml`. When enabled, API reference pages can display the configured base URL without allowing users to double-click and edit it, while preserving the current editable behavior by default for backward compatibility.

## Changes Made
<!-- List the main changes and updates implemented in this PR -->
- Added `disable-environment-editing` to the `docs.yml` schema and regenerated the docs config artifacts
- Parsed the new setting into the CLI's docs configuration output
- Added an unreleased changelog entry for the new `docs.yml` feature

## Testing
<!-- Describe how you tested these changes -->
- [ ] Unit tests added/updated
- [x] Manual testing completed