### PR TITLE
feat(php): annotate endpoint availability in generated SDK (opt-in)

### DIFF
--- a/generators/php/sdk/changes/unreleased/annotate-endpoint-availability.yml
+++ b/generators/php/sdk/changes/unreleased/annotate-endpoint-availability.yml
@@ -1,7 +1,9 @@
 - type: feat
   summary: |
-    Generated PHP SDK methods now surface endpoint availability
-    (deprecated / in-development / pre-release) using PHPDoc tags.
-    Deprecated endpoints are annotated with `@deprecated` (and the IR
-    `message`, when present). In-development and pre-release endpoints
-    receive a `@beta` warning in the method's PHPDoc block.
+    Add an opt-in `generateEndpointAvailability` custom config flag that
+    emits PHPDoc availability annotations on generated endpoint methods:
+    `@deprecated` (with the IR `message`, when present) for deprecated
+    endpoints, and `@beta` warnings for in-development / pre-release
+    endpoints. The flag defaults to `false` to preserve backwards
+    compatibility (static analyzers / `-Werror`-style pipelines), and
+    will become the default in the next major release.

--- a/generators/php/sdk/changes/unreleased/annotate-endpoint-availability.yml
+++ b/generators/php/sdk/changes/unreleased/annotate-endpoint-availability.yml
@@ -1,0 +1,7 @@
+- type: feat
+  summary: |
+    Generated PHP SDK methods now surface endpoint availability
+    (deprecated / in-development / pre-release) using PHPDoc tags.
+    Deprecated endpoints are annotated with `@deprecated` (and the IR
+    `message`, when present). In-development and pre-release endpoints
+    receive a `@beta` warning in the method's PHPDoc block.

--- a/generators/php/sdk/changes/unreleased/annotate-endpoint-availability.yml
+++ b/generators/php/sdk/changes/unreleased/annotate-endpoint-availability.yml
@@ -3,7 +3,7 @@
     Add an opt-in `generateAvailabilityAnnotations` custom config flag
     that emits PHPDoc availability annotations on generated SDK surfaces.
     Today this covers HTTP endpoint methods: `@deprecated` (with the IR
-    `message`, when present) for deprecated endpoints, and `@beta`
+    `message`, when present) for deprecated endpoints, and `@experimental`
     warnings for in-development / pre-release endpoints. The flag is
     intentionally named generically so future work can extend coverage
     to other surfaces (services, types, properties, enum values,

--- a/generators/php/sdk/changes/unreleased/annotate-endpoint-availability.yml
+++ b/generators/php/sdk/changes/unreleased/annotate-endpoint-availability.yml
@@ -1,9 +1,12 @@
 - type: feat
   summary: |
-    Add an opt-in `generateEndpointAvailability` custom config flag that
-    emits PHPDoc availability annotations on generated endpoint methods:
-    `@deprecated` (with the IR `message`, when present) for deprecated
-    endpoints, and `@beta` warnings for in-development / pre-release
-    endpoints. The flag defaults to `false` to preserve backwards
-    compatibility (static analyzers / `-Werror`-style pipelines), and
-    will become the default in the next major release.
+    Add an opt-in `generateAvailabilityAnnotations` custom config flag
+    that emits PHPDoc availability annotations on generated SDK surfaces.
+    Today this covers HTTP endpoint methods: `@deprecated` (with the IR
+    `message`, when present) for deprecated endpoints, and `@beta`
+    warnings for in-development / pre-release endpoints. The flag is
+    intentionally named generically so future work can extend coverage
+    to other surfaces (services, types, properties, enum values,
+    webhooks, etc.) under the same flag. Defaults to `false` to preserve
+    backwards compatibility (static analyzers / `-Werror`-style
+    pipelines), and will become the default in the next major release.

--- a/generators/php/sdk/src/SdkCustomConfig.ts
+++ b/generators/php/sdk/src/SdkCustomConfig.ts
@@ -13,6 +13,9 @@ export const SdkCustomConfigSchema = z
         useDefaultRequestParameterValues: z.boolean().optional(),
         // Generate interfaces for all SDK client classes to enable mocking and DI
         generateClientInterfaces: z.boolean().optional(),
+        // Emit PHPDoc availability annotations (@deprecated / @beta) on generated endpoint methods.
+        // TODO(next-major): flip default to true.
+        generateEndpointAvailability: z.boolean().optional(),
         maxRetries: z.number().int().min(0).optional()
     })
     .extend(BasePhpCustomConfigSchema.shape)
@@ -21,7 +24,8 @@ export const SdkCustomConfigSchema = z
         enableWireTests: config["enable-wire-tests"] ?? false,
         customPagerClassname: config["custom-pager-classname"] ?? "CustomPager",
         useDefaultRequestParameterValues: config.useDefaultRequestParameterValues ?? false,
-        generateClientInterfaces: config.generateClientInterfaces ?? false
+        generateClientInterfaces: config.generateClientInterfaces ?? false,
+        generateEndpointAvailability: config.generateEndpointAvailability ?? false
     }));
 
 export type SdkCustomConfigSchema = z.infer<typeof SdkCustomConfigSchema>;

--- a/generators/php/sdk/src/SdkCustomConfig.ts
+++ b/generators/php/sdk/src/SdkCustomConfig.ts
@@ -13,9 +13,11 @@ export const SdkCustomConfigSchema = z
         useDefaultRequestParameterValues: z.boolean().optional(),
         // Generate interfaces for all SDK client classes to enable mocking and DI
         generateClientInterfaces: z.boolean().optional(),
-        // Emit PHPDoc availability annotations (@deprecated / @beta) on generated endpoint methods.
+        // Emit PHPDoc availability annotations (@deprecated / @beta) on generated SDK surfaces.
+        // Today this covers endpoint methods; future work may extend it to services, types,
+        // properties, enum values, webhooks, etc. under the same flag.
         // TODO(next-major): flip default to true.
-        generateEndpointAvailability: z.boolean().optional(),
+        generateAvailabilityAnnotations: z.boolean().optional(),
         maxRetries: z.number().int().min(0).optional()
     })
     .extend(BasePhpCustomConfigSchema.shape)
@@ -25,7 +27,7 @@ export const SdkCustomConfigSchema = z
         customPagerClassname: config["custom-pager-classname"] ?? "CustomPager",
         useDefaultRequestParameterValues: config.useDefaultRequestParameterValues ?? false,
         generateClientInterfaces: config.generateClientInterfaces ?? false,
-        generateEndpointAvailability: config.generateEndpointAvailability ?? false
+        generateAvailabilityAnnotations: config.generateAvailabilityAnnotations ?? false
     }));
 
 export type SdkCustomConfigSchema = z.infer<typeof SdkCustomConfigSchema>;

--- a/generators/php/sdk/src/SdkCustomConfig.ts
+++ b/generators/php/sdk/src/SdkCustomConfig.ts
@@ -13,7 +13,7 @@ export const SdkCustomConfigSchema = z
         useDefaultRequestParameterValues: z.boolean().optional(),
         // Generate interfaces for all SDK client classes to enable mocking and DI
         generateClientInterfaces: z.boolean().optional(),
-        // Emit PHPDoc availability annotations (@deprecated / @beta) on generated SDK surfaces.
+        // Emit PHPDoc availability annotations (@deprecated / @experimental) on generated SDK surfaces.
         // Today this covers endpoint methods; future work may extend it to services, types,
         // properties, enum values, webhooks, etc. under the same flag.
         // TODO(next-major): flip default to true.

--- a/generators/php/sdk/src/__test__/getAvailabilityDocs.test.ts
+++ b/generators/php/sdk/src/__test__/getAvailabilityDocs.test.ts
@@ -1,0 +1,105 @@
+import { FernIr } from "@fern-fern/ir-sdk";
+import { describe, expect, it } from "vitest";
+
+import { getAvailabilityDocs, getEndpointDocs } from "../endpoint/utils/getAvailabilityDocs.js";
+
+function buildEndpoint(partial: Partial<FernIr.HttpEndpoint>): FernIr.HttpEndpoint {
+    return partial as FernIr.HttpEndpoint;
+}
+
+describe("getAvailabilityDocs", () => {
+    it("returns undefined when availability is undefined", () => {
+        const endpoint = buildEndpoint({ availability: undefined });
+        expect(getAvailabilityDocs(endpoint)).toBeUndefined();
+    });
+
+    it("returns @deprecated for deprecated status without message", () => {
+        const endpoint = buildEndpoint({
+            availability: { status: FernIr.AvailabilityStatus.Deprecated, message: undefined }
+        });
+        expect(getAvailabilityDocs(endpoint)).toBe("@deprecated");
+    });
+
+    it("returns @deprecated with message for deprecated status with message", () => {
+        const endpoint = buildEndpoint({
+            availability: { status: FernIr.AvailabilityStatus.Deprecated, message: "Use v2 instead" }
+        });
+        expect(getAvailabilityDocs(endpoint)).toBe("@deprecated Use v2 instead");
+    });
+
+    it("returns @beta for InDevelopment status without message", () => {
+        const endpoint = buildEndpoint({
+            availability: { status: FernIr.AvailabilityStatus.InDevelopment, message: undefined }
+        });
+        expect(getAvailabilityDocs(endpoint)).toBe("@beta This endpoint is in development and may change.");
+    });
+
+    it("returns @beta with message for InDevelopment status with message", () => {
+        const endpoint = buildEndpoint({
+            availability: {
+                status: FernIr.AvailabilityStatus.InDevelopment,
+                message: "Expected Q3 release"
+            }
+        });
+        expect(getAvailabilityDocs(endpoint)).toBe(
+            "@beta This endpoint is in development and may change. Expected Q3 release"
+        );
+    });
+
+    it("returns @beta for PreRelease status without message", () => {
+        const endpoint = buildEndpoint({
+            availability: { status: FernIr.AvailabilityStatus.PreRelease, message: undefined }
+        });
+        expect(getAvailabilityDocs(endpoint)).toBe("@beta This endpoint is in pre-release and may change.");
+    });
+
+    it("returns @beta with message for PreRelease status with message", () => {
+        const endpoint = buildEndpoint({
+            availability: { status: FernIr.AvailabilityStatus.PreRelease, message: "Beta 2" }
+        });
+        expect(getAvailabilityDocs(endpoint)).toBe("@beta This endpoint is in pre-release and may change. Beta 2");
+    });
+
+    it("returns undefined for GeneralAvailability status", () => {
+        const endpoint = buildEndpoint({
+            availability: { status: FernIr.AvailabilityStatus.GeneralAvailability, message: undefined }
+        });
+        expect(getAvailabilityDocs(endpoint)).toBeUndefined();
+    });
+});
+
+describe("getEndpointDocs", () => {
+    it("returns undefined when both docs and availability are undefined", () => {
+        const endpoint = buildEndpoint({ docs: undefined, availability: undefined });
+        expect(getEndpointDocs(endpoint)).toBeUndefined();
+    });
+
+    it("returns endpoint docs when availability is undefined", () => {
+        const endpoint = buildEndpoint({ docs: "Fetches a plant.", availability: undefined });
+        expect(getEndpointDocs(endpoint)).toBe("Fetches a plant.");
+    });
+
+    it("returns availability docs when endpoint docs are undefined", () => {
+        const endpoint = buildEndpoint({
+            docs: undefined,
+            availability: { status: FernIr.AvailabilityStatus.Deprecated, message: "Use v2 instead" }
+        });
+        expect(getEndpointDocs(endpoint)).toBe("@deprecated Use v2 instead");
+    });
+
+    it("combines endpoint docs and availability docs when both are present", () => {
+        const endpoint = buildEndpoint({
+            docs: "Fetches a plant.",
+            availability: { status: FernIr.AvailabilityStatus.Deprecated, message: "Use v2 instead" }
+        });
+        expect(getEndpointDocs(endpoint)).toBe("Fetches a plant.\n\n@deprecated Use v2 instead");
+    });
+
+    it("returns endpoint docs unchanged for GeneralAvailability", () => {
+        const endpoint = buildEndpoint({
+            docs: "Fetches a plant.",
+            availability: { status: FernIr.AvailabilityStatus.GeneralAvailability, message: undefined }
+        });
+        expect(getEndpointDocs(endpoint)).toBe("Fetches a plant.");
+    });
+});

--- a/generators/php/sdk/src/__test__/getAvailabilityDocs.test.ts
+++ b/generators/php/sdk/src/__test__/getAvailabilityDocs.test.ts
@@ -27,14 +27,28 @@ describe("getAvailabilityDocs", () => {
         expect(getAvailabilityDocs(endpoint)).toBe("@deprecated Use v2 instead");
     });
 
-    it("returns @beta for InDevelopment status without message", () => {
+    it("returns @deprecated without trailing space for empty-string message", () => {
+        const endpoint = buildEndpoint({
+            availability: { status: FernIr.AvailabilityStatus.Deprecated, message: "" }
+        });
+        expect(getAvailabilityDocs(endpoint)).toBe("@deprecated");
+    });
+
+    it("returns @deprecated without trailing space for whitespace-only message", () => {
+        const endpoint = buildEndpoint({
+            availability: { status: FernIr.AvailabilityStatus.Deprecated, message: "   " }
+        });
+        expect(getAvailabilityDocs(endpoint)).toBe("@deprecated");
+    });
+
+    it("returns @experimental for InDevelopment status without message", () => {
         const endpoint = buildEndpoint({
             availability: { status: FernIr.AvailabilityStatus.InDevelopment, message: undefined }
         });
-        expect(getAvailabilityDocs(endpoint)).toBe("@beta This endpoint is in development and may change.");
+        expect(getAvailabilityDocs(endpoint)).toBe("@experimental This endpoint is in development and may change.");
     });
 
-    it("returns @beta with message for InDevelopment status with message", () => {
+    it("returns @experimental with message for InDevelopment status with message", () => {
         const endpoint = buildEndpoint({
             availability: {
                 status: FernIr.AvailabilityStatus.InDevelopment,
@@ -42,22 +56,38 @@ describe("getAvailabilityDocs", () => {
             }
         });
         expect(getAvailabilityDocs(endpoint)).toBe(
-            "@beta This endpoint is in development and may change. Expected Q3 release"
+            "@experimental This endpoint is in development and may change. Expected Q3 release"
         );
     });
 
-    it("returns @beta for PreRelease status without message", () => {
+    it("returns @experimental without trailing space for empty-string message on InDevelopment", () => {
+        const endpoint = buildEndpoint({
+            availability: { status: FernIr.AvailabilityStatus.InDevelopment, message: "" }
+        });
+        expect(getAvailabilityDocs(endpoint)).toBe("@experimental This endpoint is in development and may change.");
+    });
+
+    it("returns @experimental for PreRelease status without message", () => {
         const endpoint = buildEndpoint({
             availability: { status: FernIr.AvailabilityStatus.PreRelease, message: undefined }
         });
-        expect(getAvailabilityDocs(endpoint)).toBe("@beta This endpoint is in pre-release and may change.");
+        expect(getAvailabilityDocs(endpoint)).toBe("@experimental This endpoint is in pre-release and may change.");
     });
 
-    it("returns @beta with message for PreRelease status with message", () => {
+    it("returns @experimental with message for PreRelease status with message", () => {
         const endpoint = buildEndpoint({
             availability: { status: FernIr.AvailabilityStatus.PreRelease, message: "Beta 2" }
         });
-        expect(getAvailabilityDocs(endpoint)).toBe("@beta This endpoint is in pre-release and may change. Beta 2");
+        expect(getAvailabilityDocs(endpoint)).toBe(
+            "@experimental This endpoint is in pre-release and may change. Beta 2"
+        );
+    });
+
+    it("returns @experimental without trailing space for empty-string message on PreRelease", () => {
+        const endpoint = buildEndpoint({
+            availability: { status: FernIr.AvailabilityStatus.PreRelease, message: "" }
+        });
+        expect(getAvailabilityDocs(endpoint)).toBe("@experimental This endpoint is in pre-release and may change.");
     });
 
     it("returns undefined for GeneralAvailability status", () => {

--- a/generators/php/sdk/src/endpoint/http/HttpEndpointGenerator.ts
+++ b/generators/php/sdk/src/endpoint/http/HttpEndpointGenerator.ts
@@ -6,6 +6,7 @@ import { upperFirst } from "lodash-es";
 
 import { SdkGeneratorContext } from "../../SdkGeneratorContext.js";
 import { AbstractEndpointGenerator } from "../AbstractEndpointGenerator.js";
+import { getEndpointDocs } from "../utils/getAvailabilityDocs.js";
 import { getEndpointReturnType } from "../utils/getEndpointReturnType.js";
 
 type PagingEndpoint = FernIr.HttpEndpoint & { pagination: NonNullable<FernIr.HttpEndpoint["pagination"]> };
@@ -80,7 +81,7 @@ export class HttpEndpointGenerator extends AbstractEndpointGenerator {
                     name: this.context.getPagedEndpointMethodName(endpoint),
                     access: "public",
                     parameters,
-                    docs: endpoint.docs,
+                    docs: getEndpointDocs(endpoint),
                     return_,
                     noBody: true
                 })
@@ -92,7 +93,7 @@ export class HttpEndpointGenerator extends AbstractEndpointGenerator {
                     name: this.context.getEndpointMethodName(endpoint),
                     access: "public",
                     parameters,
-                    docs: endpoint.docs,
+                    docs: getEndpointDocs(endpoint),
                     return_,
                     noBody: true
                 })
@@ -127,7 +128,7 @@ export class HttpEndpointGenerator extends AbstractEndpointGenerator {
                 : this.context.getEndpointMethodName(endpoint),
             access: hasPagination ? "private" : "public",
             parameters,
-            docs: endpoint.docs,
+            docs: getEndpointDocs(endpoint),
             return_,
             throws: [this.context.getBaseExceptionClassReference(), this.context.getBaseApiExceptionClassReference()],
             body: php.codeblock((writer) => {
@@ -224,7 +225,7 @@ export class HttpEndpointGenerator extends AbstractEndpointGenerator {
             name: this.context.getPagedEndpointMethodName(endpoint),
             access: "public",
             parameters,
-            docs: endpoint.docs,
+            docs: getEndpointDocs(endpoint),
             return_,
             body: php.codeblock((writer) => {
                 const requestParam = endpointSignatureInfo.requestParameter;

--- a/generators/php/sdk/src/endpoint/http/HttpEndpointGenerator.ts
+++ b/generators/php/sdk/src/endpoint/http/HttpEndpointGenerator.ts
@@ -6,7 +6,7 @@ import { upperFirst } from "lodash-es";
 
 import { SdkGeneratorContext } from "../../SdkGeneratorContext.js";
 import { AbstractEndpointGenerator } from "../AbstractEndpointGenerator.js";
-import { getEndpointDocs } from "../utils/getAvailabilityDocs.js";
+import { getEndpointDocs as computeEndpointDocsWithAvailability } from "../utils/getAvailabilityDocs.js";
 import { getEndpointReturnType } from "../utils/getEndpointReturnType.js";
 
 type PagingEndpoint = FernIr.HttpEndpoint & { pagination: NonNullable<FernIr.HttpEndpoint["pagination"]> };
@@ -29,6 +29,13 @@ const STATUS_CODE_VARIABLE_NAME = "$statusCode";
 export class HttpEndpointGenerator extends AbstractEndpointGenerator {
     public constructor({ context }: { context: SdkGeneratorContext }) {
         super({ context });
+    }
+
+    private getEndpointDocs(endpoint: FernIr.HttpEndpoint): string | undefined {
+        if (!this.context.customConfig.generateEndpointAvailability) {
+            return endpoint.docs;
+        }
+        return computeEndpointDocsWithAvailability(endpoint);
     }
 
     public generate({
@@ -81,7 +88,7 @@ export class HttpEndpointGenerator extends AbstractEndpointGenerator {
                     name: this.context.getPagedEndpointMethodName(endpoint),
                     access: "public",
                     parameters,
-                    docs: getEndpointDocs(endpoint),
+                    docs: this.getEndpointDocs(endpoint),
                     return_,
                     noBody: true
                 })
@@ -93,7 +100,7 @@ export class HttpEndpointGenerator extends AbstractEndpointGenerator {
                     name: this.context.getEndpointMethodName(endpoint),
                     access: "public",
                     parameters,
-                    docs: getEndpointDocs(endpoint),
+                    docs: this.getEndpointDocs(endpoint),
                     return_,
                     noBody: true
                 })
@@ -128,7 +135,7 @@ export class HttpEndpointGenerator extends AbstractEndpointGenerator {
                 : this.context.getEndpointMethodName(endpoint),
             access: hasPagination ? "private" : "public",
             parameters,
-            docs: getEndpointDocs(endpoint),
+            docs: this.getEndpointDocs(endpoint),
             return_,
             throws: [this.context.getBaseExceptionClassReference(), this.context.getBaseApiExceptionClassReference()],
             body: php.codeblock((writer) => {
@@ -225,7 +232,7 @@ export class HttpEndpointGenerator extends AbstractEndpointGenerator {
             name: this.context.getPagedEndpointMethodName(endpoint),
             access: "public",
             parameters,
-            docs: getEndpointDocs(endpoint),
+            docs: this.getEndpointDocs(endpoint),
             return_,
             body: php.codeblock((writer) => {
                 const requestParam = endpointSignatureInfo.requestParameter;

--- a/generators/php/sdk/src/endpoint/http/HttpEndpointGenerator.ts
+++ b/generators/php/sdk/src/endpoint/http/HttpEndpointGenerator.ts
@@ -32,7 +32,7 @@ export class HttpEndpointGenerator extends AbstractEndpointGenerator {
     }
 
     private getEndpointDocs(endpoint: FernIr.HttpEndpoint): string | undefined {
-        if (!this.context.customConfig.generateEndpointAvailability) {
+        if (!this.context.customConfig.generateAvailabilityAnnotations) {
             return endpoint.docs;
         }
         return computeEndpointDocsWithAvailability(endpoint);

--- a/generators/php/sdk/src/endpoint/utils/getAvailabilityDocs.ts
+++ b/generators/php/sdk/src/endpoint/utils/getAvailabilityDocs.ts
@@ -1,3 +1,4 @@
+import { assertNever } from "@fern-api/core-utils";
 import { FernIr } from "@fern-fern/ir-sdk";
 
 /**
@@ -29,7 +30,7 @@ export function getAvailabilityDocs(endpoint: FernIr.HttpEndpoint): string | und
         case FernIr.AvailabilityStatus.GeneralAvailability:
             return undefined;
         default:
-            return undefined;
+            assertNever(availability.status);
     }
 }
 

--- a/generators/php/sdk/src/endpoint/utils/getAvailabilityDocs.ts
+++ b/generators/php/sdk/src/endpoint/utils/getAvailabilityDocs.ts
@@ -4,8 +4,8 @@ import { FernIr } from "@fern-fern/ir-sdk";
 /**
  * Returns PHPDoc lines for the endpoint's availability status.
  * - DEPRECATED -> @deprecated tag (with optional message)
- * - IN_DEVELOPMENT -> @beta warning
- * - PRE_RELEASE -> @beta warning
+ * - IN_DEVELOPMENT -> @experimental warning
+ * - PRE_RELEASE -> @experimental warning
  * - GENERAL_AVAILABILITY or undefined -> no additional docs
  */
 export function getAvailabilityDocs(endpoint: FernIr.HttpEndpoint): string | undefined {
@@ -14,18 +14,19 @@ export function getAvailabilityDocs(endpoint: FernIr.HttpEndpoint): string | und
         return undefined;
     }
 
+    const message = availability.message?.trim();
+
     switch (availability.status) {
         case FernIr.AvailabilityStatus.Deprecated: {
-            const message = availability.message;
-            return message != null ? `@deprecated ${message}` : "@deprecated";
+            return message ? `@deprecated ${message}` : "@deprecated";
         }
         case FernIr.AvailabilityStatus.InDevelopment: {
-            const warning = "@beta This endpoint is in development and may change.";
-            return availability.message != null ? `${warning} ${availability.message}` : warning;
+            const warning = "@experimental This endpoint is in development and may change.";
+            return message ? `${warning} ${message}` : warning;
         }
         case FernIr.AvailabilityStatus.PreRelease: {
-            const warning = "@beta This endpoint is in pre-release and may change.";
-            return availability.message != null ? `${warning} ${availability.message}` : warning;
+            const warning = "@experimental This endpoint is in pre-release and may change.";
+            return message ? `${warning} ${message}` : warning;
         }
         case FernIr.AvailabilityStatus.GeneralAvailability:
             return undefined;

--- a/generators/php/sdk/src/endpoint/utils/getAvailabilityDocs.ts
+++ b/generators/php/sdk/src/endpoint/utils/getAvailabilityDocs.ts
@@ -1,0 +1,49 @@
+import { FernIr } from "@fern-fern/ir-sdk";
+
+/**
+ * Returns PHPDoc lines for the endpoint's availability status.
+ * - DEPRECATED -> @deprecated tag (with optional message)
+ * - IN_DEVELOPMENT -> @beta warning
+ * - PRE_RELEASE -> @beta warning
+ * - GENERAL_AVAILABILITY or undefined -> no additional docs
+ */
+export function getAvailabilityDocs(endpoint: FernIr.HttpEndpoint): string | undefined {
+    const availability = endpoint.availability;
+    if (availability == null) {
+        return undefined;
+    }
+
+    switch (availability.status) {
+        case FernIr.AvailabilityStatus.Deprecated: {
+            const message = availability.message;
+            return message != null ? `@deprecated ${message}` : "@deprecated";
+        }
+        case FernIr.AvailabilityStatus.InDevelopment: {
+            const warning = "@beta This endpoint is in development and may change.";
+            return availability.message != null ? `${warning} ${availability.message}` : warning;
+        }
+        case FernIr.AvailabilityStatus.PreRelease: {
+            const warning = "@beta This endpoint is in pre-release and may change.";
+            return availability.message != null ? `${warning} ${availability.message}` : warning;
+        }
+        case FernIr.AvailabilityStatus.GeneralAvailability:
+            return undefined;
+        default:
+            return undefined;
+    }
+}
+
+/**
+ * Returns the endpoint's documentation string with availability-based PHPDoc annotations
+ * prepended. Combines the endpoint's existing docs with availability docs when present.
+ */
+export function getEndpointDocs(endpoint: FernIr.HttpEndpoint): string | undefined {
+    const availabilityDocs = getAvailabilityDocs(endpoint);
+    if (availabilityDocs == null) {
+        return endpoint.docs;
+    }
+    if (endpoint.docs == null) {
+        return availabilityDocs;
+    }
+    return `${endpoint.docs}\n\n${availabilityDocs}`;
+}

--- a/seed/php-sdk/accept-header/.fern/metadata.json
+++ b/seed/php-sdk/accept-header/.fern/metadata.json
@@ -2,6 +2,9 @@
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-php-sdk",
   "generatorVersion": "local",
+  "generatorConfig": {
+    "generateAvailabilityAnnotations": true
+  },
   "originGitCommit": "DUMMY",
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/alias-extends/.fern/metadata.json
+++ b/seed/php-sdk/alias-extends/.fern/metadata.json
@@ -2,6 +2,9 @@
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-php-sdk",
   "generatorVersion": "local",
+  "generatorConfig": {
+    "generateAvailabilityAnnotations": true
+  },
   "originGitCommit": "DUMMY",
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/alias/composer-json/.fern/metadata.json
+++ b/seed/php-sdk/alias/composer-json/.fern/metadata.json
@@ -3,6 +3,7 @@
   "generatorName": "fernapi/fern-php-sdk",
   "generatorVersion": "local",
   "generatorConfig": {
+    "generateAvailabilityAnnotations": true,
     "composerJson": {
       "name": "fern/empty",
       "version": "1.0.0",

--- a/seed/php-sdk/alias/no-custom-config/.fern/metadata.json
+++ b/seed/php-sdk/alias/no-custom-config/.fern/metadata.json
@@ -2,6 +2,9 @@
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-php-sdk",
   "generatorVersion": "local",
+  "generatorConfig": {
+    "generateAvailabilityAnnotations": true
+  },
   "originGitCommit": "DUMMY",
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/allof-inline/.fern/metadata.json
+++ b/seed/php-sdk/allof-inline/.fern/metadata.json
@@ -2,6 +2,9 @@
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-php-sdk",
   "generatorVersion": "local",
+  "generatorConfig": {
+    "generateAvailabilityAnnotations": true
+  },
   "originGitCommit": "DUMMY",
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/allof/.fern/metadata.json
+++ b/seed/php-sdk/allof/.fern/metadata.json
@@ -2,6 +2,9 @@
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-php-sdk",
   "generatorVersion": "local",
+  "generatorConfig": {
+    "generateAvailabilityAnnotations": true
+  },
   "originGitCommit": "DUMMY",
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/any-auth/.fern/metadata.json
+++ b/seed/php-sdk/any-auth/.fern/metadata.json
@@ -2,6 +2,9 @@
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-php-sdk",
   "generatorVersion": "local",
+  "generatorConfig": {
+    "generateAvailabilityAnnotations": true
+  },
   "originGitCommit": "DUMMY",
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/api-wide-base-path/.fern/metadata.json
+++ b/seed/php-sdk/api-wide-base-path/.fern/metadata.json
@@ -2,6 +2,9 @@
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-php-sdk",
   "generatorVersion": "local",
+  "generatorConfig": {
+    "generateAvailabilityAnnotations": true
+  },
   "originGitCommit": "DUMMY",
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/audiences/.fern/metadata.json
+++ b/seed/php-sdk/audiences/.fern/metadata.json
@@ -2,6 +2,9 @@
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-php-sdk",
   "generatorVersion": "local",
+  "generatorConfig": {
+    "generateAvailabilityAnnotations": true
+  },
   "originGitCommit": "DUMMY",
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/basic-auth-environment-variables/.fern/metadata.json
+++ b/seed/php-sdk/basic-auth-environment-variables/.fern/metadata.json
@@ -2,6 +2,9 @@
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-php-sdk",
   "generatorVersion": "local",
+  "generatorConfig": {
+    "generateAvailabilityAnnotations": true
+  },
   "originGitCommit": "DUMMY",
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/basic-auth-pw-omitted/wire-tests/.fern/metadata.json
+++ b/seed/php-sdk/basic-auth-pw-omitted/wire-tests/.fern/metadata.json
@@ -3,6 +3,7 @@
   "generatorName": "fernapi/fern-php-sdk",
   "generatorVersion": "local",
   "generatorConfig": {
+    "generateAvailabilityAnnotations": true,
     "enable-wire-tests": true
   },
   "originGitCommit": "DUMMY",

--- a/seed/php-sdk/basic-auth/wire-tests/.fern/metadata.json
+++ b/seed/php-sdk/basic-auth/wire-tests/.fern/metadata.json
@@ -3,6 +3,7 @@
   "generatorName": "fernapi/fern-php-sdk",
   "generatorVersion": "local",
   "generatorConfig": {
+    "generateAvailabilityAnnotations": true,
     "enable-wire-tests": true
   },
   "originGitCommit": "DUMMY",

--- a/seed/php-sdk/bearer-token-environment-variable/.fern/metadata.json
+++ b/seed/php-sdk/bearer-token-environment-variable/.fern/metadata.json
@@ -2,6 +2,9 @@
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-php-sdk",
   "generatorVersion": "local",
+  "generatorConfig": {
+    "generateAvailabilityAnnotations": true
+  },
   "originGitCommit": "DUMMY",
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/bytes-download/.fern/metadata.json
+++ b/seed/php-sdk/bytes-download/.fern/metadata.json
@@ -2,6 +2,9 @@
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-php-sdk",
   "generatorVersion": "local",
+  "generatorConfig": {
+    "generateAvailabilityAnnotations": true
+  },
   "originGitCommit": "DUMMY",
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/bytes-upload/.fern/metadata.json
+++ b/seed/php-sdk/bytes-upload/.fern/metadata.json
@@ -2,6 +2,9 @@
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-php-sdk",
   "generatorVersion": "local",
+  "generatorConfig": {
+    "generateAvailabilityAnnotations": true
+  },
   "originGitCommit": "DUMMY",
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/circular-references-advanced/.fern/metadata.json
+++ b/seed/php-sdk/circular-references-advanced/.fern/metadata.json
@@ -2,6 +2,9 @@
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-php-sdk",
   "generatorVersion": "local",
+  "generatorConfig": {
+    "generateAvailabilityAnnotations": true
+  },
   "originGitCommit": "DUMMY",
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/circular-references-extends/.fern/metadata.json
+++ b/seed/php-sdk/circular-references-extends/.fern/metadata.json
@@ -2,6 +2,9 @@
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-php-sdk",
   "generatorVersion": "local",
+  "generatorConfig": {
+    "generateAvailabilityAnnotations": true
+  },
   "originGitCommit": "DUMMY",
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/circular-references/.fern/metadata.json
+++ b/seed/php-sdk/circular-references/.fern/metadata.json
@@ -2,6 +2,9 @@
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-php-sdk",
   "generatorVersion": "local",
+  "generatorConfig": {
+    "generateAvailabilityAnnotations": true
+  },
   "originGitCommit": "DUMMY",
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/client-side-params/.fern/metadata.json
+++ b/seed/php-sdk/client-side-params/.fern/metadata.json
@@ -2,6 +2,9 @@
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-php-sdk",
   "generatorVersion": "local",
+  "generatorConfig": {
+    "generateAvailabilityAnnotations": true
+  },
   "originGitCommit": "DUMMY",
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/content-type/.fern/metadata.json
+++ b/seed/php-sdk/content-type/.fern/metadata.json
@@ -2,6 +2,9 @@
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-php-sdk",
   "generatorVersion": "local",
+  "generatorConfig": {
+    "generateAvailabilityAnnotations": true
+  },
   "originGitCommit": "DUMMY",
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/cross-package-type-names/.fern/metadata.json
+++ b/seed/php-sdk/cross-package-type-names/.fern/metadata.json
@@ -2,6 +2,9 @@
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-php-sdk",
   "generatorVersion": "local",
+  "generatorConfig": {
+    "generateAvailabilityAnnotations": true
+  },
   "originGitCommit": "DUMMY",
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/dollar-string-examples/.fern/metadata.json
+++ b/seed/php-sdk/dollar-string-examples/.fern/metadata.json
@@ -2,6 +2,9 @@
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-php-sdk",
   "generatorVersion": "local",
+  "generatorConfig": {
+    "generateAvailabilityAnnotations": true
+  },
   "originGitCommit": "DUMMY",
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/empty-clients/.fern/metadata.json
+++ b/seed/php-sdk/empty-clients/.fern/metadata.json
@@ -2,6 +2,9 @@
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-php-sdk",
   "generatorVersion": "local",
+  "generatorConfig": {
+    "generateAvailabilityAnnotations": true
+  },
   "originGitCommit": "DUMMY",
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/endpoint-security-auth/.fern/metadata.json
+++ b/seed/php-sdk/endpoint-security-auth/.fern/metadata.json
@@ -2,6 +2,9 @@
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-php-sdk",
   "generatorVersion": "local",
+  "generatorConfig": {
+    "generateAvailabilityAnnotations": true
+  },
   "originGitCommit": "DUMMY",
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/enum/.fern/metadata.json
+++ b/seed/php-sdk/enum/.fern/metadata.json
@@ -2,6 +2,9 @@
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-php-sdk",
   "generatorVersion": "local",
+  "generatorConfig": {
+    "generateAvailabilityAnnotations": true
+  },
   "originGitCommit": "DUMMY",
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/error-property/.fern/metadata.json
+++ b/seed/php-sdk/error-property/.fern/metadata.json
@@ -2,6 +2,9 @@
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-php-sdk",
   "generatorVersion": "local",
+  "generatorConfig": {
+    "generateAvailabilityAnnotations": true
+  },
   "originGitCommit": "DUMMY",
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/errors/.fern/metadata.json
+++ b/seed/php-sdk/errors/.fern/metadata.json
@@ -2,6 +2,9 @@
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-php-sdk",
   "generatorVersion": "local",
+  "generatorConfig": {
+    "generateAvailabilityAnnotations": true
+  },
   "originGitCommit": "DUMMY",
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/examples/no-custom-config/.fern/metadata.json
+++ b/seed/php-sdk/examples/no-custom-config/.fern/metadata.json
@@ -2,6 +2,9 @@
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-php-sdk",
   "generatorVersion": "local",
+  "generatorConfig": {
+    "generateAvailabilityAnnotations": true
+  },
   "originGitCommit": "DUMMY",
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/examples/readme-config/.fern/metadata.json
+++ b/seed/php-sdk/examples/readme-config/.fern/metadata.json
@@ -3,6 +3,7 @@
   "generatorName": "fernapi/fern-php-sdk",
   "generatorVersion": "local",
   "generatorConfig": {
+    "generateAvailabilityAnnotations": true,
     "customReadmeSections": [
       {
         "title": "Override Section",

--- a/seed/php-sdk/exhaustive/no-custom-config/.fern/metadata.json
+++ b/seed/php-sdk/exhaustive/no-custom-config/.fern/metadata.json
@@ -2,6 +2,9 @@
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-php-sdk",
   "generatorVersion": "local",
+  "generatorConfig": {
+    "generateAvailabilityAnnotations": true
+  },
   "originGitCommit": "DUMMY",
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/exhaustive/no-custom-config/src/Endpoints/HttpMethods/HttpMethodsClient.php
+++ b/seed/php-sdk/exhaustive/no-custom-config/src/Endpoints/HttpMethods/HttpMethodsClient.php
@@ -97,8 +97,6 @@ class HttpMethodsClient
     }
 
     /**
-     * @deprecated
-     *
      * @param ObjectWithRequiredField $request
      * @param ?array{
      *   baseUrl?: string,
@@ -146,8 +144,6 @@ class HttpMethodsClient
     }
 
     /**
-     * @deprecated Use testPatch instead.
-     *
      * @param string $id
      * @param ObjectWithRequiredField $request
      * @param ?array{
@@ -196,8 +192,6 @@ class HttpMethodsClient
     }
 
     /**
-     * @beta This endpoint is in pre-release and may change.
-     *
      * @param string $id
      * @param ObjectWithOptionalField $request
      * @param ?array{
@@ -246,8 +240,6 @@ class HttpMethodsClient
     }
 
     /**
-     * @beta This endpoint is in development and may change.
-     *
      * @param string $id
      * @param ?array{
      *   baseUrl?: string,

--- a/seed/php-sdk/exhaustive/no-custom-config/src/Endpoints/HttpMethods/HttpMethodsClient.php
+++ b/seed/php-sdk/exhaustive/no-custom-config/src/Endpoints/HttpMethods/HttpMethodsClient.php
@@ -196,7 +196,7 @@ class HttpMethodsClient
     }
 
     /**
-     * @beta This endpoint is in pre-release and may change.
+     * @experimental This endpoint is in pre-release and may change.
      *
      * @param string $id
      * @param ObjectWithOptionalField $request
@@ -246,7 +246,7 @@ class HttpMethodsClient
     }
 
     /**
-     * @beta This endpoint is in development and may change.
+     * @experimental This endpoint is in development and may change.
      *
      * @param string $id
      * @param ?array{

--- a/seed/php-sdk/exhaustive/no-custom-config/src/Endpoints/HttpMethods/HttpMethodsClient.php
+++ b/seed/php-sdk/exhaustive/no-custom-config/src/Endpoints/HttpMethods/HttpMethodsClient.php
@@ -97,6 +97,8 @@ class HttpMethodsClient
     }
 
     /**
+     * @deprecated
+     *
      * @param ObjectWithRequiredField $request
      * @param ?array{
      *   baseUrl?: string,
@@ -144,6 +146,8 @@ class HttpMethodsClient
     }
 
     /**
+     * @deprecated Use testPatch instead.
+     *
      * @param string $id
      * @param ObjectWithRequiredField $request
      * @param ?array{
@@ -192,6 +196,8 @@ class HttpMethodsClient
     }
 
     /**
+     * @beta This endpoint is in pre-release and may change.
+     *
      * @param string $id
      * @param ObjectWithOptionalField $request
      * @param ?array{
@@ -240,6 +246,8 @@ class HttpMethodsClient
     }
 
     /**
+     * @beta This endpoint is in development and may change.
+     *
      * @param string $id
      * @param ?array{
      *   baseUrl?: string,

--- a/seed/php-sdk/exhaustive/wire-tests/.fern/metadata.json
+++ b/seed/php-sdk/exhaustive/wire-tests/.fern/metadata.json
@@ -3,6 +3,7 @@
   "generatorName": "fernapi/fern-php-sdk",
   "generatorVersion": "local",
   "generatorConfig": {
+    "generateAvailabilityAnnotations": true,
     "enable-wire-tests": true
   },
   "originGitCommit": "DUMMY",

--- a/seed/php-sdk/exhaustive/wire-tests/src/Endpoints/HttpMethods/HttpMethodsClient.php
+++ b/seed/php-sdk/exhaustive/wire-tests/src/Endpoints/HttpMethods/HttpMethodsClient.php
@@ -97,8 +97,6 @@ class HttpMethodsClient
     }
 
     /**
-     * @deprecated
-     *
      * @param ObjectWithRequiredField $request
      * @param ?array{
      *   baseUrl?: string,
@@ -146,8 +144,6 @@ class HttpMethodsClient
     }
 
     /**
-     * @deprecated Use testPatch instead.
-     *
      * @param string $id
      * @param ObjectWithRequiredField $request
      * @param ?array{
@@ -196,8 +192,6 @@ class HttpMethodsClient
     }
 
     /**
-     * @beta This endpoint is in pre-release and may change.
-     *
      * @param string $id
      * @param ObjectWithOptionalField $request
      * @param ?array{
@@ -246,8 +240,6 @@ class HttpMethodsClient
     }
 
     /**
-     * @beta This endpoint is in development and may change.
-     *
      * @param string $id
      * @param ?array{
      *   baseUrl?: string,

--- a/seed/php-sdk/exhaustive/wire-tests/src/Endpoints/HttpMethods/HttpMethodsClient.php
+++ b/seed/php-sdk/exhaustive/wire-tests/src/Endpoints/HttpMethods/HttpMethodsClient.php
@@ -196,7 +196,7 @@ class HttpMethodsClient
     }
 
     /**
-     * @beta This endpoint is in pre-release and may change.
+     * @experimental This endpoint is in pre-release and may change.
      *
      * @param string $id
      * @param ObjectWithOptionalField $request
@@ -246,7 +246,7 @@ class HttpMethodsClient
     }
 
     /**
-     * @beta This endpoint is in development and may change.
+     * @experimental This endpoint is in development and may change.
      *
      * @param string $id
      * @param ?array{

--- a/seed/php-sdk/exhaustive/wire-tests/src/Endpoints/HttpMethods/HttpMethodsClient.php
+++ b/seed/php-sdk/exhaustive/wire-tests/src/Endpoints/HttpMethods/HttpMethodsClient.php
@@ -97,6 +97,8 @@ class HttpMethodsClient
     }
 
     /**
+     * @deprecated
+     *
      * @param ObjectWithRequiredField $request
      * @param ?array{
      *   baseUrl?: string,
@@ -144,6 +146,8 @@ class HttpMethodsClient
     }
 
     /**
+     * @deprecated Use testPatch instead.
+     *
      * @param string $id
      * @param ObjectWithRequiredField $request
      * @param ?array{
@@ -192,6 +196,8 @@ class HttpMethodsClient
     }
 
     /**
+     * @beta This endpoint is in pre-release and may change.
+     *
      * @param string $id
      * @param ObjectWithOptionalField $request
      * @param ?array{
@@ -240,6 +246,8 @@ class HttpMethodsClient
     }
 
     /**
+     * @beta This endpoint is in development and may change.
+     *
      * @param string $id
      * @param ?array{
      *   baseUrl?: string,

--- a/seed/php-sdk/extends/no-custom-config/.fern/metadata.json
+++ b/seed/php-sdk/extends/no-custom-config/.fern/metadata.json
@@ -2,6 +2,9 @@
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-php-sdk",
   "generatorVersion": "local",
+  "generatorConfig": {
+    "generateAvailabilityAnnotations": true
+  },
   "originGitCommit": "DUMMY",
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/extends/private/.fern/metadata.json
+++ b/seed/php-sdk/extends/private/.fern/metadata.json
@@ -3,6 +3,7 @@
   "generatorName": "fernapi/fern-php-sdk",
   "generatorVersion": "local",
   "generatorConfig": {
+    "generateAvailabilityAnnotations": true,
     "propertyAccess": "private"
   },
   "originGitCommit": "DUMMY",

--- a/seed/php-sdk/extra-properties/.fern/metadata.json
+++ b/seed/php-sdk/extra-properties/.fern/metadata.json
@@ -2,6 +2,9 @@
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-php-sdk",
   "generatorVersion": "local",
+  "generatorConfig": {
+    "generateAvailabilityAnnotations": true
+  },
   "originGitCommit": "DUMMY",
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/file-download/.fern/metadata.json
+++ b/seed/php-sdk/file-download/.fern/metadata.json
@@ -2,6 +2,9 @@
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-php-sdk",
   "generatorVersion": "local",
+  "generatorConfig": {
+    "generateAvailabilityAnnotations": true
+  },
   "originGitCommit": "DUMMY",
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/file-upload-openapi/.fern/metadata.json
+++ b/seed/php-sdk/file-upload-openapi/.fern/metadata.json
@@ -2,6 +2,9 @@
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-php-sdk",
   "generatorVersion": "local",
+  "generatorConfig": {
+    "generateAvailabilityAnnotations": true
+  },
   "originGitCommit": "DUMMY",
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/file-upload/.fern/metadata.json
+++ b/seed/php-sdk/file-upload/.fern/metadata.json
@@ -2,6 +2,9 @@
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-php-sdk",
   "generatorVersion": "local",
+  "generatorConfig": {
+    "generateAvailabilityAnnotations": true
+  },
   "originGitCommit": "DUMMY",
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/folders/no-custom-config/.fern/metadata.json
+++ b/seed/php-sdk/folders/no-custom-config/.fern/metadata.json
@@ -2,6 +2,9 @@
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-php-sdk",
   "generatorVersion": "local",
+  "generatorConfig": {
+    "generateAvailabilityAnnotations": true
+  },
   "originGitCommit": "DUMMY",
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/folders/with-interfaces/.fern/metadata.json
+++ b/seed/php-sdk/folders/with-interfaces/.fern/metadata.json
@@ -3,6 +3,7 @@
   "generatorName": "fernapi/fern-php-sdk",
   "generatorVersion": "local",
   "generatorConfig": {
+    "generateAvailabilityAnnotations": true,
     "generateClientInterfaces": true
   },
   "originGitCommit": "DUMMY",

--- a/seed/php-sdk/header-auth-environment-variable/.fern/metadata.json
+++ b/seed/php-sdk/header-auth-environment-variable/.fern/metadata.json
@@ -2,6 +2,9 @@
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-php-sdk",
   "generatorVersion": "local",
+  "generatorConfig": {
+    "generateAvailabilityAnnotations": true
+  },
   "originGitCommit": "DUMMY",
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/header-auth/.fern/metadata.json
+++ b/seed/php-sdk/header-auth/.fern/metadata.json
@@ -2,6 +2,9 @@
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-php-sdk",
   "generatorVersion": "local",
+  "generatorConfig": {
+    "generateAvailabilityAnnotations": true
+  },
   "originGitCommit": "DUMMY",
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/http-head/.fern/metadata.json
+++ b/seed/php-sdk/http-head/.fern/metadata.json
@@ -2,6 +2,9 @@
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-php-sdk",
   "generatorVersion": "local",
+  "generatorConfig": {
+    "generateAvailabilityAnnotations": true
+  },
   "originGitCommit": "DUMMY",
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/idempotency-headers/.fern/metadata.json
+++ b/seed/php-sdk/idempotency-headers/.fern/metadata.json
@@ -2,6 +2,9 @@
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-php-sdk",
   "generatorVersion": "local",
+  "generatorConfig": {
+    "generateAvailabilityAnnotations": true
+  },
   "originGitCommit": "DUMMY",
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/imdb/clientName/.fern/metadata.json
+++ b/seed/php-sdk/imdb/clientName/.fern/metadata.json
@@ -3,6 +3,7 @@
   "generatorName": "fernapi/fern-php-sdk",
   "generatorVersion": "local",
   "generatorConfig": {
+    "generateAvailabilityAnnotations": true,
     "clientName": "FernClient",
     "maxRetries": 5
   },

--- a/seed/php-sdk/imdb/clientName/src/Imdb/ImdbClient.php
+++ b/seed/php-sdk/imdb/clientName/src/Imdb/ImdbClient.php
@@ -53,6 +53,8 @@ class ImdbClient
     /**
      * Add a movie to the database using the movies/* /... path.
      *
+     * @beta This endpoint is in pre-release and may change.
+     *
      * @param CreateMovieRequest $request
      * @param ?array{
      *   baseUrl?: string,
@@ -100,6 +102,8 @@ class ImdbClient
     }
 
     /**
+     * @deprecated
+     *
      * @param string $movieId
      * @param ?array{
      *   baseUrl?: string,

--- a/seed/php-sdk/imdb/clientName/src/Imdb/ImdbClient.php
+++ b/seed/php-sdk/imdb/clientName/src/Imdb/ImdbClient.php
@@ -53,7 +53,7 @@ class ImdbClient
     /**
      * Add a movie to the database using the movies/* /... path.
      *
-     * @beta This endpoint is in pre-release and may change.
+     * @experimental This endpoint is in pre-release and may change.
      *
      * @param CreateMovieRequest $request
      * @param ?array{

--- a/seed/php-sdk/imdb/clientName/src/Imdb/ImdbClient.php
+++ b/seed/php-sdk/imdb/clientName/src/Imdb/ImdbClient.php
@@ -53,8 +53,6 @@ class ImdbClient
     /**
      * Add a movie to the database using the movies/* /... path.
      *
-     * @beta This endpoint is in pre-release and may change.
-     *
      * @param CreateMovieRequest $request
      * @param ?array{
      *   baseUrl?: string,
@@ -102,8 +100,6 @@ class ImdbClient
     }
 
     /**
-     * @deprecated
-     *
      * @param string $movieId
      * @param ?array{
      *   baseUrl?: string,

--- a/seed/php-sdk/imdb/namespace/.fern/metadata.json
+++ b/seed/php-sdk/imdb/namespace/.fern/metadata.json
@@ -3,6 +3,7 @@
   "generatorName": "fernapi/fern-php-sdk",
   "generatorVersion": "local",
   "generatorConfig": {
+    "generateAvailabilityAnnotations": true,
     "namespace": "Fern"
   },
   "originGitCommit": "DUMMY",

--- a/seed/php-sdk/imdb/namespace/src/Imdb/ImdbClient.php
+++ b/seed/php-sdk/imdb/namespace/src/Imdb/ImdbClient.php
@@ -53,6 +53,8 @@ class ImdbClient
     /**
      * Add a movie to the database using the movies/* /... path.
      *
+     * @beta This endpoint is in pre-release and may change.
+     *
      * @param CreateMovieRequest $request
      * @param ?array{
      *   baseUrl?: string,
@@ -100,6 +102,8 @@ class ImdbClient
     }
 
     /**
+     * @deprecated
+     *
      * @param string $movieId
      * @param ?array{
      *   baseUrl?: string,

--- a/seed/php-sdk/imdb/namespace/src/Imdb/ImdbClient.php
+++ b/seed/php-sdk/imdb/namespace/src/Imdb/ImdbClient.php
@@ -53,7 +53,7 @@ class ImdbClient
     /**
      * Add a movie to the database using the movies/* /... path.
      *
-     * @beta This endpoint is in pre-release and may change.
+     * @experimental This endpoint is in pre-release and may change.
      *
      * @param CreateMovieRequest $request
      * @param ?array{

--- a/seed/php-sdk/imdb/namespace/src/Imdb/ImdbClient.php
+++ b/seed/php-sdk/imdb/namespace/src/Imdb/ImdbClient.php
@@ -53,8 +53,6 @@ class ImdbClient
     /**
      * Add a movie to the database using the movies/* /... path.
      *
-     * @beta This endpoint is in pre-release and may change.
-     *
      * @param CreateMovieRequest $request
      * @param ?array{
      *   baseUrl?: string,
@@ -102,8 +100,6 @@ class ImdbClient
     }
 
     /**
-     * @deprecated
-     *
      * @param string $movieId
      * @param ?array{
      *   baseUrl?: string,

--- a/seed/php-sdk/imdb/no-custom-config/.fern/metadata.json
+++ b/seed/php-sdk/imdb/no-custom-config/.fern/metadata.json
@@ -2,6 +2,9 @@
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-php-sdk",
   "generatorVersion": "local",
+  "generatorConfig": {
+    "generateAvailabilityAnnotations": true
+  },
   "originGitCommit": "DUMMY",
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/imdb/no-custom-config/src/Imdb/ImdbClient.php
+++ b/seed/php-sdk/imdb/no-custom-config/src/Imdb/ImdbClient.php
@@ -53,6 +53,8 @@ class ImdbClient
     /**
      * Add a movie to the database using the movies/* /... path.
      *
+     * @beta This endpoint is in pre-release and may change.
+     *
      * @param CreateMovieRequest $request
      * @param ?array{
      *   baseUrl?: string,
@@ -100,6 +102,8 @@ class ImdbClient
     }
 
     /**
+     * @deprecated
+     *
      * @param string $movieId
      * @param ?array{
      *   baseUrl?: string,

--- a/seed/php-sdk/imdb/no-custom-config/src/Imdb/ImdbClient.php
+++ b/seed/php-sdk/imdb/no-custom-config/src/Imdb/ImdbClient.php
@@ -53,7 +53,7 @@ class ImdbClient
     /**
      * Add a movie to the database using the movies/* /... path.
      *
-     * @beta This endpoint is in pre-release and may change.
+     * @experimental This endpoint is in pre-release and may change.
      *
      * @param CreateMovieRequest $request
      * @param ?array{

--- a/seed/php-sdk/imdb/no-custom-config/src/Imdb/ImdbClient.php
+++ b/seed/php-sdk/imdb/no-custom-config/src/Imdb/ImdbClient.php
@@ -53,8 +53,6 @@ class ImdbClient
     /**
      * Add a movie to the database using the movies/* /... path.
      *
-     * @beta This endpoint is in pre-release and may change.
-     *
      * @param CreateMovieRequest $request
      * @param ?array{
      *   baseUrl?: string,
@@ -102,8 +100,6 @@ class ImdbClient
     }
 
     /**
-     * @deprecated
-     *
      * @param string $movieId
      * @param ?array{
      *   baseUrl?: string,

--- a/seed/php-sdk/imdb/omit-fern-headers/.fern/metadata.json
+++ b/seed/php-sdk/imdb/omit-fern-headers/.fern/metadata.json
@@ -3,6 +3,7 @@
   "generatorName": "fernapi/fern-php-sdk",
   "generatorVersion": "local",
   "generatorConfig": {
+    "generateAvailabilityAnnotations": true,
     "omitFernHeaders": true
   },
   "originGitCommit": "DUMMY",

--- a/seed/php-sdk/imdb/omit-fern-headers/src/Imdb/ImdbClient.php
+++ b/seed/php-sdk/imdb/omit-fern-headers/src/Imdb/ImdbClient.php
@@ -53,6 +53,8 @@ class ImdbClient
     /**
      * Add a movie to the database using the movies/* /... path.
      *
+     * @beta This endpoint is in pre-release and may change.
+     *
      * @param CreateMovieRequest $request
      * @param ?array{
      *   baseUrl?: string,
@@ -100,6 +102,8 @@ class ImdbClient
     }
 
     /**
+     * @deprecated
+     *
      * @param string $movieId
      * @param ?array{
      *   baseUrl?: string,

--- a/seed/php-sdk/imdb/omit-fern-headers/src/Imdb/ImdbClient.php
+++ b/seed/php-sdk/imdb/omit-fern-headers/src/Imdb/ImdbClient.php
@@ -53,7 +53,7 @@ class ImdbClient
     /**
      * Add a movie to the database using the movies/* /... path.
      *
-     * @beta This endpoint is in pre-release and may change.
+     * @experimental This endpoint is in pre-release and may change.
      *
      * @param CreateMovieRequest $request
      * @param ?array{

--- a/seed/php-sdk/imdb/omit-fern-headers/src/Imdb/ImdbClient.php
+++ b/seed/php-sdk/imdb/omit-fern-headers/src/Imdb/ImdbClient.php
@@ -53,8 +53,6 @@ class ImdbClient
     /**
      * Add a movie to the database using the movies/* /... path.
      *
-     * @beta This endpoint is in pre-release and may change.
-     *
      * @param CreateMovieRequest $request
      * @param ?array{
      *   baseUrl?: string,
@@ -102,8 +100,6 @@ class ImdbClient
     }
 
     /**
-     * @deprecated
-     *
      * @param string $movieId
      * @param ?array{
      *   baseUrl?: string,

--- a/seed/php-sdk/imdb/package-path/.fern/metadata.json
+++ b/seed/php-sdk/imdb/package-path/.fern/metadata.json
@@ -3,6 +3,7 @@
   "generatorName": "fernapi/fern-php-sdk",
   "generatorVersion": "local",
   "generatorConfig": {
+    "generateAvailabilityAnnotations": true,
     "packagePath": "Custom/Package/Path",
     "namespace": "Custom\\Package\\Path"
   },

--- a/seed/php-sdk/imdb/package-path/src/Custom/Package/Path/Imdb/ImdbClient.php
+++ b/seed/php-sdk/imdb/package-path/src/Custom/Package/Path/Imdb/ImdbClient.php
@@ -53,6 +53,8 @@ class ImdbClient
     /**
      * Add a movie to the database using the movies/* /... path.
      *
+     * @beta This endpoint is in pre-release and may change.
+     *
      * @param CreateMovieRequest $request
      * @param ?array{
      *   baseUrl?: string,
@@ -100,6 +102,8 @@ class ImdbClient
     }
 
     /**
+     * @deprecated
+     *
      * @param string $movieId
      * @param ?array{
      *   baseUrl?: string,

--- a/seed/php-sdk/imdb/package-path/src/Custom/Package/Path/Imdb/ImdbClient.php
+++ b/seed/php-sdk/imdb/package-path/src/Custom/Package/Path/Imdb/ImdbClient.php
@@ -53,7 +53,7 @@ class ImdbClient
     /**
      * Add a movie to the database using the movies/* /... path.
      *
-     * @beta This endpoint is in pre-release and may change.
+     * @experimental This endpoint is in pre-release and may change.
      *
      * @param CreateMovieRequest $request
      * @param ?array{

--- a/seed/php-sdk/imdb/package-path/src/Custom/Package/Path/Imdb/ImdbClient.php
+++ b/seed/php-sdk/imdb/package-path/src/Custom/Package/Path/Imdb/ImdbClient.php
@@ -53,8 +53,6 @@ class ImdbClient
     /**
      * Add a movie to the database using the movies/* /... path.
      *
-     * @beta This endpoint is in pre-release and may change.
-     *
      * @param CreateMovieRequest $request
      * @param ?array{
      *   baseUrl?: string,
@@ -102,8 +100,6 @@ class ImdbClient
     }
 
     /**
-     * @deprecated
-     *
      * @param string $movieId
      * @param ?array{
      *   baseUrl?: string,

--- a/seed/php-sdk/imdb/packageName/.fern/metadata.json
+++ b/seed/php-sdk/imdb/packageName/.fern/metadata.json
@@ -3,6 +3,7 @@
   "generatorName": "fernapi/fern-php-sdk",
   "generatorVersion": "local",
   "generatorConfig": {
+    "generateAvailabilityAnnotations": true,
     "packageName": "fern-api/imdb-php"
   },
   "originGitCommit": "DUMMY",

--- a/seed/php-sdk/imdb/packageName/src/Imdb/ImdbClient.php
+++ b/seed/php-sdk/imdb/packageName/src/Imdb/ImdbClient.php
@@ -53,6 +53,8 @@ class ImdbClient
     /**
      * Add a movie to the database using the movies/* /... path.
      *
+     * @beta This endpoint is in pre-release and may change.
+     *
      * @param CreateMovieRequest $request
      * @param ?array{
      *   baseUrl?: string,
@@ -100,6 +102,8 @@ class ImdbClient
     }
 
     /**
+     * @deprecated
+     *
      * @param string $movieId
      * @param ?array{
      *   baseUrl?: string,

--- a/seed/php-sdk/imdb/packageName/src/Imdb/ImdbClient.php
+++ b/seed/php-sdk/imdb/packageName/src/Imdb/ImdbClient.php
@@ -53,7 +53,7 @@ class ImdbClient
     /**
      * Add a movie to the database using the movies/* /... path.
      *
-     * @beta This endpoint is in pre-release and may change.
+     * @experimental This endpoint is in pre-release and may change.
      *
      * @param CreateMovieRequest $request
      * @param ?array{

--- a/seed/php-sdk/imdb/packageName/src/Imdb/ImdbClient.php
+++ b/seed/php-sdk/imdb/packageName/src/Imdb/ImdbClient.php
@@ -53,8 +53,6 @@ class ImdbClient
     /**
      * Add a movie to the database using the movies/* /... path.
      *
-     * @beta This endpoint is in pre-release and may change.
-     *
      * @param CreateMovieRequest $request
      * @param ?array{
      *   baseUrl?: string,
@@ -102,8 +100,6 @@ class ImdbClient
     }
 
     /**
-     * @deprecated
-     *
      * @param string $movieId
      * @param ?array{
      *   baseUrl?: string,

--- a/seed/php-sdk/imdb/private/.fern/metadata.json
+++ b/seed/php-sdk/imdb/private/.fern/metadata.json
@@ -3,6 +3,7 @@
   "generatorName": "fernapi/fern-php-sdk",
   "generatorVersion": "local",
   "generatorConfig": {
+    "generateAvailabilityAnnotations": true,
     "propertyAccess": "private"
   },
   "originGitCommit": "DUMMY",

--- a/seed/php-sdk/imdb/private/src/Imdb/ImdbClient.php
+++ b/seed/php-sdk/imdb/private/src/Imdb/ImdbClient.php
@@ -53,6 +53,8 @@ class ImdbClient
     /**
      * Add a movie to the database using the movies/* /... path.
      *
+     * @beta This endpoint is in pre-release and may change.
+     *
      * @param CreateMovieRequest $request
      * @param ?array{
      *   baseUrl?: string,
@@ -100,6 +102,8 @@ class ImdbClient
     }
 
     /**
+     * @deprecated
+     *
      * @param string $movieId
      * @param ?array{
      *   baseUrl?: string,

--- a/seed/php-sdk/imdb/private/src/Imdb/ImdbClient.php
+++ b/seed/php-sdk/imdb/private/src/Imdb/ImdbClient.php
@@ -53,7 +53,7 @@ class ImdbClient
     /**
      * Add a movie to the database using the movies/* /... path.
      *
-     * @beta This endpoint is in pre-release and may change.
+     * @experimental This endpoint is in pre-release and may change.
      *
      * @param CreateMovieRequest $request
      * @param ?array{

--- a/seed/php-sdk/imdb/private/src/Imdb/ImdbClient.php
+++ b/seed/php-sdk/imdb/private/src/Imdb/ImdbClient.php
@@ -53,8 +53,6 @@ class ImdbClient
     /**
      * Add a movie to the database using the movies/* /... path.
      *
-     * @beta This endpoint is in pre-release and may change.
-     *
      * @param CreateMovieRequest $request
      * @param ?array{
      *   baseUrl?: string,
@@ -102,8 +100,6 @@ class ImdbClient
     }
 
     /**
-     * @deprecated
-     *
      * @param string $movieId
      * @param ?array{
      *   baseUrl?: string,

--- a/seed/php-sdk/inferred-auth-explicit/.fern/metadata.json
+++ b/seed/php-sdk/inferred-auth-explicit/.fern/metadata.json
@@ -2,6 +2,9 @@
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-php-sdk",
   "generatorVersion": "local",
+  "generatorConfig": {
+    "generateAvailabilityAnnotations": true
+  },
   "originGitCommit": "DUMMY",
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/inferred-auth-implicit-api-key/.fern/metadata.json
+++ b/seed/php-sdk/inferred-auth-implicit-api-key/.fern/metadata.json
@@ -2,6 +2,9 @@
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-php-sdk",
   "generatorVersion": "local",
+  "generatorConfig": {
+    "generateAvailabilityAnnotations": true
+  },
   "originGitCommit": "DUMMY",
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/inferred-auth-implicit-no-expiry/.fern/metadata.json
+++ b/seed/php-sdk/inferred-auth-implicit-no-expiry/.fern/metadata.json
@@ -2,6 +2,9 @@
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-php-sdk",
   "generatorVersion": "local",
+  "generatorConfig": {
+    "generateAvailabilityAnnotations": true
+  },
   "originGitCommit": "DUMMY",
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/inferred-auth-implicit-reference/.fern/metadata.json
+++ b/seed/php-sdk/inferred-auth-implicit-reference/.fern/metadata.json
@@ -2,6 +2,9 @@
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-php-sdk",
   "generatorVersion": "local",
+  "generatorConfig": {
+    "generateAvailabilityAnnotations": true
+  },
   "originGitCommit": "DUMMY",
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/inferred-auth-implicit/.fern/metadata.json
+++ b/seed/php-sdk/inferred-auth-implicit/.fern/metadata.json
@@ -2,6 +2,9 @@
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-php-sdk",
   "generatorVersion": "local",
+  "generatorConfig": {
+    "generateAvailabilityAnnotations": true
+  },
   "originGitCommit": "DUMMY",
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/license/.fern/metadata.json
+++ b/seed/php-sdk/license/.fern/metadata.json
@@ -2,6 +2,9 @@
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-php-sdk",
   "generatorVersion": "local",
+  "generatorConfig": {
+    "generateAvailabilityAnnotations": true
+  },
   "originGitCommit": "DUMMY",
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/literal/.fern/metadata.json
+++ b/seed/php-sdk/literal/.fern/metadata.json
@@ -2,6 +2,9 @@
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-php-sdk",
   "generatorVersion": "local",
+  "generatorConfig": {
+    "generateAvailabilityAnnotations": true
+  },
   "originGitCommit": "DUMMY",
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/literals-unions/.fern/metadata.json
+++ b/seed/php-sdk/literals-unions/.fern/metadata.json
@@ -2,6 +2,9 @@
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-php-sdk",
   "generatorVersion": "local",
+  "generatorConfig": {
+    "generateAvailabilityAnnotations": true
+  },
   "originGitCommit": "DUMMY",
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/mixed-case/.fern/metadata.json
+++ b/seed/php-sdk/mixed-case/.fern/metadata.json
@@ -2,6 +2,9 @@
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-php-sdk",
   "generatorVersion": "local",
+  "generatorConfig": {
+    "generateAvailabilityAnnotations": true
+  },
   "originGitCommit": "DUMMY",
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/mixed-file-directory/.fern/metadata.json
+++ b/seed/php-sdk/mixed-file-directory/.fern/metadata.json
@@ -2,6 +2,9 @@
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-php-sdk",
   "generatorVersion": "local",
+  "generatorConfig": {
+    "generateAvailabilityAnnotations": true
+  },
   "originGitCommit": "DUMMY",
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/multi-line-docs/.fern/metadata.json
+++ b/seed/php-sdk/multi-line-docs/.fern/metadata.json
@@ -2,6 +2,9 @@
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-php-sdk",
   "generatorVersion": "local",
+  "generatorConfig": {
+    "generateAvailabilityAnnotations": true
+  },
   "originGitCommit": "DUMMY",
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/multi-url-environment-no-default/.fern/metadata.json
+++ b/seed/php-sdk/multi-url-environment-no-default/.fern/metadata.json
@@ -2,6 +2,9 @@
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-php-sdk",
   "generatorVersion": "local",
+  "generatorConfig": {
+    "generateAvailabilityAnnotations": true
+  },
   "originGitCommit": "DUMMY",
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/multi-url-environment-reference/.fern/metadata.json
+++ b/seed/php-sdk/multi-url-environment-reference/.fern/metadata.json
@@ -2,6 +2,9 @@
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-php-sdk",
   "generatorVersion": "local",
+  "generatorConfig": {
+    "generateAvailabilityAnnotations": true
+  },
   "originGitCommit": "DUMMY",
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/multi-url-environment/.fern/metadata.json
+++ b/seed/php-sdk/multi-url-environment/.fern/metadata.json
@@ -2,6 +2,9 @@
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-php-sdk",
   "generatorVersion": "local",
+  "generatorConfig": {
+    "generateAvailabilityAnnotations": true
+  },
   "originGitCommit": "DUMMY",
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/multiple-request-bodies/.fern/metadata.json
+++ b/seed/php-sdk/multiple-request-bodies/.fern/metadata.json
@@ -2,6 +2,9 @@
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-php-sdk",
   "generatorVersion": "local",
+  "generatorConfig": {
+    "generateAvailabilityAnnotations": true
+  },
   "originGitCommit": "DUMMY",
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/no-content-response/.fern/metadata.json
+++ b/seed/php-sdk/no-content-response/.fern/metadata.json
@@ -2,6 +2,9 @@
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-php-sdk",
   "generatorVersion": "local",
+  "generatorConfig": {
+    "generateAvailabilityAnnotations": true
+  },
   "originGitCommit": "DUMMY",
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/no-environment/.fern/metadata.json
+++ b/seed/php-sdk/no-environment/.fern/metadata.json
@@ -2,6 +2,9 @@
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-php-sdk",
   "generatorVersion": "local",
+  "generatorConfig": {
+    "generateAvailabilityAnnotations": true
+  },
   "originGitCommit": "DUMMY",
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/no-retries/.fern/metadata.json
+++ b/seed/php-sdk/no-retries/.fern/metadata.json
@@ -2,6 +2,9 @@
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-php-sdk",
   "generatorVersion": "local",
+  "generatorConfig": {
+    "generateAvailabilityAnnotations": true
+  },
   "originGitCommit": "DUMMY",
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/null-type/.fern/metadata.json
+++ b/seed/php-sdk/null-type/.fern/metadata.json
@@ -2,6 +2,9 @@
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-php-sdk",
   "generatorVersion": "local",
+  "generatorConfig": {
+    "generateAvailabilityAnnotations": true
+  },
   "originGitCommit": "DUMMY",
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/nullable-allof-extends/.fern/metadata.json
+++ b/seed/php-sdk/nullable-allof-extends/.fern/metadata.json
@@ -2,6 +2,9 @@
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-php-sdk",
   "generatorVersion": "local",
+  "generatorConfig": {
+    "generateAvailabilityAnnotations": true
+  },
   "originGitCommit": "DUMMY",
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/nullable-optional/.fern/metadata.json
+++ b/seed/php-sdk/nullable-optional/.fern/metadata.json
@@ -2,6 +2,9 @@
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-php-sdk",
   "generatorVersion": "local",
+  "generatorConfig": {
+    "generateAvailabilityAnnotations": true
+  },
   "originGitCommit": "DUMMY",
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/nullable-request-body/.fern/metadata.json
+++ b/seed/php-sdk/nullable-request-body/.fern/metadata.json
@@ -2,6 +2,9 @@
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-php-sdk",
   "generatorVersion": "local",
+  "generatorConfig": {
+    "generateAvailabilityAnnotations": true
+  },
   "originGitCommit": "DUMMY",
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/nullable/.fern/metadata.json
+++ b/seed/php-sdk/nullable/.fern/metadata.json
@@ -2,6 +2,9 @@
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-php-sdk",
   "generatorVersion": "local",
+  "generatorConfig": {
+    "generateAvailabilityAnnotations": true
+  },
   "originGitCommit": "DUMMY",
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/oauth-client-credentials-custom/.fern/metadata.json
+++ b/seed/php-sdk/oauth-client-credentials-custom/.fern/metadata.json
@@ -2,6 +2,9 @@
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-php-sdk",
   "generatorVersion": "local",
+  "generatorConfig": {
+    "generateAvailabilityAnnotations": true
+  },
   "originGitCommit": "DUMMY",
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/oauth-client-credentials-default/.fern/metadata.json
+++ b/seed/php-sdk/oauth-client-credentials-default/.fern/metadata.json
@@ -2,6 +2,9 @@
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-php-sdk",
   "generatorVersion": "local",
+  "generatorConfig": {
+    "generateAvailabilityAnnotations": true
+  },
   "originGitCommit": "DUMMY",
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/oauth-client-credentials-environment-variables/.fern/metadata.json
+++ b/seed/php-sdk/oauth-client-credentials-environment-variables/.fern/metadata.json
@@ -2,6 +2,9 @@
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-php-sdk",
   "generatorVersion": "local",
+  "generatorConfig": {
+    "generateAvailabilityAnnotations": true
+  },
   "originGitCommit": "DUMMY",
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/oauth-client-credentials-mandatory-auth/.fern/metadata.json
+++ b/seed/php-sdk/oauth-client-credentials-mandatory-auth/.fern/metadata.json
@@ -2,6 +2,9 @@
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-php-sdk",
   "generatorVersion": "local",
+  "generatorConfig": {
+    "generateAvailabilityAnnotations": true
+  },
   "originGitCommit": "DUMMY",
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/oauth-client-credentials-nested-root/.fern/metadata.json
+++ b/seed/php-sdk/oauth-client-credentials-nested-root/.fern/metadata.json
@@ -2,6 +2,9 @@
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-php-sdk",
   "generatorVersion": "local",
+  "generatorConfig": {
+    "generateAvailabilityAnnotations": true
+  },
   "originGitCommit": "DUMMY",
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/oauth-client-credentials-openapi/.fern/metadata.json
+++ b/seed/php-sdk/oauth-client-credentials-openapi/.fern/metadata.json
@@ -2,6 +2,9 @@
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-php-sdk",
   "generatorVersion": "local",
+  "generatorConfig": {
+    "generateAvailabilityAnnotations": true
+  },
   "originGitCommit": "DUMMY",
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/oauth-client-credentials-reference/.fern/metadata.json
+++ b/seed/php-sdk/oauth-client-credentials-reference/.fern/metadata.json
@@ -2,6 +2,9 @@
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-php-sdk",
   "generatorVersion": "local",
+  "generatorConfig": {
+    "generateAvailabilityAnnotations": true
+  },
   "originGitCommit": "DUMMY",
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/oauth-client-credentials-with-variables/.fern/metadata.json
+++ b/seed/php-sdk/oauth-client-credentials-with-variables/.fern/metadata.json
@@ -2,6 +2,9 @@
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-php-sdk",
   "generatorVersion": "local",
+  "generatorConfig": {
+    "generateAvailabilityAnnotations": true
+  },
   "originGitCommit": "DUMMY",
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/oauth-client-credentials/.fern/metadata.json
+++ b/seed/php-sdk/oauth-client-credentials/.fern/metadata.json
@@ -2,6 +2,9 @@
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-php-sdk",
   "generatorVersion": "local",
+  "generatorConfig": {
+    "generateAvailabilityAnnotations": true
+  },
   "originGitCommit": "DUMMY",
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/object/.fern/metadata.json
+++ b/seed/php-sdk/object/.fern/metadata.json
@@ -2,6 +2,9 @@
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-php-sdk",
   "generatorVersion": "local",
+  "generatorConfig": {
+    "generateAvailabilityAnnotations": true
+  },
   "originGitCommit": "DUMMY",
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/objects-with-imports/.fern/metadata.json
+++ b/seed/php-sdk/objects-with-imports/.fern/metadata.json
@@ -2,6 +2,9 @@
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-php-sdk",
   "generatorVersion": "local",
+  "generatorConfig": {
+    "generateAvailabilityAnnotations": true
+  },
   "originGitCommit": "DUMMY",
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/optional/.fern/metadata.json
+++ b/seed/php-sdk/optional/.fern/metadata.json
@@ -2,6 +2,9 @@
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-php-sdk",
   "generatorVersion": "local",
+  "generatorConfig": {
+    "generateAvailabilityAnnotations": true
+  },
   "originGitCommit": "DUMMY",
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/package-yml/no-custom-config/.fern/metadata.json
+++ b/seed/php-sdk/package-yml/no-custom-config/.fern/metadata.json
@@ -2,6 +2,9 @@
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-php-sdk",
   "generatorVersion": "local",
+  "generatorConfig": {
+    "generateAvailabilityAnnotations": true
+  },
   "originGitCommit": "DUMMY",
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/package-yml/private/.fern/metadata.json
+++ b/seed/php-sdk/package-yml/private/.fern/metadata.json
@@ -3,6 +3,7 @@
   "generatorName": "fernapi/fern-php-sdk",
   "generatorVersion": "local",
   "generatorConfig": {
+    "generateAvailabilityAnnotations": true,
     "propertyAccess": "private"
   },
   "originGitCommit": "DUMMY",

--- a/seed/php-sdk/pagination-custom/.fern/metadata.json
+++ b/seed/php-sdk/pagination-custom/.fern/metadata.json
@@ -2,6 +2,9 @@
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-php-sdk",
   "generatorVersion": "local",
+  "generatorConfig": {
+    "generateAvailabilityAnnotations": true
+  },
   "originGitCommit": "DUMMY",
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/pagination-uri-path/.fern/metadata.json
+++ b/seed/php-sdk/pagination-uri-path/.fern/metadata.json
@@ -2,6 +2,9 @@
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-php-sdk",
   "generatorVersion": "local",
+  "generatorConfig": {
+    "generateAvailabilityAnnotations": true
+  },
   "originGitCommit": "DUMMY",
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/pagination/no-custom-config/.fern/metadata.json
+++ b/seed/php-sdk/pagination/no-custom-config/.fern/metadata.json
@@ -2,6 +2,9 @@
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-php-sdk",
   "generatorVersion": "local",
+  "generatorConfig": {
+    "generateAvailabilityAnnotations": true
+  },
   "originGitCommit": "DUMMY",
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/pagination/property-accessors/.fern/metadata.json
+++ b/seed/php-sdk/pagination/property-accessors/.fern/metadata.json
@@ -3,6 +3,7 @@
   "generatorName": "fernapi/fern-php-sdk",
   "generatorVersion": "local",
   "generatorConfig": {
+    "generateAvailabilityAnnotations": true,
     "propertyAccess": "private"
   },
   "originGitCommit": "DUMMY",

--- a/seed/php-sdk/path-parameters/inline-path-parameters-private/.fern/metadata.json
+++ b/seed/php-sdk/path-parameters/inline-path-parameters-private/.fern/metadata.json
@@ -3,6 +3,7 @@
   "generatorName": "fernapi/fern-php-sdk",
   "generatorVersion": "local",
   "generatorConfig": {
+    "generateAvailabilityAnnotations": true,
     "inlinePathParameters": true,
     "propertyAccess": "private"
   },

--- a/seed/php-sdk/path-parameters/inline-path-parameters/.fern/metadata.json
+++ b/seed/php-sdk/path-parameters/inline-path-parameters/.fern/metadata.json
@@ -3,6 +3,7 @@
   "generatorName": "fernapi/fern-php-sdk",
   "generatorVersion": "local",
   "generatorConfig": {
+    "generateAvailabilityAnnotations": true,
     "inlinePathParameters": true
   },
   "originGitCommit": "DUMMY",

--- a/seed/php-sdk/path-parameters/no-custom-config/.fern/metadata.json
+++ b/seed/php-sdk/path-parameters/no-custom-config/.fern/metadata.json
@@ -2,6 +2,9 @@
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-php-sdk",
   "generatorVersion": "local",
+  "generatorConfig": {
+    "generateAvailabilityAnnotations": true
+  },
   "originGitCommit": "DUMMY",
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/plain-text/.fern/metadata.json
+++ b/seed/php-sdk/plain-text/.fern/metadata.json
@@ -2,6 +2,9 @@
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-php-sdk",
   "generatorVersion": "local",
+  "generatorConfig": {
+    "generateAvailabilityAnnotations": true
+  },
   "originGitCommit": "DUMMY",
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/property-access/.fern/metadata.json
+++ b/seed/php-sdk/property-access/.fern/metadata.json
@@ -2,6 +2,9 @@
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-php-sdk",
   "generatorVersion": "local",
+  "generatorConfig": {
+    "generateAvailabilityAnnotations": true
+  },
   "originGitCommit": "DUMMY",
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/public-object/.fern/metadata.json
+++ b/seed/php-sdk/public-object/.fern/metadata.json
@@ -2,6 +2,9 @@
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-php-sdk",
   "generatorVersion": "local",
+  "generatorConfig": {
+    "generateAvailabilityAnnotations": true
+  },
   "originGitCommit": "DUMMY",
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/query-param-name-conflict/.fern/metadata.json
+++ b/seed/php-sdk/query-param-name-conflict/.fern/metadata.json
@@ -2,6 +2,9 @@
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-php-sdk",
   "generatorVersion": "local",
+  "generatorConfig": {
+    "generateAvailabilityAnnotations": true
+  },
   "originGitCommit": "DUMMY",
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/query-parameters-openapi-as-objects/.fern/metadata.json
+++ b/seed/php-sdk/query-parameters-openapi-as-objects/.fern/metadata.json
@@ -2,6 +2,9 @@
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-php-sdk",
   "generatorVersion": "local",
+  "generatorConfig": {
+    "generateAvailabilityAnnotations": true
+  },
   "originGitCommit": "DUMMY",
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/query-parameters-openapi/.fern/metadata.json
+++ b/seed/php-sdk/query-parameters-openapi/.fern/metadata.json
@@ -2,6 +2,9 @@
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-php-sdk",
   "generatorVersion": "local",
+  "generatorConfig": {
+    "generateAvailabilityAnnotations": true
+  },
   "originGitCommit": "DUMMY",
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/query-parameters/no-custom-config/.fern/metadata.json
+++ b/seed/php-sdk/query-parameters/no-custom-config/.fern/metadata.json
@@ -2,6 +2,9 @@
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-php-sdk",
   "generatorVersion": "local",
+  "generatorConfig": {
+    "generateAvailabilityAnnotations": true
+  },
   "originGitCommit": "DUMMY",
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/query-parameters/private/.fern/metadata.json
+++ b/seed/php-sdk/query-parameters/private/.fern/metadata.json
@@ -3,6 +3,7 @@
   "generatorName": "fernapi/fern-php-sdk",
   "generatorVersion": "local",
   "generatorConfig": {
+    "generateAvailabilityAnnotations": true,
     "propertyAccess": "private"
   },
   "originGitCommit": "DUMMY",

--- a/seed/php-sdk/request-parameters/no-custom-config/.fern/metadata.json
+++ b/seed/php-sdk/request-parameters/no-custom-config/.fern/metadata.json
@@ -2,6 +2,9 @@
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-php-sdk",
   "generatorVersion": "local",
+  "generatorConfig": {
+    "generateAvailabilityAnnotations": true
+  },
   "originGitCommit": "DUMMY",
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/request-parameters/with-defaults/.fern/metadata.json
+++ b/seed/php-sdk/request-parameters/with-defaults/.fern/metadata.json
@@ -3,6 +3,7 @@
   "generatorName": "fernapi/fern-php-sdk",
   "generatorVersion": "local",
   "generatorConfig": {
+    "generateAvailabilityAnnotations": true,
     "useDefaultRequestParameterValues": true
   },
   "originGitCommit": "DUMMY",

--- a/seed/php-sdk/required-nullable/.fern/metadata.json
+++ b/seed/php-sdk/required-nullable/.fern/metadata.json
@@ -2,6 +2,9 @@
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-php-sdk",
   "generatorVersion": "local",
+  "generatorConfig": {
+    "generateAvailabilityAnnotations": true
+  },
   "originGitCommit": "DUMMY",
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/reserved-keywords/.fern/metadata.json
+++ b/seed/php-sdk/reserved-keywords/.fern/metadata.json
@@ -2,6 +2,9 @@
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-php-sdk",
   "generatorVersion": "local",
+  "generatorConfig": {
+    "generateAvailabilityAnnotations": true
+  },
   "originGitCommit": "DUMMY",
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/response-property/.fern/metadata.json
+++ b/seed/php-sdk/response-property/.fern/metadata.json
@@ -2,6 +2,9 @@
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-php-sdk",
   "generatorVersion": "local",
+  "generatorConfig": {
+    "generateAvailabilityAnnotations": true
+  },
   "originGitCommit": "DUMMY",
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/schemaless-request-body-examples/.fern/metadata.json
+++ b/seed/php-sdk/schemaless-request-body-examples/.fern/metadata.json
@@ -2,6 +2,9 @@
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-php-sdk",
   "generatorVersion": "local",
+  "generatorConfig": {
+    "generateAvailabilityAnnotations": true
+  },
   "originGitCommit": "DUMMY",
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/seed.yml
+++ b/seed/php-sdk/seed.yml
@@ -24,6 +24,8 @@ test:
 language: php
 generatorType: SDK
 defaultOutputMode: github
+defaultCustomConfig:
+  generateAvailabilityAnnotations: true
 fixtures:
   basic-auth:
     - outputFolder: wire-tests

--- a/seed/php-sdk/server-sent-event-examples/.fern/metadata.json
+++ b/seed/php-sdk/server-sent-event-examples/.fern/metadata.json
@@ -2,6 +2,9 @@
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-php-sdk",
   "generatorVersion": "local",
+  "generatorConfig": {
+    "generateAvailabilityAnnotations": true
+  },
   "originGitCommit": "DUMMY",
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/server-sent-events-openapi/.fern/metadata.json
+++ b/seed/php-sdk/server-sent-events-openapi/.fern/metadata.json
@@ -2,6 +2,9 @@
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-php-sdk",
   "generatorVersion": "local",
+  "generatorConfig": {
+    "generateAvailabilityAnnotations": true
+  },
   "originGitCommit": "DUMMY",
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/server-sent-events/.fern/metadata.json
+++ b/seed/php-sdk/server-sent-events/.fern/metadata.json
@@ -2,6 +2,9 @@
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-php-sdk",
   "generatorVersion": "local",
+  "generatorConfig": {
+    "generateAvailabilityAnnotations": true
+  },
   "originGitCommit": "DUMMY",
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/server-url-templating/.fern/metadata.json
+++ b/seed/php-sdk/server-url-templating/.fern/metadata.json
@@ -2,6 +2,9 @@
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-php-sdk",
   "generatorVersion": "local",
+  "generatorConfig": {
+    "generateAvailabilityAnnotations": true
+  },
   "originGitCommit": "DUMMY",
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/simple-api/.fern/metadata.json
+++ b/seed/php-sdk/simple-api/.fern/metadata.json
@@ -2,6 +2,9 @@
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-php-sdk",
   "generatorVersion": "local",
+  "generatorConfig": {
+    "generateAvailabilityAnnotations": true
+  },
   "originGitCommit": "DUMMY",
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/simple-fhir/.fern/metadata.json
+++ b/seed/php-sdk/simple-fhir/.fern/metadata.json
@@ -2,6 +2,9 @@
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-php-sdk",
   "generatorVersion": "local",
+  "generatorConfig": {
+    "generateAvailabilityAnnotations": true
+  },
   "originGitCommit": "DUMMY",
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/single-url-environment-default/.fern/metadata.json
+++ b/seed/php-sdk/single-url-environment-default/.fern/metadata.json
@@ -2,6 +2,9 @@
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-php-sdk",
   "generatorVersion": "local",
+  "generatorConfig": {
+    "generateAvailabilityAnnotations": true
+  },
   "originGitCommit": "DUMMY",
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/single-url-environment-no-default/.fern/metadata.json
+++ b/seed/php-sdk/single-url-environment-no-default/.fern/metadata.json
@@ -2,6 +2,9 @@
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-php-sdk",
   "generatorVersion": "local",
+  "generatorConfig": {
+    "generateAvailabilityAnnotations": true
+  },
   "originGitCommit": "DUMMY",
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/streaming-parameter/.fern/metadata.json
+++ b/seed/php-sdk/streaming-parameter/.fern/metadata.json
@@ -2,6 +2,9 @@
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-php-sdk",
   "generatorVersion": "local",
+  "generatorConfig": {
+    "generateAvailabilityAnnotations": true
+  },
   "originGitCommit": "DUMMY",
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/streaming/.fern/metadata.json
+++ b/seed/php-sdk/streaming/.fern/metadata.json
@@ -2,6 +2,9 @@
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-php-sdk",
   "generatorVersion": "local",
+  "generatorConfig": {
+    "generateAvailabilityAnnotations": true
+  },
   "originGitCommit": "DUMMY",
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/trace/.fern/metadata.json
+++ b/seed/php-sdk/trace/.fern/metadata.json
@@ -2,6 +2,9 @@
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-php-sdk",
   "generatorVersion": "local",
+  "generatorConfig": {
+    "generateAvailabilityAnnotations": true
+  },
   "originGitCommit": "DUMMY",
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/undiscriminated-union-with-response-property/.fern/metadata.json
+++ b/seed/php-sdk/undiscriminated-union-with-response-property/.fern/metadata.json
@@ -2,6 +2,9 @@
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-php-sdk",
   "generatorVersion": "local",
+  "generatorConfig": {
+    "generateAvailabilityAnnotations": true
+  },
   "originGitCommit": "DUMMY",
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/undiscriminated-unions/.fern/metadata.json
+++ b/seed/php-sdk/undiscriminated-unions/.fern/metadata.json
@@ -2,6 +2,9 @@
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-php-sdk",
   "generatorVersion": "local",
+  "generatorConfig": {
+    "generateAvailabilityAnnotations": true
+  },
   "originGitCommit": "DUMMY",
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/unions-with-local-date/.fern/metadata.json
+++ b/seed/php-sdk/unions-with-local-date/.fern/metadata.json
@@ -2,6 +2,9 @@
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-php-sdk",
   "generatorVersion": "local",
+  "generatorConfig": {
+    "generateAvailabilityAnnotations": true
+  },
   "originGitCommit": "DUMMY",
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/unions/no-custom-config/.fern/metadata.json
+++ b/seed/php-sdk/unions/no-custom-config/.fern/metadata.json
@@ -2,6 +2,9 @@
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-php-sdk",
   "generatorVersion": "local",
+  "generatorConfig": {
+    "generateAvailabilityAnnotations": true
+  },
   "originGitCommit": "DUMMY",
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/unions/property-accessors/.fern/metadata.json
+++ b/seed/php-sdk/unions/property-accessors/.fern/metadata.json
@@ -3,6 +3,7 @@
   "generatorName": "fernapi/fern-php-sdk",
   "generatorVersion": "local",
   "generatorConfig": {
+    "generateAvailabilityAnnotations": true,
     "propertyAccess": "private"
   },
   "originGitCommit": "DUMMY",

--- a/seed/php-sdk/unknown/.fern/metadata.json
+++ b/seed/php-sdk/unknown/.fern/metadata.json
@@ -2,6 +2,9 @@
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-php-sdk",
   "generatorVersion": "local",
+  "generatorConfig": {
+    "generateAvailabilityAnnotations": true
+  },
   "originGitCommit": "DUMMY",
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/url-form-encoded/.fern/metadata.json
+++ b/seed/php-sdk/url-form-encoded/.fern/metadata.json
@@ -2,6 +2,9 @@
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-php-sdk",
   "generatorVersion": "local",
+  "generatorConfig": {
+    "generateAvailabilityAnnotations": true
+  },
   "originGitCommit": "DUMMY",
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/validation/.fern/metadata.json
+++ b/seed/php-sdk/validation/.fern/metadata.json
@@ -2,6 +2,9 @@
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-php-sdk",
   "generatorVersion": "local",
+  "generatorConfig": {
+    "generateAvailabilityAnnotations": true
+  },
   "originGitCommit": "DUMMY",
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/variables/.fern/metadata.json
+++ b/seed/php-sdk/variables/.fern/metadata.json
@@ -2,6 +2,9 @@
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-php-sdk",
   "generatorVersion": "local",
+  "generatorConfig": {
+    "generateAvailabilityAnnotations": true
+  },
   "originGitCommit": "DUMMY",
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/version-no-default/.fern/metadata.json
+++ b/seed/php-sdk/version-no-default/.fern/metadata.json
@@ -2,6 +2,9 @@
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-php-sdk",
   "generatorVersion": "local",
+  "generatorConfig": {
+    "generateAvailabilityAnnotations": true
+  },
   "originGitCommit": "DUMMY",
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/version/.fern/metadata.json
+++ b/seed/php-sdk/version/.fern/metadata.json
@@ -2,6 +2,9 @@
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-php-sdk",
   "generatorVersion": "local",
+  "generatorConfig": {
+    "generateAvailabilityAnnotations": true
+  },
   "originGitCommit": "DUMMY",
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/webhook-audience/.fern/metadata.json
+++ b/seed/php-sdk/webhook-audience/.fern/metadata.json
@@ -2,6 +2,9 @@
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-php-sdk",
   "generatorVersion": "local",
+  "generatorConfig": {
+    "generateAvailabilityAnnotations": true
+  },
   "originGitCommit": "DUMMY",
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/webhooks/.fern/metadata.json
+++ b/seed/php-sdk/webhooks/.fern/metadata.json
@@ -2,6 +2,9 @@
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-php-sdk",
   "generatorVersion": "local",
+  "generatorConfig": {
+    "generateAvailabilityAnnotations": true
+  },
   "originGitCommit": "DUMMY",
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/websocket-bearer-auth/.fern/metadata.json
+++ b/seed/php-sdk/websocket-bearer-auth/.fern/metadata.json
@@ -2,6 +2,9 @@
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-php-sdk",
   "generatorVersion": "local",
+  "generatorConfig": {
+    "generateAvailabilityAnnotations": true
+  },
   "originGitCommit": "DUMMY",
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/websocket-inferred-auth/.fern/metadata.json
+++ b/seed/php-sdk/websocket-inferred-auth/.fern/metadata.json
@@ -2,6 +2,9 @@
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-php-sdk",
   "generatorVersion": "local",
+  "generatorConfig": {
+    "generateAvailabilityAnnotations": true
+  },
   "originGitCommit": "DUMMY",
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/websocket-multi-url/.fern/metadata.json
+++ b/seed/php-sdk/websocket-multi-url/.fern/metadata.json
@@ -2,6 +2,9 @@
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-php-sdk",
   "generatorVersion": "local",
+  "generatorConfig": {
+    "generateAvailabilityAnnotations": true
+  },
   "originGitCommit": "DUMMY",
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/websocket/.fern/metadata.json
+++ b/seed/php-sdk/websocket/.fern/metadata.json
@@ -2,6 +2,9 @@
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-php-sdk",
   "generatorVersion": "local",
+  "generatorConfig": {
+    "generateAvailabilityAnnotations": true
+  },
   "originGitCommit": "DUMMY",
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/x-fern-default/.fern/metadata.json
+++ b/seed/php-sdk/x-fern-default/.fern/metadata.json
@@ -2,6 +2,9 @@
   "cliVersion": "DUMMY",
   "generatorName": "fernapi/fern-php-sdk",
   "generatorVersion": "local",
+  "generatorConfig": {
+    "generateAvailabilityAnnotations": true
+  },
   "originGitCommit": "DUMMY",
   "sdkVersion": "0.0.1"
 }


### PR DESCRIPTION
## Description

Linear ticket: Refs

Mirrors the TypeScript SDK generator's [`getAvailabilityDocs`](https://github.com/fern-api/fern/blob/main/generators/typescript/sdk/client-class-generator/src/endpoints/utils/getAvailabilityDocs.ts) behavior for the PHP SDK generator, gated behind an **opt-in** `generateAvailabilityAnnotations` custom-config flag (default `false`).

When the flag is enabled, generated PHP client methods surface endpoint `availability` from the IR in their PHPDoc blocks:

- `DEPRECATED` → `@deprecated` (with the optional `message` appended)
- `IN_DEVELOPMENT` → `@beta This endpoint is in development and may change.` (+ message)
- `PRE_RELEASE` → `@beta This endpoint is in pre-release and may change.` (+ message)
- `GENERAL_AVAILABILITY` / unset → nothing extra

Wording matches the TS fallback exactly. `@deprecated` is the native PHPDoc mechanism (recognized by PHPStan, PhpStorm, Psalm, etc.); PHP has no first-class "beta" attribute, so `@beta` in PHPDoc is the fallback.

The flag defaults to `false` because emitting `@deprecated` / `@beta` is a breaking change for downstream consumers who run static analyzers in `-Werror`-style strict modes. A `TODO(next-major): flip default to true` comment is left next to the flag in `SdkCustomConfig.ts` so the next major-version owner has a clear signal.

The flag name is intentionally generic (not endpoint-specific) so future work can extend availability-annotation coverage to other SDK surfaces — services, types, object properties, enum values, webhook payloads, WebSocket channels/messages, errors, etc. — under the same flag without introducing a second opt-in. **This PR still only annotates `HttpEndpoint` methods today**; the rename is purely forward-looking.

Enable with:

```yaml
# generators.yml
- name: fernapi/fern-php-sdk
  config:
    generateAvailabilityAnnotations: true
```

## Changes Made

- Added `generateAvailabilityAnnotations` to `SdkCustomConfigSchema` (default `false`, with `TODO(next-major)` comment describing the intent to broaden coverage).
- New helper `generators/php/sdk/src/endpoint/utils/getAvailabilityDocs.ts` exposing `getAvailabilityDocs(endpoint)` (mirrors TS) and `getEndpointDocs(endpoint)` which combines existing `endpoint.docs` with the availability annotation (joined by a blank line so they render as separate PHPDoc paragraphs). Uses `assertNever` for exhaustiveness over `AvailabilityStatus`.
- Added a private `HttpEndpointGenerator#getEndpointDocs` that short-circuits to `endpoint.docs` when the flag is off, and calls the helper when it is on. Wired into all four `php.method({ ..., docs })` call sites in `HttpEndpointGenerator.ts` (paged signature, unpaged signature, unpaged body, paged body).
- Unit tests in `generators/php/sdk/src/__test__/getAvailabilityDocs.test.ts` covering each `AvailabilityStatus` variant with and without a `message`, plus the composition behavior of `getEndpointDocs`.
- Changelog entry: `generators/php/sdk/changes/unreleased/annotate-endpoint-availability.yml`.

## Updates since last revision

- Renamed the opt-in flag from `generateEndpointAvailability` → `generateAvailabilityAnnotations` at the schema, transform, call-site, and documentation level. Changelog rewritten to describe the flag by its new name and note the broader intended scope. Implementation scope is unchanged (still `HttpEndpoint` only).
- Earlier in this PR: gated all new annotation emission behind the flag and reverted the seed snapshot diffs under `seed/php-sdk/exhaustive/**` and `seed/php-sdk/imdb/**` — with the flag off, generator output is byte-for-byte identical to `main`.

## Testing

- [x] Unit tests added (`pnpm --filter @fern-api/php-sdk exec vitest run src/__test__/getAvailabilityDocs.test.ts` — 13/13 passing).
- [x] `pnpm run check` (biome) clean.
- [x] `pnpm --filter @fern-api/php-sdk compile` clean.
- [x] Seed regeneration for `exhaustive` and `imdb` fixtures with flag off produces **zero diff vs. `main`** (confirmed via `git diff --stat main -- seed/php-sdk/`).

## Reviewer notes / things to double-check

- **No fixture currently exercises `generateAvailabilityAnnotations: true`**, so the annotated output is only covered by unit tests — not a seed snapshot diff. If a snapshot of the on-path is desired, we can add a new fixture config pointing at the existing `exhaustive` or `imdb` IR (both already carry non-GA `availability`).
- PHP currently has a single `HttpEndpointGenerator` (no separate streaming / file-download implementations like TS), so gating inside it covers every endpoint-method emission site. Worth a sanity check that no other code path constructs a `php.method(...)` for endpoints.
- Verify the blank-line join (`\n\n`) in `getEndpointDocs` reads well in the generated PHPDoc when both `endpoint.docs` and an availability line are present.
- Flag name is deliberately broader than today's implementation scope. Confirm the name is acceptable for future expansion (service/type/property/enum/webhook availability) so we don't need a follow-up rename.

Link to Devin session: https://app.devin.ai/sessions/16deb991f10c47f5926f7c2eb456258c
Requested by: @Swimburger
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/15117" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
