### PR TITLE
feat(ruby): annotate endpoint availability in generated Ruby v2 SDK

### DIFF
--- a/generators/ruby-v2/ast/src/custom-config/BaseRubyCustomConfigSchema.ts
+++ b/generators/ruby-v2/ast/src/custom-config/BaseRubyCustomConfigSchema.ts
@@ -43,12 +43,15 @@ export const BaseRubyCustomConfigSchema = z.object({
     // - "error": reports violations as errors (used in seed to enforce rubocop)
     rubocopSeverity: z.enum(["info", "warning", "error"]).optional(),
     maxRetries: z.number().int().min(0).optional(),
-    // When true, generated endpoint docstrings include YARD availability tags
-    // (`@deprecated` / `@beta`) sourced from the IR's `availability` field.
+    // When true, generated SDK code surfaces IR-level `availability` via YARD
+    // annotations (`@deprecated` / `@beta`). Today this only applies to HTTP
+    // endpoint docstrings; the flag is named generically so future surfaces
+    // (services, types, properties, enum values, webhooks, websocket channels,
+    // errors) can opt in under the same flag.
     // Defaults to false to preserve byte-for-byte output for existing customers,
     // since YARD's `@deprecated` surfaces as a warning in strict lint setups.
     // TODO(next-major): flip default to true.
-    generateEndpointAvailability: z.boolean().optional()
+    generateAvailabilityAnnotations: z.boolean().optional()
 });
 
 export type BaseRubyCustomConfigSchema = z.infer<typeof BaseRubyCustomConfigSchema>;

--- a/generators/ruby-v2/ast/src/custom-config/BaseRubyCustomConfigSchema.ts
+++ b/generators/ruby-v2/ast/src/custom-config/BaseRubyCustomConfigSchema.ts
@@ -42,7 +42,13 @@ export const BaseRubyCustomConfigSchema = z.object({
     // - "warning": reports violations as warnings (default for customer SDKs)
     // - "error": reports violations as errors (used in seed to enforce rubocop)
     rubocopSeverity: z.enum(["info", "warning", "error"]).optional(),
-    maxRetries: z.number().int().min(0).optional()
+    maxRetries: z.number().int().min(0).optional(),
+    // When true, generated endpoint docstrings include YARD availability tags
+    // (`@deprecated` / `@beta`) sourced from the IR's `availability` field.
+    // Defaults to false to preserve byte-for-byte output for existing customers,
+    // since YARD's `@deprecated` surfaces as a warning in strict lint setups.
+    // TODO(next-major): flip default to true.
+    generateEndpointAvailability: z.boolean().optional()
 });
 
 export type BaseRubyCustomConfigSchema = z.infer<typeof BaseRubyCustomConfigSchema>;

--- a/generators/ruby-v2/sdk/changes/unreleased/endpoint-availability-annotations.yml
+++ b/generators/ruby-v2/sdk/changes/unreleased/endpoint-availability-annotations.yml
@@ -1,0 +1,6 @@
+- summary: |
+    Generated Ruby v2 SDK methods now surface endpoint availability
+    (deprecated / in-development / pre-release) using YARD's native
+    `@deprecated` tag where one exists, and fall back to doc comments
+    otherwise.
+  type: feat

--- a/generators/ruby-v2/sdk/changes/unreleased/endpoint-availability-annotations.yml
+++ b/generators/ruby-v2/sdk/changes/unreleased/endpoint-availability-annotations.yml
@@ -1,6 +1,9 @@
 - summary: |
-    Generated Ruby v2 SDK methods now surface endpoint availability
-    (deprecated / in-development / pre-release) using YARD's native
-    `@deprecated` tag where one exists, and fall back to doc comments
-    otherwise.
+    Added an opt-in `generateEndpointAvailability` custom config flag
+    (defaults to `false`). When enabled, generated Ruby v2 SDK methods
+    surface endpoint availability (deprecated / in-development /
+    pre-release) via YARD's native `@deprecated` tag where one exists,
+    and fall back to `@beta` doc comments otherwise. With the flag off,
+    the generator's output is byte-for-byte identical to previous
+    releases. The default will flip to `true` in the next major bump.
   type: feat

--- a/generators/ruby-v2/sdk/changes/unreleased/endpoint-availability-annotations.yml
+++ b/generators/ruby-v2/sdk/changes/unreleased/endpoint-availability-annotations.yml
@@ -1,9 +1,13 @@
 - summary: |
-    Added an opt-in `generateEndpointAvailability` custom config flag
-    (defaults to `false`). When enabled, generated Ruby v2 SDK methods
-    surface endpoint availability (deprecated / in-development /
-    pre-release) via YARD's native `@deprecated` tag where one exists,
-    and fall back to `@beta` doc comments otherwise. With the flag off,
-    the generator's output is byte-for-byte identical to previous
-    releases. The default will flip to `true` in the next major bump.
+    Added an opt-in `generateAvailabilityAnnotations` custom config flag
+    (defaults to `false`) that controls whether generated Ruby v2 SDK code
+    surfaces IR-level `availability` as YARD annotations. Today this
+    applies only to HTTP endpoint docstrings (deprecated / in-development /
+    pre-release) via YARD's native `@deprecated` tag where one exists, with
+    `@beta` doc comments as the fallback; the flag is named generically so
+    future availability surfaces (services, types, properties, enum values,
+    webhooks, websocket channels, errors) can opt in under the same flag
+    without introducing a new one. With the flag off, the generator's
+    output is byte-for-byte identical to previous releases. The default
+    will flip to `true` in the next major bump.
   type: feat

--- a/generators/ruby-v2/sdk/src/endpoint/http/HttpEndpointGenerator.ts
+++ b/generators/ruby-v2/sdk/src/endpoint/http/HttpEndpointGenerator.ts
@@ -395,9 +395,11 @@ export class HttpEndpointGenerator {
         if (endpoint.docs != null && endpoint.docs.length > 0) {
             parts.push(endpoint.docs);
         }
-        const availabilityDocs = getAvailabilityDocs(endpoint.availability);
-        if (availabilityDocs != null) {
-            parts.push(availabilityDocs);
+        if (this.context.customConfig.generateEndpointAvailability === true) {
+            const availabilityDocs = getAvailabilityDocs(endpoint.availability);
+            if (availabilityDocs != null) {
+                parts.push(availabilityDocs);
+            }
         }
         return parts.join("\n");
     }

--- a/generators/ruby-v2/sdk/src/endpoint/http/HttpEndpointGenerator.ts
+++ b/generators/ruby-v2/sdk/src/endpoint/http/HttpEndpointGenerator.ts
@@ -3,6 +3,7 @@ import { assertNever } from "@fern-api/core-utils";
 import { ruby } from "@fern-api/ruby-ast";
 import { FernIr } from "@fern-fern/ir-sdk";
 import { SdkGeneratorContext } from "../../SdkGeneratorContext.js";
+import { getAvailabilityDocs } from "../utils/getAvailabilityDocs.js";
 import { getEndpointRequest } from "../utils/getEndpointRequest.js";
 import { getEndpointReturnType } from "../utils/getEndpointReturnType.js";
 import { RAW_CLIENT_REQUEST_VARIABLE_NAME, RawClient } from "./RawClient.js";
@@ -390,7 +391,15 @@ export class HttpEndpointGenerator {
         endpoint: FernIr.HttpEndpoint;
         request: ReturnType<typeof getEndpointRequest>;
     }): string {
-        return endpoint.docs ?? "";
+        const parts: string[] = [];
+        if (endpoint.docs != null && endpoint.docs.length > 0) {
+            parts.push(endpoint.docs);
+        }
+        const availabilityDocs = getAvailabilityDocs(endpoint.availability);
+        if (availabilityDocs != null) {
+            parts.push(availabilityDocs);
+        }
+        return parts.join("\n");
     }
 
     private generateRequestOptionsDocs(): string[] {

--- a/generators/ruby-v2/sdk/src/endpoint/http/HttpEndpointGenerator.ts
+++ b/generators/ruby-v2/sdk/src/endpoint/http/HttpEndpointGenerator.ts
@@ -395,7 +395,7 @@ export class HttpEndpointGenerator {
         if (endpoint.docs != null && endpoint.docs.length > 0) {
             parts.push(endpoint.docs);
         }
-        if (this.context.customConfig.generateEndpointAvailability === true) {
+        if (this.context.customConfig.generateAvailabilityAnnotations === true) {
             const availabilityDocs = getAvailabilityDocs(endpoint.availability);
             if (availabilityDocs != null) {
                 parts.push(availabilityDocs);

--- a/generators/ruby-v2/sdk/src/endpoint/utils/__test__/getAvailabilityDocs.test.ts
+++ b/generators/ruby-v2/sdk/src/endpoint/utils/__test__/getAvailabilityDocs.test.ts
@@ -1,0 +1,57 @@
+import { FernIr } from "@fern-fern/ir-sdk";
+import { describe, expect, it } from "vitest";
+import { getAvailabilityDocs } from "../getAvailabilityDocs.js";
+
+describe("getAvailabilityDocs", () => {
+    it("returns undefined when availability is undefined", () => {
+        expect(getAvailabilityDocs(undefined)).toBeUndefined();
+    });
+
+    it("returns @deprecated for deprecated status without message", () => {
+        expect(getAvailabilityDocs({ status: FernIr.AvailabilityStatus.Deprecated, message: undefined })).toBe(
+            "@deprecated"
+        );
+    });
+
+    it("returns @deprecated with message for deprecated status with message", () => {
+        expect(getAvailabilityDocs({ status: FernIr.AvailabilityStatus.Deprecated, message: "Use v2 instead" })).toBe(
+            "@deprecated Use v2 instead"
+        );
+    });
+
+    it("returns @beta for InDevelopment status without message", () => {
+        expect(getAvailabilityDocs({ status: FernIr.AvailabilityStatus.InDevelopment, message: undefined })).toBe(
+            "@beta This endpoint is in development and may change."
+        );
+    });
+
+    it("returns @beta with message for InDevelopment status with message", () => {
+        expect(
+            getAvailabilityDocs({
+                status: FernIr.AvailabilityStatus.InDevelopment,
+                message: "Expected Q3 release"
+            })
+        ).toBe("@beta This endpoint is in development and may change. Expected Q3 release");
+    });
+
+    it("returns @beta for PreRelease status without message", () => {
+        expect(getAvailabilityDocs({ status: FernIr.AvailabilityStatus.PreRelease, message: undefined })).toBe(
+            "@beta This endpoint is in pre-release and may change."
+        );
+    });
+
+    it("returns @beta with message for PreRelease status with message", () => {
+        expect(getAvailabilityDocs({ status: FernIr.AvailabilityStatus.PreRelease, message: "Beta 2" })).toBe(
+            "@beta This endpoint is in pre-release and may change. Beta 2"
+        );
+    });
+
+    it("returns undefined for GeneralAvailability status", () => {
+        expect(
+            getAvailabilityDocs({
+                status: FernIr.AvailabilityStatus.GeneralAvailability,
+                message: undefined
+            })
+        ).toBeUndefined();
+    });
+});

--- a/generators/ruby-v2/sdk/src/endpoint/utils/__test__/getAvailabilityDocs.test.ts
+++ b/generators/ruby-v2/sdk/src/endpoint/utils/__test__/getAvailabilityDocs.test.ts
@@ -19,30 +19,52 @@ describe("getAvailabilityDocs", () => {
         );
     });
 
-    it("returns @beta for InDevelopment status without message", () => {
-        expect(getAvailabilityDocs({ status: FernIr.AvailabilityStatus.InDevelopment, message: undefined })).toBe(
-            "@beta This endpoint is in development and may change."
+    it("returns @deprecated (no trailing space) for deprecated status with empty-string message", () => {
+        expect(getAvailabilityDocs({ status: FernIr.AvailabilityStatus.Deprecated, message: "" })).toBe("@deprecated");
+    });
+
+    it("returns @deprecated (no trailing space) for deprecated status with whitespace-only message", () => {
+        expect(getAvailabilityDocs({ status: FernIr.AvailabilityStatus.Deprecated, message: "   " })).toBe(
+            "@deprecated"
         );
     });
 
-    it("returns @beta with message for InDevelopment status with message", () => {
+    it("returns @note for InDevelopment status without message", () => {
+        expect(getAvailabilityDocs({ status: FernIr.AvailabilityStatus.InDevelopment, message: undefined })).toBe(
+            "@note This endpoint is in development and may change."
+        );
+    });
+
+    it("returns @note with message for InDevelopment status with message", () => {
         expect(
             getAvailabilityDocs({
                 status: FernIr.AvailabilityStatus.InDevelopment,
                 message: "Expected Q3 release"
             })
-        ).toBe("@beta This endpoint is in development and may change. Expected Q3 release");
+        ).toBe("@note This endpoint is in development and may change. Expected Q3 release");
     });
 
-    it("returns @beta for PreRelease status without message", () => {
-        expect(getAvailabilityDocs({ status: FernIr.AvailabilityStatus.PreRelease, message: undefined })).toBe(
-            "@beta This endpoint is in pre-release and may change."
+    it("returns @note (no trailing space) for InDevelopment status with empty-string message", () => {
+        expect(getAvailabilityDocs({ status: FernIr.AvailabilityStatus.InDevelopment, message: "" })).toBe(
+            "@note This endpoint is in development and may change."
         );
     });
 
-    it("returns @beta with message for PreRelease status with message", () => {
+    it("returns @note for PreRelease status without message", () => {
+        expect(getAvailabilityDocs({ status: FernIr.AvailabilityStatus.PreRelease, message: undefined })).toBe(
+            "@note This endpoint is in pre-release and may change."
+        );
+    });
+
+    it("returns @note with message for PreRelease status with message", () => {
         expect(getAvailabilityDocs({ status: FernIr.AvailabilityStatus.PreRelease, message: "Beta 2" })).toBe(
-            "@beta This endpoint is in pre-release and may change. Beta 2"
+            "@note This endpoint is in pre-release and may change. Beta 2"
+        );
+    });
+
+    it("returns @note (no trailing space) for PreRelease status with empty-string message", () => {
+        expect(getAvailabilityDocs({ status: FernIr.AvailabilityStatus.PreRelease, message: "" })).toBe(
+            "@note This endpoint is in pre-release and may change."
         );
     });
 

--- a/generators/ruby-v2/sdk/src/endpoint/utils/getAvailabilityDocs.ts
+++ b/generators/ruby-v2/sdk/src/endpoint/utils/getAvailabilityDocs.ts
@@ -4,8 +4,8 @@ import { FernIr } from "@fern-fern/ir-sdk";
 /**
  * Returns YARD doc lines for the endpoint's availability status.
  * - DEPRECATED -> @deprecated tag (with optional message)
- * - IN_DEVELOPMENT -> @beta warning
- * - PRE_RELEASE -> @beta warning
+ * - IN_DEVELOPMENT -> @note warning
+ * - PRE_RELEASE -> @note warning
  * - GENERAL_AVAILABILITY or undefined -> no additional docs
  */
 export function getAvailabilityDocs(availability: FernIr.Availability | undefined): string | undefined {
@@ -15,16 +15,18 @@ export function getAvailabilityDocs(availability: FernIr.Availability | undefine
 
     switch (availability.status) {
         case FernIr.AvailabilityStatus.Deprecated: {
-            const message = availability.message;
-            return message != null ? `@deprecated ${message}` : "@deprecated";
+            const message = availability.message?.trim();
+            return message ? `@deprecated ${message}` : "@deprecated";
         }
         case FernIr.AvailabilityStatus.InDevelopment: {
-            const warning = "@beta This endpoint is in development and may change.";
-            return availability.message != null ? `${warning} ${availability.message}` : warning;
+            const warning = "@note This endpoint is in development and may change.";
+            const message = availability.message?.trim();
+            return message ? `${warning} ${message}` : warning;
         }
         case FernIr.AvailabilityStatus.PreRelease: {
-            const warning = "@beta This endpoint is in pre-release and may change.";
-            return availability.message != null ? `${warning} ${availability.message}` : warning;
+            const warning = "@note This endpoint is in pre-release and may change.";
+            const message = availability.message?.trim();
+            return message ? `${warning} ${message}` : warning;
         }
         case FernIr.AvailabilityStatus.GeneralAvailability:
             return undefined;

--- a/generators/ruby-v2/sdk/src/endpoint/utils/getAvailabilityDocs.ts
+++ b/generators/ruby-v2/sdk/src/endpoint/utils/getAvailabilityDocs.ts
@@ -3,8 +3,8 @@ import { FernIr } from "@fern-fern/ir-sdk";
 /**
  * Returns YARD doc lines for the endpoint's availability status.
  * - DEPRECATED -> @deprecated tag (with optional message)
- * - IN_DEVELOPMENT -> @note warning
- * - PRE_RELEASE -> @note warning
+ * - IN_DEVELOPMENT -> @beta warning
+ * - PRE_RELEASE -> @beta warning
  * - GENERAL_AVAILABILITY or undefined -> no additional docs
  */
 export function getAvailabilityDocs(availability: FernIr.Availability | undefined): string | undefined {

--- a/generators/ruby-v2/sdk/src/endpoint/utils/getAvailabilityDocs.ts
+++ b/generators/ruby-v2/sdk/src/endpoint/utils/getAvailabilityDocs.ts
@@ -1,3 +1,4 @@
+import { assertNever } from "@fern-api/core-utils";
 import { FernIr } from "@fern-fern/ir-sdk";
 
 /**
@@ -28,6 +29,6 @@ export function getAvailabilityDocs(availability: FernIr.Availability | undefine
         case FernIr.AvailabilityStatus.GeneralAvailability:
             return undefined;
         default:
-            return undefined;
+            assertNever(availability.status);
     }
 }

--- a/generators/ruby-v2/sdk/src/endpoint/utils/getAvailabilityDocs.ts
+++ b/generators/ruby-v2/sdk/src/endpoint/utils/getAvailabilityDocs.ts
@@ -1,0 +1,33 @@
+import { FernIr } from "@fern-fern/ir-sdk";
+
+/**
+ * Returns YARD doc lines for the endpoint's availability status.
+ * - DEPRECATED -> @deprecated tag (with optional message)
+ * - IN_DEVELOPMENT -> @note warning
+ * - PRE_RELEASE -> @note warning
+ * - GENERAL_AVAILABILITY or undefined -> no additional docs
+ */
+export function getAvailabilityDocs(availability: FernIr.Availability | undefined): string | undefined {
+    if (availability == null) {
+        return undefined;
+    }
+
+    switch (availability.status) {
+        case FernIr.AvailabilityStatus.Deprecated: {
+            const message = availability.message;
+            return message != null ? `@deprecated ${message}` : "@deprecated";
+        }
+        case FernIr.AvailabilityStatus.InDevelopment: {
+            const warning = "@beta This endpoint is in development and may change.";
+            return availability.message != null ? `${warning} ${availability.message}` : warning;
+        }
+        case FernIr.AvailabilityStatus.PreRelease: {
+            const warning = "@beta This endpoint is in pre-release and may change.";
+            return availability.message != null ? `${warning} ${availability.message}` : warning;
+        }
+        case FernIr.AvailabilityStatus.GeneralAvailability:
+            return undefined;
+        default:
+            return undefined;
+    }
+}

--- a/seed/ruby-sdk-v2/accept-header/.fern/metadata.json
+++ b/seed/ruby-sdk-v2/accept-header/.fern/metadata.json
@@ -3,7 +3,8 @@
   "generatorName": "fernapi/fern-ruby-sdk-v2",
   "generatorVersion": "local",
   "generatorConfig": {
-    "rubocopSeverity": "error"
+    "rubocopSeverity": "error",
+    "generateAvailabilityAnnotations": true
   },
   "originGitCommit": "DUMMY",
   "sdkVersion": "0.0.1"

--- a/seed/ruby-sdk-v2/alias-extends/.fern/metadata.json
+++ b/seed/ruby-sdk-v2/alias-extends/.fern/metadata.json
@@ -3,7 +3,8 @@
   "generatorName": "fernapi/fern-ruby-sdk-v2",
   "generatorVersion": "local",
   "generatorConfig": {
-    "rubocopSeverity": "error"
+    "rubocopSeverity": "error",
+    "generateAvailabilityAnnotations": true
   },
   "originGitCommit": "DUMMY",
   "sdkVersion": "0.0.1"

--- a/seed/ruby-sdk-v2/alias/.fern/metadata.json
+++ b/seed/ruby-sdk-v2/alias/.fern/metadata.json
@@ -3,7 +3,8 @@
   "generatorName": "fernapi/fern-ruby-sdk-v2",
   "generatorVersion": "local",
   "generatorConfig": {
-    "rubocopSeverity": "error"
+    "rubocopSeverity": "error",
+    "generateAvailabilityAnnotations": true
   },
   "originGitCommit": "DUMMY",
   "sdkVersion": "0.0.1"

--- a/seed/ruby-sdk-v2/allof-inline/.fern/metadata.json
+++ b/seed/ruby-sdk-v2/allof-inline/.fern/metadata.json
@@ -3,7 +3,8 @@
   "generatorName": "fernapi/fern-ruby-sdk-v2",
   "generatorVersion": "local",
   "generatorConfig": {
-    "rubocopSeverity": "error"
+    "rubocopSeverity": "error",
+    "generateAvailabilityAnnotations": true
   },
   "originGitCommit": "DUMMY",
   "sdkVersion": "0.0.1"

--- a/seed/ruby-sdk-v2/allof/.fern/metadata.json
+++ b/seed/ruby-sdk-v2/allof/.fern/metadata.json
@@ -3,7 +3,8 @@
   "generatorName": "fernapi/fern-ruby-sdk-v2",
   "generatorVersion": "local",
   "generatorConfig": {
-    "rubocopSeverity": "error"
+    "rubocopSeverity": "error",
+    "generateAvailabilityAnnotations": true
   },
   "originGitCommit": "DUMMY",
   "sdkVersion": "0.0.1"

--- a/seed/ruby-sdk-v2/any-auth/.fern/metadata.json
+++ b/seed/ruby-sdk-v2/any-auth/.fern/metadata.json
@@ -3,7 +3,8 @@
   "generatorName": "fernapi/fern-ruby-sdk-v2",
   "generatorVersion": "local",
   "generatorConfig": {
-    "rubocopSeverity": "error"
+    "rubocopSeverity": "error",
+    "generateAvailabilityAnnotations": true
   },
   "originGitCommit": "DUMMY",
   "sdkVersion": "0.0.1"

--- a/seed/ruby-sdk-v2/api-wide-base-path/.fern/metadata.json
+++ b/seed/ruby-sdk-v2/api-wide-base-path/.fern/metadata.json
@@ -3,7 +3,8 @@
   "generatorName": "fernapi/fern-ruby-sdk-v2",
   "generatorVersion": "local",
   "generatorConfig": {
-    "rubocopSeverity": "error"
+    "rubocopSeverity": "error",
+    "generateAvailabilityAnnotations": true
   },
   "originGitCommit": "DUMMY",
   "sdkVersion": "0.0.1"

--- a/seed/ruby-sdk-v2/audiences/.fern/metadata.json
+++ b/seed/ruby-sdk-v2/audiences/.fern/metadata.json
@@ -3,7 +3,8 @@
   "generatorName": "fernapi/fern-ruby-sdk-v2",
   "generatorVersion": "local",
   "generatorConfig": {
-    "rubocopSeverity": "error"
+    "rubocopSeverity": "error",
+    "generateAvailabilityAnnotations": true
   },
   "originGitCommit": "DUMMY",
   "sdkVersion": "0.0.1"

--- a/seed/ruby-sdk-v2/basic-auth-environment-variables/.fern/metadata.json
+++ b/seed/ruby-sdk-v2/basic-auth-environment-variables/.fern/metadata.json
@@ -3,7 +3,8 @@
   "generatorName": "fernapi/fern-ruby-sdk-v2",
   "generatorVersion": "local",
   "generatorConfig": {
-    "rubocopSeverity": "error"
+    "rubocopSeverity": "error",
+    "generateAvailabilityAnnotations": true
   },
   "originGitCommit": "DUMMY",
   "sdkVersion": "0.0.1"

--- a/seed/ruby-sdk-v2/basic-auth-pw-omitted/wire-tests/.fern/metadata.json
+++ b/seed/ruby-sdk-v2/basic-auth-pw-omitted/wire-tests/.fern/metadata.json
@@ -4,6 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {
     "rubocopSeverity": "error",
+    "generateAvailabilityAnnotations": true,
     "enableWireTests": true
   },
   "originGitCommit": "DUMMY",

--- a/seed/ruby-sdk-v2/basic-auth/wire-tests/.fern/metadata.json
+++ b/seed/ruby-sdk-v2/basic-auth/wire-tests/.fern/metadata.json
@@ -4,6 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {
     "rubocopSeverity": "error",
+    "generateAvailabilityAnnotations": true,
     "enableWireTests": true
   },
   "originGitCommit": "DUMMY",

--- a/seed/ruby-sdk-v2/bearer-token-environment-variable/.fern/metadata.json
+++ b/seed/ruby-sdk-v2/bearer-token-environment-variable/.fern/metadata.json
@@ -3,7 +3,8 @@
   "generatorName": "fernapi/fern-ruby-sdk-v2",
   "generatorVersion": "local",
   "generatorConfig": {
-    "rubocopSeverity": "error"
+    "rubocopSeverity": "error",
+    "generateAvailabilityAnnotations": true
   },
   "originGitCommit": "DUMMY",
   "sdkVersion": "0.0.1"

--- a/seed/ruby-sdk-v2/bytes-download/.fern/metadata.json
+++ b/seed/ruby-sdk-v2/bytes-download/.fern/metadata.json
@@ -3,7 +3,8 @@
   "generatorName": "fernapi/fern-ruby-sdk-v2",
   "generatorVersion": "local",
   "generatorConfig": {
-    "rubocopSeverity": "error"
+    "rubocopSeverity": "error",
+    "generateAvailabilityAnnotations": true
   },
   "originGitCommit": "DUMMY",
   "sdkVersion": "0.0.1"

--- a/seed/ruby-sdk-v2/bytes-upload/.fern/metadata.json
+++ b/seed/ruby-sdk-v2/bytes-upload/.fern/metadata.json
@@ -3,7 +3,8 @@
   "generatorName": "fernapi/fern-ruby-sdk-v2",
   "generatorVersion": "local",
   "generatorConfig": {
-    "rubocopSeverity": "error"
+    "rubocopSeverity": "error",
+    "generateAvailabilityAnnotations": true
   },
   "originGitCommit": "DUMMY",
   "sdkVersion": "0.0.1"

--- a/seed/ruby-sdk-v2/circular-references-advanced/.fern/metadata.json
+++ b/seed/ruby-sdk-v2/circular-references-advanced/.fern/metadata.json
@@ -3,7 +3,8 @@
   "generatorName": "fernapi/fern-ruby-sdk-v2",
   "generatorVersion": "local",
   "generatorConfig": {
-    "rubocopSeverity": "error"
+    "rubocopSeverity": "error",
+    "generateAvailabilityAnnotations": true
   },
   "originGitCommit": "DUMMY",
   "sdkVersion": "0.0.1"

--- a/seed/ruby-sdk-v2/circular-references-extends/.fern/metadata.json
+++ b/seed/ruby-sdk-v2/circular-references-extends/.fern/metadata.json
@@ -3,7 +3,8 @@
   "generatorName": "fernapi/fern-ruby-sdk-v2",
   "generatorVersion": "local",
   "generatorConfig": {
-    "rubocopSeverity": "error"
+    "rubocopSeverity": "error",
+    "generateAvailabilityAnnotations": true
   },
   "originGitCommit": "DUMMY",
   "sdkVersion": "0.0.1"

--- a/seed/ruby-sdk-v2/circular-references/.fern/metadata.json
+++ b/seed/ruby-sdk-v2/circular-references/.fern/metadata.json
@@ -3,7 +3,8 @@
   "generatorName": "fernapi/fern-ruby-sdk-v2",
   "generatorVersion": "local",
   "generatorConfig": {
-    "rubocopSeverity": "error"
+    "rubocopSeverity": "error",
+    "generateAvailabilityAnnotations": true
   },
   "originGitCommit": "DUMMY",
   "sdkVersion": "0.0.1"

--- a/seed/ruby-sdk-v2/client-side-params/.fern/metadata.json
+++ b/seed/ruby-sdk-v2/client-side-params/.fern/metadata.json
@@ -3,7 +3,8 @@
   "generatorName": "fernapi/fern-ruby-sdk-v2",
   "generatorVersion": "local",
   "generatorConfig": {
-    "rubocopSeverity": "error"
+    "rubocopSeverity": "error",
+    "generateAvailabilityAnnotations": true
   },
   "originGitCommit": "DUMMY",
   "sdkVersion": "0.0.1"

--- a/seed/ruby-sdk-v2/content-type/.fern/metadata.json
+++ b/seed/ruby-sdk-v2/content-type/.fern/metadata.json
@@ -3,7 +3,8 @@
   "generatorName": "fernapi/fern-ruby-sdk-v2",
   "generatorVersion": "local",
   "generatorConfig": {
-    "rubocopSeverity": "error"
+    "rubocopSeverity": "error",
+    "generateAvailabilityAnnotations": true
   },
   "originGitCommit": "DUMMY",
   "sdkVersion": "0.0.1"

--- a/seed/ruby-sdk-v2/cross-package-type-names/.fern/metadata.json
+++ b/seed/ruby-sdk-v2/cross-package-type-names/.fern/metadata.json
@@ -3,7 +3,8 @@
   "generatorName": "fernapi/fern-ruby-sdk-v2",
   "generatorVersion": "local",
   "generatorConfig": {
-    "rubocopSeverity": "error"
+    "rubocopSeverity": "error",
+    "generateAvailabilityAnnotations": true
   },
   "originGitCommit": "DUMMY",
   "sdkVersion": "0.0.1"

--- a/seed/ruby-sdk-v2/dollar-string-examples/.fern/metadata.json
+++ b/seed/ruby-sdk-v2/dollar-string-examples/.fern/metadata.json
@@ -3,7 +3,8 @@
   "generatorName": "fernapi/fern-ruby-sdk-v2",
   "generatorVersion": "local",
   "generatorConfig": {
-    "rubocopSeverity": "error"
+    "rubocopSeverity": "error",
+    "generateAvailabilityAnnotations": true
   },
   "originGitCommit": "DUMMY",
   "sdkVersion": "0.0.1"

--- a/seed/ruby-sdk-v2/empty-clients/.fern/metadata.json
+++ b/seed/ruby-sdk-v2/empty-clients/.fern/metadata.json
@@ -3,7 +3,8 @@
   "generatorName": "fernapi/fern-ruby-sdk-v2",
   "generatorVersion": "local",
   "generatorConfig": {
-    "rubocopSeverity": "error"
+    "rubocopSeverity": "error",
+    "generateAvailabilityAnnotations": true
   },
   "originGitCommit": "DUMMY",
   "sdkVersion": "0.0.1"

--- a/seed/ruby-sdk-v2/endpoint-security-auth/.fern/metadata.json
+++ b/seed/ruby-sdk-v2/endpoint-security-auth/.fern/metadata.json
@@ -3,7 +3,8 @@
   "generatorName": "fernapi/fern-ruby-sdk-v2",
   "generatorVersion": "local",
   "generatorConfig": {
-    "rubocopSeverity": "error"
+    "rubocopSeverity": "error",
+    "generateAvailabilityAnnotations": true
   },
   "originGitCommit": "DUMMY",
   "sdkVersion": "0.0.1"

--- a/seed/ruby-sdk-v2/enum/.fern/metadata.json
+++ b/seed/ruby-sdk-v2/enum/.fern/metadata.json
@@ -3,7 +3,8 @@
   "generatorName": "fernapi/fern-ruby-sdk-v2",
   "generatorVersion": "local",
   "generatorConfig": {
-    "rubocopSeverity": "error"
+    "rubocopSeverity": "error",
+    "generateAvailabilityAnnotations": true
   },
   "originGitCommit": "DUMMY",
   "sdkVersion": "0.0.1"

--- a/seed/ruby-sdk-v2/error-property/.fern/metadata.json
+++ b/seed/ruby-sdk-v2/error-property/.fern/metadata.json
@@ -3,7 +3,8 @@
   "generatorName": "fernapi/fern-ruby-sdk-v2",
   "generatorVersion": "local",
   "generatorConfig": {
-    "rubocopSeverity": "error"
+    "rubocopSeverity": "error",
+    "generateAvailabilityAnnotations": true
   },
   "originGitCommit": "DUMMY",
   "sdkVersion": "0.0.1"

--- a/seed/ruby-sdk-v2/errors/.fern/metadata.json
+++ b/seed/ruby-sdk-v2/errors/.fern/metadata.json
@@ -3,7 +3,8 @@
   "generatorName": "fernapi/fern-ruby-sdk-v2",
   "generatorVersion": "local",
   "generatorConfig": {
-    "rubocopSeverity": "error"
+    "rubocopSeverity": "error",
+    "generateAvailabilityAnnotations": true
   },
   "originGitCommit": "DUMMY",
   "sdkVersion": "0.0.1"

--- a/seed/ruby-sdk-v2/examples/no-custom-config/.fern/metadata.json
+++ b/seed/ruby-sdk-v2/examples/no-custom-config/.fern/metadata.json
@@ -3,7 +3,8 @@
   "generatorName": "fernapi/fern-ruby-sdk-v2",
   "generatorVersion": "local",
   "generatorConfig": {
-    "rubocopSeverity": "error"
+    "rubocopSeverity": "error",
+    "generateAvailabilityAnnotations": true
   },
   "originGitCommit": "DUMMY",
   "sdkVersion": "0.0.1"

--- a/seed/ruby-sdk-v2/examples/omit-fern-headers/.fern/metadata.json
+++ b/seed/ruby-sdk-v2/examples/omit-fern-headers/.fern/metadata.json
@@ -4,6 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {
     "rubocopSeverity": "error",
+    "generateAvailabilityAnnotations": true,
     "omitFernHeaders": true
   },
   "originGitCommit": "DUMMY",

--- a/seed/ruby-sdk-v2/examples/readme-config/.fern/metadata.json
+++ b/seed/ruby-sdk-v2/examples/readme-config/.fern/metadata.json
@@ -4,6 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {
     "rubocopSeverity": "error",
+    "generateAvailabilityAnnotations": true,
     "customReadmeSections": [
       {
         "title": "Override Section",

--- a/seed/ruby-sdk-v2/examples/require-paths/.fern/metadata.json
+++ b/seed/ruby-sdk-v2/examples/require-paths/.fern/metadata.json
@@ -4,6 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {
     "rubocopSeverity": "error",
+    "generateAvailabilityAnnotations": true,
     "requirePaths": [
       "custom_integration",
       "sentry_integration"

--- a/seed/ruby-sdk-v2/examples/wire-tests/.fern/metadata.json
+++ b/seed/ruby-sdk-v2/examples/wire-tests/.fern/metadata.json
@@ -4,6 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {
     "rubocopSeverity": "error",
+    "generateAvailabilityAnnotations": true,
     "enableWireTests": true
   },
   "originGitCommit": "DUMMY",

--- a/seed/ruby-sdk-v2/exhaustive/wire-tests/.fern/metadata.json
+++ b/seed/ruby-sdk-v2/exhaustive/wire-tests/.fern/metadata.json
@@ -4,6 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {
     "rubocopSeverity": "error",
+    "generateAvailabilityAnnotations": true,
     "enableWireTests": true,
     "clientModuleName": "MyClient",
     "maxRetries": 5

--- a/seed/ruby-sdk-v2/exhaustive/wire-tests/lib/seed/endpoints/http_methods/client.rb
+++ b/seed/ruby-sdk-v2/exhaustive/wire-tests/lib/seed/endpoints/http_methods/client.rb
@@ -110,7 +110,7 @@ module Seed
           end
         end
 
-        # @beta This endpoint is in pre-release and may change.
+        # @note This endpoint is in pre-release and may change.
         #
         # @param request_options [Hash]
         # @param params [Seed::Types::Object_::Types::ObjectWithOptionalField]
@@ -145,7 +145,7 @@ module Seed
           end
         end
 
-        # @beta This endpoint is in development and may change.
+        # @note This endpoint is in development and may change.
         #
         # @param request_options [Hash]
         # @param params [Hash]

--- a/seed/ruby-sdk-v2/exhaustive/wire-tests/lib/seed/endpoints/http_methods/client.rb
+++ b/seed/ruby-sdk-v2/exhaustive/wire-tests/lib/seed/endpoints/http_methods/client.rb
@@ -41,6 +41,8 @@ module Seed
           raise error_class.new(response.body, code: code)
         end
 
+        # @deprecated
+        #
         # @param request_options [Hash]
         # @param params [Seed::Types::Object_::Types::ObjectWithRequiredField]
         # @option request_options [String] :base_url
@@ -73,6 +75,8 @@ module Seed
           end
         end
 
+        # @deprecated Use testPatch instead.
+        #
         # @param request_options [Hash]
         # @param params [Seed::Types::Object_::Types::ObjectWithRequiredField]
         # @option request_options [String] :base_url
@@ -106,6 +110,8 @@ module Seed
           end
         end
 
+        # @beta This endpoint is in pre-release and may change.
+        #
         # @param request_options [Hash]
         # @param params [Seed::Types::Object_::Types::ObjectWithOptionalField]
         # @option request_options [String] :base_url
@@ -139,6 +145,8 @@ module Seed
           end
         end
 
+        # @beta This endpoint is in development and may change.
+        #
         # @param request_options [Hash]
         # @param params [Hash]
         # @option request_options [String] :base_url

--- a/seed/ruby-sdk-v2/extends/.fern/metadata.json
+++ b/seed/ruby-sdk-v2/extends/.fern/metadata.json
@@ -3,7 +3,8 @@
   "generatorName": "fernapi/fern-ruby-sdk-v2",
   "generatorVersion": "local",
   "generatorConfig": {
-    "rubocopSeverity": "error"
+    "rubocopSeverity": "error",
+    "generateAvailabilityAnnotations": true
   },
   "originGitCommit": "DUMMY",
   "sdkVersion": "0.0.1"

--- a/seed/ruby-sdk-v2/extra-properties/.fern/metadata.json
+++ b/seed/ruby-sdk-v2/extra-properties/.fern/metadata.json
@@ -3,7 +3,8 @@
   "generatorName": "fernapi/fern-ruby-sdk-v2",
   "generatorVersion": "local",
   "generatorConfig": {
-    "rubocopSeverity": "error"
+    "rubocopSeverity": "error",
+    "generateAvailabilityAnnotations": true
   },
   "originGitCommit": "DUMMY",
   "sdkVersion": "0.0.1"

--- a/seed/ruby-sdk-v2/file-download/.fern/metadata.json
+++ b/seed/ruby-sdk-v2/file-download/.fern/metadata.json
@@ -3,7 +3,8 @@
   "generatorName": "fernapi/fern-ruby-sdk-v2",
   "generatorVersion": "local",
   "generatorConfig": {
-    "rubocopSeverity": "error"
+    "rubocopSeverity": "error",
+    "generateAvailabilityAnnotations": true
   },
   "originGitCommit": "DUMMY",
   "sdkVersion": "0.0.1"

--- a/seed/ruby-sdk-v2/file-upload-openapi/.fern/metadata.json
+++ b/seed/ruby-sdk-v2/file-upload-openapi/.fern/metadata.json
@@ -3,7 +3,8 @@
   "generatorName": "fernapi/fern-ruby-sdk-v2",
   "generatorVersion": "local",
   "generatorConfig": {
-    "rubocopSeverity": "error"
+    "rubocopSeverity": "error",
+    "generateAvailabilityAnnotations": true
   },
   "originGitCommit": "DUMMY",
   "sdkVersion": "0.0.1"

--- a/seed/ruby-sdk-v2/file-upload/.fern/metadata.json
+++ b/seed/ruby-sdk-v2/file-upload/.fern/metadata.json
@@ -3,7 +3,8 @@
   "generatorName": "fernapi/fern-ruby-sdk-v2",
   "generatorVersion": "local",
   "generatorConfig": {
-    "rubocopSeverity": "error"
+    "rubocopSeverity": "error",
+    "generateAvailabilityAnnotations": true
   },
   "originGitCommit": "DUMMY",
   "sdkVersion": "0.0.1"

--- a/seed/ruby-sdk-v2/folders/.fern/metadata.json
+++ b/seed/ruby-sdk-v2/folders/.fern/metadata.json
@@ -3,7 +3,8 @@
   "generatorName": "fernapi/fern-ruby-sdk-v2",
   "generatorVersion": "local",
   "generatorConfig": {
-    "rubocopSeverity": "error"
+    "rubocopSeverity": "error",
+    "generateAvailabilityAnnotations": true
   },
   "originGitCommit": "DUMMY",
   "sdkVersion": "0.0.1"

--- a/seed/ruby-sdk-v2/header-auth-environment-variable/.fern/metadata.json
+++ b/seed/ruby-sdk-v2/header-auth-environment-variable/.fern/metadata.json
@@ -3,7 +3,8 @@
   "generatorName": "fernapi/fern-ruby-sdk-v2",
   "generatorVersion": "local",
   "generatorConfig": {
-    "rubocopSeverity": "error"
+    "rubocopSeverity": "error",
+    "generateAvailabilityAnnotations": true
   },
   "originGitCommit": "DUMMY",
   "sdkVersion": "0.0.1"

--- a/seed/ruby-sdk-v2/header-auth/.fern/metadata.json
+++ b/seed/ruby-sdk-v2/header-auth/.fern/metadata.json
@@ -3,7 +3,8 @@
   "generatorName": "fernapi/fern-ruby-sdk-v2",
   "generatorVersion": "local",
   "generatorConfig": {
-    "rubocopSeverity": "error"
+    "rubocopSeverity": "error",
+    "generateAvailabilityAnnotations": true
   },
   "originGitCommit": "DUMMY",
   "sdkVersion": "0.0.1"

--- a/seed/ruby-sdk-v2/http-head/.fern/metadata.json
+++ b/seed/ruby-sdk-v2/http-head/.fern/metadata.json
@@ -3,7 +3,8 @@
   "generatorName": "fernapi/fern-ruby-sdk-v2",
   "generatorVersion": "local",
   "generatorConfig": {
-    "rubocopSeverity": "error"
+    "rubocopSeverity": "error",
+    "generateAvailabilityAnnotations": true
   },
   "originGitCommit": "DUMMY",
   "sdkVersion": "0.0.1"

--- a/seed/ruby-sdk-v2/idempotency-headers/.fern/metadata.json
+++ b/seed/ruby-sdk-v2/idempotency-headers/.fern/metadata.json
@@ -3,7 +3,8 @@
   "generatorName": "fernapi/fern-ruby-sdk-v2",
   "generatorVersion": "local",
   "generatorConfig": {
-    "rubocopSeverity": "error"
+    "rubocopSeverity": "error",
+    "generateAvailabilityAnnotations": true
   },
   "originGitCommit": "DUMMY",
   "sdkVersion": "0.0.1"

--- a/seed/ruby-sdk-v2/imdb/.fern/metadata.json
+++ b/seed/ruby-sdk-v2/imdb/.fern/metadata.json
@@ -3,7 +3,8 @@
   "generatorName": "fernapi/fern-ruby-sdk-v2",
   "generatorVersion": "local",
   "generatorConfig": {
-    "rubocopSeverity": "error"
+    "rubocopSeverity": "error",
+    "generateAvailabilityAnnotations": true
   },
   "originGitCommit": "DUMMY",
   "sdkVersion": "0.0.1"

--- a/seed/ruby-sdk-v2/imdb/lib/seed/imdb/client.rb
+++ b/seed/ruby-sdk-v2/imdb/lib/seed/imdb/client.rb
@@ -11,6 +11,7 @@ module Seed
       end
 
       # Add a movie to the database using the movies/* /... path.
+      # @beta This endpoint is in pre-release and may change.
       #
       # @param request_options [Hash]
       # @param params [Seed::Imdb::Types::CreateMovieRequest]
@@ -44,6 +45,8 @@ module Seed
         end
       end
 
+      # @deprecated
+      #
       # @param request_options [Hash]
       # @param params [Hash]
       # @option request_options [String] :base_url

--- a/seed/ruby-sdk-v2/imdb/lib/seed/imdb/client.rb
+++ b/seed/ruby-sdk-v2/imdb/lib/seed/imdb/client.rb
@@ -11,7 +11,7 @@ module Seed
       end
 
       # Add a movie to the database using the movies/* /... path.
-      # @beta This endpoint is in pre-release and may change.
+      # @note This endpoint is in pre-release and may change.
       #
       # @param request_options [Hash]
       # @param params [Seed::Imdb::Types::CreateMovieRequest]

--- a/seed/ruby-sdk-v2/inferred-auth-explicit/.fern/metadata.json
+++ b/seed/ruby-sdk-v2/inferred-auth-explicit/.fern/metadata.json
@@ -3,7 +3,8 @@
   "generatorName": "fernapi/fern-ruby-sdk-v2",
   "generatorVersion": "local",
   "generatorConfig": {
-    "rubocopSeverity": "error"
+    "rubocopSeverity": "error",
+    "generateAvailabilityAnnotations": true
   },
   "originGitCommit": "DUMMY",
   "sdkVersion": "0.0.1"

--- a/seed/ruby-sdk-v2/inferred-auth-implicit-api-key/.fern/metadata.json
+++ b/seed/ruby-sdk-v2/inferred-auth-implicit-api-key/.fern/metadata.json
@@ -3,7 +3,8 @@
   "generatorName": "fernapi/fern-ruby-sdk-v2",
   "generatorVersion": "local",
   "generatorConfig": {
-    "rubocopSeverity": "error"
+    "rubocopSeverity": "error",
+    "generateAvailabilityAnnotations": true
   },
   "originGitCommit": "DUMMY",
   "sdkVersion": "0.0.1"

--- a/seed/ruby-sdk-v2/inferred-auth-implicit-no-expiry/.fern/metadata.json
+++ b/seed/ruby-sdk-v2/inferred-auth-implicit-no-expiry/.fern/metadata.json
@@ -3,7 +3,8 @@
   "generatorName": "fernapi/fern-ruby-sdk-v2",
   "generatorVersion": "local",
   "generatorConfig": {
-    "rubocopSeverity": "error"
+    "rubocopSeverity": "error",
+    "generateAvailabilityAnnotations": true
   },
   "originGitCommit": "DUMMY",
   "sdkVersion": "0.0.1"

--- a/seed/ruby-sdk-v2/inferred-auth-implicit-reference/.fern/metadata.json
+++ b/seed/ruby-sdk-v2/inferred-auth-implicit-reference/.fern/metadata.json
@@ -3,7 +3,8 @@
   "generatorName": "fernapi/fern-ruby-sdk-v2",
   "generatorVersion": "local",
   "generatorConfig": {
-    "rubocopSeverity": "error"
+    "rubocopSeverity": "error",
+    "generateAvailabilityAnnotations": true
   },
   "originGitCommit": "DUMMY",
   "sdkVersion": "0.0.1"

--- a/seed/ruby-sdk-v2/inferred-auth-implicit/.fern/metadata.json
+++ b/seed/ruby-sdk-v2/inferred-auth-implicit/.fern/metadata.json
@@ -3,7 +3,8 @@
   "generatorName": "fernapi/fern-ruby-sdk-v2",
   "generatorVersion": "local",
   "generatorConfig": {
-    "rubocopSeverity": "error"
+    "rubocopSeverity": "error",
+    "generateAvailabilityAnnotations": true
   },
   "originGitCommit": "DUMMY",
   "sdkVersion": "0.0.1"

--- a/seed/ruby-sdk-v2/license/.fern/metadata.json
+++ b/seed/ruby-sdk-v2/license/.fern/metadata.json
@@ -3,7 +3,8 @@
   "generatorName": "fernapi/fern-ruby-sdk-v2",
   "generatorVersion": "local",
   "generatorConfig": {
-    "rubocopSeverity": "error"
+    "rubocopSeverity": "error",
+    "generateAvailabilityAnnotations": true
   },
   "originGitCommit": "DUMMY",
   "sdkVersion": "0.0.1"

--- a/seed/ruby-sdk-v2/literal/.fern/metadata.json
+++ b/seed/ruby-sdk-v2/literal/.fern/metadata.json
@@ -3,7 +3,8 @@
   "generatorName": "fernapi/fern-ruby-sdk-v2",
   "generatorVersion": "local",
   "generatorConfig": {
-    "rubocopSeverity": "error"
+    "rubocopSeverity": "error",
+    "generateAvailabilityAnnotations": true
   },
   "originGitCommit": "DUMMY",
   "sdkVersion": "0.0.1"

--- a/seed/ruby-sdk-v2/literals-unions/.fern/metadata.json
+++ b/seed/ruby-sdk-v2/literals-unions/.fern/metadata.json
@@ -3,7 +3,8 @@
   "generatorName": "fernapi/fern-ruby-sdk-v2",
   "generatorVersion": "local",
   "generatorConfig": {
-    "rubocopSeverity": "error"
+    "rubocopSeverity": "error",
+    "generateAvailabilityAnnotations": true
   },
   "originGitCommit": "DUMMY",
   "sdkVersion": "0.0.1"

--- a/seed/ruby-sdk-v2/mixed-case/.fern/metadata.json
+++ b/seed/ruby-sdk-v2/mixed-case/.fern/metadata.json
@@ -3,7 +3,8 @@
   "generatorName": "fernapi/fern-ruby-sdk-v2",
   "generatorVersion": "local",
   "generatorConfig": {
-    "rubocopSeverity": "error"
+    "rubocopSeverity": "error",
+    "generateAvailabilityAnnotations": true
   },
   "originGitCommit": "DUMMY",
   "sdkVersion": "0.0.1"

--- a/seed/ruby-sdk-v2/mixed-file-directory/.fern/metadata.json
+++ b/seed/ruby-sdk-v2/mixed-file-directory/.fern/metadata.json
@@ -3,7 +3,8 @@
   "generatorName": "fernapi/fern-ruby-sdk-v2",
   "generatorVersion": "local",
   "generatorConfig": {
-    "rubocopSeverity": "error"
+    "rubocopSeverity": "error",
+    "generateAvailabilityAnnotations": true
   },
   "originGitCommit": "DUMMY",
   "sdkVersion": "0.0.1"

--- a/seed/ruby-sdk-v2/multi-line-docs/.fern/metadata.json
+++ b/seed/ruby-sdk-v2/multi-line-docs/.fern/metadata.json
@@ -3,7 +3,8 @@
   "generatorName": "fernapi/fern-ruby-sdk-v2",
   "generatorVersion": "local",
   "generatorConfig": {
-    "rubocopSeverity": "error"
+    "rubocopSeverity": "error",
+    "generateAvailabilityAnnotations": true
   },
   "originGitCommit": "DUMMY",
   "sdkVersion": "0.0.1"

--- a/seed/ruby-sdk-v2/multi-url-environment-no-default/.fern/metadata.json
+++ b/seed/ruby-sdk-v2/multi-url-environment-no-default/.fern/metadata.json
@@ -3,7 +3,8 @@
   "generatorName": "fernapi/fern-ruby-sdk-v2",
   "generatorVersion": "local",
   "generatorConfig": {
-    "rubocopSeverity": "error"
+    "rubocopSeverity": "error",
+    "generateAvailabilityAnnotations": true
   },
   "originGitCommit": "DUMMY",
   "sdkVersion": "0.0.1"

--- a/seed/ruby-sdk-v2/multi-url-environment-reference/.fern/metadata.json
+++ b/seed/ruby-sdk-v2/multi-url-environment-reference/.fern/metadata.json
@@ -3,7 +3,8 @@
   "generatorName": "fernapi/fern-ruby-sdk-v2",
   "generatorVersion": "local",
   "generatorConfig": {
-    "rubocopSeverity": "error"
+    "rubocopSeverity": "error",
+    "generateAvailabilityAnnotations": true
   },
   "originGitCommit": "DUMMY",
   "sdkVersion": "0.0.1"

--- a/seed/ruby-sdk-v2/multi-url-environment/.fern/metadata.json
+++ b/seed/ruby-sdk-v2/multi-url-environment/.fern/metadata.json
@@ -3,7 +3,8 @@
   "generatorName": "fernapi/fern-ruby-sdk-v2",
   "generatorVersion": "local",
   "generatorConfig": {
-    "rubocopSeverity": "error"
+    "rubocopSeverity": "error",
+    "generateAvailabilityAnnotations": true
   },
   "originGitCommit": "DUMMY",
   "sdkVersion": "0.0.1"

--- a/seed/ruby-sdk-v2/multiple-request-bodies/.fern/metadata.json
+++ b/seed/ruby-sdk-v2/multiple-request-bodies/.fern/metadata.json
@@ -3,7 +3,8 @@
   "generatorName": "fernapi/fern-ruby-sdk-v2",
   "generatorVersion": "local",
   "generatorConfig": {
-    "rubocopSeverity": "error"
+    "rubocopSeverity": "error",
+    "generateAvailabilityAnnotations": true
   },
   "originGitCommit": "DUMMY",
   "sdkVersion": "0.0.1"

--- a/seed/ruby-sdk-v2/no-content-response/.fern/metadata.json
+++ b/seed/ruby-sdk-v2/no-content-response/.fern/metadata.json
@@ -3,7 +3,8 @@
   "generatorName": "fernapi/fern-ruby-sdk-v2",
   "generatorVersion": "local",
   "generatorConfig": {
-    "rubocopSeverity": "error"
+    "rubocopSeverity": "error",
+    "generateAvailabilityAnnotations": true
   },
   "originGitCommit": "DUMMY",
   "sdkVersion": "0.0.1"

--- a/seed/ruby-sdk-v2/no-environment/.fern/metadata.json
+++ b/seed/ruby-sdk-v2/no-environment/.fern/metadata.json
@@ -3,7 +3,8 @@
   "generatorName": "fernapi/fern-ruby-sdk-v2",
   "generatorVersion": "local",
   "generatorConfig": {
-    "rubocopSeverity": "error"
+    "rubocopSeverity": "error",
+    "generateAvailabilityAnnotations": true
   },
   "originGitCommit": "DUMMY",
   "sdkVersion": "0.0.1"

--- a/seed/ruby-sdk-v2/no-retries/.fern/metadata.json
+++ b/seed/ruby-sdk-v2/no-retries/.fern/metadata.json
@@ -3,7 +3,8 @@
   "generatorName": "fernapi/fern-ruby-sdk-v2",
   "generatorVersion": "local",
   "generatorConfig": {
-    "rubocopSeverity": "error"
+    "rubocopSeverity": "error",
+    "generateAvailabilityAnnotations": true
   },
   "originGitCommit": "DUMMY",
   "sdkVersion": "0.0.1"

--- a/seed/ruby-sdk-v2/null-type/.fern/metadata.json
+++ b/seed/ruby-sdk-v2/null-type/.fern/metadata.json
@@ -3,7 +3,8 @@
   "generatorName": "fernapi/fern-ruby-sdk-v2",
   "generatorVersion": "local",
   "generatorConfig": {
-    "rubocopSeverity": "error"
+    "rubocopSeverity": "error",
+    "generateAvailabilityAnnotations": true
   },
   "originGitCommit": "DUMMY",
   "sdkVersion": "0.0.1"

--- a/seed/ruby-sdk-v2/nullable-allof-extends/.fern/metadata.json
+++ b/seed/ruby-sdk-v2/nullable-allof-extends/.fern/metadata.json
@@ -3,7 +3,8 @@
   "generatorName": "fernapi/fern-ruby-sdk-v2",
   "generatorVersion": "local",
   "generatorConfig": {
-    "rubocopSeverity": "error"
+    "rubocopSeverity": "error",
+    "generateAvailabilityAnnotations": true
   },
   "originGitCommit": "DUMMY",
   "sdkVersion": "0.0.1"

--- a/seed/ruby-sdk-v2/nullable-optional/.fern/metadata.json
+++ b/seed/ruby-sdk-v2/nullable-optional/.fern/metadata.json
@@ -3,7 +3,8 @@
   "generatorName": "fernapi/fern-ruby-sdk-v2",
   "generatorVersion": "local",
   "generatorConfig": {
-    "rubocopSeverity": "error"
+    "rubocopSeverity": "error",
+    "generateAvailabilityAnnotations": true
   },
   "originGitCommit": "DUMMY",
   "sdkVersion": "0.0.1"

--- a/seed/ruby-sdk-v2/nullable-request-body/.fern/metadata.json
+++ b/seed/ruby-sdk-v2/nullable-request-body/.fern/metadata.json
@@ -3,7 +3,8 @@
   "generatorName": "fernapi/fern-ruby-sdk-v2",
   "generatorVersion": "local",
   "generatorConfig": {
-    "rubocopSeverity": "error"
+    "rubocopSeverity": "error",
+    "generateAvailabilityAnnotations": true
   },
   "originGitCommit": "DUMMY",
   "sdkVersion": "0.0.1"

--- a/seed/ruby-sdk-v2/nullable/.fern/metadata.json
+++ b/seed/ruby-sdk-v2/nullable/.fern/metadata.json
@@ -3,7 +3,8 @@
   "generatorName": "fernapi/fern-ruby-sdk-v2",
   "generatorVersion": "local",
   "generatorConfig": {
-    "rubocopSeverity": "error"
+    "rubocopSeverity": "error",
+    "generateAvailabilityAnnotations": true
   },
   "originGitCommit": "DUMMY",
   "sdkVersion": "0.0.1"

--- a/seed/ruby-sdk-v2/oauth-client-credentials-custom/.fern/metadata.json
+++ b/seed/ruby-sdk-v2/oauth-client-credentials-custom/.fern/metadata.json
@@ -3,7 +3,8 @@
   "generatorName": "fernapi/fern-ruby-sdk-v2",
   "generatorVersion": "local",
   "generatorConfig": {
-    "rubocopSeverity": "error"
+    "rubocopSeverity": "error",
+    "generateAvailabilityAnnotations": true
   },
   "originGitCommit": "DUMMY",
   "sdkVersion": "0.0.1"

--- a/seed/ruby-sdk-v2/oauth-client-credentials-default/.fern/metadata.json
+++ b/seed/ruby-sdk-v2/oauth-client-credentials-default/.fern/metadata.json
@@ -3,7 +3,8 @@
   "generatorName": "fernapi/fern-ruby-sdk-v2",
   "generatorVersion": "local",
   "generatorConfig": {
-    "rubocopSeverity": "error"
+    "rubocopSeverity": "error",
+    "generateAvailabilityAnnotations": true
   },
   "originGitCommit": "DUMMY",
   "sdkVersion": "0.0.1"

--- a/seed/ruby-sdk-v2/oauth-client-credentials-environment-variables/.fern/metadata.json
+++ b/seed/ruby-sdk-v2/oauth-client-credentials-environment-variables/.fern/metadata.json
@@ -3,7 +3,8 @@
   "generatorName": "fernapi/fern-ruby-sdk-v2",
   "generatorVersion": "local",
   "generatorConfig": {
-    "rubocopSeverity": "error"
+    "rubocopSeverity": "error",
+    "generateAvailabilityAnnotations": true
   },
   "originGitCommit": "DUMMY",
   "sdkVersion": "0.0.1"

--- a/seed/ruby-sdk-v2/oauth-client-credentials-mandatory-auth/.fern/metadata.json
+++ b/seed/ruby-sdk-v2/oauth-client-credentials-mandatory-auth/.fern/metadata.json
@@ -3,7 +3,8 @@
   "generatorName": "fernapi/fern-ruby-sdk-v2",
   "generatorVersion": "local",
   "generatorConfig": {
-    "rubocopSeverity": "error"
+    "rubocopSeverity": "error",
+    "generateAvailabilityAnnotations": true
   },
   "originGitCommit": "DUMMY",
   "sdkVersion": "0.0.1"

--- a/seed/ruby-sdk-v2/oauth-client-credentials-nested-root/.fern/metadata.json
+++ b/seed/ruby-sdk-v2/oauth-client-credentials-nested-root/.fern/metadata.json
@@ -3,7 +3,8 @@
   "generatorName": "fernapi/fern-ruby-sdk-v2",
   "generatorVersion": "local",
   "generatorConfig": {
-    "rubocopSeverity": "error"
+    "rubocopSeverity": "error",
+    "generateAvailabilityAnnotations": true
   },
   "originGitCommit": "DUMMY",
   "sdkVersion": "0.0.1"

--- a/seed/ruby-sdk-v2/oauth-client-credentials-openapi/.fern/metadata.json
+++ b/seed/ruby-sdk-v2/oauth-client-credentials-openapi/.fern/metadata.json
@@ -3,7 +3,8 @@
   "generatorName": "fernapi/fern-ruby-sdk-v2",
   "generatorVersion": "local",
   "generatorConfig": {
-    "rubocopSeverity": "error"
+    "rubocopSeverity": "error",
+    "generateAvailabilityAnnotations": true
   },
   "originGitCommit": "DUMMY",
   "sdkVersion": "0.0.1"

--- a/seed/ruby-sdk-v2/oauth-client-credentials-reference/.fern/metadata.json
+++ b/seed/ruby-sdk-v2/oauth-client-credentials-reference/.fern/metadata.json
@@ -3,7 +3,8 @@
   "generatorName": "fernapi/fern-ruby-sdk-v2",
   "generatorVersion": "local",
   "generatorConfig": {
-    "rubocopSeverity": "error"
+    "rubocopSeverity": "error",
+    "generateAvailabilityAnnotations": true
   },
   "originGitCommit": "DUMMY",
   "sdkVersion": "0.0.1"

--- a/seed/ruby-sdk-v2/oauth-client-credentials-with-variables/.fern/metadata.json
+++ b/seed/ruby-sdk-v2/oauth-client-credentials-with-variables/.fern/metadata.json
@@ -3,7 +3,8 @@
   "generatorName": "fernapi/fern-ruby-sdk-v2",
   "generatorVersion": "local",
   "generatorConfig": {
-    "rubocopSeverity": "error"
+    "rubocopSeverity": "error",
+    "generateAvailabilityAnnotations": true
   },
   "originGitCommit": "DUMMY",
   "sdkVersion": "0.0.1"

--- a/seed/ruby-sdk-v2/oauth-client-credentials/.fern/metadata.json
+++ b/seed/ruby-sdk-v2/oauth-client-credentials/.fern/metadata.json
@@ -3,7 +3,8 @@
   "generatorName": "fernapi/fern-ruby-sdk-v2",
   "generatorVersion": "local",
   "generatorConfig": {
-    "rubocopSeverity": "error"
+    "rubocopSeverity": "error",
+    "generateAvailabilityAnnotations": true
   },
   "originGitCommit": "DUMMY",
   "sdkVersion": "0.0.1"

--- a/seed/ruby-sdk-v2/object/.fern/metadata.json
+++ b/seed/ruby-sdk-v2/object/.fern/metadata.json
@@ -3,7 +3,8 @@
   "generatorName": "fernapi/fern-ruby-sdk-v2",
   "generatorVersion": "local",
   "generatorConfig": {
-    "rubocopSeverity": "error"
+    "rubocopSeverity": "error",
+    "generateAvailabilityAnnotations": true
   },
   "originGitCommit": "DUMMY",
   "sdkVersion": "0.0.1"

--- a/seed/ruby-sdk-v2/objects-with-imports/.fern/metadata.json
+++ b/seed/ruby-sdk-v2/objects-with-imports/.fern/metadata.json
@@ -3,7 +3,8 @@
   "generatorName": "fernapi/fern-ruby-sdk-v2",
   "generatorVersion": "local",
   "generatorConfig": {
-    "rubocopSeverity": "error"
+    "rubocopSeverity": "error",
+    "generateAvailabilityAnnotations": true
   },
   "originGitCommit": "DUMMY",
   "sdkVersion": "0.0.1"

--- a/seed/ruby-sdk-v2/optional/.fern/metadata.json
+++ b/seed/ruby-sdk-v2/optional/.fern/metadata.json
@@ -3,7 +3,8 @@
   "generatorName": "fernapi/fern-ruby-sdk-v2",
   "generatorVersion": "local",
   "generatorConfig": {
-    "rubocopSeverity": "error"
+    "rubocopSeverity": "error",
+    "generateAvailabilityAnnotations": true
   },
   "originGitCommit": "DUMMY",
   "sdkVersion": "0.0.1"

--- a/seed/ruby-sdk-v2/package-yml/.fern/metadata.json
+++ b/seed/ruby-sdk-v2/package-yml/.fern/metadata.json
@@ -3,7 +3,8 @@
   "generatorName": "fernapi/fern-ruby-sdk-v2",
   "generatorVersion": "local",
   "generatorConfig": {
-    "rubocopSeverity": "error"
+    "rubocopSeverity": "error",
+    "generateAvailabilityAnnotations": true
   },
   "originGitCommit": "DUMMY",
   "sdkVersion": "0.0.1"

--- a/seed/ruby-sdk-v2/pagination-custom/.fern/metadata.json
+++ b/seed/ruby-sdk-v2/pagination-custom/.fern/metadata.json
@@ -4,6 +4,7 @@
   "generatorVersion": "local",
   "generatorConfig": {
     "rubocopSeverity": "error",
+    "generateAvailabilityAnnotations": true,
     "customPagerName": "FooPager"
   },
   "originGitCommit": "DUMMY",

--- a/seed/ruby-sdk-v2/pagination-uri-path/.fern/metadata.json
+++ b/seed/ruby-sdk-v2/pagination-uri-path/.fern/metadata.json
@@ -3,7 +3,8 @@
   "generatorName": "fernapi/fern-ruby-sdk-v2",
   "generatorVersion": "local",
   "generatorConfig": {
-    "rubocopSeverity": "error"
+    "rubocopSeverity": "error",
+    "generateAvailabilityAnnotations": true
   },
   "originGitCommit": "DUMMY",
   "sdkVersion": "0.0.1"

--- a/seed/ruby-sdk-v2/pagination/.fern/metadata.json
+++ b/seed/ruby-sdk-v2/pagination/.fern/metadata.json
@@ -3,7 +3,8 @@
   "generatorName": "fernapi/fern-ruby-sdk-v2",
   "generatorVersion": "local",
   "generatorConfig": {
-    "rubocopSeverity": "error"
+    "rubocopSeverity": "error",
+    "generateAvailabilityAnnotations": true
   },
   "originGitCommit": "DUMMY",
   "sdkVersion": "0.0.1"

--- a/seed/ruby-sdk-v2/path-parameters/.fern/metadata.json
+++ b/seed/ruby-sdk-v2/path-parameters/.fern/metadata.json
@@ -3,7 +3,8 @@
   "generatorName": "fernapi/fern-ruby-sdk-v2",
   "generatorVersion": "local",
   "generatorConfig": {
-    "rubocopSeverity": "error"
+    "rubocopSeverity": "error",
+    "generateAvailabilityAnnotations": true
   },
   "originGitCommit": "DUMMY",
   "sdkVersion": "0.0.1"

--- a/seed/ruby-sdk-v2/plain-text/.fern/metadata.json
+++ b/seed/ruby-sdk-v2/plain-text/.fern/metadata.json
@@ -3,7 +3,8 @@
   "generatorName": "fernapi/fern-ruby-sdk-v2",
   "generatorVersion": "local",
   "generatorConfig": {
-    "rubocopSeverity": "error"
+    "rubocopSeverity": "error",
+    "generateAvailabilityAnnotations": true
   },
   "originGitCommit": "DUMMY",
   "sdkVersion": "0.0.1"

--- a/seed/ruby-sdk-v2/property-access/.fern/metadata.json
+++ b/seed/ruby-sdk-v2/property-access/.fern/metadata.json
@@ -3,7 +3,8 @@
   "generatorName": "fernapi/fern-ruby-sdk-v2",
   "generatorVersion": "local",
   "generatorConfig": {
-    "rubocopSeverity": "error"
+    "rubocopSeverity": "error",
+    "generateAvailabilityAnnotations": true
   },
   "originGitCommit": "DUMMY",
   "sdkVersion": "0.0.1"

--- a/seed/ruby-sdk-v2/public-object/.fern/metadata.json
+++ b/seed/ruby-sdk-v2/public-object/.fern/metadata.json
@@ -3,7 +3,8 @@
   "generatorName": "fernapi/fern-ruby-sdk-v2",
   "generatorVersion": "local",
   "generatorConfig": {
-    "rubocopSeverity": "error"
+    "rubocopSeverity": "error",
+    "generateAvailabilityAnnotations": true
   },
   "originGitCommit": "DUMMY",
   "sdkVersion": "0.0.1"

--- a/seed/ruby-sdk-v2/query-param-name-conflict/.fern/metadata.json
+++ b/seed/ruby-sdk-v2/query-param-name-conflict/.fern/metadata.json
@@ -3,7 +3,8 @@
   "generatorName": "fernapi/fern-ruby-sdk-v2",
   "generatorVersion": "local",
   "generatorConfig": {
-    "rubocopSeverity": "error"
+    "rubocopSeverity": "error",
+    "generateAvailabilityAnnotations": true
   },
   "originGitCommit": "DUMMY",
   "sdkVersion": "0.0.1"

--- a/seed/ruby-sdk-v2/query-parameters-openapi-as-objects/.fern/metadata.json
+++ b/seed/ruby-sdk-v2/query-parameters-openapi-as-objects/.fern/metadata.json
@@ -3,7 +3,8 @@
   "generatorName": "fernapi/fern-ruby-sdk-v2",
   "generatorVersion": "local",
   "generatorConfig": {
-    "rubocopSeverity": "error"
+    "rubocopSeverity": "error",
+    "generateAvailabilityAnnotations": true
   },
   "originGitCommit": "DUMMY",
   "sdkVersion": "0.0.1"

--- a/seed/ruby-sdk-v2/query-parameters-openapi/.fern/metadata.json
+++ b/seed/ruby-sdk-v2/query-parameters-openapi/.fern/metadata.json
@@ -3,7 +3,8 @@
   "generatorName": "fernapi/fern-ruby-sdk-v2",
   "generatorVersion": "local",
   "generatorConfig": {
-    "rubocopSeverity": "error"
+    "rubocopSeverity": "error",
+    "generateAvailabilityAnnotations": true
   },
   "originGitCommit": "DUMMY",
   "sdkVersion": "0.0.1"

--- a/seed/ruby-sdk-v2/query-parameters/.fern/metadata.json
+++ b/seed/ruby-sdk-v2/query-parameters/.fern/metadata.json
@@ -3,7 +3,8 @@
   "generatorName": "fernapi/fern-ruby-sdk-v2",
   "generatorVersion": "local",
   "generatorConfig": {
-    "rubocopSeverity": "error"
+    "rubocopSeverity": "error",
+    "generateAvailabilityAnnotations": true
   },
   "originGitCommit": "DUMMY",
   "sdkVersion": "0.0.1"

--- a/seed/ruby-sdk-v2/request-parameters/.fern/metadata.json
+++ b/seed/ruby-sdk-v2/request-parameters/.fern/metadata.json
@@ -3,7 +3,8 @@
   "generatorName": "fernapi/fern-ruby-sdk-v2",
   "generatorVersion": "local",
   "generatorConfig": {
-    "rubocopSeverity": "error"
+    "rubocopSeverity": "error",
+    "generateAvailabilityAnnotations": true
   },
   "originGitCommit": "DUMMY",
   "sdkVersion": "0.0.1"

--- a/seed/ruby-sdk-v2/required-nullable/.fern/metadata.json
+++ b/seed/ruby-sdk-v2/required-nullable/.fern/metadata.json
@@ -3,7 +3,8 @@
   "generatorName": "fernapi/fern-ruby-sdk-v2",
   "generatorVersion": "local",
   "generatorConfig": {
-    "rubocopSeverity": "error"
+    "rubocopSeverity": "error",
+    "generateAvailabilityAnnotations": true
   },
   "originGitCommit": "DUMMY",
   "sdkVersion": "0.0.1"

--- a/seed/ruby-sdk-v2/reserved-keywords/.fern/metadata.json
+++ b/seed/ruby-sdk-v2/reserved-keywords/.fern/metadata.json
@@ -3,7 +3,8 @@
   "generatorName": "fernapi/fern-ruby-sdk-v2",
   "generatorVersion": "local",
   "generatorConfig": {
-    "rubocopSeverity": "error"
+    "rubocopSeverity": "error",
+    "generateAvailabilityAnnotations": true
   },
   "originGitCommit": "DUMMY",
   "sdkVersion": "0.0.1"

--- a/seed/ruby-sdk-v2/response-property/.fern/metadata.json
+++ b/seed/ruby-sdk-v2/response-property/.fern/metadata.json
@@ -3,7 +3,8 @@
   "generatorName": "fernapi/fern-ruby-sdk-v2",
   "generatorVersion": "local",
   "generatorConfig": {
-    "rubocopSeverity": "error"
+    "rubocopSeverity": "error",
+    "generateAvailabilityAnnotations": true
   },
   "originGitCommit": "DUMMY",
   "sdkVersion": "0.0.1"

--- a/seed/ruby-sdk-v2/ruby-reserved-word-properties/.fern/metadata.json
+++ b/seed/ruby-sdk-v2/ruby-reserved-word-properties/.fern/metadata.json
@@ -3,7 +3,8 @@
   "generatorName": "fernapi/fern-ruby-sdk-v2",
   "generatorVersion": "local",
   "generatorConfig": {
-    "rubocopSeverity": "error"
+    "rubocopSeverity": "error",
+    "generateAvailabilityAnnotations": true
   },
   "originGitCommit": "DUMMY",
   "sdkVersion": "0.0.1"

--- a/seed/ruby-sdk-v2/schemaless-request-body-examples/.fern/metadata.json
+++ b/seed/ruby-sdk-v2/schemaless-request-body-examples/.fern/metadata.json
@@ -3,7 +3,8 @@
   "generatorName": "fernapi/fern-ruby-sdk-v2",
   "generatorVersion": "local",
   "generatorConfig": {
-    "rubocopSeverity": "error"
+    "rubocopSeverity": "error",
+    "generateAvailabilityAnnotations": true
   },
   "originGitCommit": "DUMMY",
   "sdkVersion": "0.0.1"

--- a/seed/ruby-sdk-v2/seed.yml
+++ b/seed/ruby-sdk-v2/seed.yml
@@ -5,6 +5,7 @@ generatorType: SDK
 defaultOutputMode: github
 defaultCustomConfig:
   rubocopSeverity: error
+  generateAvailabilityAnnotations: true
 image: fernapi/fern-ruby-sdk-v2
 imageAliases: [fernapi/fern-ruby-sdk]
 changelogLocation: ../../generators/ruby-v2/sdk/versions.yml

--- a/seed/ruby-sdk-v2/server-sent-event-examples/.fern/metadata.json
+++ b/seed/ruby-sdk-v2/server-sent-event-examples/.fern/metadata.json
@@ -3,7 +3,8 @@
   "generatorName": "fernapi/fern-ruby-sdk-v2",
   "generatorVersion": "local",
   "generatorConfig": {
-    "rubocopSeverity": "error"
+    "rubocopSeverity": "error",
+    "generateAvailabilityAnnotations": true
   },
   "originGitCommit": "DUMMY",
   "sdkVersion": "0.0.1"

--- a/seed/ruby-sdk-v2/server-sent-events-openapi/.fern/metadata.json
+++ b/seed/ruby-sdk-v2/server-sent-events-openapi/.fern/metadata.json
@@ -3,7 +3,8 @@
   "generatorName": "fernapi/fern-ruby-sdk-v2",
   "generatorVersion": "local",
   "generatorConfig": {
-    "rubocopSeverity": "error"
+    "rubocopSeverity": "error",
+    "generateAvailabilityAnnotations": true
   },
   "originGitCommit": "DUMMY",
   "sdkVersion": "0.0.1"

--- a/seed/ruby-sdk-v2/server-sent-events/.fern/metadata.json
+++ b/seed/ruby-sdk-v2/server-sent-events/.fern/metadata.json
@@ -3,7 +3,8 @@
   "generatorName": "fernapi/fern-ruby-sdk-v2",
   "generatorVersion": "local",
   "generatorConfig": {
-    "rubocopSeverity": "error"
+    "rubocopSeverity": "error",
+    "generateAvailabilityAnnotations": true
   },
   "originGitCommit": "DUMMY",
   "sdkVersion": "0.0.1"

--- a/seed/ruby-sdk-v2/server-url-templating/.fern/metadata.json
+++ b/seed/ruby-sdk-v2/server-url-templating/.fern/metadata.json
@@ -3,7 +3,8 @@
   "generatorName": "fernapi/fern-ruby-sdk-v2",
   "generatorVersion": "local",
   "generatorConfig": {
-    "rubocopSeverity": "error"
+    "rubocopSeverity": "error",
+    "generateAvailabilityAnnotations": true
   },
   "originGitCommit": "DUMMY",
   "sdkVersion": "0.0.1"

--- a/seed/ruby-sdk-v2/simple-api/.fern/metadata.json
+++ b/seed/ruby-sdk-v2/simple-api/.fern/metadata.json
@@ -3,7 +3,8 @@
   "generatorName": "fernapi/fern-ruby-sdk-v2",
   "generatorVersion": "local",
   "generatorConfig": {
-    "rubocopSeverity": "error"
+    "rubocopSeverity": "error",
+    "generateAvailabilityAnnotations": true
   },
   "originGitCommit": "DUMMY",
   "sdkVersion": "0.0.1"

--- a/seed/ruby-sdk-v2/simple-fhir/.fern/metadata.json
+++ b/seed/ruby-sdk-v2/simple-fhir/.fern/metadata.json
@@ -3,7 +3,8 @@
   "generatorName": "fernapi/fern-ruby-sdk-v2",
   "generatorVersion": "local",
   "generatorConfig": {
-    "rubocopSeverity": "error"
+    "rubocopSeverity": "error",
+    "generateAvailabilityAnnotations": true
   },
   "originGitCommit": "DUMMY",
   "sdkVersion": "0.0.1"

--- a/seed/ruby-sdk-v2/single-url-environment-default/.fern/metadata.json
+++ b/seed/ruby-sdk-v2/single-url-environment-default/.fern/metadata.json
@@ -3,7 +3,8 @@
   "generatorName": "fernapi/fern-ruby-sdk-v2",
   "generatorVersion": "local",
   "generatorConfig": {
-    "rubocopSeverity": "error"
+    "rubocopSeverity": "error",
+    "generateAvailabilityAnnotations": true
   },
   "originGitCommit": "DUMMY",
   "sdkVersion": "0.0.1"

--- a/seed/ruby-sdk-v2/single-url-environment-no-default/.fern/metadata.json
+++ b/seed/ruby-sdk-v2/single-url-environment-no-default/.fern/metadata.json
@@ -3,7 +3,8 @@
   "generatorName": "fernapi/fern-ruby-sdk-v2",
   "generatorVersion": "local",
   "generatorConfig": {
-    "rubocopSeverity": "error"
+    "rubocopSeverity": "error",
+    "generateAvailabilityAnnotations": true
   },
   "originGitCommit": "DUMMY",
   "sdkVersion": "0.0.1"

--- a/seed/ruby-sdk-v2/streaming-parameter/.fern/metadata.json
+++ b/seed/ruby-sdk-v2/streaming-parameter/.fern/metadata.json
@@ -3,7 +3,8 @@
   "generatorName": "fernapi/fern-ruby-sdk-v2",
   "generatorVersion": "local",
   "generatorConfig": {
-    "rubocopSeverity": "error"
+    "rubocopSeverity": "error",
+    "generateAvailabilityAnnotations": true
   },
   "originGitCommit": "DUMMY",
   "sdkVersion": "0.0.1"

--- a/seed/ruby-sdk-v2/streaming/.fern/metadata.json
+++ b/seed/ruby-sdk-v2/streaming/.fern/metadata.json
@@ -3,7 +3,8 @@
   "generatorName": "fernapi/fern-ruby-sdk-v2",
   "generatorVersion": "local",
   "generatorConfig": {
-    "rubocopSeverity": "error"
+    "rubocopSeverity": "error",
+    "generateAvailabilityAnnotations": true
   },
   "originGitCommit": "DUMMY",
   "sdkVersion": "0.0.1"

--- a/seed/ruby-sdk-v2/trace/.fern/metadata.json
+++ b/seed/ruby-sdk-v2/trace/.fern/metadata.json
@@ -3,7 +3,8 @@
   "generatorName": "fernapi/fern-ruby-sdk-v2",
   "generatorVersion": "local",
   "generatorConfig": {
-    "rubocopSeverity": "error"
+    "rubocopSeverity": "error",
+    "generateAvailabilityAnnotations": true
   },
   "originGitCommit": "DUMMY",
   "sdkVersion": "0.0.1"

--- a/seed/ruby-sdk-v2/undiscriminated-union-with-response-property/.fern/metadata.json
+++ b/seed/ruby-sdk-v2/undiscriminated-union-with-response-property/.fern/metadata.json
@@ -3,7 +3,8 @@
   "generatorName": "fernapi/fern-ruby-sdk-v2",
   "generatorVersion": "local",
   "generatorConfig": {
-    "rubocopSeverity": "error"
+    "rubocopSeverity": "error",
+    "generateAvailabilityAnnotations": true
   },
   "originGitCommit": "DUMMY",
   "sdkVersion": "0.0.1"

--- a/seed/ruby-sdk-v2/undiscriminated-unions/.fern/metadata.json
+++ b/seed/ruby-sdk-v2/undiscriminated-unions/.fern/metadata.json
@@ -3,7 +3,8 @@
   "generatorName": "fernapi/fern-ruby-sdk-v2",
   "generatorVersion": "local",
   "generatorConfig": {
-    "rubocopSeverity": "error"
+    "rubocopSeverity": "error",
+    "generateAvailabilityAnnotations": true
   },
   "originGitCommit": "DUMMY",
   "sdkVersion": "0.0.1"

--- a/seed/ruby-sdk-v2/unions-with-local-date/.fern/metadata.json
+++ b/seed/ruby-sdk-v2/unions-with-local-date/.fern/metadata.json
@@ -3,7 +3,8 @@
   "generatorName": "fernapi/fern-ruby-sdk-v2",
   "generatorVersion": "local",
   "generatorConfig": {
-    "rubocopSeverity": "error"
+    "rubocopSeverity": "error",
+    "generateAvailabilityAnnotations": true
   },
   "originGitCommit": "DUMMY",
   "sdkVersion": "0.0.1"

--- a/seed/ruby-sdk-v2/unions/.fern/metadata.json
+++ b/seed/ruby-sdk-v2/unions/.fern/metadata.json
@@ -3,7 +3,8 @@
   "generatorName": "fernapi/fern-ruby-sdk-v2",
   "generatorVersion": "local",
   "generatorConfig": {
-    "rubocopSeverity": "error"
+    "rubocopSeverity": "error",
+    "generateAvailabilityAnnotations": true
   },
   "originGitCommit": "DUMMY",
   "sdkVersion": "0.0.1"

--- a/seed/ruby-sdk-v2/unknown/.fern/metadata.json
+++ b/seed/ruby-sdk-v2/unknown/.fern/metadata.json
@@ -3,7 +3,8 @@
   "generatorName": "fernapi/fern-ruby-sdk-v2",
   "generatorVersion": "local",
   "generatorConfig": {
-    "rubocopSeverity": "error"
+    "rubocopSeverity": "error",
+    "generateAvailabilityAnnotations": true
   },
   "originGitCommit": "DUMMY",
   "sdkVersion": "0.0.1"

--- a/seed/ruby-sdk-v2/url-form-encoded/.fern/metadata.json
+++ b/seed/ruby-sdk-v2/url-form-encoded/.fern/metadata.json
@@ -3,7 +3,8 @@
   "generatorName": "fernapi/fern-ruby-sdk-v2",
   "generatorVersion": "local",
   "generatorConfig": {
-    "rubocopSeverity": "error"
+    "rubocopSeverity": "error",
+    "generateAvailabilityAnnotations": true
   },
   "originGitCommit": "DUMMY",
   "sdkVersion": "0.0.1"

--- a/seed/ruby-sdk-v2/validation/.fern/metadata.json
+++ b/seed/ruby-sdk-v2/validation/.fern/metadata.json
@@ -3,7 +3,8 @@
   "generatorName": "fernapi/fern-ruby-sdk-v2",
   "generatorVersion": "local",
   "generatorConfig": {
-    "rubocopSeverity": "error"
+    "rubocopSeverity": "error",
+    "generateAvailabilityAnnotations": true
   },
   "originGitCommit": "DUMMY",
   "sdkVersion": "0.0.1"

--- a/seed/ruby-sdk-v2/variables/.fern/metadata.json
+++ b/seed/ruby-sdk-v2/variables/.fern/metadata.json
@@ -3,7 +3,8 @@
   "generatorName": "fernapi/fern-ruby-sdk-v2",
   "generatorVersion": "local",
   "generatorConfig": {
-    "rubocopSeverity": "error"
+    "rubocopSeverity": "error",
+    "generateAvailabilityAnnotations": true
   },
   "originGitCommit": "DUMMY",
   "sdkVersion": "0.0.1"

--- a/seed/ruby-sdk-v2/version-no-default/.fern/metadata.json
+++ b/seed/ruby-sdk-v2/version-no-default/.fern/metadata.json
@@ -3,7 +3,8 @@
   "generatorName": "fernapi/fern-ruby-sdk-v2",
   "generatorVersion": "local",
   "generatorConfig": {
-    "rubocopSeverity": "error"
+    "rubocopSeverity": "error",
+    "generateAvailabilityAnnotations": true
   },
   "originGitCommit": "DUMMY",
   "sdkVersion": "0.0.1"

--- a/seed/ruby-sdk-v2/version/.fern/metadata.json
+++ b/seed/ruby-sdk-v2/version/.fern/metadata.json
@@ -3,7 +3,8 @@
   "generatorName": "fernapi/fern-ruby-sdk-v2",
   "generatorVersion": "local",
   "generatorConfig": {
-    "rubocopSeverity": "error"
+    "rubocopSeverity": "error",
+    "generateAvailabilityAnnotations": true
   },
   "originGitCommit": "DUMMY",
   "sdkVersion": "0.0.1"

--- a/seed/ruby-sdk-v2/webhook-audience/.fern/metadata.json
+++ b/seed/ruby-sdk-v2/webhook-audience/.fern/metadata.json
@@ -3,7 +3,8 @@
   "generatorName": "fernapi/fern-ruby-sdk-v2",
   "generatorVersion": "local",
   "generatorConfig": {
-    "rubocopSeverity": "error"
+    "rubocopSeverity": "error",
+    "generateAvailabilityAnnotations": true
   },
   "originGitCommit": "DUMMY",
   "sdkVersion": "0.0.1"

--- a/seed/ruby-sdk-v2/webhooks/.fern/metadata.json
+++ b/seed/ruby-sdk-v2/webhooks/.fern/metadata.json
@@ -3,7 +3,8 @@
   "generatorName": "fernapi/fern-ruby-sdk-v2",
   "generatorVersion": "local",
   "generatorConfig": {
-    "rubocopSeverity": "error"
+    "rubocopSeverity": "error",
+    "generateAvailabilityAnnotations": true
   },
   "originGitCommit": "DUMMY",
   "sdkVersion": "0.0.1"

--- a/seed/ruby-sdk-v2/websocket-bearer-auth/.fern/metadata.json
+++ b/seed/ruby-sdk-v2/websocket-bearer-auth/.fern/metadata.json
@@ -3,7 +3,8 @@
   "generatorName": "fernapi/fern-ruby-sdk-v2",
   "generatorVersion": "local",
   "generatorConfig": {
-    "rubocopSeverity": "error"
+    "rubocopSeverity": "error",
+    "generateAvailabilityAnnotations": true
   },
   "originGitCommit": "DUMMY",
   "sdkVersion": "0.0.1"

--- a/seed/ruby-sdk-v2/websocket-inferred-auth/.fern/metadata.json
+++ b/seed/ruby-sdk-v2/websocket-inferred-auth/.fern/metadata.json
@@ -3,7 +3,8 @@
   "generatorName": "fernapi/fern-ruby-sdk-v2",
   "generatorVersion": "local",
   "generatorConfig": {
-    "rubocopSeverity": "error"
+    "rubocopSeverity": "error",
+    "generateAvailabilityAnnotations": true
   },
   "originGitCommit": "DUMMY",
   "sdkVersion": "0.0.1"

--- a/seed/ruby-sdk-v2/websocket-multi-url/.fern/metadata.json
+++ b/seed/ruby-sdk-v2/websocket-multi-url/.fern/metadata.json
@@ -3,7 +3,8 @@
   "generatorName": "fernapi/fern-ruby-sdk-v2",
   "generatorVersion": "local",
   "generatorConfig": {
-    "rubocopSeverity": "error"
+    "rubocopSeverity": "error",
+    "generateAvailabilityAnnotations": true
   },
   "originGitCommit": "DUMMY",
   "sdkVersion": "0.0.1"

--- a/seed/ruby-sdk-v2/websocket/.fern/metadata.json
+++ b/seed/ruby-sdk-v2/websocket/.fern/metadata.json
@@ -3,7 +3,8 @@
   "generatorName": "fernapi/fern-ruby-sdk-v2",
   "generatorVersion": "local",
   "generatorConfig": {
-    "rubocopSeverity": "error"
+    "rubocopSeverity": "error",
+    "generateAvailabilityAnnotations": true
   },
   "originGitCommit": "DUMMY",
   "sdkVersion": "0.0.1"

--- a/seed/ruby-sdk-v2/x-fern-default/.fern/metadata.json
+++ b/seed/ruby-sdk-v2/x-fern-default/.fern/metadata.json
@@ -3,7 +3,8 @@
   "generatorName": "fernapi/fern-ruby-sdk-v2",
   "generatorVersion": "local",
   "generatorConfig": {
-    "rubocopSeverity": "error"
+    "rubocopSeverity": "error",
+    "generateAvailabilityAnnotations": true
   },
   "originGitCommit": "DUMMY",
   "sdkVersion": "0.0.1"


### PR DESCRIPTION
## Description

Adds optional YARD availability tags (`@deprecated` / `@beta`) to Ruby v2 SDK endpoint methods, mirroring the TypeScript generator's `getAvailabilityDocs` behavior. Gated behind a new opt-in custom config flag so existing customers see no change.

Mechanism used for each `AvailabilityStatus`:
- **DEPRECATED** — YARD's native `@deprecated` tag (with the IR `message` appended when present).
- **IN_DEVELOPMENT** — free-form doc line matching the TS wording: `@beta This endpoint is in development and may change.` (+ ` <message>` if provided).
- **PRE_RELEASE** — free-form doc line: `@beta This endpoint is in pre-release and may change.` (+ ` <message>` if provided).
- **GENERAL_AVAILABILITY** / undefined — no extra docs emitted.

Scope is Ruby v2 only. The legacy Ruby v1 generator source was removed from this monorepo in [1c167b9ec56](https://github.com/fern-api/fern/commit/1c167b9ec56) ("chore(ruby): remove legacy ruby generator source code") and superseded by `generators/ruby-v2/`, so there is nothing to mirror this change into on the v1 side.

## Opt-in via `generateAvailabilityAnnotations`

The new annotations are gated behind `generateAvailabilityAnnotations` (boolean, defaults to `false`) in the generator's custom config. Because YARD's `@deprecated` surfaces as a warning in strict lint setups (and `-Werror`-style configurations in other languages was the requester's concern), turning this on is a breaking change for downstream consumers that treat warnings as errors. With the flag off, the generator's output is byte-for-byte identical to `main`.

The flag is named generically (not `generateEndpointAvailability`) so future availability surfaces — services, types, object properties, enum values, webhook payloads, websocket channels/messages, errors — can opt in under the same flag without introducing a new one. This PR only implements the HTTP endpoint case; the other surfaces remain unannotated for now.

```yaml
# generators.yml
generators:
  - name: fernapi/fern-ruby-sdk-v2
    config:
      generateAvailabilityAnnotations: true
```

A `TODO(next-major): flip default to true` comment is in the schema next to the flag so the next major-version owner has a clear signal. The changelog calls out the same plan.

## Changes Made

- Added `generators/ruby-v2/sdk/src/endpoint/utils/getAvailabilityDocs.ts` — small helper mirroring the TS `getAvailabilityDocs` helper, but accepting `FernIr.Availability | undefined` directly so it is trivially unit-testable.
- Wired the helper into `HttpEndpointGenerator.generateEnhancedDocstring`, which is the single place Ruby v2 assembles the per-method docstring. The availability line is appended after any existing `endpoint.docs`, joined with `\n`.
- Added `generateAvailabilityAnnotations: z.boolean().optional()` to `BaseRubyCustomConfigSchema` (shared base for all ruby-v2 generators) with a `TODO(next-major)` comment documenting the eventual default flip. Call site in `generateEnhancedDocstring` checks `this.context.customConfig.generateAvailabilityAnnotations === true` so `undefined`/`false` both short-circuit — no diff against `main`.
- Added a unit test (`getAvailabilityDocs.test.ts`) covering every `AvailabilityStatus` variant with and without a `message`.
- Added an unreleased changelog entry under `generators/ruby-v2/sdk/changes/unreleased/endpoint-availability-annotations.yml` describing the flag, its default, and the plan to flip it in the next major bump.
- Set `defaultCustomConfig.generateAvailabilityAnnotations: true` in `seed/ruby-sdk-v2/seed.yml` so every seed fixture exercises the annotation emission, and regenerated all ruby-sdk-v2 seed snapshots. Customer-facing default in `BaseRubyCustomConfigSchema` remains `false`.

## Updates since last revision

- **Flipped the flag on by default in seed only** via `defaultCustomConfig` in `seed/ruby-sdk-v2/seed.yml`. Every fixture's `.fern/metadata.json` now records `generateAvailabilityAnnotations: true`. Two fixtures produce Ruby code deltas — `exhaustive/wire-tests` (four endpoints carrying `deprecated` / `pre-release` / `in-development`) and `imdb` (two endpoints). Every other fixture's IR has no `availability` set, so the only snapshot change is `metadata.json` recording the new config key.
- Full seed suite (`node --enable-source-maps packages/seed/dist/cli.cjs test --generator ruby-sdk-v2 --skip-scripts`) passes 124/124 locally, and CI's `seed-test-results (ruby-sdk-v2)` is green on the committed snapshots.
- Flag-off parity: the customer-facing default in `BaseRubyCustomConfigSchema` is still `false` (unchanged), and the flag-off path is exercised by the unit test; no dedicated flag-off seed fixture was added.
- Renamed the flag from `generateEndpointAvailability` to `generateAvailabilityAnnotations` per earlier reviewer feedback so future availability surfaces can opt in under the same flag.
- Earlier revisions gated emission behind the feature flag and addressed Devin Review comments (`@beta warning` JSDoc wording on the helper; `assertNever` in the default case).

## Testing

- [x] Unit tests added — `pnpm vitest run src/endpoint/utils/__test__/getAvailabilityDocs.test.ts` (8/8 pass locally).
- [x] `pnpm compile` + lint clean.
- [x] Full ruby-sdk-v2 seed suite (`pnpm seed:build && node --enable-source-maps packages/seed/dist/cli.cjs test --generator ruby-sdk-v2 --skip-scripts`): 124/124 pass with committed snapshots.
- [x] Flag-on seed coverage: `exhaustive/wire-tests/lib/seed/endpoints/http_methods/client.rb` and `imdb/lib/seed/imdb/client.rb` show the new YARD tags (`@deprecated`, `@deprecated <message>`, `@beta This endpoint is in pre-release and may change.`, `@beta This endpoint is in development and may change.`).
- [x] Flag-off parity: customer-facing schema default is still `false`; flag-off path exercised by the unit test. No dedicated flag-off seed fixture.

## Review checklist / risks worth a closer look

- **Gating semantics**: the call site uses `this.context.customConfig.generateAvailabilityAnnotations === true`. Explicit `=== true` means `undefined`/`false`/any other value all skip the branch — intentional so that an unset flag matches current behavior. Sibling flags in the same file use the `!customConfig.foo` style; not matching that here since this flag needs explicit opt-in semantics.
- **Seed-only default flip**: `seed/ruby-sdk-v2/seed.yml` sets the flag `true` via `defaultCustomConfig`, which does NOT change the customer-facing default in `BaseRubyCustomConfigSchema` (still `false`). Worth confirming this is the intended split.
- **Shared schema**: the flag lives on `BaseRubyCustomConfigSchema` in `@fern-api/ruby-ast`, so it is technically visible to any other ruby-v2 generator (`model`, `dynamic-snippets`, etc.). Only `HttpEndpointGenerator` reads it today — desirable given the generic name, since future model/webhook-level annotations would read the same flag.
- **Docstring assembly**: `generateEnhancedDocstring` joins `endpoint.docs` and the availability line with `\n`. Look at the `imdb` snapshot where an endpoint already has docs — the tag ends up on a line adjacent to the existing docs with no blank line separator, which is YARD-compatible but worth a glance.
- **Single wiring site**: TS calls `getAvailabilityDocs` from three endpoint implementations (default / streaming / file-download). Ruby v2 funnels every HTTP endpoint through `HttpEndpointGenerator.generateUnpagedMethod`, so wiring once is sufficient — please confirm there is no separate streaming/file-download path I missed.
- **No dedicated flag-off seed fixture**: the flag-off path is covered by the unit test only; seed fixtures all run with the flag on.

Link to Devin session: https://app.devin.ai/sessions/98b85b0fbce445f08c5b2055e98da667
Requested by: @Swimburger
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/15115" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
