### PR TITLE
fix(ruby): synthesize default values for missing required properties in dynamic snippets

### DIFF
--- a/generators/ruby-v2/dynamic-snippets/src/EndpointSnippetGenerator.ts
+++ b/generators/ruby-v2/dynamic-snippets/src/EndpointSnippetGenerator.ts
@@ -633,7 +633,6 @@ export class EndpointSnippetGenerator {
     }): ruby.KeywordArgument[] {
         const args: ruby.KeywordArgument[] = [];
         const record = this.context.getRecord(snippet.requestBody) ?? {};
-        const providedWireValues = new Set<string>(Object.keys(record));
 
         const bodyProperties = this.context.associateByWireValue({
             parameters: request.value,
@@ -651,25 +650,6 @@ export class EndpointSnippetGenerator {
                     value
                 })
             );
-        }
-
-        // Synthesize default values for required properties missing from the example
-        for (const property of request.value) {
-            if (providedWireValues.has(property.name.wireValue)) {
-                continue;
-            }
-            if (this.context.isOptional(property.typeReference) || this.context.isNullable(property.typeReference)) {
-                continue;
-            }
-            const defaultValue = this.context.dynamicTypeLiteralMapper.synthesizeDefaultValue(property.typeReference);
-            if (!ruby.TypeLiteral.isNop(defaultValue)) {
-                args.push(
-                    ruby.keywordArgument({
-                        name: this.context.getPropertyName(property.name.name),
-                        value: defaultValue
-                    })
-                );
-            }
         }
 
         return args;
@@ -880,8 +860,6 @@ export class EndpointSnippetGenerator {
         // Handle different type shapes
         switch (namedType.type) {
             case "object": {
-                const providedWireValues = new Set<string>(Object.keys(bodyRecord));
-
                 // For objects, convert each property to a keyword argument
                 for (const property of namedType.properties) {
                     const wireValue = property.name.wireValue;
@@ -905,29 +883,6 @@ export class EndpointSnippetGenerator {
                     }
                 }
 
-                // Synthesize default values for required properties missing from the example
-                for (const property of namedType.properties) {
-                    if (providedWireValues.has(property.name.wireValue)) {
-                        continue;
-                    }
-                    if (
-                        this.context.isOptional(property.typeReference) ||
-                        this.context.isNullable(property.typeReference)
-                    ) {
-                        continue;
-                    }
-                    const defaultValue = this.context.dynamicTypeLiteralMapper.synthesizeDefaultValue(
-                        property.typeReference
-                    );
-                    if (!ruby.TypeLiteral.isNop(defaultValue)) {
-                        args.push(
-                            ruby.keywordArgument({
-                                name: this.context.getPropertyName(property.name.name),
-                                value: defaultValue
-                            })
-                        );
-                    }
-                }
                 break;
             }
             case "alias":

--- a/generators/ruby-v2/dynamic-snippets/src/EndpointSnippetGenerator.ts
+++ b/generators/ruby-v2/dynamic-snippets/src/EndpointSnippetGenerator.ts
@@ -632,10 +632,12 @@ export class EndpointSnippetGenerator {
         snippet: FernIr.dynamic.EndpointSnippetRequest;
     }): ruby.KeywordArgument[] {
         const args: ruby.KeywordArgument[] = [];
+        const record = this.context.getRecord(snippet.requestBody) ?? {};
+        const providedWireValues = new Set<string>(Object.keys(record));
 
         const bodyProperties = this.context.associateByWireValue({
             parameters: request.value,
-            values: this.context.getRecord(snippet.requestBody) ?? {}
+            values: record
         });
         for (const parameter of bodyProperties) {
             const value = this.context.dynamicTypeLiteralMapper.convert(parameter);
@@ -650,6 +652,26 @@ export class EndpointSnippetGenerator {
                 })
             );
         }
+
+        // Synthesize default values for required properties missing from the example
+        for (const property of request.value) {
+            if (providedWireValues.has(property.name.wireValue)) {
+                continue;
+            }
+            if (this.context.isOptional(property.typeReference) || this.context.isNullable(property.typeReference)) {
+                continue;
+            }
+            const defaultValue = this.context.dynamicTypeLiteralMapper.synthesizeDefaultValue(property.typeReference);
+            if (!ruby.TypeLiteral.isNop(defaultValue)) {
+                args.push(
+                    ruby.keywordArgument({
+                        name: this.context.getPropertyName(property.name.name),
+                        value: defaultValue
+                    })
+                );
+            }
+        }
+
         return args;
     }
 
@@ -858,6 +880,8 @@ export class EndpointSnippetGenerator {
         // Handle different type shapes
         switch (namedType.type) {
             case "object": {
+                const providedWireValues = new Set<string>(Object.keys(bodyRecord));
+
                 // For objects, convert each property to a keyword argument
                 for (const property of namedType.properties) {
                     const wireValue = property.name.wireValue;
@@ -878,6 +902,30 @@ export class EndpointSnippetGenerator {
                                 })
                             );
                         }
+                    }
+                }
+
+                // Synthesize default values for required properties missing from the example
+                for (const property of namedType.properties) {
+                    if (providedWireValues.has(property.name.wireValue)) {
+                        continue;
+                    }
+                    if (
+                        this.context.isOptional(property.typeReference) ||
+                        this.context.isNullable(property.typeReference)
+                    ) {
+                        continue;
+                    }
+                    const defaultValue = this.context.dynamicTypeLiteralMapper.synthesizeDefaultValue(
+                        property.typeReference
+                    );
+                    if (!ruby.TypeLiteral.isNop(defaultValue)) {
+                        args.push(
+                            ruby.keywordArgument({
+                                name: this.context.getPropertyName(property.name.name),
+                                value: defaultValue
+                            })
+                        );
                     }
                 }
                 break;

--- a/generators/ruby-v2/dynamic-snippets/src/__test__/__snapshots__/DynamicSnippetsGenerator.test.ts.snap
+++ b/generators/ruby-v2/dynamic-snippets/src/__test__/__snapshots__/DynamicSnippetsGenerator.test.ts.snap
@@ -327,9 +327,7 @@ client.create_user(
       verified: "string"
     },
     ssn: "ssn"
-  },
-  id: "string",
-  email: "string"
+  }
 )
 "
 `;
@@ -348,8 +346,7 @@ client.create_user(
       verified: "string"
     },
     ssn: "ssn"
-  },
-  email: "string"
+  }
 )
 "
 `;

--- a/generators/ruby-v2/dynamic-snippets/src/__test__/__snapshots__/DynamicSnippetsGenerator.test.ts.snap
+++ b/generators/ruby-v2/dynamic-snippets/src/__test__/__snapshots__/DynamicSnippetsGenerator.test.ts.snap
@@ -323,9 +323,13 @@ client.create_user(
   password: "password",
   profile: {
     name: "name",
-    verification: {},
+    verification: {
+      verified: "string"
+    },
     ssn: "ssn"
-  }
+  },
+  id: "string",
+  email: "string"
 )
 "
 `;
@@ -340,9 +344,12 @@ client.create_user(
   password: "password",
   profile: {
     name: "name",
-    verification: {},
+    verification: {
+      verified: "string"
+    },
     ssn: "ssn"
-  }
+  },
+  email: "string"
 )
 "
 `;

--- a/generators/ruby-v2/dynamic-snippets/src/context/DynamicToLiteralMapper.ts
+++ b/generators/ruby-v2/dynamic-snippets/src/context/DynamicToLiteralMapper.ts
@@ -435,21 +435,189 @@ export class DynamicTypeLiteralMapper {
             return ruby.TypeLiteral.nop();
         }
 
-        return ruby.TypeLiteral.hash(
-            Object.entries(value as Record<string, unknown>).map(([key, val]) => {
-                this.context.errors.scope(key);
-                const property = object.properties.find((p) => p.name.wireValue === key);
-                const typeReference = property?.typeReference ?? { type: "unknown" };
-                // Use snake_case property name for Ruby, falling back to wire value if not found
-                const propertyName = property?.name.name.snakeCase.safeName ?? key;
-                const astNode = {
+        const entries = this.convertObjectEntries({ object, value });
+        return ruby.TypeLiteral.hash(entries);
+    }
+
+    private convertObjectEntries({
+        object,
+        value
+    }: {
+        object: FernIr.dynamic.ObjectType;
+        value: unknown;
+    }): ruby.HashEntry[] {
+        const record = (typeof value === "object" && value != null ? value : {}) as Record<string, unknown>;
+        const providedWireValues = new Set<string>(Object.keys(record));
+
+        const entries: ruby.HashEntry[] = [];
+
+        // Convert provided values
+        for (const [key, val] of Object.entries(record)) {
+            this.context.errors.scope(key);
+            const property = object.properties.find((p) => p.name.wireValue === key);
+            const typeReference = property?.typeReference ?? { type: "unknown" as const };
+            const propertyName = property?.name.name.snakeCase.safeName ?? key;
+            const converted = this.convert({ typeReference, value: val });
+            if (!ruby.TypeLiteral.isNop(converted)) {
+                entries.push({
                     key: ruby.TypeLiteral.string(propertyName),
-                    value: this.convert({ typeReference, value: val })
-                };
-                this.context.errors.unscope();
-                return astNode;
-            })
-        );
+                    value: converted
+                });
+            }
+            this.context.errors.unscope();
+        }
+
+        // Synthesize default values for required properties missing from the example
+        for (const property of object.properties) {
+            if (providedWireValues.has(property.name.wireValue)) {
+                continue;
+            }
+            if (this.context.isOptional(property.typeReference) || this.context.isNullable(property.typeReference)) {
+                continue;
+            }
+            const defaultValue = this.synthesizeDefaultValue(property.typeReference);
+            if (!ruby.TypeLiteral.isNop(defaultValue)) {
+                entries.push({
+                    key: ruby.TypeLiteral.string(property.name.name.snakeCase.safeName),
+                    value: defaultValue
+                });
+            }
+        }
+
+        return entries.filter((entry) => !ruby.TypeLiteral.isNop(entry.value));
+    }
+
+    // =============================================================================
+    // DEFAULT VALUE SYNTHESIS
+    // =============================================================================
+
+    /**
+     * Synthesizes a reasonable default value for a given type reference.
+     * Used to populate required fields that are missing from examples,
+     * preventing invalid code generation (e.g. empty hashes for types
+     * with required fields).
+     */
+    public synthesizeDefaultValue(
+        typeReference: FernIr.dynamic.TypeReference,
+        seen: Set<string> = new Set()
+    ): ruby.AstNode {
+        switch (typeReference.type) {
+            case "optional":
+            case "nullable":
+                return ruby.TypeLiteral.nop();
+            case "primitive":
+                return this.synthesizeDefaultPrimitive(typeReference.value);
+            case "literal":
+                return this.synthesizeDefaultLiteral(typeReference.value);
+            case "list":
+                return ruby.TypeLiteral.list([]);
+            case "set":
+                return ruby.TypeLiteral.list([]);
+            case "map":
+                return ruby.TypeLiteral.hash([]);
+            case "named": {
+                if (seen.has(typeReference.value)) {
+                    return ruby.TypeLiteral.nop();
+                }
+                const named = this.context.resolveNamedType({ typeId: typeReference.value });
+                if (named == null) {
+                    return ruby.TypeLiteral.nop();
+                }
+                return this.synthesizeDefaultNamed({ named, typeId: typeReference.value, seen });
+            }
+            case "unknown":
+                return ruby.TypeLiteral.nop();
+            default:
+                assertNever(typeReference);
+        }
+    }
+
+    private synthesizeDefaultPrimitive(primitive: FernIr.dynamic.PrimitiveTypeV1): ruby.AstNode {
+        switch (primitive) {
+            case "STRING":
+            case "BASE_64":
+            case "BIG_INTEGER":
+                return ruby.TypeLiteral.string("string");
+            case "INTEGER":
+            case "LONG":
+            case "UINT":
+            case "UINT_64":
+                return ruby.TypeLiteral.integer(1);
+            case "FLOAT":
+            case "DOUBLE":
+                return ruby.TypeLiteral.float(1.1);
+            case "BOOLEAN":
+                return ruby.TypeLiteral.boolean(true);
+            case "DATE":
+                return ruby.TypeLiteral.string("2024-01-15");
+            case "DATE_TIME":
+            case "DATE_TIME_RFC_2822":
+                return ruby.TypeLiteral.string("2024-01-15T09:30:00Z");
+            case "UUID":
+                return ruby.TypeLiteral.string("d5e9c84f-c2b2-4bf4-b4b0-7ffd7a9ffc32");
+            default:
+                assertNever(primitive);
+        }
+    }
+
+    private synthesizeDefaultLiteral(literalType: FernIr.dynamic.LiteralType): ruby.AstNode {
+        switch (literalType.type) {
+            case "boolean":
+                return ruby.TypeLiteral.boolean(literalType.value);
+            case "string":
+                return ruby.TypeLiteral.string(literalType.value);
+            default:
+                assertNever(literalType);
+        }
+    }
+
+    private synthesizeDefaultNamed({
+        named,
+        typeId,
+        seen
+    }: {
+        named: FernIr.dynamic.NamedType;
+        typeId: string;
+        seen: Set<string>;
+    }): ruby.AstNode {
+        const newSeen = new Set(seen);
+        newSeen.add(typeId);
+
+        switch (named.type) {
+            case "alias":
+                return this.synthesizeDefaultValue(named.typeReference, newSeen);
+            case "enum": {
+                const firstValue = named.values[0];
+                if (firstValue == null) {
+                    return ruby.TypeLiteral.nop();
+                }
+                return ruby.TypeLiteral.string(firstValue.wireValue);
+            }
+            case "object": {
+                const entries: ruby.HashEntry[] = [];
+                for (const property of named.properties) {
+                    if (
+                        this.context.isOptional(property.typeReference) ||
+                        this.context.isNullable(property.typeReference)
+                    ) {
+                        continue;
+                    }
+                    const defaultValue = this.synthesizeDefaultValue(property.typeReference, newSeen);
+                    if (!ruby.TypeLiteral.isNop(defaultValue)) {
+                        entries.push({
+                            key: ruby.TypeLiteral.string(property.name.name.snakeCase.safeName),
+                            value: defaultValue
+                        });
+                    }
+                }
+                return ruby.TypeLiteral.hash(entries);
+            }
+            case "discriminatedUnion":
+            case "undiscriminatedUnion":
+                return ruby.TypeLiteral.nop();
+            default:
+                assertNever(named);
+        }
     }
 
     private getValueAsNumber({

--- a/generators/ruby-v2/sdk/changes/unreleased/fix-dynamic-snippets-default-values.yml
+++ b/generators/ruby-v2/sdk/changes/unreleased/fix-dynamic-snippets-default-values.yml
@@ -1,0 +1,7 @@
+- summary: |
+    Fix Ruby dynamic snippet generation to synthesize default values for
+    required properties missing from examples. Previously, empty objects
+    and arrays were rendered as `{}` and `[{}]`; now required fields are
+    populated with reasonable placeholder values matching the behavior of
+    the Python generator.
+  type: fix


### PR DESCRIPTION
## Description

Fixes an issue where Ruby dynamic snippet generation produced empty hashes `{}` and `[{}]` for complex types with required properties. The Python generator already had `synthesizeDefaultValue` logic to populate missing required fields with reasonable placeholder values — this PR adds the same capability to the Ruby generator.

**Before** (Ruby):
```ruby
client.messages.send_(
  to: [{}],
  content: { text: "Hello, World!" },
  from: {}
)
```

**After** (Ruby — nested objects now have required fields populated):
```ruby
client.messages.send_(
  to: [{ addresses: [{ address: "string", channel: "WHATSAPP" }] }],
  content: { text: "Hello, World!" }
)
```

## Changes Made

- Added `synthesizeDefaultValue`, `synthesizeDefaultPrimitive`, `synthesizeDefaultLiteral`, and `synthesizeDefaultNamed` methods to `DynamicToLiteralMapper` — generates reasonable placeholder values (strings, integers, booleans, dates, enums, nested objects) for required fields missing from examples
- Refactored `convertObject` to use a new `convertObjectEntries` helper that iterates over schema properties and synthesizes defaults for missing required ones (matching the Python generator's approach)
- Default synthesis only applies to **nested objects**, not top-level endpoint arguments — matching Python's behavior where only provided example values appear as method arguments
- [ ] Updated README.md generator (if applicable)

## Testing

- [x] Unit tests updated (2 snapshots updated to reflect synthesized default values in nested objects)
- [x] All 32 dynamic snippet unit tests pass
- [x] Seed tests pass for `exhaustive`, `allof`, `objects-with-imports`, `alias-extends` fixtures
- [x] Compilation succeeds
- [x] Formatting verified with `pnpm format`

Link to Devin session: https://app.devin.ai/sessions/bc5667ce727e47f09af0499186ff4a2b
Requested by: @iamnamananand996