### PR TITLE
fix(cli): ignore stale slug history in missing redirects check

### DIFF
--- a/packages/cli/cli/changes/unreleased/fix-missing-redirects-stale-slugs.yml
+++ b/packages/cli/cli/changes/unreleased/fix-missing-redirects-stale-slugs.yml
@@ -1,0 +1,4 @@
+- summary: |
+    Fix the missing-redirects check to ignore stale historical slug-table rows
+    and only compare against the most recent published slug per page.
+  type: fix

--- a/packages/cli/yaml/docs-validator/src/rules/missing-redirects/__test__/missing-redirects.test.ts
+++ b/packages/cli/yaml/docs-validator/src/rules/missing-redirects/__test__/missing-redirects.test.ts
@@ -29,7 +29,9 @@ describe("findRemovedSlugs", () => {
     });
 
     it("detects a moved page (same pageId, different slug)", () => {
-        const published: MarkdownEntry[] = [{ pageId: "docs/guide.mdx", slug: "getting-started", lastUpdated: "2024-01-01T00:00:00.000Z" }];
+        const published: MarkdownEntry[] = [
+            { pageId: "docs/guide.mdx", slug: "getting-started", lastUpdated: "2024-01-01T00:00:00.000Z" }
+        ];
         const local = new Map([["docs/guide.mdx", "guides/quickstart"]]);
         const removed = findRemovedSlugs(published, local);
         expect(removed).toEqual([
@@ -54,7 +56,9 @@ describe("findRemovedSlugs", () => {
     });
 
     it("ignores new pages that only exist locally", () => {
-        const published: MarkdownEntry[] = [{ pageId: "docs/existing.mdx", slug: "existing", lastUpdated: "2024-01-01T00:00:00.000Z" }];
+        const published: MarkdownEntry[] = [
+            { pageId: "docs/existing.mdx", slug: "existing", lastUpdated: "2024-01-01T00:00:00.000Z" }
+        ];
         const local = new Map([
             ["docs/existing.mdx", "existing"],
             ["docs/brand-new.mdx", "brand-new"]
@@ -80,7 +84,9 @@ describe("findRemovedSlugs", () => {
     });
 
     it("skips moved page when another local page still serves the old slug", () => {
-        const published: MarkdownEntry[] = [{ pageId: "docs/guide.mdx", slug: "shared-slug", lastUpdated: "2024-01-01T00:00:00.000Z" }];
+        const published: MarkdownEntry[] = [
+            { pageId: "docs/guide.mdx", slug: "shared-slug", lastUpdated: "2024-01-01T00:00:00.000Z" }
+        ];
         const local = new Map([
             ["docs/guide.mdx", "new-slug"],
             ["docs/other.mdx", "shared-slug"]
@@ -90,8 +96,16 @@ describe("findRemovedSlugs", () => {
 
     it("skips changelog entries that share their parent slug when entry is removed", () => {
         const published: MarkdownEntry[] = [
-            { pageId: "changelog/2024-01-15.mdx", slug: "whats-new/changelog", lastUpdated: "2024-01-01T00:00:00.000Z" },
-            { pageId: "changelog/2024-01-15-hotfix.mdx", slug: "whats-new/changelog", lastUpdated: "2024-01-01T00:00:00.000Z" },
+            {
+                pageId: "changelog/2024-01-15.mdx",
+                slug: "whats-new/changelog",
+                lastUpdated: "2024-01-01T00:00:00.000Z"
+            },
+            {
+                pageId: "changelog/2024-01-15-hotfix.mdx",
+                slug: "whats-new/changelog",
+                lastUpdated: "2024-01-01T00:00:00.000Z"
+            },
             { pageId: "changelog/2024-02-01.mdx", slug: "whats-new/changelog", lastUpdated: "2024-01-01T00:00:00.000Z" }
         ];
         const local = new Map([["changelog/2024-02-01.mdx", "whats-new/changelog"]]);
@@ -99,13 +113,17 @@ describe("findRemovedSlugs", () => {
     });
 
     it("skips published entries with empty slug when landing page serves root", () => {
-        const published: MarkdownEntry[] = [{ pageId: "changelog/2024-01-15.mdx", slug: "", lastUpdated: "2024-01-01T00:00:00.000Z" }];
+        const published: MarkdownEntry[] = [
+            { pageId: "changelog/2024-01-15.mdx", slug: "", lastUpdated: "2024-01-01T00:00:00.000Z" }
+        ];
         const local = new Map([["pages/landing.mdx", ""]]);
         expect(findRemovedSlugs(published, local)).toEqual([]);
     });
 
     it("still flags removed page when no local page serves the old slug", () => {
-        const published: MarkdownEntry[] = [{ pageId: "docs/old.mdx", slug: "unique-old-slug", lastUpdated: "2024-01-01T00:00:00.000Z" }];
+        const published: MarkdownEntry[] = [
+            { pageId: "docs/old.mdx", slug: "unique-old-slug", lastUpdated: "2024-01-01T00:00:00.000Z" }
+        ];
         const local = new Map([["docs/new.mdx", "different-slug"]]);
         const removed = findRemovedSlugs(published, local);
         expect(removed).toEqual([{ pageId: "docs/old.mdx", oldSlug: "unique-old-slug", newSlug: undefined }]);
@@ -278,10 +296,26 @@ describe("integration: keepLatestEntryPerPageId + findRemovedSlugs", () => {
         // After dedup, findRemovedSlugs should see one row per pageId at the
         // current slug and produce zero warnings.
         const published: MarkdownEntry[] = [
-            { pageId: "docs/api-clients.md", slug: "api-reference/getting-started/api-clients", lastUpdated: "2022-01-01T00:00:00.000Z" },
-            { pageId: "docs/api-clients.md", slug: "api/getting-started/api-clients", lastUpdated: "2023-06-01T00:00:00.000Z" },
-            { pageId: "docs/api-clients.md", slug: "api/overview/api-clients", lastUpdated: "2024-12-01T00:00:00.000Z" },
-            { pageId: "docs/intro.md", slug: "api-reference/getting-started/introduction", lastUpdated: "2022-01-01T00:00:00.000Z" },
+            {
+                pageId: "docs/api-clients.md",
+                slug: "api-reference/getting-started/api-clients",
+                lastUpdated: "2022-01-01T00:00:00.000Z"
+            },
+            {
+                pageId: "docs/api-clients.md",
+                slug: "api/getting-started/api-clients",
+                lastUpdated: "2023-06-01T00:00:00.000Z"
+            },
+            {
+                pageId: "docs/api-clients.md",
+                slug: "api/overview/api-clients",
+                lastUpdated: "2024-12-01T00:00:00.000Z"
+            },
+            {
+                pageId: "docs/intro.md",
+                slug: "api-reference/getting-started/introduction",
+                lastUpdated: "2022-01-01T00:00:00.000Z"
+            },
             { pageId: "docs/intro.md", slug: "api/overview", lastUpdated: "2024-12-01T00:00:00.000Z" }
         ];
         const local = new Map([
@@ -311,9 +345,7 @@ describe("integration: keepLatestEntryPerPageId + findRemovedSlugs", () => {
         const deduped = keepLatestEntryPerPageId(published);
         const removed = findRemovedSlugs(deduped, local);
 
-        expect(removed).toEqual([
-            { pageId: "docs/guide.md", oldSlug: "v3/guide", newSlug: "v4/guide" }
-        ]);
+        expect(removed).toEqual([{ pageId: "docs/guide.md", oldSlug: "v3/guide", newSlug: "v4/guide" }]);
     });
 
     it("flags the most recent slug when a pageId is removed entirely, ignoring stale history", () => {
@@ -329,9 +361,7 @@ describe("integration: keepLatestEntryPerPageId + findRemovedSlugs", () => {
         const deduped = keepLatestEntryPerPageId(published);
         const removed = findRemovedSlugs(deduped, local);
 
-        expect(removed).toEqual([
-            { pageId: "docs/deprecated.md", oldSlug: "v3/deprecated", newSlug: undefined }
-        ]);
+        expect(removed).toEqual([{ pageId: "docs/deprecated.md", oldSlug: "v3/deprecated", newSlug: undefined }]);
     });
 
     it("emits zero warnings for a changelog whose parent slug has been renamed over time", () => {
@@ -342,10 +372,26 @@ describe("integration: keepLatestEntryPerPageId + findRemovedSlugs", () => {
         // the findRemovedSlugs activeSlugs skip does, because the current
         // parent slug serves all entries.
         const published: MarkdownEntry[] = [
-            { pageId: "changelog/2024-01.mdx", slug: "api-reference/getting-started/changelog", lastUpdated: "2022-01-01T00:00:00.000Z" },
-            { pageId: "changelog/2024-01.mdx", slug: "api/getting-started/changelog", lastUpdated: "2023-06-01T00:00:00.000Z" },
-            { pageId: "changelog/2024-01.mdx", slug: "api/overview/changelog", lastUpdated: "2024-12-01T00:00:00.000Z" },
-            { pageId: "changelog/2024-02.mdx", slug: "api/getting-started/changelog", lastUpdated: "2023-06-01T00:00:00.000Z" },
+            {
+                pageId: "changelog/2024-01.mdx",
+                slug: "api-reference/getting-started/changelog",
+                lastUpdated: "2022-01-01T00:00:00.000Z"
+            },
+            {
+                pageId: "changelog/2024-01.mdx",
+                slug: "api/getting-started/changelog",
+                lastUpdated: "2023-06-01T00:00:00.000Z"
+            },
+            {
+                pageId: "changelog/2024-01.mdx",
+                slug: "api/overview/changelog",
+                lastUpdated: "2024-12-01T00:00:00.000Z"
+            },
+            {
+                pageId: "changelog/2024-02.mdx",
+                slug: "api/getting-started/changelog",
+                lastUpdated: "2023-06-01T00:00:00.000Z"
+            },
             { pageId: "changelog/2024-02.mdx", slug: "api/overview/changelog", lastUpdated: "2024-12-01T00:00:00.000Z" }
         ];
         const local = new Map([

--- a/packages/cli/yaml/docs-validator/src/rules/missing-redirects/__test__/missing-redirects.test.ts
+++ b/packages/cli/yaml/docs-validator/src/rules/missing-redirects/__test__/missing-redirects.test.ts
@@ -1,10 +1,15 @@
-import { checkMissingRedirects, findRemovedSlugs, type MarkdownEntry } from "../missing-redirects-logic.js";
+import {
+    checkMissingRedirects,
+    findRemovedSlugs,
+    keepLatestEntryPerPageId,
+    type MarkdownEntry
+} from "../missing-redirects-logic.js";
 
 describe("findRemovedSlugs", () => {
     it("returns empty when published and local are identical", () => {
         const published: MarkdownEntry[] = [
-            { pageId: "docs/welcome.mdx", slug: "welcome" },
-            { pageId: "docs/guide.mdx", slug: "guide" }
+            { pageId: "docs/welcome.mdx", slug: "welcome", lastUpdated: "2024-01-01T00:00:00.000Z" },
+            { pageId: "docs/guide.mdx", slug: "guide", lastUpdated: "2024-01-01T00:00:00.000Z" }
         ];
         const local = new Map([
             ["docs/welcome.mdx", "welcome"],
@@ -15,8 +20,8 @@ describe("findRemovedSlugs", () => {
 
     it("detects a removed page (pageId absent from local)", () => {
         const published: MarkdownEntry[] = [
-            { pageId: "docs/welcome.mdx", slug: "welcome" },
-            { pageId: "docs/old-page.mdx", slug: "old-page" }
+            { pageId: "docs/welcome.mdx", slug: "welcome", lastUpdated: "2024-01-01T00:00:00.000Z" },
+            { pageId: "docs/old-page.mdx", slug: "old-page", lastUpdated: "2024-01-01T00:00:00.000Z" }
         ];
         const local = new Map([["docs/welcome.mdx", "welcome"]]);
         const removed = findRemovedSlugs(published, local);
@@ -24,7 +29,7 @@ describe("findRemovedSlugs", () => {
     });
 
     it("detects a moved page (same pageId, different slug)", () => {
-        const published: MarkdownEntry[] = [{ pageId: "docs/guide.mdx", slug: "getting-started" }];
+        const published: MarkdownEntry[] = [{ pageId: "docs/guide.mdx", slug: "getting-started", lastUpdated: "2024-01-01T00:00:00.000Z" }];
         const local = new Map([["docs/guide.mdx", "guides/quickstart"]]);
         const removed = findRemovedSlugs(published, local);
         expect(removed).toEqual([
@@ -34,9 +39,9 @@ describe("findRemovedSlugs", () => {
 
     it("detects multiple removals and moves together", () => {
         const published: MarkdownEntry[] = [
-            { pageId: "docs/a.mdx", slug: "a" },
-            { pageId: "docs/b.mdx", slug: "b" },
-            { pageId: "docs/c.mdx", slug: "c" }
+            { pageId: "docs/a.mdx", slug: "a", lastUpdated: "2024-01-01T00:00:00.000Z" },
+            { pageId: "docs/b.mdx", slug: "b", lastUpdated: "2024-01-01T00:00:00.000Z" },
+            { pageId: "docs/c.mdx", slug: "c", lastUpdated: "2024-01-01T00:00:00.000Z" }
         ];
         const local = new Map([
             ["docs/a.mdx", "a"],
@@ -49,7 +54,7 @@ describe("findRemovedSlugs", () => {
     });
 
     it("ignores new pages that only exist locally", () => {
-        const published: MarkdownEntry[] = [{ pageId: "docs/existing.mdx", slug: "existing" }];
+        const published: MarkdownEntry[] = [{ pageId: "docs/existing.mdx", slug: "existing", lastUpdated: "2024-01-01T00:00:00.000Z" }];
         const local = new Map([
             ["docs/existing.mdx", "existing"],
             ["docs/brand-new.mdx", "brand-new"]
@@ -64,8 +69,8 @@ describe("findRemovedSlugs", () => {
 
     it("skips removed page when another local page still serves the same slug", () => {
         const published: MarkdownEntry[] = [
-            { pageId: "docs/welcome.mdx", slug: "welcome" },
-            { pageId: "changelog/2024-01-15.mdx", slug: "changelog" }
+            { pageId: "docs/welcome.mdx", slug: "welcome", lastUpdated: "2024-01-01T00:00:00.000Z" },
+            { pageId: "changelog/2024-01-15.mdx", slug: "changelog", lastUpdated: "2024-01-01T00:00:00.000Z" }
         ];
         const local = new Map([
             ["docs/welcome.mdx", "welcome"],
@@ -75,7 +80,7 @@ describe("findRemovedSlugs", () => {
     });
 
     it("skips moved page when another local page still serves the old slug", () => {
-        const published: MarkdownEntry[] = [{ pageId: "docs/guide.mdx", slug: "shared-slug" }];
+        const published: MarkdownEntry[] = [{ pageId: "docs/guide.mdx", slug: "shared-slug", lastUpdated: "2024-01-01T00:00:00.000Z" }];
         const local = new Map([
             ["docs/guide.mdx", "new-slug"],
             ["docs/other.mdx", "shared-slug"]
@@ -85,22 +90,22 @@ describe("findRemovedSlugs", () => {
 
     it("skips changelog entries that share their parent slug when entry is removed", () => {
         const published: MarkdownEntry[] = [
-            { pageId: "changelog/2024-01-15.mdx", slug: "whats-new/changelog" },
-            { pageId: "changelog/2024-01-15-hotfix.mdx", slug: "whats-new/changelog" },
-            { pageId: "changelog/2024-02-01.mdx", slug: "whats-new/changelog" }
+            { pageId: "changelog/2024-01-15.mdx", slug: "whats-new/changelog", lastUpdated: "2024-01-01T00:00:00.000Z" },
+            { pageId: "changelog/2024-01-15-hotfix.mdx", slug: "whats-new/changelog", lastUpdated: "2024-01-01T00:00:00.000Z" },
+            { pageId: "changelog/2024-02-01.mdx", slug: "whats-new/changelog", lastUpdated: "2024-01-01T00:00:00.000Z" }
         ];
         const local = new Map([["changelog/2024-02-01.mdx", "whats-new/changelog"]]);
         expect(findRemovedSlugs(published, local)).toEqual([]);
     });
 
     it("skips published entries with empty slug when landing page serves root", () => {
-        const published: MarkdownEntry[] = [{ pageId: "changelog/2024-01-15.mdx", slug: "" }];
+        const published: MarkdownEntry[] = [{ pageId: "changelog/2024-01-15.mdx", slug: "", lastUpdated: "2024-01-01T00:00:00.000Z" }];
         const local = new Map([["pages/landing.mdx", ""]]);
         expect(findRemovedSlugs(published, local)).toEqual([]);
     });
 
     it("still flags removed page when no local page serves the old slug", () => {
-        const published: MarkdownEntry[] = [{ pageId: "docs/old.mdx", slug: "unique-old-slug" }];
+        const published: MarkdownEntry[] = [{ pageId: "docs/old.mdx", slug: "unique-old-slug", lastUpdated: "2024-01-01T00:00:00.000Z" }];
         const local = new Map([["docs/new.mdx", "different-slug"]]);
         const removed = findRemovedSlugs(published, local);
         expect(removed).toEqual([{ pageId: "docs/old.mdx", oldSlug: "unique-old-slug", newSlug: undefined }]);
@@ -211,5 +216,56 @@ describe("checkMissingRedirects", () => {
         expect(violations).toHaveLength(1);
         expect(violations[0]?.message).toContain('source: "/old-path"');
         expect(violations[0]?.message).toContain('destination: "/new-path"');
+    });
+});
+
+describe("keepLatestEntryPerPageId", () => {
+    it("returns empty for empty input", () => {
+        expect(keepLatestEntryPerPageId([])).toEqual([]);
+    });
+
+    it("passes through rows that already have unique pageIds", () => {
+        const entries: MarkdownEntry[] = [
+            { pageId: "a.mdx", slug: "a", lastUpdated: "2024-01-01T00:00:00.000Z" },
+            { pageId: "b.mdx", slug: "b", lastUpdated: "2024-02-01T00:00:00.000Z" }
+        ];
+        expect(keepLatestEntryPerPageId(entries)).toEqual(entries);
+    });
+
+    it("keeps only the row with the highest lastUpdated per pageId", () => {
+        const entries: MarkdownEntry[] = [
+            { pageId: "a.mdx", slug: "old", lastUpdated: "2024-01-01T00:00:00.000Z" },
+            { pageId: "a.mdx", slug: "new", lastUpdated: "2024-03-01T00:00:00.000Z" },
+            { pageId: "a.mdx", slug: "middle", lastUpdated: "2024-02-01T00:00:00.000Z" }
+        ];
+        expect(keepLatestEntryPerPageId(entries)).toEqual([
+            { pageId: "a.mdx", slug: "new", lastUpdated: "2024-03-01T00:00:00.000Z" }
+        ]);
+    });
+
+    it("dedupes per pageId across many pages independently", () => {
+        const entries: MarkdownEntry[] = [
+            { pageId: "a.mdx", slug: "a-old", lastUpdated: "2024-01-01T00:00:00.000Z" },
+            { pageId: "a.mdx", slug: "a-new", lastUpdated: "2024-02-01T00:00:00.000Z" },
+            { pageId: "b.mdx", slug: "b-old", lastUpdated: "2024-01-15T00:00:00.000Z" },
+            { pageId: "b.mdx", slug: "b-new", lastUpdated: "2024-04-01T00:00:00.000Z" },
+            { pageId: "c.mdx", slug: "c-only", lastUpdated: "2023-12-01T00:00:00.000Z" }
+        ];
+        const result = keepLatestEntryPerPageId(entries);
+        expect(result).toHaveLength(3);
+        expect(result).toContainEqual({ pageId: "a.mdx", slug: "a-new", lastUpdated: "2024-02-01T00:00:00.000Z" });
+        expect(result).toContainEqual({ pageId: "b.mdx", slug: "b-new", lastUpdated: "2024-04-01T00:00:00.000Z" });
+        expect(result).toContainEqual({ pageId: "c.mdx", slug: "c-only", lastUpdated: "2023-12-01T00:00:00.000Z" });
+    });
+
+    it("is order-independent on the input", () => {
+        const entries: MarkdownEntry[] = [
+            { pageId: "a.mdx", slug: "old", lastUpdated: "2024-01-01T00:00:00.000Z" },
+            { pageId: "a.mdx", slug: "new", lastUpdated: "2024-03-01T00:00:00.000Z" }
+        ];
+        const reversed = [...entries].reverse();
+        expect(keepLatestEntryPerPageId(reversed)).toEqual([
+            { pageId: "a.mdx", slug: "new", lastUpdated: "2024-03-01T00:00:00.000Z" }
+        ]);
     });
 });

--- a/packages/cli/yaml/docs-validator/src/rules/missing-redirects/__test__/missing-redirects.test.ts
+++ b/packages/cli/yaml/docs-validator/src/rules/missing-redirects/__test__/missing-redirects.test.ts
@@ -269,3 +269,119 @@ describe("keepLatestEntryPerPageId", () => {
         ]);
     });
 });
+
+describe("integration: keepLatestEntryPerPageId + findRemovedSlugs", () => {
+    it("emits zero warnings when every stale row's pageId is at its latest slug locally", () => {
+        // Simulates the Close case: the slug table has accumulated multiple
+        // historical (pageId, slug) rows per pageId from past nav restructurings,
+        // but the customer has not changed anything since the most recent publish.
+        // After dedup, findRemovedSlugs should see one row per pageId at the
+        // current slug and produce zero warnings.
+        const published: MarkdownEntry[] = [
+            { pageId: "docs/api-clients.md", slug: "api-reference/getting-started/api-clients", lastUpdated: "2022-01-01T00:00:00.000Z" },
+            { pageId: "docs/api-clients.md", slug: "api/getting-started/api-clients", lastUpdated: "2023-06-01T00:00:00.000Z" },
+            { pageId: "docs/api-clients.md", slug: "api/overview/api-clients", lastUpdated: "2024-12-01T00:00:00.000Z" },
+            { pageId: "docs/intro.md", slug: "api-reference/getting-started/introduction", lastUpdated: "2022-01-01T00:00:00.000Z" },
+            { pageId: "docs/intro.md", slug: "api/overview", lastUpdated: "2024-12-01T00:00:00.000Z" }
+        ];
+        const local = new Map([
+            ["docs/api-clients.md", "api/overview/api-clients"],
+            ["docs/intro.md", "api/overview"]
+        ]);
+
+        const deduped = keepLatestEntryPerPageId(published);
+        const removed = findRemovedSlugs(deduped, local);
+
+        expect(removed).toEqual([]);
+    });
+
+    it("flags only the most recent slug when there are stale rows AND a real slug change", () => {
+        // The customer restructured the nav multiple times historically (all those
+        // old slugs linger as stale rows in FDR). They have also just moved a page
+        // one more time locally, without publishing yet. We want exactly ONE
+        // warning about the latest transition — not additional warnings for each
+        // ancient slug.
+        const published: MarkdownEntry[] = [
+            { pageId: "docs/guide.md", slug: "v1/guide", lastUpdated: "2022-01-01T00:00:00.000Z" },
+            { pageId: "docs/guide.md", slug: "v2/guide", lastUpdated: "2023-01-01T00:00:00.000Z" },
+            { pageId: "docs/guide.md", slug: "v3/guide", lastUpdated: "2024-06-01T00:00:00.000Z" }
+        ];
+        const local = new Map([["docs/guide.md", "v4/guide"]]);
+
+        const deduped = keepLatestEntryPerPageId(published);
+        const removed = findRemovedSlugs(deduped, local);
+
+        expect(removed).toEqual([
+            { pageId: "docs/guide.md", oldSlug: "v3/guide", newSlug: "v4/guide" }
+        ]);
+    });
+
+    it("flags the most recent slug when a pageId is removed entirely, ignoring stale history", () => {
+        // Similar to above but the page is fully gone locally, not just moved.
+        // Expect one warning about the most recent slug, not N warnings.
+        const published: MarkdownEntry[] = [
+            { pageId: "docs/deprecated.md", slug: "v1/deprecated", lastUpdated: "2022-01-01T00:00:00.000Z" },
+            { pageId: "docs/deprecated.md", slug: "v2/deprecated", lastUpdated: "2023-01-01T00:00:00.000Z" },
+            { pageId: "docs/deprecated.md", slug: "v3/deprecated", lastUpdated: "2024-06-01T00:00:00.000Z" }
+        ];
+        const local = new Map<string, string>();
+
+        const deduped = keepLatestEntryPerPageId(published);
+        const removed = findRemovedSlugs(deduped, local);
+
+        expect(removed).toEqual([
+            { pageId: "docs/deprecated.md", oldSlug: "v3/deprecated", newSlug: undefined }
+        ]);
+    });
+
+    it("emits zero warnings for a changelog whose parent slug has been renamed over time", () => {
+        // Direct analogue of Close's changelog situation: one row per entry per
+        // historical parent slug (api-reference/getting-started/changelog →
+        // api/getting-started/changelog → api/overview/changelog). Each row
+        // has a distinct pageId, so dedup alone doesn't collapse them — but
+        // the findRemovedSlugs activeSlugs skip does, because the current
+        // parent slug serves all entries.
+        const published: MarkdownEntry[] = [
+            { pageId: "changelog/2024-01.mdx", slug: "api-reference/getting-started/changelog", lastUpdated: "2022-01-01T00:00:00.000Z" },
+            { pageId: "changelog/2024-01.mdx", slug: "api/getting-started/changelog", lastUpdated: "2023-06-01T00:00:00.000Z" },
+            { pageId: "changelog/2024-01.mdx", slug: "api/overview/changelog", lastUpdated: "2024-12-01T00:00:00.000Z" },
+            { pageId: "changelog/2024-02.mdx", slug: "api/getting-started/changelog", lastUpdated: "2023-06-01T00:00:00.000Z" },
+            { pageId: "changelog/2024-02.mdx", slug: "api/overview/changelog", lastUpdated: "2024-12-01T00:00:00.000Z" }
+        ];
+        const local = new Map([
+            ["changelog/2024-01.mdx", "api/overview/changelog"],
+            ["changelog/2024-02.mdx", "api/overview/changelog"]
+        ]);
+
+        const deduped = keepLatestEntryPerPageId(published);
+        const removed = findRemovedSlugs(deduped, local);
+
+        expect(removed).toEqual([]);
+    });
+
+    it("handles a mix of stable pages, stale-only pages, and a real change in one table", () => {
+        // Realistic mixed scenario: most pages are stable, some have stale rows
+        // at their current slug (no-op), one page has a genuine pending move.
+        // The rule should fire exactly one warning — for the genuine move.
+        const published: MarkdownEntry[] = [
+            // Stable page, one row.
+            { pageId: "docs/a.md", slug: "a", lastUpdated: "2024-12-01T00:00:00.000Z" },
+            // Stable page but with historical stale rows.
+            { pageId: "docs/b.md", slug: "old-b", lastUpdated: "2022-01-01T00:00:00.000Z" },
+            { pageId: "docs/b.md", slug: "b", lastUpdated: "2024-12-01T00:00:00.000Z" },
+            // Pending move: last published slug is "c", but local has moved it to "new-c".
+            { pageId: "docs/c.md", slug: "ancient-c", lastUpdated: "2022-01-01T00:00:00.000Z" },
+            { pageId: "docs/c.md", slug: "c", lastUpdated: "2024-06-01T00:00:00.000Z" }
+        ];
+        const local = new Map([
+            ["docs/a.md", "a"],
+            ["docs/b.md", "b"],
+            ["docs/c.md", "new-c"]
+        ]);
+
+        const deduped = keepLatestEntryPerPageId(published);
+        const removed = findRemovedSlugs(deduped, local);
+
+        expect(removed).toEqual([{ pageId: "docs/c.md", oldSlug: "c", newSlug: "new-c" }]);
+    });
+});

--- a/packages/cli/yaml/docs-validator/src/rules/missing-redirects/missing-redirects-logic.ts
+++ b/packages/cli/yaml/docs-validator/src/rules/missing-redirects/missing-redirects-logic.ts
@@ -7,13 +7,11 @@ export interface MarkdownEntry {
 }
 
 /**
- * FDR's slug table may legitimately contain multiple historical (pageId, slug)
- * rows per pageId — either as a side effect of the slug-change row-leak before
- * it was fixed, or deliberately once FDR starts preserving old mappings for
- * docs-site versioning. For the missing-redirects check we only care about the
- * most recent slug per pageId: that's the one representing the last published
- * state of the page. Older rows would otherwise produce warnings for URLs the
- * customer already handled at the time (if they were ever served at all).
+ * FDR's slug table may contain multiple (pageId, slug) rows per pageId —
+ * either as the tail of a past slug change, or deliberately as part of future
+ * docs-site versioning. The missing-redirects check only needs the most recent
+ * row per pageId; older rows describe an older published state and would
+ * otherwise produce false positives.
  */
 export function keepLatestEntryPerPageId(entries: MarkdownEntry[]): MarkdownEntry[] {
     const latestByPageId = new Map<string, MarkdownEntry>();

--- a/packages/cli/yaml/docs-validator/src/rules/missing-redirects/missing-redirects-logic.ts
+++ b/packages/cli/yaml/docs-validator/src/rules/missing-redirects/missing-redirects-logic.ts
@@ -3,6 +3,27 @@ import { match } from "path-to-regexp";
 export interface MarkdownEntry {
     pageId: string;
     slug: string;
+    lastUpdated: string;
+}
+
+/**
+ * FDR's slug table may legitimately contain multiple historical (pageId, slug)
+ * rows per pageId — either as a side effect of the slug-change row-leak before
+ * it was fixed, or deliberately once FDR starts preserving old mappings for
+ * docs-site versioning. For the missing-redirects check we only care about the
+ * most recent slug per pageId: that's the one representing the last published
+ * state of the page. Older rows would otherwise produce warnings for URLs the
+ * customer already handled at the time (if they were ever served at all).
+ */
+export function keepLatestEntryPerPageId(entries: MarkdownEntry[]): MarkdownEntry[] {
+    const latestByPageId = new Map<string, MarkdownEntry>();
+    for (const entry of entries) {
+        const existing = latestByPageId.get(entry.pageId);
+        if (existing == null || Date.parse(entry.lastUpdated) >= Date.parse(existing.lastUpdated)) {
+            latestByPageId.set(entry.pageId, entry);
+        }
+    }
+    return Array.from(latestByPageId.values());
 }
 
 export interface RemovedSlug {

--- a/packages/cli/yaml/docs-validator/src/rules/missing-redirects/missing-redirects.ts
+++ b/packages/cli/yaml/docs-validator/src/rules/missing-redirects/missing-redirects.ts
@@ -8,7 +8,12 @@ import { createMockTaskContext } from "@fern-api/task-context";
 import { Rule } from "../../Rule.js";
 import { getInstanceUrls, toBaseUrl } from "../valid-markdown-link/url-utils.js";
 import { buildPageIdToSlugMap } from "./buildPageIdToSlugMap.js";
-import { checkMissingRedirects, findRemovedSlugs, type MarkdownEntry } from "./missing-redirects-logic.js";
+import {
+    checkMissingRedirects,
+    findRemovedSlugs,
+    keepLatestEntryPerPageId,
+    type MarkdownEntry
+} from "./missing-redirects-logic.js";
 
 const NOOP_CONTEXT = createMockTaskContext({ logger: createLogger(noop) });
 
@@ -46,13 +51,10 @@ async function fetchMarkdownEntries(
             return { error: `FDR returned ${response.status}` };
         }
         const data = (await response.json()) as {
-            entries?: Array<{ pageId: string; slug: string }>;
+            entries: MarkdownEntry[];
         };
         return {
-            entries: (data.entries ?? []).map((entry) => ({
-                pageId: entry.pageId,
-                slug: entry.slug
-            }))
+            entries: data.entries
         };
     } catch (error) {
         const message = error instanceof Error ? error.message : String(error);
@@ -114,7 +116,8 @@ export const MissingRedirectsRule: Rule = {
 
         const root = FernNavigation.migrate.FernNavigationV1ToLatest.create().root(resolvedDocsDefinition.config.root);
         const localPageIdToSlug = buildPageIdToSlugMap(root);
-        const removedSlugs = findRemovedSlugs(result.entries, localPageIdToSlug);
+        const latestEntries = keepLatestEntryPerPageId(result.entries);
+        const removedSlugs = findRemovedSlugs(latestEntries, localPageIdToSlug);
 
         if (removedSlugs.length === 0) {
             return {};


### PR DESCRIPTION
## Description
Linear ticket: Closes FER-9430
<!-- Use "Closes" to automatically close the ticket when PR merges, or "Refs" to link without closing -->
<!-- Provide a clear and concise description of the changes made in this PR -->

Fixes false positives in the `missing-redirects` check when FDR returns multiple historical slug mappings for the same `pageId`.

The rule now keeps only the most recent slug-table row per `pageId` before comparing published state against the local docs config. This makes the check resilient both to stale rows already present in FDR and to future FDR behavior where older mappings may be preserved intentionally for docs-site versioning.

## Changes Made
<!-- List the main changes and updates implemented in this PR -->
- Added `keepLatestEntryPerPageId()` to dedupe FDR markdown entries down to the latest slug per page before running redirect validation
- Updated the missing-redirects rule and test suite to cover stale historical rows, changelog-style shared slugs, and real move/remove cases

## Testing
<!-- Describe how you tested these changes -->
- [x] Unit tests added/updated
- [x] Manual testing completed