### PR TITLE
feat(cli): shell completion support for CLI v2 and fix v1 side effects

### DIFF
--- a/packages/cli/cli-v2/src/cli.ts
+++ b/packages/cli/cli-v2/src/cli.ts
@@ -44,15 +44,17 @@ function completionHandler(
     const prev = args[args.length - 2];
 
     if (prev === "--group" || prev === "--api" || prev === "--instance") {
-        void getCompletionValues(process.cwd()).then((values) => {
-            if (prev === "--group") {
-                done(values.groups);
-            } else if (prev === "--api") {
-                done(values.apis);
-            } else {
-                done(values.instances);
-            }
-        });
+        void getCompletionValues(process.cwd())
+            .then((values) => {
+                if (prev === "--group") {
+                    done(values.groups);
+                } else if (prev === "--api") {
+                    done(values.apis);
+                } else {
+                    done(values.instances);
+                }
+            })
+            .catch(() => done([]));
         return;
     }
 

--- a/packages/cli/cli-v2/src/cli.ts
+++ b/packages/cli/cli-v2/src/cli.ts
@@ -12,13 +12,53 @@ import { addInitCommand } from "./commands/init/index.js";
 import { addOrgCommand } from "./commands/org/index.js";
 import { addSdkCommand } from "./commands/sdk/index.js";
 import { addTelemetryCommand } from "./commands/telemetry/index.js";
+import { getCompletionValues, isCompletionMode } from "./completion.js";
 import { GlobalArgs } from "./context/GlobalArgs.js";
 import { Version } from "./version.js";
 
 export async function runCliV2(argv?: string[]): Promise<void> {
-    getOrCreateFernRunId();
+    // Skip telemetry setup during shell completion so TAB stays fast
+    // and side-effect-free.
+    if (!isCompletionMode(argv)) {
+        getOrCreateFernRunId();
+    }
     const cli = createCliV2(argv);
     await cli.parse();
+}
+
+/**
+ * Content-aware shell completion handler.
+ *
+ * When the previous token is a flag that accepts workspace-derived values
+ * (e.g. `--group`, `--api`, `--instance`) we do a lightweight fern.yml
+ * parse and return matching entries. Otherwise we fall back to default
+ * yargs completions (commands, other flags, etc.).
+ */
+function completionHandler(
+    _current: string,
+    _argv: Record<string, unknown>,
+    defaultCompletionsFn: (onCompleted?: (err: Error | null, completions: string[] | undefined) => void) => void,
+    done: (completions: string[]) => void
+): void {
+    const args = process.argv;
+    const prev = args[args.length - 2];
+
+    if (prev === "--group" || prev === "--api" || prev === "--instance") {
+        void getCompletionValues(process.cwd()).then((values) => {
+            if (prev === "--group") {
+                done(values.groups);
+            } else if (prev === "--api") {
+                done(values.apis);
+            } else {
+                done(values.instances);
+            }
+        });
+        return;
+    }
+
+    defaultCompletionsFn((_err, defaults) => {
+        done(defaults ?? []);
+    });
 }
 
 function createCliV2(argv?: string[]): Argv<GlobalArgs> {
@@ -34,6 +74,7 @@ function createCliV2(argv?: string[]): Argv<GlobalArgs> {
             choices: ["debug", "info", "warn", "error"] as const,
             default: "info"
         })
+        .completion("completion", "Generate shell completion script", completionHandler)
         .strict()
         .demandCommand()
         .recommendCommands()

--- a/packages/cli/cli-v2/src/completion.ts
+++ b/packages/cli/cli-v2/src/completion.ts
@@ -1,0 +1,131 @@
+import { readFile } from "fs/promises";
+import yaml from "js-yaml";
+import { resolve } from "path";
+
+/**
+ * Returns true when the CLI is being invoked for shell completion
+ * (i.e. the user pressed TAB). This is used to skip heavy
+ * initialisation (telemetry, Sentry, network calls) so that
+ * completions are fast and side-effect-free.
+ */
+export function isCompletionMode(argv?: string[]): boolean {
+    const args = argv ?? process.argv;
+    return args.includes("--get-yargs-completions");
+}
+
+/**
+ * Lightweight fern.yml reader used exclusively during shell completion.
+ *
+ * Walks up from `cwd` looking for `fern.yml`, parses it as plain YAML
+ * (no Zod validation, no $ref resolution) and extracts the values
+ * needed for content-aware flag completion.
+ */
+export async function getCompletionValues(cwd: string): Promise<CompletionValues> {
+    const raw = await readFernYmlRaw(cwd);
+    if (raw == null) {
+        return { groups: [], apis: [], instances: [] };
+    }
+
+    const groups = extractGroups(raw);
+    const apis = extractApis(raw);
+    const instances = extractInstances(raw);
+
+    return { groups, apis, instances };
+}
+
+export interface CompletionValues {
+    groups: string[];
+    apis: string[];
+    instances: string[];
+}
+
+// ---------------------------------------------------------------------------
+// Internals
+// ---------------------------------------------------------------------------
+
+interface RawFernYml {
+    sdks?: {
+        defaultGroup?: string;
+        targets?: Record<string, { group?: string[] }>;
+    };
+    apis?: Record<string, unknown>;
+    api?: unknown;
+    docs?:
+        | {
+              instances?: Array<{ url?: string }>;
+          }
+        | string;
+}
+
+/**
+ * Walk up from `start` looking for fern.yml and parse it as untyped YAML.
+ * Returns undefined if not found or unparseable.
+ */
+async function readFernYmlRaw(start: string): Promise<RawFernYml | undefined> {
+    let dir = start;
+    for (let i = 0; i < 50; i++) {
+        const candidate = resolve(dir, "fern.yml");
+        try {
+            const content = await readFile(candidate, "utf-8");
+            const parsed = yaml.load(content);
+            if (parsed != null && typeof parsed === "object") {
+                return parsed as RawFernYml;
+            }
+            return undefined;
+        } catch {
+            // file not found or unreadable — walk up
+        }
+        const parent = resolve(dir, "..");
+        if (parent === dir) {
+            break;
+        }
+        dir = parent;
+    }
+    return undefined;
+}
+
+/**
+ * Collect all unique group names from sdks.targets[*].group[].
+ */
+function extractGroups(raw: RawFernYml): string[] {
+    const groups = new Set<string>();
+    if (raw.sdks?.targets != null) {
+        for (const target of Object.values(raw.sdks.targets)) {
+            if (Array.isArray(target?.group)) {
+                for (const g of target.group) {
+                    if (typeof g === "string") {
+                        groups.add(g);
+                    }
+                }
+            }
+        }
+    }
+    return [...groups].sort();
+}
+
+/**
+ * Collect API names from the `apis` map (keys) or return ["api"] for
+ * single-API projects that use the `api` key.
+ */
+function extractApis(raw: RawFernYml): string[] {
+    if (raw.apis != null && typeof raw.apis === "object") {
+        return Object.keys(raw.apis).sort();
+    }
+    if (raw.api != null) {
+        return ["api"];
+    }
+    return [];
+}
+
+/**
+ * Collect docs instance URLs.
+ */
+function extractInstances(raw: RawFernYml): string[] {
+    if (raw.docs == null || typeof raw.docs === "string") {
+        return [];
+    }
+    if (!Array.isArray(raw.docs.instances)) {
+        return [];
+    }
+    return raw.docs.instances.filter((inst) => typeof inst?.url === "string").map((inst) => inst.url as string);
+}

--- a/packages/cli/cli-v2/src/completion.ts
+++ b/packages/cli/cli-v2/src/completion.ts
@@ -57,6 +57,10 @@ interface RawFernYml {
         | string;
 }
 
+function isRawFernYml(value: unknown): value is RawFernYml {
+    return value != null && typeof value === "object";
+}
+
 /**
  * Walk up from `start` looking for fern.yml and parse it as untyped YAML.
  * Returns undefined if not found or unparseable.
@@ -68,10 +72,10 @@ async function readFernYmlRaw(start: string): Promise<RawFernYml | undefined> {
         try {
             const content = await readFile(candidate, "utf-8");
             const parsed = yaml.load(content);
-            if (parsed != null && typeof parsed === "object") {
-                return parsed as RawFernYml;
+            if (isRawFernYml(parsed)) {
+                return parsed;
             }
-            return undefined;
+            // file found but not an object — continue walking up
         } catch {
             // file not found or unreadable — walk up
         }
@@ -127,5 +131,5 @@ function extractInstances(raw: RawFernYml): string[] {
     if (!Array.isArray(raw.docs.instances)) {
         return [];
     }
-    return raw.docs.instances.filter((inst) => typeof inst?.url === "string").map((inst) => inst.url as string);
+    return raw.docs.instances.flatMap((inst) => (typeof inst?.url === "string" ? [inst.url] : []));
 }

--- a/packages/cli/cli/changes/unreleased/shell-completion.yml
+++ b/packages/cli/cli/changes/unreleased/shell-completion.yml
@@ -1,0 +1,14 @@
+# yaml-language-server: $schema=../../../../../fern-changes-yml.schema.json
+
+- summary: |
+    Fix shell completion triggering upgrade notices and slow network calls.
+    Suppress upgrade messages and skip version redirection when the shell
+    invokes `--get-yargs-completions` so that TAB completions are fast and
+    side-effect-free.
+  type: fix
+
+- summary: |
+    Add shell completion support to CLI v2 with content-aware completions
+    for `--group`, `--api`, and `--instance` flags. The completion reads
+    `fern.yml` to suggest valid values when the user presses TAB.
+  type: feat

--- a/packages/cli/cli/src/cli.ts
+++ b/packages/cli/cli/src/cli.ts
@@ -91,13 +91,15 @@ import { RUNTIME } from "./runtime.js";
 void runCli();
 
 async function runCli() {
-    getOrCreateFernRunId();
-
     // Shell completion must be fast and side-effect-free. When the shell
     // invokes `fern --get-yargs-completions …` we skip version redirection
     // (network call) and suppress upgrade notices so TAB never produces
     // extraneous output.
     const isCompletion = process.argv.includes("--get-yargs-completions");
+
+    if (!isCompletion) {
+        getOrCreateFernRunId();
+    }
 
     const isLocal = process.argv.includes("--local");
     const cliContext = await CliContext.create(process.stdout, process.stderr, { isLocal });

--- a/packages/cli/cli/src/cli.ts
+++ b/packages/cli/cli/src/cli.ts
@@ -93,8 +93,18 @@ void runCli();
 async function runCli() {
     getOrCreateFernRunId();
 
+    // Shell completion must be fast and side-effect-free. When the shell
+    // invokes `fern --get-yargs-completions …` we skip version redirection
+    // (network call) and suppress upgrade notices so TAB never produces
+    // extraneous output.
+    const isCompletion = process.argv.includes("--get-yargs-completions");
+
     const isLocal = process.argv.includes("--local");
     const cliContext = await CliContext.create(process.stdout, process.stderr, { isLocal });
+
+    if (isCompletion) {
+        cliContext.suppressUpgradeMessage();
+    }
 
     const exit = async () => {
         await cliContext.exit();
@@ -124,14 +134,21 @@ async function runCli() {
         if (cwd != null) {
             process.chdir(cwd);
         }
-        const versionOfCliToRun = await getIntendedVersionOfCli(cliContext);
-        if (cliContext.environment.packageVersion === versionOfCliToRun) {
+
+        // During completion, skip version redirection to avoid a slow network
+        // round-trip that blocks every TAB press.
+        if (isCompletion) {
             await tryRunCli(cliContext);
         } else {
-            await rerunFernCliAtVersion({
-                version: versionOfCliToRun,
-                cliContext
-            });
+            const versionOfCliToRun = await getIntendedVersionOfCli(cliContext);
+            if (cliContext.environment.packageVersion === versionOfCliToRun) {
+                await tryRunCli(cliContext);
+            } else {
+                await rerunFernCliAtVersion({
+                    version: versionOfCliToRun,
+                    cliContext
+                });
+            }
         }
     } catch (error) {
         cliContext.failWithoutThrowing(undefined, error);

--- a/packages/core/src/services/fdr.ts
+++ b/packages/core/src/services/fdr.ts
@@ -13,7 +13,7 @@ export function createFdrService({
     const overrideEnvironment = process.env.FERN_FDR_ORIGIN ?? process.env.OVERRIDE_FDR_ORIGIN;
     return new FdrClient({
         environment: overrideEnvironment ?? environment,
-        token,
+        token: typeof token === "function" ? token() : token,
         headers
     });
 }


### PR DESCRIPTION
## Description
Linear ticket: Closes [FER-8704](https://linear.app/buildwithfern/issue/FER-8704/cli-v2-shell-completion)

Shell completion currently triggers upgrade notices and slow network calls every time the user presses TAB. This PR fixes those side effects in CLI v1 and adds full shell completion support to CLI v2, including content-aware completions for workspace-derived flags.


<img width="807" height="199" alt="iScreen Shoter - Cursor - 260422001732" src="https://github.com/user-attachments/assets/73b865e1-6686-47db-9674-d46cbbc44c20" />
<br/>
<img width="552" height="150" alt="iScreen Shoter - Cursor - 260422002315" src="https://github.com/user-attachments/assets/242e867a-73d1-425f-a199-b433c40508c8" />


## Changes Made

### CLI v1 — Fix side effects during completion (`packages/cli/cli/src/cli.ts`)
- Detect `--get-yargs-completions` in `process.argv` early in `runCli()`
- Call `cliContext.suppressUpgradeMessage()` to prevent upgrade notices from appearing during TAB completion
- Skip `getIntendedVersionOfCli()` (network call for version redirection) during completion mode so TAB stays fast

### CLI v2 — Add shell completion (`packages/cli/cli-v2/src/cli.ts`)
- Register `.completion()` on the yargs instance to enable `fern completion` (outputs the shell completion script) and `--get-yargs-completions` (provides completions on TAB)
- Skip `getOrCreateFernRunId()` telemetry setup during completion mode
- Add a `completionHandler` that provides content-aware completions for `--group`, `--api`, and `--instance` flags by reading values from `fern.yml`

### Content-aware completion module (`packages/cli/cli-v2/src/completion.ts`)
- Lightweight `fern.yml` parser that walks up from `cwd` and parses as plain YAML (no Zod validation, no `$ref` resolution) for speed
- `isCompletionMode()` — detects when CLI is invoked for shell completion
- `getCompletionValues()` — extracts group names (from `sdks.targets[*].group[]`), API names (from `apis` keys), and docs instance URLs (from `docs.instances[*].url`)
- Falls back to default yargs completions for commands and other flags

## Testing
- [x] `pnpm run check` (biome lint) passes
- [x] `pnpm turbo run compile --filter @fern-api/cli-v2` compiles successfully
- [x] Manual review of yargs completion API compatibility

Link to Devin session: https://app.devin.ai/sessions/acbef1fddc974c579f764955a105160e
Requested by: @iamnamananand996