### PR TITLE
fix(ci): use ruby-sdk-v2 workspace name in publish workflow

### DIFF
--- a/.github/actions/publish-generator/action.yaml
+++ b/.github/actions/publish-generator/action.yaml
@@ -121,7 +121,7 @@ runs:
             SNIPPET_PACKAGE="@fern-api/csharp-dynamic-snippets"
             SNIPPET_DIR="generators/csharp/dynamic-snippets"
             ;;
-          "ruby-sdk")
+          "ruby-sdk"|"ruby-sdk-v2")
             SNIPPET_PACKAGE="@fern-api/ruby-dynamic-snippets"
             SNIPPET_DIR="generators/ruby-v2/dynamic-snippets"
             ;;

--- a/.github/workflows/publish-generator-ruby-sdk.yml
+++ b/.github/workflows/publish-generator-ruby-sdk.yml
@@ -34,7 +34,7 @@ jobs:
         if: ${{ github.event_name == 'push' }}
         uses: ./.github/actions/publish-generator
         with:
-          generator-name: "ruby-sdk"
+          generator-name: "ruby-sdk-v2"
           version-file: "generators/ruby-v2/sdk/versions.yml"
           fern-token: ${{ secrets.FERN_TOKEN }}
           docker-pwd: ${{ secrets.FERN_API_DOCKERHUB_PASSWORD }}
@@ -42,7 +42,7 @@ jobs:
         if: ${{ github.event_name == 'workflow_dispatch' }}
         uses: ./.github/actions/publish-generator
         with:
-          generator-name: "ruby-sdk"
+          generator-name: "ruby-sdk-v2"
           version: ${{ inputs.version }}
           manual-trigger: "true"
           fern-token: ${{ secrets.FERN_TOKEN }}


### PR DESCRIPTION
## Description

Fixes the Ruby SDK publish workflow which has been failing on all recent runs with `Specified generator ruby-sdk not found.`

## Changes Made

- Updated `publish-generator-ruby-sdk.yml` to use `generator-name: "ruby-sdk-v2"` (matching the actual seed directory name `seed/ruby-sdk-v2/`)
- Added `"ruby-sdk-v2"` as an alias in the snippet package case statement in `publish-generator/action.yaml`

**Root cause:** The publish workflow was passing `generator-name: "ruby-sdk"` but the seed CLI looks up generators by directory name (`seed/ruby-sdk-v2/`). Since no `seed/ruby-sdk/` directory exists, the lookup failed. All other generators have matching names (e.g., `python-sdk` → `seed/python-sdk/`), but Ruby's seed directory was renamed to `ruby-sdk-v2` without updating the workflow.

## Testing

- Verified the seed directory is `seed/ruby-sdk-v2/` with a valid `seed.yml`
- Confirmed all other generators have matching workflow names and seed directory names
- The snippet package mapping now handles both `ruby-sdk` and `ruby-sdk-v2` for backward compatibility

Link to Devin session: https://app.devin.ai/sessions/bc5667ce727e47f09af0499186ff4a2b
Requested by: @iamnamananand996