### PR TITLE
chore(php): sync seed fixtures with phpunit ^12.5.22 (GHSA-qrr6-mg7r-m243)

### DIFF
--- a/seed/php-model/accept-header/.github/workflows/ci.yml
+++ b/seed/php-model/accept-header/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.1"
+          php-version: "8.3"
 
       - name: Install tools
         run: |
@@ -41,7 +41,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.1"
+          php-version: "8.3"
 
       - name: Install tools
         run: |

--- a/seed/php-model/accept-header/composer.json
+++ b/seed/php-model/accept-header/composer.json
@@ -20,7 +20,7 @@
     "php-http/multipart-stream-builder": "^1.0"
   },
   "require-dev": {
-    "phpunit/phpunit": "^9.0",
+    "phpunit/phpunit": "^12.5.22",
     "friendsofphp/php-cs-fixer": "3.5.0",
     "phpstan/phpstan": "^1.12",
     "guzzlehttp/guzzle": "^7.4"

--- a/seed/php-model/alias-extends/.github/workflows/ci.yml
+++ b/seed/php-model/alias-extends/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.1"
+          php-version: "8.3"
 
       - name: Install tools
         run: |
@@ -41,7 +41,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.1"
+          php-version: "8.3"
 
       - name: Install tools
         run: |

--- a/seed/php-model/alias-extends/composer.json
+++ b/seed/php-model/alias-extends/composer.json
@@ -20,7 +20,7 @@
     "php-http/multipart-stream-builder": "^1.0"
   },
   "require-dev": {
-    "phpunit/phpunit": "^9.0",
+    "phpunit/phpunit": "^12.5.22",
     "friendsofphp/php-cs-fixer": "3.5.0",
     "phpstan/phpstan": "^1.12",
     "guzzlehttp/guzzle": "^7.4"

--- a/seed/php-model/alias/.github/workflows/ci.yml
+++ b/seed/php-model/alias/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.1"
+          php-version: "8.3"
 
       - name: Install tools
         run: |
@@ -41,7 +41,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.1"
+          php-version: "8.3"
 
       - name: Install tools
         run: |

--- a/seed/php-model/alias/composer.json
+++ b/seed/php-model/alias/composer.json
@@ -20,7 +20,7 @@
     "php-http/multipart-stream-builder": "^1.0"
   },
   "require-dev": {
-    "phpunit/phpunit": "^9.0",
+    "phpunit/phpunit": "^12.5.22",
     "friendsofphp/php-cs-fixer": "3.5.0",
     "phpstan/phpstan": "^1.12",
     "guzzlehttp/guzzle": "^7.4"

--- a/seed/php-model/allof-inline/.github/workflows/ci.yml
+++ b/seed/php-model/allof-inline/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.1"
+          php-version: "8.3"
 
       - name: Install tools
         run: |
@@ -41,7 +41,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.1"
+          php-version: "8.3"
 
       - name: Install tools
         run: |

--- a/seed/php-model/allof-inline/composer.json
+++ b/seed/php-model/allof-inline/composer.json
@@ -20,7 +20,7 @@
     "php-http/multipart-stream-builder": "^1.0"
   },
   "require-dev": {
-    "phpunit/phpunit": "^9.0",
+    "phpunit/phpunit": "^12.5.22",
     "friendsofphp/php-cs-fixer": "3.5.0",
     "phpstan/phpstan": "^1.12",
     "guzzlehttp/guzzle": "^7.4"

--- a/seed/php-model/allof/.github/workflows/ci.yml
+++ b/seed/php-model/allof/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.1"
+          php-version: "8.3"
 
       - name: Install tools
         run: |
@@ -41,7 +41,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.1"
+          php-version: "8.3"
 
       - name: Install tools
         run: |

--- a/seed/php-model/allof/composer.json
+++ b/seed/php-model/allof/composer.json
@@ -20,7 +20,7 @@
     "php-http/multipart-stream-builder": "^1.0"
   },
   "require-dev": {
-    "phpunit/phpunit": "^9.0",
+    "phpunit/phpunit": "^12.5.22",
     "friendsofphp/php-cs-fixer": "3.5.0",
     "phpstan/phpstan": "^1.12",
     "guzzlehttp/guzzle": "^7.4"

--- a/seed/php-model/any-auth/.github/workflows/ci.yml
+++ b/seed/php-model/any-auth/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.1"
+          php-version: "8.3"
 
       - name: Install tools
         run: |
@@ -41,7 +41,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.1"
+          php-version: "8.3"
 
       - name: Install tools
         run: |

--- a/seed/php-model/any-auth/composer.json
+++ b/seed/php-model/any-auth/composer.json
@@ -20,7 +20,7 @@
     "php-http/multipart-stream-builder": "^1.0"
   },
   "require-dev": {
-    "phpunit/phpunit": "^9.0",
+    "phpunit/phpunit": "^12.5.22",
     "friendsofphp/php-cs-fixer": "3.5.0",
     "phpstan/phpstan": "^1.12",
     "guzzlehttp/guzzle": "^7.4"

--- a/seed/php-model/api-wide-base-path/.github/workflows/ci.yml
+++ b/seed/php-model/api-wide-base-path/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.1"
+          php-version: "8.3"
 
       - name: Install tools
         run: |
@@ -41,7 +41,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.1"
+          php-version: "8.3"
 
       - name: Install tools
         run: |

--- a/seed/php-model/api-wide-base-path/composer.json
+++ b/seed/php-model/api-wide-base-path/composer.json
@@ -20,7 +20,7 @@
     "php-http/multipart-stream-builder": "^1.0"
   },
   "require-dev": {
-    "phpunit/phpunit": "^9.0",
+    "phpunit/phpunit": "^12.5.22",
     "friendsofphp/php-cs-fixer": "3.5.0",
     "phpstan/phpstan": "^1.12",
     "guzzlehttp/guzzle": "^7.4"

--- a/seed/php-model/audiences/.github/workflows/ci.yml
+++ b/seed/php-model/audiences/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.1"
+          php-version: "8.3"
 
       - name: Install tools
         run: |
@@ -41,7 +41,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.1"
+          php-version: "8.3"
 
       - name: Install tools
         run: |

--- a/seed/php-model/audiences/composer.json
+++ b/seed/php-model/audiences/composer.json
@@ -20,7 +20,7 @@
     "php-http/multipart-stream-builder": "^1.0"
   },
   "require-dev": {
-    "phpunit/phpunit": "^9.0",
+    "phpunit/phpunit": "^12.5.22",
     "friendsofphp/php-cs-fixer": "3.5.0",
     "phpstan/phpstan": "^1.12",
     "guzzlehttp/guzzle": "^7.4"

--- a/seed/php-model/basic-auth-environment-variables/.github/workflows/ci.yml
+++ b/seed/php-model/basic-auth-environment-variables/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.1"
+          php-version: "8.3"
 
       - name: Install tools
         run: |
@@ -41,7 +41,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.1"
+          php-version: "8.3"
 
       - name: Install tools
         run: |

--- a/seed/php-model/basic-auth-environment-variables/composer.json
+++ b/seed/php-model/basic-auth-environment-variables/composer.json
@@ -20,7 +20,7 @@
     "php-http/multipart-stream-builder": "^1.0"
   },
   "require-dev": {
-    "phpunit/phpunit": "^9.0",
+    "phpunit/phpunit": "^12.5.22",
     "friendsofphp/php-cs-fixer": "3.5.0",
     "phpstan/phpstan": "^1.12",
     "guzzlehttp/guzzle": "^7.4"

--- a/seed/php-model/basic-auth-pw-omitted/.github/workflows/ci.yml
+++ b/seed/php-model/basic-auth-pw-omitted/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.1"
+          php-version: "8.3"
 
       - name: Install tools
         run: |
@@ -41,7 +41,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.1"
+          php-version: "8.3"
 
       - name: Install tools
         run: |

--- a/seed/php-model/basic-auth-pw-omitted/composer.json
+++ b/seed/php-model/basic-auth-pw-omitted/composer.json
@@ -20,7 +20,7 @@
     "php-http/multipart-stream-builder": "^1.0"
   },
   "require-dev": {
-    "phpunit/phpunit": "^9.0",
+    "phpunit/phpunit": "^12.5.22",
     "friendsofphp/php-cs-fixer": "3.5.0",
     "phpstan/phpstan": "^1.12",
     "guzzlehttp/guzzle": "^7.4"

--- a/seed/php-model/basic-auth/.github/workflows/ci.yml
+++ b/seed/php-model/basic-auth/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.1"
+          php-version: "8.3"
 
       - name: Install tools
         run: |
@@ -41,7 +41,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.1"
+          php-version: "8.3"
 
       - name: Install tools
         run: |

--- a/seed/php-model/basic-auth/composer.json
+++ b/seed/php-model/basic-auth/composer.json
@@ -20,7 +20,7 @@
     "php-http/multipart-stream-builder": "^1.0"
   },
   "require-dev": {
-    "phpunit/phpunit": "^9.0",
+    "phpunit/phpunit": "^12.5.22",
     "friendsofphp/php-cs-fixer": "3.5.0",
     "phpstan/phpstan": "^1.12",
     "guzzlehttp/guzzle": "^7.4"

--- a/seed/php-model/bearer-token-environment-variable/.github/workflows/ci.yml
+++ b/seed/php-model/bearer-token-environment-variable/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.1"
+          php-version: "8.3"
 
       - name: Install tools
         run: |
@@ -41,7 +41,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.1"
+          php-version: "8.3"
 
       - name: Install tools
         run: |

--- a/seed/php-model/bearer-token-environment-variable/composer.json
+++ b/seed/php-model/bearer-token-environment-variable/composer.json
@@ -20,7 +20,7 @@
     "php-http/multipart-stream-builder": "^1.0"
   },
   "require-dev": {
-    "phpunit/phpunit": "^9.0",
+    "phpunit/phpunit": "^12.5.22",
     "friendsofphp/php-cs-fixer": "3.5.0",
     "phpstan/phpstan": "^1.12",
     "guzzlehttp/guzzle": "^7.4"

--- a/seed/php-model/bytes-download/.github/workflows/ci.yml
+++ b/seed/php-model/bytes-download/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.1"
+          php-version: "8.3"
 
       - name: Install tools
         run: |
@@ -41,7 +41,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.1"
+          php-version: "8.3"
 
       - name: Install tools
         run: |

--- a/seed/php-model/bytes-download/composer.json
+++ b/seed/php-model/bytes-download/composer.json
@@ -20,7 +20,7 @@
     "php-http/multipart-stream-builder": "^1.0"
   },
   "require-dev": {
-    "phpunit/phpunit": "^9.0",
+    "phpunit/phpunit": "^12.5.22",
     "friendsofphp/php-cs-fixer": "3.5.0",
     "phpstan/phpstan": "^1.12",
     "guzzlehttp/guzzle": "^7.4"

--- a/seed/php-model/bytes-upload/.github/workflows/ci.yml
+++ b/seed/php-model/bytes-upload/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.1"
+          php-version: "8.3"
 
       - name: Install tools
         run: |
@@ -41,7 +41,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.1"
+          php-version: "8.3"
 
       - name: Install tools
         run: |

--- a/seed/php-model/bytes-upload/composer.json
+++ b/seed/php-model/bytes-upload/composer.json
@@ -20,7 +20,7 @@
     "php-http/multipart-stream-builder": "^1.0"
   },
   "require-dev": {
-    "phpunit/phpunit": "^9.0",
+    "phpunit/phpunit": "^12.5.22",
     "friendsofphp/php-cs-fixer": "3.5.0",
     "phpstan/phpstan": "^1.12",
     "guzzlehttp/guzzle": "^7.4"

--- a/seed/php-model/circular-references-advanced/.github/workflows/ci.yml
+++ b/seed/php-model/circular-references-advanced/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.1"
+          php-version: "8.3"
 
       - name: Install tools
         run: |
@@ -41,7 +41,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.1"
+          php-version: "8.3"
 
       - name: Install tools
         run: |

--- a/seed/php-model/circular-references-advanced/composer.json
+++ b/seed/php-model/circular-references-advanced/composer.json
@@ -20,7 +20,7 @@
     "php-http/multipart-stream-builder": "^1.0"
   },
   "require-dev": {
-    "phpunit/phpunit": "^9.0",
+    "phpunit/phpunit": "^12.5.22",
     "friendsofphp/php-cs-fixer": "3.5.0",
     "phpstan/phpstan": "^1.12",
     "guzzlehttp/guzzle": "^7.4"

--- a/seed/php-model/circular-references-extends/.github/workflows/ci.yml
+++ b/seed/php-model/circular-references-extends/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.1"
+          php-version: "8.3"
 
       - name: Install tools
         run: |
@@ -41,7 +41,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.1"
+          php-version: "8.3"
 
       - name: Install tools
         run: |

--- a/seed/php-model/circular-references-extends/composer.json
+++ b/seed/php-model/circular-references-extends/composer.json
@@ -20,7 +20,7 @@
     "php-http/multipart-stream-builder": "^1.0"
   },
   "require-dev": {
-    "phpunit/phpunit": "^9.0",
+    "phpunit/phpunit": "^12.5.22",
     "friendsofphp/php-cs-fixer": "3.5.0",
     "phpstan/phpstan": "^1.12",
     "guzzlehttp/guzzle": "^7.4"

--- a/seed/php-model/circular-references/.github/workflows/ci.yml
+++ b/seed/php-model/circular-references/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.1"
+          php-version: "8.3"
 
       - name: Install tools
         run: |
@@ -41,7 +41,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.1"
+          php-version: "8.3"
 
       - name: Install tools
         run: |

--- a/seed/php-model/circular-references/composer.json
+++ b/seed/php-model/circular-references/composer.json
@@ -20,7 +20,7 @@
     "php-http/multipart-stream-builder": "^1.0"
   },
   "require-dev": {
-    "phpunit/phpunit": "^9.0",
+    "phpunit/phpunit": "^12.5.22",
     "friendsofphp/php-cs-fixer": "3.5.0",
     "phpstan/phpstan": "^1.12",
     "guzzlehttp/guzzle": "^7.4"

--- a/seed/php-model/client-side-params/.github/workflows/ci.yml
+++ b/seed/php-model/client-side-params/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.1"
+          php-version: "8.3"
 
       - name: Install tools
         run: |
@@ -41,7 +41,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.1"
+          php-version: "8.3"
 
       - name: Install tools
         run: |

--- a/seed/php-model/client-side-params/composer.json
+++ b/seed/php-model/client-side-params/composer.json
@@ -20,7 +20,7 @@
     "php-http/multipart-stream-builder": "^1.0"
   },
   "require-dev": {
-    "phpunit/phpunit": "^9.0",
+    "phpunit/phpunit": "^12.5.22",
     "friendsofphp/php-cs-fixer": "3.5.0",
     "phpstan/phpstan": "^1.12",
     "guzzlehttp/guzzle": "^7.4"

--- a/seed/php-model/content-type/.github/workflows/ci.yml
+++ b/seed/php-model/content-type/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.1"
+          php-version: "8.3"
 
       - name: Install tools
         run: |
@@ -41,7 +41,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.1"
+          php-version: "8.3"
 
       - name: Install tools
         run: |

--- a/seed/php-model/content-type/composer.json
+++ b/seed/php-model/content-type/composer.json
@@ -20,7 +20,7 @@
     "php-http/multipart-stream-builder": "^1.0"
   },
   "require-dev": {
-    "phpunit/phpunit": "^9.0",
+    "phpunit/phpunit": "^12.5.22",
     "friendsofphp/php-cs-fixer": "3.5.0",
     "phpstan/phpstan": "^1.12",
     "guzzlehttp/guzzle": "^7.4"

--- a/seed/php-model/cross-package-type-names/.github/workflows/ci.yml
+++ b/seed/php-model/cross-package-type-names/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.1"
+          php-version: "8.3"
 
       - name: Install tools
         run: |
@@ -41,7 +41,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.1"
+          php-version: "8.3"
 
       - name: Install tools
         run: |

--- a/seed/php-model/cross-package-type-names/composer.json
+++ b/seed/php-model/cross-package-type-names/composer.json
@@ -20,7 +20,7 @@
     "php-http/multipart-stream-builder": "^1.0"
   },
   "require-dev": {
-    "phpunit/phpunit": "^9.0",
+    "phpunit/phpunit": "^12.5.22",
     "friendsofphp/php-cs-fixer": "3.5.0",
     "phpstan/phpstan": "^1.12",
     "guzzlehttp/guzzle": "^7.4"

--- a/seed/php-model/dollar-string-examples/.github/workflows/ci.yml
+++ b/seed/php-model/dollar-string-examples/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.1"
+          php-version: "8.3"
 
       - name: Install tools
         run: |
@@ -41,7 +41,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.1"
+          php-version: "8.3"
 
       - name: Install tools
         run: |

--- a/seed/php-model/dollar-string-examples/composer.json
+++ b/seed/php-model/dollar-string-examples/composer.json
@@ -20,7 +20,7 @@
     "php-http/multipart-stream-builder": "^1.0"
   },
   "require-dev": {
-    "phpunit/phpunit": "^9.0",
+    "phpunit/phpunit": "^12.5.22",
     "friendsofphp/php-cs-fixer": "3.5.0",
     "phpstan/phpstan": "^1.12",
     "guzzlehttp/guzzle": "^7.4"

--- a/seed/php-model/empty-clients/.github/workflows/ci.yml
+++ b/seed/php-model/empty-clients/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.1"
+          php-version: "8.3"
 
       - name: Install tools
         run: |
@@ -41,7 +41,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.1"
+          php-version: "8.3"
 
       - name: Install tools
         run: |

--- a/seed/php-model/empty-clients/composer.json
+++ b/seed/php-model/empty-clients/composer.json
@@ -20,7 +20,7 @@
     "php-http/multipart-stream-builder": "^1.0"
   },
   "require-dev": {
-    "phpunit/phpunit": "^9.0",
+    "phpunit/phpunit": "^12.5.22",
     "friendsofphp/php-cs-fixer": "3.5.0",
     "phpstan/phpstan": "^1.12",
     "guzzlehttp/guzzle": "^7.4"

--- a/seed/php-model/endpoint-security-auth/.github/workflows/ci.yml
+++ b/seed/php-model/endpoint-security-auth/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.1"
+          php-version: "8.3"
 
       - name: Install tools
         run: |
@@ -41,7 +41,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.1"
+          php-version: "8.3"
 
       - name: Install tools
         run: |

--- a/seed/php-model/endpoint-security-auth/composer.json
+++ b/seed/php-model/endpoint-security-auth/composer.json
@@ -20,7 +20,7 @@
     "php-http/multipart-stream-builder": "^1.0"
   },
   "require-dev": {
-    "phpunit/phpunit": "^9.0",
+    "phpunit/phpunit": "^12.5.22",
     "friendsofphp/php-cs-fixer": "3.5.0",
     "phpstan/phpstan": "^1.12",
     "guzzlehttp/guzzle": "^7.4"

--- a/seed/php-model/enum/.github/workflows/ci.yml
+++ b/seed/php-model/enum/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.1"
+          php-version: "8.3"
 
       - name: Install tools
         run: |
@@ -41,7 +41,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.1"
+          php-version: "8.3"
 
       - name: Install tools
         run: |

--- a/seed/php-model/enum/composer.json
+++ b/seed/php-model/enum/composer.json
@@ -20,7 +20,7 @@
     "php-http/multipart-stream-builder": "^1.0"
   },
   "require-dev": {
-    "phpunit/phpunit": "^9.0",
+    "phpunit/phpunit": "^12.5.22",
     "friendsofphp/php-cs-fixer": "3.5.0",
     "phpstan/phpstan": "^1.12",
     "guzzlehttp/guzzle": "^7.4"

--- a/seed/php-model/error-property/.github/workflows/ci.yml
+++ b/seed/php-model/error-property/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.1"
+          php-version: "8.3"
 
       - name: Install tools
         run: |
@@ -41,7 +41,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.1"
+          php-version: "8.3"
 
       - name: Install tools
         run: |

--- a/seed/php-model/error-property/composer.json
+++ b/seed/php-model/error-property/composer.json
@@ -20,7 +20,7 @@
     "php-http/multipart-stream-builder": "^1.0"
   },
   "require-dev": {
-    "phpunit/phpunit": "^9.0",
+    "phpunit/phpunit": "^12.5.22",
     "friendsofphp/php-cs-fixer": "3.5.0",
     "phpstan/phpstan": "^1.12",
     "guzzlehttp/guzzle": "^7.4"

--- a/seed/php-model/errors/.github/workflows/ci.yml
+++ b/seed/php-model/errors/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.1"
+          php-version: "8.3"
 
       - name: Install tools
         run: |
@@ -41,7 +41,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.1"
+          php-version: "8.3"
 
       - name: Install tools
         run: |

--- a/seed/php-model/errors/composer.json
+++ b/seed/php-model/errors/composer.json
@@ -20,7 +20,7 @@
     "php-http/multipart-stream-builder": "^1.0"
   },
   "require-dev": {
-    "phpunit/phpunit": "^9.0",
+    "phpunit/phpunit": "^12.5.22",
     "friendsofphp/php-cs-fixer": "3.5.0",
     "phpstan/phpstan": "^1.12",
     "guzzlehttp/guzzle": "^7.4"

--- a/seed/php-model/examples/.github/workflows/ci.yml
+++ b/seed/php-model/examples/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.1"
+          php-version: "8.3"
 
       - name: Install tools
         run: |
@@ -41,7 +41,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.1"
+          php-version: "8.3"
 
       - name: Install tools
         run: |

--- a/seed/php-model/examples/composer.json
+++ b/seed/php-model/examples/composer.json
@@ -20,7 +20,7 @@
     "php-http/multipart-stream-builder": "^1.0"
   },
   "require-dev": {
-    "phpunit/phpunit": "^9.0",
+    "phpunit/phpunit": "^12.5.22",
     "friendsofphp/php-cs-fixer": "3.5.0",
     "phpstan/phpstan": "^1.12",
     "guzzlehttp/guzzle": "^7.4"

--- a/seed/php-model/exhaustive/.github/workflows/ci.yml
+++ b/seed/php-model/exhaustive/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.1"
+          php-version: "8.3"
 
       - name: Install tools
         run: |
@@ -41,7 +41,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.1"
+          php-version: "8.3"
 
       - name: Install tools
         run: |

--- a/seed/php-model/exhaustive/composer.json
+++ b/seed/php-model/exhaustive/composer.json
@@ -20,7 +20,7 @@
     "php-http/multipart-stream-builder": "^1.0"
   },
   "require-dev": {
-    "phpunit/phpunit": "^9.0",
+    "phpunit/phpunit": "^12.5.22",
     "friendsofphp/php-cs-fixer": "3.5.0",
     "phpstan/phpstan": "^1.12",
     "guzzlehttp/guzzle": "^7.4"

--- a/seed/php-model/extends/.github/workflows/ci.yml
+++ b/seed/php-model/extends/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.1"
+          php-version: "8.3"
 
       - name: Install tools
         run: |
@@ -41,7 +41,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.1"
+          php-version: "8.3"
 
       - name: Install tools
         run: |

--- a/seed/php-model/extends/composer.json
+++ b/seed/php-model/extends/composer.json
@@ -20,7 +20,7 @@
     "php-http/multipart-stream-builder": "^1.0"
   },
   "require-dev": {
-    "phpunit/phpunit": "^9.0",
+    "phpunit/phpunit": "^12.5.22",
     "friendsofphp/php-cs-fixer": "3.5.0",
     "phpstan/phpstan": "^1.12",
     "guzzlehttp/guzzle": "^7.4"

--- a/seed/php-model/extra-properties/.github/workflows/ci.yml
+++ b/seed/php-model/extra-properties/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.1"
+          php-version: "8.3"
 
       - name: Install tools
         run: |
@@ -41,7 +41,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.1"
+          php-version: "8.3"
 
       - name: Install tools
         run: |

--- a/seed/php-model/extra-properties/composer.json
+++ b/seed/php-model/extra-properties/composer.json
@@ -20,7 +20,7 @@
     "php-http/multipart-stream-builder": "^1.0"
   },
   "require-dev": {
-    "phpunit/phpunit": "^9.0",
+    "phpunit/phpunit": "^12.5.22",
     "friendsofphp/php-cs-fixer": "3.5.0",
     "phpstan/phpstan": "^1.12",
     "guzzlehttp/guzzle": "^7.4"

--- a/seed/php-model/file-download/.github/workflows/ci.yml
+++ b/seed/php-model/file-download/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.1"
+          php-version: "8.3"
 
       - name: Install tools
         run: |
@@ -41,7 +41,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.1"
+          php-version: "8.3"
 
       - name: Install tools
         run: |

--- a/seed/php-model/file-download/composer.json
+++ b/seed/php-model/file-download/composer.json
@@ -20,7 +20,7 @@
     "php-http/multipart-stream-builder": "^1.0"
   },
   "require-dev": {
-    "phpunit/phpunit": "^9.0",
+    "phpunit/phpunit": "^12.5.22",
     "friendsofphp/php-cs-fixer": "3.5.0",
     "phpstan/phpstan": "^1.12",
     "guzzlehttp/guzzle": "^7.4"

--- a/seed/php-model/file-upload-openapi/.github/workflows/ci.yml
+++ b/seed/php-model/file-upload-openapi/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.1"
+          php-version: "8.3"
 
       - name: Install tools
         run: |
@@ -41,7 +41,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.1"
+          php-version: "8.3"
 
       - name: Install tools
         run: |

--- a/seed/php-model/file-upload-openapi/composer.json
+++ b/seed/php-model/file-upload-openapi/composer.json
@@ -20,7 +20,7 @@
     "php-http/multipart-stream-builder": "^1.0"
   },
   "require-dev": {
-    "phpunit/phpunit": "^9.0",
+    "phpunit/phpunit": "^12.5.22",
     "friendsofphp/php-cs-fixer": "3.5.0",
     "phpstan/phpstan": "^1.12",
     "guzzlehttp/guzzle": "^7.4"

--- a/seed/php-model/file-upload/.github/workflows/ci.yml
+++ b/seed/php-model/file-upload/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.1"
+          php-version: "8.3"
 
       - name: Install tools
         run: |
@@ -41,7 +41,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.1"
+          php-version: "8.3"
 
       - name: Install tools
         run: |

--- a/seed/php-model/file-upload/composer.json
+++ b/seed/php-model/file-upload/composer.json
@@ -20,7 +20,7 @@
     "php-http/multipart-stream-builder": "^1.0"
   },
   "require-dev": {
-    "phpunit/phpunit": "^9.0",
+    "phpunit/phpunit": "^12.5.22",
     "friendsofphp/php-cs-fixer": "3.5.0",
     "phpstan/phpstan": "^1.12",
     "guzzlehttp/guzzle": "^7.4"

--- a/seed/php-model/folders/.github/workflows/ci.yml
+++ b/seed/php-model/folders/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.1"
+          php-version: "8.3"
 
       - name: Install tools
         run: |
@@ -41,7 +41,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.1"
+          php-version: "8.3"
 
       - name: Install tools
         run: |

--- a/seed/php-model/folders/composer.json
+++ b/seed/php-model/folders/composer.json
@@ -20,7 +20,7 @@
     "php-http/multipart-stream-builder": "^1.0"
   },
   "require-dev": {
-    "phpunit/phpunit": "^9.0",
+    "phpunit/phpunit": "^12.5.22",
     "friendsofphp/php-cs-fixer": "3.5.0",
     "phpstan/phpstan": "^1.12",
     "guzzlehttp/guzzle": "^7.4"

--- a/seed/php-model/header-auth-environment-variable/.github/workflows/ci.yml
+++ b/seed/php-model/header-auth-environment-variable/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.1"
+          php-version: "8.3"
 
       - name: Install tools
         run: |
@@ -41,7 +41,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.1"
+          php-version: "8.3"
 
       - name: Install tools
         run: |

--- a/seed/php-model/header-auth-environment-variable/composer.json
+++ b/seed/php-model/header-auth-environment-variable/composer.json
@@ -20,7 +20,7 @@
     "php-http/multipart-stream-builder": "^1.0"
   },
   "require-dev": {
-    "phpunit/phpunit": "^9.0",
+    "phpunit/phpunit": "^12.5.22",
     "friendsofphp/php-cs-fixer": "3.5.0",
     "phpstan/phpstan": "^1.12",
     "guzzlehttp/guzzle": "^7.4"

--- a/seed/php-model/header-auth/.github/workflows/ci.yml
+++ b/seed/php-model/header-auth/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.1"
+          php-version: "8.3"
 
       - name: Install tools
         run: |
@@ -41,7 +41,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.1"
+          php-version: "8.3"
 
       - name: Install tools
         run: |

--- a/seed/php-model/header-auth/composer.json
+++ b/seed/php-model/header-auth/composer.json
@@ -20,7 +20,7 @@
     "php-http/multipart-stream-builder": "^1.0"
   },
   "require-dev": {
-    "phpunit/phpunit": "^9.0",
+    "phpunit/phpunit": "^12.5.22",
     "friendsofphp/php-cs-fixer": "3.5.0",
     "phpstan/phpstan": "^1.12",
     "guzzlehttp/guzzle": "^7.4"

--- a/seed/php-model/http-head/.github/workflows/ci.yml
+++ b/seed/php-model/http-head/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.1"
+          php-version: "8.3"
 
       - name: Install tools
         run: |
@@ -41,7 +41,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.1"
+          php-version: "8.3"
 
       - name: Install tools
         run: |

--- a/seed/php-model/http-head/composer.json
+++ b/seed/php-model/http-head/composer.json
@@ -20,7 +20,7 @@
     "php-http/multipart-stream-builder": "^1.0"
   },
   "require-dev": {
-    "phpunit/phpunit": "^9.0",
+    "phpunit/phpunit": "^12.5.22",
     "friendsofphp/php-cs-fixer": "3.5.0",
     "phpstan/phpstan": "^1.12",
     "guzzlehttp/guzzle": "^7.4"

--- a/seed/php-model/idempotency-headers/.github/workflows/ci.yml
+++ b/seed/php-model/idempotency-headers/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.1"
+          php-version: "8.3"
 
       - name: Install tools
         run: |
@@ -41,7 +41,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.1"
+          php-version: "8.3"
 
       - name: Install tools
         run: |

--- a/seed/php-model/idempotency-headers/composer.json
+++ b/seed/php-model/idempotency-headers/composer.json
@@ -20,7 +20,7 @@
     "php-http/multipart-stream-builder": "^1.0"
   },
   "require-dev": {
-    "phpunit/phpunit": "^9.0",
+    "phpunit/phpunit": "^12.5.22",
     "friendsofphp/php-cs-fixer": "3.5.0",
     "phpstan/phpstan": "^1.12",
     "guzzlehttp/guzzle": "^7.4"

--- a/seed/php-model/imdb/.github/workflows/ci.yml
+++ b/seed/php-model/imdb/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.1"
+          php-version: "8.3"
 
       - name: Install tools
         run: |
@@ -41,7 +41,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.1"
+          php-version: "8.3"
 
       - name: Install tools
         run: |

--- a/seed/php-model/imdb/composer.json
+++ b/seed/php-model/imdb/composer.json
@@ -20,7 +20,7 @@
     "php-http/multipart-stream-builder": "^1.0"
   },
   "require-dev": {
-    "phpunit/phpunit": "^9.0",
+    "phpunit/phpunit": "^12.5.22",
     "friendsofphp/php-cs-fixer": "3.5.0",
     "phpstan/phpstan": "^1.12",
     "guzzlehttp/guzzle": "^7.4"

--- a/seed/php-model/inferred-auth-explicit/.github/workflows/ci.yml
+++ b/seed/php-model/inferred-auth-explicit/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.1"
+          php-version: "8.3"
 
       - name: Install tools
         run: |
@@ -41,7 +41,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.1"
+          php-version: "8.3"
 
       - name: Install tools
         run: |

--- a/seed/php-model/inferred-auth-explicit/composer.json
+++ b/seed/php-model/inferred-auth-explicit/composer.json
@@ -20,7 +20,7 @@
     "php-http/multipart-stream-builder": "^1.0"
   },
   "require-dev": {
-    "phpunit/phpunit": "^9.0",
+    "phpunit/phpunit": "^12.5.22",
     "friendsofphp/php-cs-fixer": "3.5.0",
     "phpstan/phpstan": "^1.12",
     "guzzlehttp/guzzle": "^7.4"

--- a/seed/php-model/inferred-auth-implicit-api-key/.github/workflows/ci.yml
+++ b/seed/php-model/inferred-auth-implicit-api-key/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.1"
+          php-version: "8.3"
 
       - name: Install tools
         run: |
@@ -41,7 +41,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.1"
+          php-version: "8.3"
 
       - name: Install tools
         run: |

--- a/seed/php-model/inferred-auth-implicit-api-key/composer.json
+++ b/seed/php-model/inferred-auth-implicit-api-key/composer.json
@@ -20,7 +20,7 @@
     "php-http/multipart-stream-builder": "^1.0"
   },
   "require-dev": {
-    "phpunit/phpunit": "^9.0",
+    "phpunit/phpunit": "^12.5.22",
     "friendsofphp/php-cs-fixer": "3.5.0",
     "phpstan/phpstan": "^1.12",
     "guzzlehttp/guzzle": "^7.4"

--- a/seed/php-model/inferred-auth-implicit-no-expiry/.github/workflows/ci.yml
+++ b/seed/php-model/inferred-auth-implicit-no-expiry/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.1"
+          php-version: "8.3"
 
       - name: Install tools
         run: |
@@ -41,7 +41,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.1"
+          php-version: "8.3"
 
       - name: Install tools
         run: |

--- a/seed/php-model/inferred-auth-implicit-no-expiry/composer.json
+++ b/seed/php-model/inferred-auth-implicit-no-expiry/composer.json
@@ -20,7 +20,7 @@
     "php-http/multipart-stream-builder": "^1.0"
   },
   "require-dev": {
-    "phpunit/phpunit": "^9.0",
+    "phpunit/phpunit": "^12.5.22",
     "friendsofphp/php-cs-fixer": "3.5.0",
     "phpstan/phpstan": "^1.12",
     "guzzlehttp/guzzle": "^7.4"

--- a/seed/php-model/inferred-auth-implicit-reference/.github/workflows/ci.yml
+++ b/seed/php-model/inferred-auth-implicit-reference/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.1"
+          php-version: "8.3"
 
       - name: Install tools
         run: |
@@ -41,7 +41,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.1"
+          php-version: "8.3"
 
       - name: Install tools
         run: |

--- a/seed/php-model/inferred-auth-implicit-reference/composer.json
+++ b/seed/php-model/inferred-auth-implicit-reference/composer.json
@@ -20,7 +20,7 @@
     "php-http/multipart-stream-builder": "^1.0"
   },
   "require-dev": {
-    "phpunit/phpunit": "^9.0",
+    "phpunit/phpunit": "^12.5.22",
     "friendsofphp/php-cs-fixer": "3.5.0",
     "phpstan/phpstan": "^1.12",
     "guzzlehttp/guzzle": "^7.4"

--- a/seed/php-model/inferred-auth-implicit/.github/workflows/ci.yml
+++ b/seed/php-model/inferred-auth-implicit/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.1"
+          php-version: "8.3"
 
       - name: Install tools
         run: |
@@ -41,7 +41,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.1"
+          php-version: "8.3"
 
       - name: Install tools
         run: |

--- a/seed/php-model/inferred-auth-implicit/composer.json
+++ b/seed/php-model/inferred-auth-implicit/composer.json
@@ -20,7 +20,7 @@
     "php-http/multipart-stream-builder": "^1.0"
   },
   "require-dev": {
-    "phpunit/phpunit": "^9.0",
+    "phpunit/phpunit": "^12.5.22",
     "friendsofphp/php-cs-fixer": "3.5.0",
     "phpstan/phpstan": "^1.12",
     "guzzlehttp/guzzle": "^7.4"

--- a/seed/php-model/license/.github/workflows/ci.yml
+++ b/seed/php-model/license/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.1"
+          php-version: "8.3"
 
       - name: Install tools
         run: |
@@ -41,7 +41,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.1"
+          php-version: "8.3"
 
       - name: Install tools
         run: |

--- a/seed/php-model/license/composer.json
+++ b/seed/php-model/license/composer.json
@@ -20,7 +20,7 @@
     "php-http/multipart-stream-builder": "^1.0"
   },
   "require-dev": {
-    "phpunit/phpunit": "^9.0",
+    "phpunit/phpunit": "^12.5.22",
     "friendsofphp/php-cs-fixer": "3.5.0",
     "phpstan/phpstan": "^1.12",
     "guzzlehttp/guzzle": "^7.4"

--- a/seed/php-model/literal/.github/workflows/ci.yml
+++ b/seed/php-model/literal/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.1"
+          php-version: "8.3"
 
       - name: Install tools
         run: |
@@ -41,7 +41,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.1"
+          php-version: "8.3"
 
       - name: Install tools
         run: |

--- a/seed/php-model/literal/composer.json
+++ b/seed/php-model/literal/composer.json
@@ -20,7 +20,7 @@
     "php-http/multipart-stream-builder": "^1.0"
   },
   "require-dev": {
-    "phpunit/phpunit": "^9.0",
+    "phpunit/phpunit": "^12.5.22",
     "friendsofphp/php-cs-fixer": "3.5.0",
     "phpstan/phpstan": "^1.12",
     "guzzlehttp/guzzle": "^7.4"

--- a/seed/php-model/literals-unions/.github/workflows/ci.yml
+++ b/seed/php-model/literals-unions/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.1"
+          php-version: "8.3"
 
       - name: Install tools
         run: |
@@ -41,7 +41,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.1"
+          php-version: "8.3"
 
       - name: Install tools
         run: |

--- a/seed/php-model/literals-unions/composer.json
+++ b/seed/php-model/literals-unions/composer.json
@@ -20,7 +20,7 @@
     "php-http/multipart-stream-builder": "^1.0"
   },
   "require-dev": {
-    "phpunit/phpunit": "^9.0",
+    "phpunit/phpunit": "^12.5.22",
     "friendsofphp/php-cs-fixer": "3.5.0",
     "phpstan/phpstan": "^1.12",
     "guzzlehttp/guzzle": "^7.4"

--- a/seed/php-model/mixed-case/.github/workflows/ci.yml
+++ b/seed/php-model/mixed-case/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.1"
+          php-version: "8.3"
 
       - name: Install tools
         run: |
@@ -41,7 +41,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.1"
+          php-version: "8.3"
 
       - name: Install tools
         run: |

--- a/seed/php-model/mixed-case/composer.json
+++ b/seed/php-model/mixed-case/composer.json
@@ -20,7 +20,7 @@
     "php-http/multipart-stream-builder": "^1.0"
   },
   "require-dev": {
-    "phpunit/phpunit": "^9.0",
+    "phpunit/phpunit": "^12.5.22",
     "friendsofphp/php-cs-fixer": "3.5.0",
     "phpstan/phpstan": "^1.12",
     "guzzlehttp/guzzle": "^7.4"

--- a/seed/php-model/mixed-file-directory/.github/workflows/ci.yml
+++ b/seed/php-model/mixed-file-directory/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.1"
+          php-version: "8.3"
 
       - name: Install tools
         run: |
@@ -41,7 +41,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.1"
+          php-version: "8.3"
 
       - name: Install tools
         run: |

--- a/seed/php-model/mixed-file-directory/composer.json
+++ b/seed/php-model/mixed-file-directory/composer.json
@@ -20,7 +20,7 @@
     "php-http/multipart-stream-builder": "^1.0"
   },
   "require-dev": {
-    "phpunit/phpunit": "^9.0",
+    "phpunit/phpunit": "^12.5.22",
     "friendsofphp/php-cs-fixer": "3.5.0",
     "phpstan/phpstan": "^1.12",
     "guzzlehttp/guzzle": "^7.4"

--- a/seed/php-model/multi-line-docs/.github/workflows/ci.yml
+++ b/seed/php-model/multi-line-docs/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.1"
+          php-version: "8.3"
 
       - name: Install tools
         run: |
@@ -41,7 +41,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.1"
+          php-version: "8.3"
 
       - name: Install tools
         run: |

--- a/seed/php-model/multi-line-docs/composer.json
+++ b/seed/php-model/multi-line-docs/composer.json
@@ -20,7 +20,7 @@
     "php-http/multipart-stream-builder": "^1.0"
   },
   "require-dev": {
-    "phpunit/phpunit": "^9.0",
+    "phpunit/phpunit": "^12.5.22",
     "friendsofphp/php-cs-fixer": "3.5.0",
     "phpstan/phpstan": "^1.12",
     "guzzlehttp/guzzle": "^7.4"

--- a/seed/php-model/multi-url-environment-no-default/.github/workflows/ci.yml
+++ b/seed/php-model/multi-url-environment-no-default/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.1"
+          php-version: "8.3"
 
       - name: Install tools
         run: |
@@ -41,7 +41,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.1"
+          php-version: "8.3"
 
       - name: Install tools
         run: |

--- a/seed/php-model/multi-url-environment-no-default/composer.json
+++ b/seed/php-model/multi-url-environment-no-default/composer.json
@@ -20,7 +20,7 @@
     "php-http/multipart-stream-builder": "^1.0"
   },
   "require-dev": {
-    "phpunit/phpunit": "^9.0",
+    "phpunit/phpunit": "^12.5.22",
     "friendsofphp/php-cs-fixer": "3.5.0",
     "phpstan/phpstan": "^1.12",
     "guzzlehttp/guzzle": "^7.4"

--- a/seed/php-model/multi-url-environment-reference/.github/workflows/ci.yml
+++ b/seed/php-model/multi-url-environment-reference/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.1"
+          php-version: "8.3"
 
       - name: Install tools
         run: |
@@ -41,7 +41,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.1"
+          php-version: "8.3"
 
       - name: Install tools
         run: |

--- a/seed/php-model/multi-url-environment-reference/composer.json
+++ b/seed/php-model/multi-url-environment-reference/composer.json
@@ -20,7 +20,7 @@
     "php-http/multipart-stream-builder": "^1.0"
   },
   "require-dev": {
-    "phpunit/phpunit": "^9.0",
+    "phpunit/phpunit": "^12.5.22",
     "friendsofphp/php-cs-fixer": "3.5.0",
     "phpstan/phpstan": "^1.12",
     "guzzlehttp/guzzle": "^7.4"

--- a/seed/php-model/multi-url-environment/.github/workflows/ci.yml
+++ b/seed/php-model/multi-url-environment/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.1"
+          php-version: "8.3"
 
       - name: Install tools
         run: |
@@ -41,7 +41,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.1"
+          php-version: "8.3"
 
       - name: Install tools
         run: |

--- a/seed/php-model/multi-url-environment/composer.json
+++ b/seed/php-model/multi-url-environment/composer.json
@@ -20,7 +20,7 @@
     "php-http/multipart-stream-builder": "^1.0"
   },
   "require-dev": {
-    "phpunit/phpunit": "^9.0",
+    "phpunit/phpunit": "^12.5.22",
     "friendsofphp/php-cs-fixer": "3.5.0",
     "phpstan/phpstan": "^1.12",
     "guzzlehttp/guzzle": "^7.4"

--- a/seed/php-model/multiple-request-bodies/.github/workflows/ci.yml
+++ b/seed/php-model/multiple-request-bodies/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.1"
+          php-version: "8.3"
 
       - name: Install tools
         run: |
@@ -41,7 +41,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.1"
+          php-version: "8.3"
 
       - name: Install tools
         run: |

--- a/seed/php-model/multiple-request-bodies/composer.json
+++ b/seed/php-model/multiple-request-bodies/composer.json
@@ -20,7 +20,7 @@
     "php-http/multipart-stream-builder": "^1.0"
   },
   "require-dev": {
-    "phpunit/phpunit": "^9.0",
+    "phpunit/phpunit": "^12.5.22",
     "friendsofphp/php-cs-fixer": "3.5.0",
     "phpstan/phpstan": "^1.12",
     "guzzlehttp/guzzle": "^7.4"

--- a/seed/php-model/no-content-response/.github/workflows/ci.yml
+++ b/seed/php-model/no-content-response/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.1"
+          php-version: "8.3"
 
       - name: Install tools
         run: |
@@ -41,7 +41,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.1"
+          php-version: "8.3"
 
       - name: Install tools
         run: |

--- a/seed/php-model/no-content-response/composer.json
+++ b/seed/php-model/no-content-response/composer.json
@@ -20,7 +20,7 @@
     "php-http/multipart-stream-builder": "^1.0"
   },
   "require-dev": {
-    "phpunit/phpunit": "^9.0",
+    "phpunit/phpunit": "^12.5.22",
     "friendsofphp/php-cs-fixer": "3.5.0",
     "phpstan/phpstan": "^1.12",
     "guzzlehttp/guzzle": "^7.4"

--- a/seed/php-model/no-environment/.github/workflows/ci.yml
+++ b/seed/php-model/no-environment/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.1"
+          php-version: "8.3"
 
       - name: Install tools
         run: |
@@ -41,7 +41,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.1"
+          php-version: "8.3"
 
       - name: Install tools
         run: |

--- a/seed/php-model/no-environment/composer.json
+++ b/seed/php-model/no-environment/composer.json
@@ -20,7 +20,7 @@
     "php-http/multipart-stream-builder": "^1.0"
   },
   "require-dev": {
-    "phpunit/phpunit": "^9.0",
+    "phpunit/phpunit": "^12.5.22",
     "friendsofphp/php-cs-fixer": "3.5.0",
     "phpstan/phpstan": "^1.12",
     "guzzlehttp/guzzle": "^7.4"

--- a/seed/php-model/no-retries/.github/workflows/ci.yml
+++ b/seed/php-model/no-retries/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.1"
+          php-version: "8.3"
 
       - name: Install tools
         run: |
@@ -41,7 +41,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.1"
+          php-version: "8.3"
 
       - name: Install tools
         run: |

--- a/seed/php-model/no-retries/composer.json
+++ b/seed/php-model/no-retries/composer.json
@@ -20,7 +20,7 @@
     "php-http/multipart-stream-builder": "^1.0"
   },
   "require-dev": {
-    "phpunit/phpunit": "^9.0",
+    "phpunit/phpunit": "^12.5.22",
     "friendsofphp/php-cs-fixer": "3.5.0",
     "phpstan/phpstan": "^1.12",
     "guzzlehttp/guzzle": "^7.4"

--- a/seed/php-model/null-type/.github/workflows/ci.yml
+++ b/seed/php-model/null-type/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.1"
+          php-version: "8.3"
 
       - name: Install tools
         run: |
@@ -41,7 +41,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.1"
+          php-version: "8.3"
 
       - name: Install tools
         run: |

--- a/seed/php-model/null-type/composer.json
+++ b/seed/php-model/null-type/composer.json
@@ -20,7 +20,7 @@
     "php-http/multipart-stream-builder": "^1.0"
   },
   "require-dev": {
-    "phpunit/phpunit": "^9.0",
+    "phpunit/phpunit": "^12.5.22",
     "friendsofphp/php-cs-fixer": "3.5.0",
     "phpstan/phpstan": "^1.12",
     "guzzlehttp/guzzle": "^7.4"

--- a/seed/php-model/nullable-allof-extends/.github/workflows/ci.yml
+++ b/seed/php-model/nullable-allof-extends/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.1"
+          php-version: "8.3"
 
       - name: Install tools
         run: |
@@ -41,7 +41,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.1"
+          php-version: "8.3"
 
       - name: Install tools
         run: |

--- a/seed/php-model/nullable-allof-extends/composer.json
+++ b/seed/php-model/nullable-allof-extends/composer.json
@@ -20,7 +20,7 @@
     "php-http/multipart-stream-builder": "^1.0"
   },
   "require-dev": {
-    "phpunit/phpunit": "^9.0",
+    "phpunit/phpunit": "^12.5.22",
     "friendsofphp/php-cs-fixer": "3.5.0",
     "phpstan/phpstan": "^1.12",
     "guzzlehttp/guzzle": "^7.4"

--- a/seed/php-model/nullable-optional/.github/workflows/ci.yml
+++ b/seed/php-model/nullable-optional/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.1"
+          php-version: "8.3"
 
       - name: Install tools
         run: |
@@ -41,7 +41,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.1"
+          php-version: "8.3"
 
       - name: Install tools
         run: |

--- a/seed/php-model/nullable-optional/composer.json
+++ b/seed/php-model/nullable-optional/composer.json
@@ -20,7 +20,7 @@
     "php-http/multipart-stream-builder": "^1.0"
   },
   "require-dev": {
-    "phpunit/phpunit": "^9.0",
+    "phpunit/phpunit": "^12.5.22",
     "friendsofphp/php-cs-fixer": "3.5.0",
     "phpstan/phpstan": "^1.12",
     "guzzlehttp/guzzle": "^7.4"

--- a/seed/php-model/nullable-request-body/.github/workflows/ci.yml
+++ b/seed/php-model/nullable-request-body/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.1"
+          php-version: "8.3"
 
       - name: Install tools
         run: |
@@ -41,7 +41,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.1"
+          php-version: "8.3"
 
       - name: Install tools
         run: |

--- a/seed/php-model/nullable-request-body/composer.json
+++ b/seed/php-model/nullable-request-body/composer.json
@@ -20,7 +20,7 @@
     "php-http/multipart-stream-builder": "^1.0"
   },
   "require-dev": {
-    "phpunit/phpunit": "^9.0",
+    "phpunit/phpunit": "^12.5.22",
     "friendsofphp/php-cs-fixer": "3.5.0",
     "phpstan/phpstan": "^1.12",
     "guzzlehttp/guzzle": "^7.4"

--- a/seed/php-model/nullable/.github/workflows/ci.yml
+++ b/seed/php-model/nullable/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.1"
+          php-version: "8.3"
 
       - name: Install tools
         run: |
@@ -41,7 +41,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.1"
+          php-version: "8.3"
 
       - name: Install tools
         run: |

--- a/seed/php-model/nullable/composer.json
+++ b/seed/php-model/nullable/composer.json
@@ -20,7 +20,7 @@
     "php-http/multipart-stream-builder": "^1.0"
   },
   "require-dev": {
-    "phpunit/phpunit": "^9.0",
+    "phpunit/phpunit": "^12.5.22",
     "friendsofphp/php-cs-fixer": "3.5.0",
     "phpstan/phpstan": "^1.12",
     "guzzlehttp/guzzle": "^7.4"

--- a/seed/php-model/oauth-client-credentials-custom/.github/workflows/ci.yml
+++ b/seed/php-model/oauth-client-credentials-custom/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.1"
+          php-version: "8.3"
 
       - name: Install tools
         run: |
@@ -41,7 +41,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.1"
+          php-version: "8.3"
 
       - name: Install tools
         run: |

--- a/seed/php-model/oauth-client-credentials-custom/composer.json
+++ b/seed/php-model/oauth-client-credentials-custom/composer.json
@@ -20,7 +20,7 @@
     "php-http/multipart-stream-builder": "^1.0"
   },
   "require-dev": {
-    "phpunit/phpunit": "^9.0",
+    "phpunit/phpunit": "^12.5.22",
     "friendsofphp/php-cs-fixer": "3.5.0",
     "phpstan/phpstan": "^1.12",
     "guzzlehttp/guzzle": "^7.4"

--- a/seed/php-model/oauth-client-credentials-default/.github/workflows/ci.yml
+++ b/seed/php-model/oauth-client-credentials-default/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.1"
+          php-version: "8.3"
 
       - name: Install tools
         run: |
@@ -41,7 +41,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.1"
+          php-version: "8.3"
 
       - name: Install tools
         run: |

--- a/seed/php-model/oauth-client-credentials-default/composer.json
+++ b/seed/php-model/oauth-client-credentials-default/composer.json
@@ -20,7 +20,7 @@
     "php-http/multipart-stream-builder": "^1.0"
   },
   "require-dev": {
-    "phpunit/phpunit": "^9.0",
+    "phpunit/phpunit": "^12.5.22",
     "friendsofphp/php-cs-fixer": "3.5.0",
     "phpstan/phpstan": "^1.12",
     "guzzlehttp/guzzle": "^7.4"

--- a/seed/php-model/oauth-client-credentials-environment-variables/.github/workflows/ci.yml
+++ b/seed/php-model/oauth-client-credentials-environment-variables/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.1"
+          php-version: "8.3"
 
       - name: Install tools
         run: |
@@ -41,7 +41,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.1"
+          php-version: "8.3"
 
       - name: Install tools
         run: |

--- a/seed/php-model/oauth-client-credentials-environment-variables/composer.json
+++ b/seed/php-model/oauth-client-credentials-environment-variables/composer.json
@@ -20,7 +20,7 @@
     "php-http/multipart-stream-builder": "^1.0"
   },
   "require-dev": {
-    "phpunit/phpunit": "^9.0",
+    "phpunit/phpunit": "^12.5.22",
     "friendsofphp/php-cs-fixer": "3.5.0",
     "phpstan/phpstan": "^1.12",
     "guzzlehttp/guzzle": "^7.4"

--- a/seed/php-model/oauth-client-credentials-mandatory-auth/.github/workflows/ci.yml
+++ b/seed/php-model/oauth-client-credentials-mandatory-auth/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.1"
+          php-version: "8.3"
 
       - name: Install tools
         run: |
@@ -41,7 +41,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.1"
+          php-version: "8.3"
 
       - name: Install tools
         run: |

--- a/seed/php-model/oauth-client-credentials-mandatory-auth/composer.json
+++ b/seed/php-model/oauth-client-credentials-mandatory-auth/composer.json
@@ -20,7 +20,7 @@
     "php-http/multipart-stream-builder": "^1.0"
   },
   "require-dev": {
-    "phpunit/phpunit": "^9.0",
+    "phpunit/phpunit": "^12.5.22",
     "friendsofphp/php-cs-fixer": "3.5.0",
     "phpstan/phpstan": "^1.12",
     "guzzlehttp/guzzle": "^7.4"

--- a/seed/php-model/oauth-client-credentials-nested-root/.github/workflows/ci.yml
+++ b/seed/php-model/oauth-client-credentials-nested-root/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.1"
+          php-version: "8.3"
 
       - name: Install tools
         run: |
@@ -41,7 +41,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.1"
+          php-version: "8.3"
 
       - name: Install tools
         run: |

--- a/seed/php-model/oauth-client-credentials-nested-root/composer.json
+++ b/seed/php-model/oauth-client-credentials-nested-root/composer.json
@@ -20,7 +20,7 @@
     "php-http/multipart-stream-builder": "^1.0"
   },
   "require-dev": {
-    "phpunit/phpunit": "^9.0",
+    "phpunit/phpunit": "^12.5.22",
     "friendsofphp/php-cs-fixer": "3.5.0",
     "phpstan/phpstan": "^1.12",
     "guzzlehttp/guzzle": "^7.4"

--- a/seed/php-model/oauth-client-credentials-openapi/.github/workflows/ci.yml
+++ b/seed/php-model/oauth-client-credentials-openapi/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.1"
+          php-version: "8.3"
 
       - name: Install tools
         run: |
@@ -41,7 +41,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.1"
+          php-version: "8.3"
 
       - name: Install tools
         run: |

--- a/seed/php-model/oauth-client-credentials-openapi/composer.json
+++ b/seed/php-model/oauth-client-credentials-openapi/composer.json
@@ -20,7 +20,7 @@
     "php-http/multipart-stream-builder": "^1.0"
   },
   "require-dev": {
-    "phpunit/phpunit": "^9.0",
+    "phpunit/phpunit": "^12.5.22",
     "friendsofphp/php-cs-fixer": "3.5.0",
     "phpstan/phpstan": "^1.12",
     "guzzlehttp/guzzle": "^7.4"

--- a/seed/php-model/oauth-client-credentials-reference/.github/workflows/ci.yml
+++ b/seed/php-model/oauth-client-credentials-reference/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.1"
+          php-version: "8.3"
 
       - name: Install tools
         run: |
@@ -41,7 +41,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.1"
+          php-version: "8.3"
 
       - name: Install tools
         run: |

--- a/seed/php-model/oauth-client-credentials-reference/composer.json
+++ b/seed/php-model/oauth-client-credentials-reference/composer.json
@@ -20,7 +20,7 @@
     "php-http/multipart-stream-builder": "^1.0"
   },
   "require-dev": {
-    "phpunit/phpunit": "^9.0",
+    "phpunit/phpunit": "^12.5.22",
     "friendsofphp/php-cs-fixer": "3.5.0",
     "phpstan/phpstan": "^1.12",
     "guzzlehttp/guzzle": "^7.4"

--- a/seed/php-model/oauth-client-credentials-with-variables/.github/workflows/ci.yml
+++ b/seed/php-model/oauth-client-credentials-with-variables/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.1"
+          php-version: "8.3"
 
       - name: Install tools
         run: |
@@ -41,7 +41,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.1"
+          php-version: "8.3"
 
       - name: Install tools
         run: |

--- a/seed/php-model/oauth-client-credentials-with-variables/composer.json
+++ b/seed/php-model/oauth-client-credentials-with-variables/composer.json
@@ -20,7 +20,7 @@
     "php-http/multipart-stream-builder": "^1.0"
   },
   "require-dev": {
-    "phpunit/phpunit": "^9.0",
+    "phpunit/phpunit": "^12.5.22",
     "friendsofphp/php-cs-fixer": "3.5.0",
     "phpstan/phpstan": "^1.12",
     "guzzlehttp/guzzle": "^7.4"

--- a/seed/php-model/oauth-client-credentials/.github/workflows/ci.yml
+++ b/seed/php-model/oauth-client-credentials/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.1"
+          php-version: "8.3"
 
       - name: Install tools
         run: |
@@ -41,7 +41,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.1"
+          php-version: "8.3"
 
       - name: Install tools
         run: |

--- a/seed/php-model/oauth-client-credentials/composer.json
+++ b/seed/php-model/oauth-client-credentials/composer.json
@@ -20,7 +20,7 @@
     "php-http/multipart-stream-builder": "^1.0"
   },
   "require-dev": {
-    "phpunit/phpunit": "^9.0",
+    "phpunit/phpunit": "^12.5.22",
     "friendsofphp/php-cs-fixer": "3.5.0",
     "phpstan/phpstan": "^1.12",
     "guzzlehttp/guzzle": "^7.4"

--- a/seed/php-model/object/.github/workflows/ci.yml
+++ b/seed/php-model/object/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.1"
+          php-version: "8.3"
 
       - name: Install tools
         run: |
@@ -41,7 +41,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.1"
+          php-version: "8.3"
 
       - name: Install tools
         run: |

--- a/seed/php-model/object/composer.json
+++ b/seed/php-model/object/composer.json
@@ -20,7 +20,7 @@
     "php-http/multipart-stream-builder": "^1.0"
   },
   "require-dev": {
-    "phpunit/phpunit": "^9.0",
+    "phpunit/phpunit": "^12.5.22",
     "friendsofphp/php-cs-fixer": "3.5.0",
     "phpstan/phpstan": "^1.12",
     "guzzlehttp/guzzle": "^7.4"

--- a/seed/php-model/objects-with-imports/.github/workflows/ci.yml
+++ b/seed/php-model/objects-with-imports/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.1"
+          php-version: "8.3"
 
       - name: Install tools
         run: |
@@ -41,7 +41,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.1"
+          php-version: "8.3"
 
       - name: Install tools
         run: |

--- a/seed/php-model/objects-with-imports/composer.json
+++ b/seed/php-model/objects-with-imports/composer.json
@@ -20,7 +20,7 @@
     "php-http/multipart-stream-builder": "^1.0"
   },
   "require-dev": {
-    "phpunit/phpunit": "^9.0",
+    "phpunit/phpunit": "^12.5.22",
     "friendsofphp/php-cs-fixer": "3.5.0",
     "phpstan/phpstan": "^1.12",
     "guzzlehttp/guzzle": "^7.4"

--- a/seed/php-model/optional/.github/workflows/ci.yml
+++ b/seed/php-model/optional/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.1"
+          php-version: "8.3"
 
       - name: Install tools
         run: |
@@ -41,7 +41,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.1"
+          php-version: "8.3"
 
       - name: Install tools
         run: |

--- a/seed/php-model/optional/composer.json
+++ b/seed/php-model/optional/composer.json
@@ -20,7 +20,7 @@
     "php-http/multipart-stream-builder": "^1.0"
   },
   "require-dev": {
-    "phpunit/phpunit": "^9.0",
+    "phpunit/phpunit": "^12.5.22",
     "friendsofphp/php-cs-fixer": "3.5.0",
     "phpstan/phpstan": "^1.12",
     "guzzlehttp/guzzle": "^7.4"

--- a/seed/php-model/package-yml/.github/workflows/ci.yml
+++ b/seed/php-model/package-yml/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.1"
+          php-version: "8.3"
 
       - name: Install tools
         run: |
@@ -41,7 +41,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.1"
+          php-version: "8.3"
 
       - name: Install tools
         run: |

--- a/seed/php-model/package-yml/composer.json
+++ b/seed/php-model/package-yml/composer.json
@@ -20,7 +20,7 @@
     "php-http/multipart-stream-builder": "^1.0"
   },
   "require-dev": {
-    "phpunit/phpunit": "^9.0",
+    "phpunit/phpunit": "^12.5.22",
     "friendsofphp/php-cs-fixer": "3.5.0",
     "phpstan/phpstan": "^1.12",
     "guzzlehttp/guzzle": "^7.4"

--- a/seed/php-model/pagination-custom/.github/workflows/ci.yml
+++ b/seed/php-model/pagination-custom/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.1"
+          php-version: "8.3"
 
       - name: Install tools
         run: |
@@ -41,7 +41,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.1"
+          php-version: "8.3"
 
       - name: Install tools
         run: |

--- a/seed/php-model/pagination-custom/composer.json
+++ b/seed/php-model/pagination-custom/composer.json
@@ -20,7 +20,7 @@
     "php-http/multipart-stream-builder": "^1.0"
   },
   "require-dev": {
-    "phpunit/phpunit": "^9.0",
+    "phpunit/phpunit": "^12.5.22",
     "friendsofphp/php-cs-fixer": "3.5.0",
     "phpstan/phpstan": "^1.12",
     "guzzlehttp/guzzle": "^7.4"

--- a/seed/php-model/pagination-uri-path/.github/workflows/ci.yml
+++ b/seed/php-model/pagination-uri-path/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.1"
+          php-version: "8.3"
 
       - name: Install tools
         run: |
@@ -41,7 +41,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.1"
+          php-version: "8.3"
 
       - name: Install tools
         run: |

--- a/seed/php-model/pagination-uri-path/composer.json
+++ b/seed/php-model/pagination-uri-path/composer.json
@@ -20,7 +20,7 @@
     "php-http/multipart-stream-builder": "^1.0"
   },
   "require-dev": {
-    "phpunit/phpunit": "^9.0",
+    "phpunit/phpunit": "^12.5.22",
     "friendsofphp/php-cs-fixer": "3.5.0",
     "phpstan/phpstan": "^1.12",
     "guzzlehttp/guzzle": "^7.4"

--- a/seed/php-model/pagination/.github/workflows/ci.yml
+++ b/seed/php-model/pagination/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.1"
+          php-version: "8.3"
 
       - name: Install tools
         run: |
@@ -41,7 +41,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.1"
+          php-version: "8.3"
 
       - name: Install tools
         run: |

--- a/seed/php-model/pagination/composer.json
+++ b/seed/php-model/pagination/composer.json
@@ -20,7 +20,7 @@
     "php-http/multipart-stream-builder": "^1.0"
   },
   "require-dev": {
-    "phpunit/phpunit": "^9.0",
+    "phpunit/phpunit": "^12.5.22",
     "friendsofphp/php-cs-fixer": "3.5.0",
     "phpstan/phpstan": "^1.12",
     "guzzlehttp/guzzle": "^7.4"

--- a/seed/php-model/path-parameters/.github/workflows/ci.yml
+++ b/seed/php-model/path-parameters/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.1"
+          php-version: "8.3"
 
       - name: Install tools
         run: |
@@ -41,7 +41,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.1"
+          php-version: "8.3"
 
       - name: Install tools
         run: |

--- a/seed/php-model/path-parameters/composer.json
+++ b/seed/php-model/path-parameters/composer.json
@@ -20,7 +20,7 @@
     "php-http/multipart-stream-builder": "^1.0"
   },
   "require-dev": {
-    "phpunit/phpunit": "^9.0",
+    "phpunit/phpunit": "^12.5.22",
     "friendsofphp/php-cs-fixer": "3.5.0",
     "phpstan/phpstan": "^1.12",
     "guzzlehttp/guzzle": "^7.4"

--- a/seed/php-model/plain-text/.github/workflows/ci.yml
+++ b/seed/php-model/plain-text/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.1"
+          php-version: "8.3"
 
       - name: Install tools
         run: |
@@ -41,7 +41,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.1"
+          php-version: "8.3"
 
       - name: Install tools
         run: |

--- a/seed/php-model/plain-text/composer.json
+++ b/seed/php-model/plain-text/composer.json
@@ -20,7 +20,7 @@
     "php-http/multipart-stream-builder": "^1.0"
   },
   "require-dev": {
-    "phpunit/phpunit": "^9.0",
+    "phpunit/phpunit": "^12.5.22",
     "friendsofphp/php-cs-fixer": "3.5.0",
     "phpstan/phpstan": "^1.12",
     "guzzlehttp/guzzle": "^7.4"

--- a/seed/php-model/property-access/.github/workflows/ci.yml
+++ b/seed/php-model/property-access/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.1"
+          php-version: "8.3"
 
       - name: Install tools
         run: |
@@ -41,7 +41,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.1"
+          php-version: "8.3"
 
       - name: Install tools
         run: |

--- a/seed/php-model/property-access/composer.json
+++ b/seed/php-model/property-access/composer.json
@@ -20,7 +20,7 @@
     "php-http/multipart-stream-builder": "^1.0"
   },
   "require-dev": {
-    "phpunit/phpunit": "^9.0",
+    "phpunit/phpunit": "^12.5.22",
     "friendsofphp/php-cs-fixer": "3.5.0",
     "phpstan/phpstan": "^1.12",
     "guzzlehttp/guzzle": "^7.4"

--- a/seed/php-model/public-object/.github/workflows/ci.yml
+++ b/seed/php-model/public-object/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.1"
+          php-version: "8.3"
 
       - name: Install tools
         run: |
@@ -41,7 +41,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.1"
+          php-version: "8.3"
 
       - name: Install tools
         run: |

--- a/seed/php-model/public-object/composer.json
+++ b/seed/php-model/public-object/composer.json
@@ -20,7 +20,7 @@
     "php-http/multipart-stream-builder": "^1.0"
   },
   "require-dev": {
-    "phpunit/phpunit": "^9.0",
+    "phpunit/phpunit": "^12.5.22",
     "friendsofphp/php-cs-fixer": "3.5.0",
     "phpstan/phpstan": "^1.12",
     "guzzlehttp/guzzle": "^7.4"

--- a/seed/php-model/query-param-name-conflict/.github/workflows/ci.yml
+++ b/seed/php-model/query-param-name-conflict/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.1"
+          php-version: "8.3"
 
       - name: Install tools
         run: |
@@ -41,7 +41,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.1"
+          php-version: "8.3"
 
       - name: Install tools
         run: |

--- a/seed/php-model/query-param-name-conflict/composer.json
+++ b/seed/php-model/query-param-name-conflict/composer.json
@@ -20,7 +20,7 @@
     "php-http/multipart-stream-builder": "^1.0"
   },
   "require-dev": {
-    "phpunit/phpunit": "^9.0",
+    "phpunit/phpunit": "^12.5.22",
     "friendsofphp/php-cs-fixer": "3.5.0",
     "phpstan/phpstan": "^1.12",
     "guzzlehttp/guzzle": "^7.4"

--- a/seed/php-model/query-parameters-openapi-as-objects/.github/workflows/ci.yml
+++ b/seed/php-model/query-parameters-openapi-as-objects/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.1"
+          php-version: "8.3"
 
       - name: Install tools
         run: |
@@ -41,7 +41,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.1"
+          php-version: "8.3"
 
       - name: Install tools
         run: |

--- a/seed/php-model/query-parameters-openapi-as-objects/composer.json
+++ b/seed/php-model/query-parameters-openapi-as-objects/composer.json
@@ -20,7 +20,7 @@
     "php-http/multipart-stream-builder": "^1.0"
   },
   "require-dev": {
-    "phpunit/phpunit": "^9.0",
+    "phpunit/phpunit": "^12.5.22",
     "friendsofphp/php-cs-fixer": "3.5.0",
     "phpstan/phpstan": "^1.12",
     "guzzlehttp/guzzle": "^7.4"

--- a/seed/php-model/query-parameters-openapi/.github/workflows/ci.yml
+++ b/seed/php-model/query-parameters-openapi/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.1"
+          php-version: "8.3"
 
       - name: Install tools
         run: |
@@ -41,7 +41,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.1"
+          php-version: "8.3"
 
       - name: Install tools
         run: |

--- a/seed/php-model/query-parameters-openapi/composer.json
+++ b/seed/php-model/query-parameters-openapi/composer.json
@@ -20,7 +20,7 @@
     "php-http/multipart-stream-builder": "^1.0"
   },
   "require-dev": {
-    "phpunit/phpunit": "^9.0",
+    "phpunit/phpunit": "^12.5.22",
     "friendsofphp/php-cs-fixer": "3.5.0",
     "phpstan/phpstan": "^1.12",
     "guzzlehttp/guzzle": "^7.4"

--- a/seed/php-model/query-parameters/.github/workflows/ci.yml
+++ b/seed/php-model/query-parameters/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.1"
+          php-version: "8.3"
 
       - name: Install tools
         run: |
@@ -41,7 +41,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.1"
+          php-version: "8.3"
 
       - name: Install tools
         run: |

--- a/seed/php-model/query-parameters/composer.json
+++ b/seed/php-model/query-parameters/composer.json
@@ -20,7 +20,7 @@
     "php-http/multipart-stream-builder": "^1.0"
   },
   "require-dev": {
-    "phpunit/phpunit": "^9.0",
+    "phpunit/phpunit": "^12.5.22",
     "friendsofphp/php-cs-fixer": "3.5.0",
     "phpstan/phpstan": "^1.12",
     "guzzlehttp/guzzle": "^7.4"

--- a/seed/php-model/request-parameters/.github/workflows/ci.yml
+++ b/seed/php-model/request-parameters/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.1"
+          php-version: "8.3"
 
       - name: Install tools
         run: |
@@ -41,7 +41,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.1"
+          php-version: "8.3"
 
       - name: Install tools
         run: |

--- a/seed/php-model/request-parameters/composer.json
+++ b/seed/php-model/request-parameters/composer.json
@@ -20,7 +20,7 @@
     "php-http/multipart-stream-builder": "^1.0"
   },
   "require-dev": {
-    "phpunit/phpunit": "^9.0",
+    "phpunit/phpunit": "^12.5.22",
     "friendsofphp/php-cs-fixer": "3.5.0",
     "phpstan/phpstan": "^1.12",
     "guzzlehttp/guzzle": "^7.4"

--- a/seed/php-model/required-nullable/.github/workflows/ci.yml
+++ b/seed/php-model/required-nullable/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.1"
+          php-version: "8.3"
 
       - name: Install tools
         run: |
@@ -41,7 +41,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.1"
+          php-version: "8.3"
 
       - name: Install tools
         run: |

--- a/seed/php-model/required-nullable/composer.json
+++ b/seed/php-model/required-nullable/composer.json
@@ -20,7 +20,7 @@
     "php-http/multipart-stream-builder": "^1.0"
   },
   "require-dev": {
-    "phpunit/phpunit": "^9.0",
+    "phpunit/phpunit": "^12.5.22",
     "friendsofphp/php-cs-fixer": "3.5.0",
     "phpstan/phpstan": "^1.12",
     "guzzlehttp/guzzle": "^7.4"

--- a/seed/php-model/reserved-keywords/.github/workflows/ci.yml
+++ b/seed/php-model/reserved-keywords/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.1"
+          php-version: "8.3"
 
       - name: Install tools
         run: |
@@ -41,7 +41,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.1"
+          php-version: "8.3"
 
       - name: Install tools
         run: |

--- a/seed/php-model/reserved-keywords/composer.json
+++ b/seed/php-model/reserved-keywords/composer.json
@@ -20,7 +20,7 @@
     "php-http/multipart-stream-builder": "^1.0"
   },
   "require-dev": {
-    "phpunit/phpunit": "^9.0",
+    "phpunit/phpunit": "^12.5.22",
     "friendsofphp/php-cs-fixer": "3.5.0",
     "phpstan/phpstan": "^1.12",
     "guzzlehttp/guzzle": "^7.4"

--- a/seed/php-model/response-property/.github/workflows/ci.yml
+++ b/seed/php-model/response-property/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.1"
+          php-version: "8.3"
 
       - name: Install tools
         run: |
@@ -41,7 +41,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.1"
+          php-version: "8.3"
 
       - name: Install tools
         run: |

--- a/seed/php-model/response-property/composer.json
+++ b/seed/php-model/response-property/composer.json
@@ -20,7 +20,7 @@
     "php-http/multipart-stream-builder": "^1.0"
   },
   "require-dev": {
-    "phpunit/phpunit": "^9.0",
+    "phpunit/phpunit": "^12.5.22",
     "friendsofphp/php-cs-fixer": "3.5.0",
     "phpstan/phpstan": "^1.12",
     "guzzlehttp/guzzle": "^7.4"

--- a/seed/php-model/schemaless-request-body-examples/.github/workflows/ci.yml
+++ b/seed/php-model/schemaless-request-body-examples/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.1"
+          php-version: "8.3"
 
       - name: Install tools
         run: |
@@ -41,7 +41,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.1"
+          php-version: "8.3"
 
       - name: Install tools
         run: |

--- a/seed/php-model/schemaless-request-body-examples/composer.json
+++ b/seed/php-model/schemaless-request-body-examples/composer.json
@@ -20,7 +20,7 @@
     "php-http/multipart-stream-builder": "^1.0"
   },
   "require-dev": {
-    "phpunit/phpunit": "^9.0",
+    "phpunit/phpunit": "^12.5.22",
     "friendsofphp/php-cs-fixer": "3.5.0",
     "phpstan/phpstan": "^1.12",
     "guzzlehttp/guzzle": "^7.4"

--- a/seed/php-model/server-sent-event-examples/.github/workflows/ci.yml
+++ b/seed/php-model/server-sent-event-examples/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.1"
+          php-version: "8.3"
 
       - name: Install tools
         run: |
@@ -41,7 +41,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.1"
+          php-version: "8.3"
 
       - name: Install tools
         run: |

--- a/seed/php-model/server-sent-event-examples/composer.json
+++ b/seed/php-model/server-sent-event-examples/composer.json
@@ -20,7 +20,7 @@
     "php-http/multipart-stream-builder": "^1.0"
   },
   "require-dev": {
-    "phpunit/phpunit": "^9.0",
+    "phpunit/phpunit": "^12.5.22",
     "friendsofphp/php-cs-fixer": "3.5.0",
     "phpstan/phpstan": "^1.12",
     "guzzlehttp/guzzle": "^7.4"

--- a/seed/php-model/server-sent-events-openapi/.github/workflows/ci.yml
+++ b/seed/php-model/server-sent-events-openapi/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.1"
+          php-version: "8.3"
 
       - name: Install tools
         run: |
@@ -41,7 +41,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.1"
+          php-version: "8.3"
 
       - name: Install tools
         run: |

--- a/seed/php-model/server-sent-events-openapi/composer.json
+++ b/seed/php-model/server-sent-events-openapi/composer.json
@@ -20,7 +20,7 @@
     "php-http/multipart-stream-builder": "^1.0"
   },
   "require-dev": {
-    "phpunit/phpunit": "^9.0",
+    "phpunit/phpunit": "^12.5.22",
     "friendsofphp/php-cs-fixer": "3.5.0",
     "phpstan/phpstan": "^1.12",
     "guzzlehttp/guzzle": "^7.4"

--- a/seed/php-model/server-sent-events/.github/workflows/ci.yml
+++ b/seed/php-model/server-sent-events/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.1"
+          php-version: "8.3"
 
       - name: Install tools
         run: |
@@ -41,7 +41,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.1"
+          php-version: "8.3"
 
       - name: Install tools
         run: |

--- a/seed/php-model/server-sent-events/composer.json
+++ b/seed/php-model/server-sent-events/composer.json
@@ -20,7 +20,7 @@
     "php-http/multipart-stream-builder": "^1.0"
   },
   "require-dev": {
-    "phpunit/phpunit": "^9.0",
+    "phpunit/phpunit": "^12.5.22",
     "friendsofphp/php-cs-fixer": "3.5.0",
     "phpstan/phpstan": "^1.12",
     "guzzlehttp/guzzle": "^7.4"

--- a/seed/php-model/server-url-templating/.github/workflows/ci.yml
+++ b/seed/php-model/server-url-templating/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.1"
+          php-version: "8.3"
 
       - name: Install tools
         run: |
@@ -41,7 +41,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.1"
+          php-version: "8.3"
 
       - name: Install tools
         run: |

--- a/seed/php-model/server-url-templating/composer.json
+++ b/seed/php-model/server-url-templating/composer.json
@@ -20,7 +20,7 @@
     "php-http/multipart-stream-builder": "^1.0"
   },
   "require-dev": {
-    "phpunit/phpunit": "^9.0",
+    "phpunit/phpunit": "^12.5.22",
     "friendsofphp/php-cs-fixer": "3.5.0",
     "phpstan/phpstan": "^1.12",
     "guzzlehttp/guzzle": "^7.4"

--- a/seed/php-model/simple-api/.github/workflows/ci.yml
+++ b/seed/php-model/simple-api/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.1"
+          php-version: "8.3"
 
       - name: Install tools
         run: |
@@ -41,7 +41,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.1"
+          php-version: "8.3"
 
       - name: Install tools
         run: |

--- a/seed/php-model/simple-api/composer.json
+++ b/seed/php-model/simple-api/composer.json
@@ -20,7 +20,7 @@
     "php-http/multipart-stream-builder": "^1.0"
   },
   "require-dev": {
-    "phpunit/phpunit": "^9.0",
+    "phpunit/phpunit": "^12.5.22",
     "friendsofphp/php-cs-fixer": "3.5.0",
     "phpstan/phpstan": "^1.12",
     "guzzlehttp/guzzle": "^7.4"

--- a/seed/php-model/simple-fhir/.github/workflows/ci.yml
+++ b/seed/php-model/simple-fhir/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.1"
+          php-version: "8.3"
 
       - name: Install tools
         run: |
@@ -41,7 +41,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.1"
+          php-version: "8.3"
 
       - name: Install tools
         run: |

--- a/seed/php-model/simple-fhir/composer.json
+++ b/seed/php-model/simple-fhir/composer.json
@@ -20,7 +20,7 @@
     "php-http/multipart-stream-builder": "^1.0"
   },
   "require-dev": {
-    "phpunit/phpunit": "^9.0",
+    "phpunit/phpunit": "^12.5.22",
     "friendsofphp/php-cs-fixer": "3.5.0",
     "phpstan/phpstan": "^1.12",
     "guzzlehttp/guzzle": "^7.4"

--- a/seed/php-model/single-url-environment-default/.github/workflows/ci.yml
+++ b/seed/php-model/single-url-environment-default/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.1"
+          php-version: "8.3"
 
       - name: Install tools
         run: |
@@ -41,7 +41,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.1"
+          php-version: "8.3"
 
       - name: Install tools
         run: |

--- a/seed/php-model/single-url-environment-default/composer.json
+++ b/seed/php-model/single-url-environment-default/composer.json
@@ -20,7 +20,7 @@
     "php-http/multipart-stream-builder": "^1.0"
   },
   "require-dev": {
-    "phpunit/phpunit": "^9.0",
+    "phpunit/phpunit": "^12.5.22",
     "friendsofphp/php-cs-fixer": "3.5.0",
     "phpstan/phpstan": "^1.12",
     "guzzlehttp/guzzle": "^7.4"

--- a/seed/php-model/single-url-environment-no-default/.github/workflows/ci.yml
+++ b/seed/php-model/single-url-environment-no-default/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.1"
+          php-version: "8.3"
 
       - name: Install tools
         run: |
@@ -41,7 +41,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.1"
+          php-version: "8.3"
 
       - name: Install tools
         run: |

--- a/seed/php-model/single-url-environment-no-default/composer.json
+++ b/seed/php-model/single-url-environment-no-default/composer.json
@@ -20,7 +20,7 @@
     "php-http/multipart-stream-builder": "^1.0"
   },
   "require-dev": {
-    "phpunit/phpunit": "^9.0",
+    "phpunit/phpunit": "^12.5.22",
     "friendsofphp/php-cs-fixer": "3.5.0",
     "phpstan/phpstan": "^1.12",
     "guzzlehttp/guzzle": "^7.4"

--- a/seed/php-model/streaming-parameter/.github/workflows/ci.yml
+++ b/seed/php-model/streaming-parameter/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.1"
+          php-version: "8.3"
 
       - name: Install tools
         run: |
@@ -41,7 +41,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.1"
+          php-version: "8.3"
 
       - name: Install tools
         run: |

--- a/seed/php-model/streaming-parameter/composer.json
+++ b/seed/php-model/streaming-parameter/composer.json
@@ -20,7 +20,7 @@
     "php-http/multipart-stream-builder": "^1.0"
   },
   "require-dev": {
-    "phpunit/phpunit": "^9.0",
+    "phpunit/phpunit": "^12.5.22",
     "friendsofphp/php-cs-fixer": "3.5.0",
     "phpstan/phpstan": "^1.12",
     "guzzlehttp/guzzle": "^7.4"

--- a/seed/php-model/streaming/.github/workflows/ci.yml
+++ b/seed/php-model/streaming/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.1"
+          php-version: "8.3"
 
       - name: Install tools
         run: |
@@ -41,7 +41,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.1"
+          php-version: "8.3"
 
       - name: Install tools
         run: |

--- a/seed/php-model/streaming/composer.json
+++ b/seed/php-model/streaming/composer.json
@@ -20,7 +20,7 @@
     "php-http/multipart-stream-builder": "^1.0"
   },
   "require-dev": {
-    "phpunit/phpunit": "^9.0",
+    "phpunit/phpunit": "^12.5.22",
     "friendsofphp/php-cs-fixer": "3.5.0",
     "phpstan/phpstan": "^1.12",
     "guzzlehttp/guzzle": "^7.4"

--- a/seed/php-model/trace/.github/workflows/ci.yml
+++ b/seed/php-model/trace/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.1"
+          php-version: "8.3"
 
       - name: Install tools
         run: |
@@ -41,7 +41,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.1"
+          php-version: "8.3"
 
       - name: Install tools
         run: |

--- a/seed/php-model/trace/composer.json
+++ b/seed/php-model/trace/composer.json
@@ -20,7 +20,7 @@
     "php-http/multipart-stream-builder": "^1.0"
   },
   "require-dev": {
-    "phpunit/phpunit": "^9.0",
+    "phpunit/phpunit": "^12.5.22",
     "friendsofphp/php-cs-fixer": "3.5.0",
     "phpstan/phpstan": "^1.12",
     "guzzlehttp/guzzle": "^7.4"

--- a/seed/php-model/undiscriminated-union-with-response-property/.github/workflows/ci.yml
+++ b/seed/php-model/undiscriminated-union-with-response-property/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.1"
+          php-version: "8.3"
 
       - name: Install tools
         run: |
@@ -41,7 +41,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.1"
+          php-version: "8.3"
 
       - name: Install tools
         run: |

--- a/seed/php-model/undiscriminated-union-with-response-property/composer.json
+++ b/seed/php-model/undiscriminated-union-with-response-property/composer.json
@@ -20,7 +20,7 @@
     "php-http/multipart-stream-builder": "^1.0"
   },
   "require-dev": {
-    "phpunit/phpunit": "^9.0",
+    "phpunit/phpunit": "^12.5.22",
     "friendsofphp/php-cs-fixer": "3.5.0",
     "phpstan/phpstan": "^1.12",
     "guzzlehttp/guzzle": "^7.4"

--- a/seed/php-model/undiscriminated-unions/.github/workflows/ci.yml
+++ b/seed/php-model/undiscriminated-unions/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.1"
+          php-version: "8.3"
 
       - name: Install tools
         run: |
@@ -41,7 +41,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.1"
+          php-version: "8.3"
 
       - name: Install tools
         run: |

--- a/seed/php-model/undiscriminated-unions/composer.json
+++ b/seed/php-model/undiscriminated-unions/composer.json
@@ -20,7 +20,7 @@
     "php-http/multipart-stream-builder": "^1.0"
   },
   "require-dev": {
-    "phpunit/phpunit": "^9.0",
+    "phpunit/phpunit": "^12.5.22",
     "friendsofphp/php-cs-fixer": "3.5.0",
     "phpstan/phpstan": "^1.12",
     "guzzlehttp/guzzle": "^7.4"

--- a/seed/php-model/unions-with-local-date/.github/workflows/ci.yml
+++ b/seed/php-model/unions-with-local-date/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.1"
+          php-version: "8.3"
 
       - name: Install tools
         run: |
@@ -41,7 +41,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.1"
+          php-version: "8.3"
 
       - name: Install tools
         run: |

--- a/seed/php-model/unions-with-local-date/composer.json
+++ b/seed/php-model/unions-with-local-date/composer.json
@@ -20,7 +20,7 @@
     "php-http/multipart-stream-builder": "^1.0"
   },
   "require-dev": {
-    "phpunit/phpunit": "^9.0",
+    "phpunit/phpunit": "^12.5.22",
     "friendsofphp/php-cs-fixer": "3.5.0",
     "phpstan/phpstan": "^1.12",
     "guzzlehttp/guzzle": "^7.4"

--- a/seed/php-model/unions/.github/workflows/ci.yml
+++ b/seed/php-model/unions/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.1"
+          php-version: "8.3"
 
       - name: Install tools
         run: |
@@ -41,7 +41,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.1"
+          php-version: "8.3"
 
       - name: Install tools
         run: |

--- a/seed/php-model/unions/composer.json
+++ b/seed/php-model/unions/composer.json
@@ -20,7 +20,7 @@
     "php-http/multipart-stream-builder": "^1.0"
   },
   "require-dev": {
-    "phpunit/phpunit": "^9.0",
+    "phpunit/phpunit": "^12.5.22",
     "friendsofphp/php-cs-fixer": "3.5.0",
     "phpstan/phpstan": "^1.12",
     "guzzlehttp/guzzle": "^7.4"

--- a/seed/php-model/unknown/.github/workflows/ci.yml
+++ b/seed/php-model/unknown/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.1"
+          php-version: "8.3"
 
       - name: Install tools
         run: |
@@ -41,7 +41,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.1"
+          php-version: "8.3"
 
       - name: Install tools
         run: |

--- a/seed/php-model/unknown/composer.json
+++ b/seed/php-model/unknown/composer.json
@@ -20,7 +20,7 @@
     "php-http/multipart-stream-builder": "^1.0"
   },
   "require-dev": {
-    "phpunit/phpunit": "^9.0",
+    "phpunit/phpunit": "^12.5.22",
     "friendsofphp/php-cs-fixer": "3.5.0",
     "phpstan/phpstan": "^1.12",
     "guzzlehttp/guzzle": "^7.4"

--- a/seed/php-model/url-form-encoded/.github/workflows/ci.yml
+++ b/seed/php-model/url-form-encoded/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.1"
+          php-version: "8.3"
 
       - name: Install tools
         run: |
@@ -41,7 +41,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.1"
+          php-version: "8.3"
 
       - name: Install tools
         run: |

--- a/seed/php-model/url-form-encoded/composer.json
+++ b/seed/php-model/url-form-encoded/composer.json
@@ -20,7 +20,7 @@
     "php-http/multipart-stream-builder": "^1.0"
   },
   "require-dev": {
-    "phpunit/phpunit": "^9.0",
+    "phpunit/phpunit": "^12.5.22",
     "friendsofphp/php-cs-fixer": "3.5.0",
     "phpstan/phpstan": "^1.12",
     "guzzlehttp/guzzle": "^7.4"

--- a/seed/php-model/validation/.github/workflows/ci.yml
+++ b/seed/php-model/validation/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.1"
+          php-version: "8.3"
 
       - name: Install tools
         run: |
@@ -41,7 +41,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.1"
+          php-version: "8.3"
 
       - name: Install tools
         run: |

--- a/seed/php-model/validation/composer.json
+++ b/seed/php-model/validation/composer.json
@@ -20,7 +20,7 @@
     "php-http/multipart-stream-builder": "^1.0"
   },
   "require-dev": {
-    "phpunit/phpunit": "^9.0",
+    "phpunit/phpunit": "^12.5.22",
     "friendsofphp/php-cs-fixer": "3.5.0",
     "phpstan/phpstan": "^1.12",
     "guzzlehttp/guzzle": "^7.4"

--- a/seed/php-model/variables/.github/workflows/ci.yml
+++ b/seed/php-model/variables/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.1"
+          php-version: "8.3"
 
       - name: Install tools
         run: |
@@ -41,7 +41,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.1"
+          php-version: "8.3"
 
       - name: Install tools
         run: |

--- a/seed/php-model/variables/composer.json
+++ b/seed/php-model/variables/composer.json
@@ -20,7 +20,7 @@
     "php-http/multipart-stream-builder": "^1.0"
   },
   "require-dev": {
-    "phpunit/phpunit": "^9.0",
+    "phpunit/phpunit": "^12.5.22",
     "friendsofphp/php-cs-fixer": "3.5.0",
     "phpstan/phpstan": "^1.12",
     "guzzlehttp/guzzle": "^7.4"

--- a/seed/php-model/version-no-default/.github/workflows/ci.yml
+++ b/seed/php-model/version-no-default/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.1"
+          php-version: "8.3"
 
       - name: Install tools
         run: |
@@ -41,7 +41,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.1"
+          php-version: "8.3"
 
       - name: Install tools
         run: |

--- a/seed/php-model/version-no-default/composer.json
+++ b/seed/php-model/version-no-default/composer.json
@@ -20,7 +20,7 @@
     "php-http/multipart-stream-builder": "^1.0"
   },
   "require-dev": {
-    "phpunit/phpunit": "^9.0",
+    "phpunit/phpunit": "^12.5.22",
     "friendsofphp/php-cs-fixer": "3.5.0",
     "phpstan/phpstan": "^1.12",
     "guzzlehttp/guzzle": "^7.4"

--- a/seed/php-model/version/.github/workflows/ci.yml
+++ b/seed/php-model/version/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.1"
+          php-version: "8.3"
 
       - name: Install tools
         run: |
@@ -41,7 +41,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.1"
+          php-version: "8.3"
 
       - name: Install tools
         run: |

--- a/seed/php-model/version/composer.json
+++ b/seed/php-model/version/composer.json
@@ -20,7 +20,7 @@
     "php-http/multipart-stream-builder": "^1.0"
   },
   "require-dev": {
-    "phpunit/phpunit": "^9.0",
+    "phpunit/phpunit": "^12.5.22",
     "friendsofphp/php-cs-fixer": "3.5.0",
     "phpstan/phpstan": "^1.12",
     "guzzlehttp/guzzle": "^7.4"

--- a/seed/php-model/webhook-audience/.github/workflows/ci.yml
+++ b/seed/php-model/webhook-audience/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.1"
+          php-version: "8.3"
 
       - name: Install tools
         run: |
@@ -41,7 +41,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.1"
+          php-version: "8.3"
 
       - name: Install tools
         run: |

--- a/seed/php-model/webhook-audience/composer.json
+++ b/seed/php-model/webhook-audience/composer.json
@@ -20,7 +20,7 @@
     "php-http/multipart-stream-builder": "^1.0"
   },
   "require-dev": {
-    "phpunit/phpunit": "^9.0",
+    "phpunit/phpunit": "^12.5.22",
     "friendsofphp/php-cs-fixer": "3.5.0",
     "phpstan/phpstan": "^1.12",
     "guzzlehttp/guzzle": "^7.4"

--- a/seed/php-model/webhooks/.github/workflows/ci.yml
+++ b/seed/php-model/webhooks/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.1"
+          php-version: "8.3"
 
       - name: Install tools
         run: |
@@ -41,7 +41,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.1"
+          php-version: "8.3"
 
       - name: Install tools
         run: |

--- a/seed/php-model/webhooks/composer.json
+++ b/seed/php-model/webhooks/composer.json
@@ -20,7 +20,7 @@
     "php-http/multipart-stream-builder": "^1.0"
   },
   "require-dev": {
-    "phpunit/phpunit": "^9.0",
+    "phpunit/phpunit": "^12.5.22",
     "friendsofphp/php-cs-fixer": "3.5.0",
     "phpstan/phpstan": "^1.12",
     "guzzlehttp/guzzle": "^7.4"

--- a/seed/php-model/websocket-bearer-auth/.github/workflows/ci.yml
+++ b/seed/php-model/websocket-bearer-auth/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.1"
+          php-version: "8.3"
 
       - name: Install tools
         run: |
@@ -41,7 +41,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.1"
+          php-version: "8.3"
 
       - name: Install tools
         run: |

--- a/seed/php-model/websocket-bearer-auth/composer.json
+++ b/seed/php-model/websocket-bearer-auth/composer.json
@@ -20,7 +20,7 @@
     "php-http/multipart-stream-builder": "^1.0"
   },
   "require-dev": {
-    "phpunit/phpunit": "^9.0",
+    "phpunit/phpunit": "^12.5.22",
     "friendsofphp/php-cs-fixer": "3.5.0",
     "phpstan/phpstan": "^1.12",
     "guzzlehttp/guzzle": "^7.4"

--- a/seed/php-model/websocket-inferred-auth/.github/workflows/ci.yml
+++ b/seed/php-model/websocket-inferred-auth/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.1"
+          php-version: "8.3"
 
       - name: Install tools
         run: |
@@ -41,7 +41,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.1"
+          php-version: "8.3"
 
       - name: Install tools
         run: |

--- a/seed/php-model/websocket-inferred-auth/composer.json
+++ b/seed/php-model/websocket-inferred-auth/composer.json
@@ -20,7 +20,7 @@
     "php-http/multipart-stream-builder": "^1.0"
   },
   "require-dev": {
-    "phpunit/phpunit": "^9.0",
+    "phpunit/phpunit": "^12.5.22",
     "friendsofphp/php-cs-fixer": "3.5.0",
     "phpstan/phpstan": "^1.12",
     "guzzlehttp/guzzle": "^7.4"

--- a/seed/php-model/websocket-multi-url/.github/workflows/ci.yml
+++ b/seed/php-model/websocket-multi-url/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.1"
+          php-version: "8.3"
 
       - name: Install tools
         run: |
@@ -41,7 +41,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.1"
+          php-version: "8.3"
 
       - name: Install tools
         run: |

--- a/seed/php-model/websocket-multi-url/composer.json
+++ b/seed/php-model/websocket-multi-url/composer.json
@@ -20,7 +20,7 @@
     "php-http/multipart-stream-builder": "^1.0"
   },
   "require-dev": {
-    "phpunit/phpunit": "^9.0",
+    "phpunit/phpunit": "^12.5.22",
     "friendsofphp/php-cs-fixer": "3.5.0",
     "phpstan/phpstan": "^1.12",
     "guzzlehttp/guzzle": "^7.4"

--- a/seed/php-model/websocket/.github/workflows/ci.yml
+++ b/seed/php-model/websocket/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.1"
+          php-version: "8.3"
 
       - name: Install tools
         run: |
@@ -41,7 +41,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.1"
+          php-version: "8.3"
 
       - name: Install tools
         run: |

--- a/seed/php-model/websocket/composer.json
+++ b/seed/php-model/websocket/composer.json
@@ -20,7 +20,7 @@
     "php-http/multipart-stream-builder": "^1.0"
   },
   "require-dev": {
-    "phpunit/phpunit": "^9.0",
+    "phpunit/phpunit": "^12.5.22",
     "friendsofphp/php-cs-fixer": "3.5.0",
     "phpstan/phpstan": "^1.12",
     "guzzlehttp/guzzle": "^7.4"

--- a/seed/php-model/x-fern-default/.github/workflows/ci.yml
+++ b/seed/php-model/x-fern-default/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.1"
+          php-version: "8.3"
 
       - name: Install tools
         run: |
@@ -41,7 +41,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.1"
+          php-version: "8.3"
 
       - name: Install tools
         run: |

--- a/seed/php-model/x-fern-default/composer.json
+++ b/seed/php-model/x-fern-default/composer.json
@@ -20,7 +20,7 @@
     "php-http/multipart-stream-builder": "^1.0"
   },
   "require-dev": {
-    "phpunit/phpunit": "^9.0",
+    "phpunit/phpunit": "^12.5.22",
     "friendsofphp/php-cs-fixer": "3.5.0",
     "phpstan/phpstan": "^1.12",
     "guzzlehttp/guzzle": "^7.4"

--- a/seed/php-sdk/basic-auth-pw-omitted/composer.json
+++ b/seed/php-sdk/basic-auth-pw-omitted/composer.json
@@ -20,7 +20,7 @@
     "php-http/multipart-stream-builder": "^1.0"
   },
   "require-dev": {
-    "phpunit/phpunit": "^9.0",
+    "phpunit/phpunit": "^12.5.22",
     "friendsofphp/php-cs-fixer": "3.5.0",
     "phpstan/phpstan": "^1.12",
     "guzzlehttp/guzzle": "^7.4"

--- a/seed/php-sdk/basic-auth/composer.json
+++ b/seed/php-sdk/basic-auth/composer.json
@@ -20,7 +20,7 @@
     "php-http/multipart-stream-builder": "^1.0"
   },
   "require-dev": {
-    "phpunit/phpunit": "^9.0",
+    "phpunit/phpunit": "^12.5.22",
     "friendsofphp/php-cs-fixer": "3.5.0",
     "phpstan/phpstan": "^1.12",
     "guzzlehttp/guzzle": "^7.4"


### PR DESCRIPTION
## Description
Follow-up to #15145. After that PR merged, Dependabot is still flagging GHSA-qrr6-mg7r-m243 across 121 `composer.json` files because the automatic Update Seed run only regenerated `seed/php-sdk/**` — it didn't cover `seed/php-model/**`, and it left two orphaned top-level fixtures in `seed/php-sdk/`.

No generator source changes; this PR only brings the committed seed fixtures in line with the already-released generator output.

## Changes Made
- Bump `phpunit/phpunit` from `^9.0` to `^12.5.22` in every remaining `seed/**/composer.json` (119 × `seed/php-model/**`, 2 × stale top-level `seed/php-sdk/basic-auth{,-pw-omitted}/composer.json`).
- Bump `php-version` from `"8.1"` to `"8.3"` in every remaining `seed/**/.github/workflows/ci.yml` (119 files under `seed/php-model/**`) so the generated CI matches PHPUnit 12's minimum PHP version.
- No changes to generator source or shared templates — `generators/php/base/src/project/PhpProject.ts` and `generators/php/base/src/asIs/github-ci.yml` already landed with the correct values in #15145. `php-model` consumes the same `@fern-api/php-base` template, so this PR is identical to what a fresh `pnpm seed test --generator php-model --update` would produce.
- [ ] Updated README.md generator (if applicable) — N/A

## Testing
- [ ] Unit tests added/updated — N/A (fixture-only change)
- [x] Manual testing completed — verified zero remaining `"^9.0"` references in `seed/**/composer.json` and zero remaining `php-version: "8.1"` references in `seed/**/.github/workflows/ci.yml`. CI will run the `php-sdk` and `php-model` seed matrices against the updated fixtures (composer install → build → analyze → test in the `fernapi/php-seed` image on PHP 8.3), which is the same end-to-end validation that passed on #15145.

Link to Devin session: https://app.devin.ai/sessions/c5b565d232774db4a701669017d1fce9
Requested by: @davidkonigsberg