### PR TITLE
chore(python): bump generated pytest to ^9.0.3 to address CVE-2025-71176

### DIFF
--- a/generators/python/pydantic/versions.yml
+++ b/generators/python/pydantic/versions.yml
@@ -1,5 +1,17 @@
 # yaml-language-server: $schema=../../../fern-versions-yml.schema.json
 
+- version: 1.12.0-rc.1
+  changelogEntry:
+    - summary: |
+        Bump generated `pytest` dev dependency from `^8.2.0` to `^9.0.3` for SDKs
+        targeting Python 3.9+. This addresses CVE-2025-71176 (GHSA-6w46-j5rx-g56g),
+        a moderate-severity issue with insecure `/tmp/pytest-of-{user}` handling
+        on UNIX. Projects that still support Python 3.8 continue to use `pytest ^7.4.0`
+        since pytest 9 requires Python 3.9+.
+      type: chore
+  createdAt: "2026-04-20"
+  irVersion: 66
+
 - version: 1.12.0-rc.0
   changelogEntry:
     - summary: |

--- a/generators/python/sdk/changes/unreleased/bump-pytest-cve-2025-71176.yml
+++ b/generators/python/sdk/changes/unreleased/bump-pytest-cve-2025-71176.yml
@@ -1,0 +1,9 @@
+# yaml-language-server: $schema=../../../../../fern-changes-yml.schema.json
+
+- summary: |
+    Bump generated `pytest` dev dependency from `^8.2.0` to `^9.0.3` for SDKs
+    targeting Python 3.9+. This addresses CVE-2025-71176 (GHSA-6w46-j5rx-g56g),
+    a moderate-severity issue with insecure `/tmp/pytest-of-{user}` handling
+    on UNIX. Projects that still support Python 3.8 continue to use `pytest ^7.4.0`
+    since pytest 9 requires Python 3.9+.
+  type: chore

--- a/generators/python/src/fern_python/codegen/pyproject_toml.py
+++ b/generators/python/src/fern_python/codegen/pyproject_toml.py
@@ -226,9 +226,10 @@ packages = [
             if self.enable_wire_tests:
                 wire_test_deps = 'requests = "^2.31.0"\ntypes-requests = "^2.31.0"\n'
 
-            # pytest-asyncio ^1.0.0 fixes Python 3.14+ deprecation warnings but
-            # requires pytest >= 8.2 and Python >= 3.9.  Fall back to the older
-            # pair when the project still supports Python 3.8.
+            # pytest >= 9.0.3 addresses CVE-2025-71176 (insecure tmpdir handling).
+            # pytest 9 requires Python >= 3.9, and pytest-asyncio ^1.0.0 requires
+            # pytest >= 8.2 and Python >= 3.9.  Fall back to the older pair when
+            # the project still supports Python 3.8.
             #
             # Extract the minimum minor version from the constraint string
             # (e.g. "^3.8" -> 8, "^3.8.1" -> 8, "^3.10" -> 10, ">=3.9" -> 9).
@@ -238,7 +239,7 @@ packages = [
                 min_minor = int(match.group(2))
 
             if min_minor >= 9:
-                pytest_version = "^8.2.0"
+                pytest_version = "^9.0.3"
                 pytest_asyncio_version = "^1.0.0"
             else:
                 pytest_version = "^7.4.0"

--- a/seed/python-sdk/accept-header/poetry.lock
+++ b/seed/python-sdk/accept-header/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "28b2f27f6557e25ed97ac93c05b375557c16d2b86619ef95b310744803b3b417"

--- a/seed/python-sdk/accept-header/pyproject.toml
+++ b/seed/python-sdk/accept-header/pyproject.toml
@@ -51,7 +51,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
+pytest = "^9.0.3"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/alias-extends/no-custom-config/poetry.lock
+++ b/seed/python-sdk/alias-extends/no-custom-config/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "28b2f27f6557e25ed97ac93c05b375557c16d2b86619ef95b310744803b3b417"

--- a/seed/python-sdk/alias-extends/no-custom-config/pyproject.toml
+++ b/seed/python-sdk/alias-extends/no-custom-config/pyproject.toml
@@ -51,7 +51,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
+pytest = "^9.0.3"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/alias-extends/no-inheritance-for-extended-models/poetry.lock
+++ b/seed/python-sdk/alias-extends/no-inheritance-for-extended-models/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "28b2f27f6557e25ed97ac93c05b375557c16d2b86619ef95b310744803b3b417"

--- a/seed/python-sdk/alias-extends/no-inheritance-for-extended-models/pyproject.toml
+++ b/seed/python-sdk/alias-extends/no-inheritance-for-extended-models/pyproject.toml
@@ -51,7 +51,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
+pytest = "^9.0.3"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/alias/poetry.lock
+++ b/seed/python-sdk/alias/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "28b2f27f6557e25ed97ac93c05b375557c16d2b86619ef95b310744803b3b417"

--- a/seed/python-sdk/alias/pyproject.toml
+++ b/seed/python-sdk/alias/pyproject.toml
@@ -51,7 +51,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
+pytest = "^9.0.3"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/allof-inline/no-custom-config/poetry.lock
+++ b/seed/python-sdk/allof-inline/no-custom-config/poetry.lock
@@ -1206,20 +1206,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1611,4 +1611,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "7ac12b5d251e81a278fba2c051cbf4f768fb951f006f23ad0faedb1289539c1a"
+content-hash = "ef16dc9427b6268d92a87a70148ea623679f5adc0e8892f62d993e74711ad6ad"

--- a/seed/python-sdk/allof-inline/no-custom-config/pyproject.toml
+++ b/seed/python-sdk/allof-inline/no-custom-config/pyproject.toml
@@ -51,7 +51,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
+pytest = "^9.0.3"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/allof/no-custom-config/poetry.lock
+++ b/seed/python-sdk/allof/no-custom-config/poetry.lock
@@ -1206,20 +1206,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1611,4 +1611,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "7ac12b5d251e81a278fba2c051cbf4f768fb951f006f23ad0faedb1289539c1a"
+content-hash = "ef16dc9427b6268d92a87a70148ea623679f5adc0e8892f62d993e74711ad6ad"

--- a/seed/python-sdk/allof/no-custom-config/pyproject.toml
+++ b/seed/python-sdk/allof/no-custom-config/pyproject.toml
@@ -51,7 +51,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
+pytest = "^9.0.3"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/any-auth/poetry.lock
+++ b/seed/python-sdk/any-auth/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "28b2f27f6557e25ed97ac93c05b375557c16d2b86619ef95b310744803b3b417"

--- a/seed/python-sdk/any-auth/pyproject.toml
+++ b/seed/python-sdk/any-auth/pyproject.toml
@@ -51,7 +51,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
+pytest = "^9.0.3"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/api-wide-base-path/poetry.lock
+++ b/seed/python-sdk/api-wide-base-path/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "28b2f27f6557e25ed97ac93c05b375557c16d2b86619ef95b310744803b3b417"

--- a/seed/python-sdk/api-wide-base-path/pyproject.toml
+++ b/seed/python-sdk/api-wide-base-path/pyproject.toml
@@ -51,7 +51,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
+pytest = "^9.0.3"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/audiences/poetry.lock
+++ b/seed/python-sdk/audiences/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "28b2f27f6557e25ed97ac93c05b375557c16d2b86619ef95b310744803b3b417"

--- a/seed/python-sdk/audiences/pyproject.toml
+++ b/seed/python-sdk/audiences/pyproject.toml
@@ -51,7 +51,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
+pytest = "^9.0.3"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/basic-auth-environment-variables/poetry.lock
+++ b/seed/python-sdk/basic-auth-environment-variables/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "28b2f27f6557e25ed97ac93c05b375557c16d2b86619ef95b310744803b3b417"

--- a/seed/python-sdk/basic-auth-environment-variables/pyproject.toml
+++ b/seed/python-sdk/basic-auth-environment-variables/pyproject.toml
@@ -51,7 +51,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
+pytest = "^9.0.3"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/basic-auth-pw-omitted/poetry.lock
+++ b/seed/python-sdk/basic-auth-pw-omitted/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "28b2f27f6557e25ed97ac93c05b375557c16d2b86619ef95b310744803b3b417"

--- a/seed/python-sdk/basic-auth-pw-omitted/pyproject.toml
+++ b/seed/python-sdk/basic-auth-pw-omitted/pyproject.toml
@@ -51,7 +51,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
+pytest = "^9.0.3"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/basic-auth/poetry.lock
+++ b/seed/python-sdk/basic-auth/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "28b2f27f6557e25ed97ac93c05b375557c16d2b86619ef95b310744803b3b417"

--- a/seed/python-sdk/basic-auth/pyproject.toml
+++ b/seed/python-sdk/basic-auth/pyproject.toml
@@ -51,7 +51,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
+pytest = "^9.0.3"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/bearer-token-environment-variable/poetry.lock
+++ b/seed/python-sdk/bearer-token-environment-variable/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "28b2f27f6557e25ed97ac93c05b375557c16d2b86619ef95b310744803b3b417"

--- a/seed/python-sdk/bearer-token-environment-variable/pyproject.toml
+++ b/seed/python-sdk/bearer-token-environment-variable/pyproject.toml
@@ -51,7 +51,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
+pytest = "^9.0.3"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/bytes-download/poetry.lock
+++ b/seed/python-sdk/bytes-download/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "28b2f27f6557e25ed97ac93c05b375557c16d2b86619ef95b310744803b3b417"

--- a/seed/python-sdk/bytes-download/pyproject.toml
+++ b/seed/python-sdk/bytes-download/pyproject.toml
@@ -51,7 +51,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
+pytest = "^9.0.3"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/bytes-upload/poetry.lock
+++ b/seed/python-sdk/bytes-upload/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "28b2f27f6557e25ed97ac93c05b375557c16d2b86619ef95b310744803b3b417"

--- a/seed/python-sdk/bytes-upload/pyproject.toml
+++ b/seed/python-sdk/bytes-upload/pyproject.toml
@@ -51,7 +51,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
+pytest = "^9.0.3"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/circular-references-advanced/no-inheritance-for-extended-models/poetry.lock
+++ b/seed/python-sdk/circular-references-advanced/no-inheritance-for-extended-models/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "28b2f27f6557e25ed97ac93c05b375557c16d2b86619ef95b310744803b3b417"

--- a/seed/python-sdk/circular-references-advanced/no-inheritance-for-extended-models/pyproject.toml
+++ b/seed/python-sdk/circular-references-advanced/no-inheritance-for-extended-models/pyproject.toml
@@ -51,7 +51,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
+pytest = "^9.0.3"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/circular-references-extends/no-custom-config/poetry.lock
+++ b/seed/python-sdk/circular-references-extends/no-custom-config/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "28b2f27f6557e25ed97ac93c05b375557c16d2b86619ef95b310744803b3b417"

--- a/seed/python-sdk/circular-references-extends/no-custom-config/pyproject.toml
+++ b/seed/python-sdk/circular-references-extends/no-custom-config/pyproject.toml
@@ -51,7 +51,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
+pytest = "^9.0.3"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/circular-references/no-custom-config/poetry.lock
+++ b/seed/python-sdk/circular-references/no-custom-config/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "28b2f27f6557e25ed97ac93c05b375557c16d2b86619ef95b310744803b3b417"

--- a/seed/python-sdk/circular-references/no-custom-config/pyproject.toml
+++ b/seed/python-sdk/circular-references/no-custom-config/pyproject.toml
@@ -51,7 +51,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
+pytest = "^9.0.3"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/circular-references/no-inheritance-for-extended-models/poetry.lock
+++ b/seed/python-sdk/circular-references/no-inheritance-for-extended-models/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "28b2f27f6557e25ed97ac93c05b375557c16d2b86619ef95b310744803b3b417"

--- a/seed/python-sdk/circular-references/no-inheritance-for-extended-models/pyproject.toml
+++ b/seed/python-sdk/circular-references/no-inheritance-for-extended-models/pyproject.toml
@@ -51,7 +51,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
+pytest = "^9.0.3"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/client-side-params/poetry.lock
+++ b/seed/python-sdk/client-side-params/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "28b2f27f6557e25ed97ac93c05b375557c16d2b86619ef95b310744803b3b417"

--- a/seed/python-sdk/client-side-params/pyproject.toml
+++ b/seed/python-sdk/client-side-params/pyproject.toml
@@ -51,7 +51,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
+pytest = "^9.0.3"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/content-type/poetry.lock
+++ b/seed/python-sdk/content-type/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "28b2f27f6557e25ed97ac93c05b375557c16d2b86619ef95b310744803b3b417"

--- a/seed/python-sdk/content-type/pyproject.toml
+++ b/seed/python-sdk/content-type/pyproject.toml
@@ -51,7 +51,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
+pytest = "^9.0.3"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/cross-package-type-names/poetry.lock
+++ b/seed/python-sdk/cross-package-type-names/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "28b2f27f6557e25ed97ac93c05b375557c16d2b86619ef95b310744803b3b417"

--- a/seed/python-sdk/cross-package-type-names/pyproject.toml
+++ b/seed/python-sdk/cross-package-type-names/pyproject.toml
@@ -51,7 +51,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
+pytest = "^9.0.3"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/dollar-string-examples/poetry.lock
+++ b/seed/python-sdk/dollar-string-examples/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "28b2f27f6557e25ed97ac93c05b375557c16d2b86619ef95b310744803b3b417"

--- a/seed/python-sdk/dollar-string-examples/pyproject.toml
+++ b/seed/python-sdk/dollar-string-examples/pyproject.toml
@@ -51,7 +51,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
+pytest = "^9.0.3"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/empty-clients/poetry.lock
+++ b/seed/python-sdk/empty-clients/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "28b2f27f6557e25ed97ac93c05b375557c16d2b86619ef95b310744803b3b417"

--- a/seed/python-sdk/empty-clients/pyproject.toml
+++ b/seed/python-sdk/empty-clients/pyproject.toml
@@ -51,7 +51,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
+pytest = "^9.0.3"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/endpoint-security-auth/poetry.lock
+++ b/seed/python-sdk/endpoint-security-auth/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "28b2f27f6557e25ed97ac93c05b375557c16d2b86619ef95b310744803b3b417"

--- a/seed/python-sdk/endpoint-security-auth/pyproject.toml
+++ b/seed/python-sdk/endpoint-security-auth/pyproject.toml
@@ -51,7 +51,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
+pytest = "^9.0.3"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/enum/no-custom-config/poetry.lock
+++ b/seed/python-sdk/enum/no-custom-config/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "28b2f27f6557e25ed97ac93c05b375557c16d2b86619ef95b310744803b3b417"

--- a/seed/python-sdk/enum/no-custom-config/pyproject.toml
+++ b/seed/python-sdk/enum/no-custom-config/pyproject.toml
@@ -51,7 +51,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
+pytest = "^9.0.3"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/enum/real-enum-forward-compat/poetry.lock
+++ b/seed/python-sdk/enum/real-enum-forward-compat/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "28b2f27f6557e25ed97ac93c05b375557c16d2b86619ef95b310744803b3b417"

--- a/seed/python-sdk/enum/real-enum-forward-compat/pyproject.toml
+++ b/seed/python-sdk/enum/real-enum-forward-compat/pyproject.toml
@@ -51,7 +51,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
+pytest = "^9.0.3"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/enum/real-enum/poetry.lock
+++ b/seed/python-sdk/enum/real-enum/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "28b2f27f6557e25ed97ac93c05b375557c16d2b86619ef95b310744803b3b417"

--- a/seed/python-sdk/enum/real-enum/pyproject.toml
+++ b/seed/python-sdk/enum/real-enum/pyproject.toml
@@ -51,7 +51,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
+pytest = "^9.0.3"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/enum/strenum/poetry.lock
+++ b/seed/python-sdk/enum/strenum/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "28b2f27f6557e25ed97ac93c05b375557c16d2b86619ef95b310744803b3b417"

--- a/seed/python-sdk/enum/strenum/pyproject.toml
+++ b/seed/python-sdk/enum/strenum/pyproject.toml
@@ -51,7 +51,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
+pytest = "^9.0.3"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/error-property/poetry.lock
+++ b/seed/python-sdk/error-property/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "28b2f27f6557e25ed97ac93c05b375557c16d2b86619ef95b310744803b3b417"

--- a/seed/python-sdk/error-property/pyproject.toml
+++ b/seed/python-sdk/error-property/pyproject.toml
@@ -51,7 +51,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
+pytest = "^9.0.3"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/errors/poetry.lock
+++ b/seed/python-sdk/errors/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "28b2f27f6557e25ed97ac93c05b375557c16d2b86619ef95b310744803b3b417"

--- a/seed/python-sdk/errors/pyproject.toml
+++ b/seed/python-sdk/errors/pyproject.toml
@@ -51,7 +51,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
+pytest = "^9.0.3"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/examples/additional_init_exports_with_duplicates/poetry.lock
+++ b/seed/python-sdk/examples/additional_init_exports_with_duplicates/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "28b2f27f6557e25ed97ac93c05b375557c16d2b86619ef95b310744803b3b417"

--- a/seed/python-sdk/examples/additional_init_exports_with_duplicates/pyproject.toml
+++ b/seed/python-sdk/examples/additional_init_exports_with_duplicates/pyproject.toml
@@ -51,7 +51,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
+pytest = "^9.0.3"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/examples/client-filename/poetry.lock
+++ b/seed/python-sdk/examples/client-filename/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "28b2f27f6557e25ed97ac93c05b375557c16d2b86619ef95b310744803b3b417"

--- a/seed/python-sdk/examples/client-filename/pyproject.toml
+++ b/seed/python-sdk/examples/client-filename/pyproject.toml
@@ -51,7 +51,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
+pytest = "^9.0.3"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/examples/legacy-wire-tests/poetry.lock
+++ b/seed/python-sdk/examples/legacy-wire-tests/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "28b2f27f6557e25ed97ac93c05b375557c16d2b86619ef95b310744803b3b417"

--- a/seed/python-sdk/examples/legacy-wire-tests/pyproject.toml
+++ b/seed/python-sdk/examples/legacy-wire-tests/pyproject.toml
@@ -51,7 +51,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
+pytest = "^9.0.3"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/examples/no-custom-config/poetry.lock
+++ b/seed/python-sdk/examples/no-custom-config/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "28b2f27f6557e25ed97ac93c05b375557c16d2b86619ef95b310744803b3b417"

--- a/seed/python-sdk/examples/no-custom-config/pyproject.toml
+++ b/seed/python-sdk/examples/no-custom-config/pyproject.toml
@@ -51,7 +51,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
+pytest = "^9.0.3"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/examples/omit-fern-headers/poetry.lock
+++ b/seed/python-sdk/examples/omit-fern-headers/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "28b2f27f6557e25ed97ac93c05b375557c16d2b86619ef95b310744803b3b417"

--- a/seed/python-sdk/examples/omit-fern-headers/pyproject.toml
+++ b/seed/python-sdk/examples/omit-fern-headers/pyproject.toml
@@ -51,7 +51,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
+pytest = "^9.0.3"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/examples/readme/poetry.lock
+++ b/seed/python-sdk/examples/readme/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "28b2f27f6557e25ed97ac93c05b375557c16d2b86619ef95b310744803b3b417"

--- a/seed/python-sdk/examples/readme/pyproject.toml
+++ b/seed/python-sdk/examples/readme/pyproject.toml
@@ -51,7 +51,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
+pytest = "^9.0.3"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/exhaustive/additional_init_exports/poetry.lock
+++ b/seed/python-sdk/exhaustive/additional_init_exports/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "28b2f27f6557e25ed97ac93c05b375557c16d2b86619ef95b310744803b3b417"

--- a/seed/python-sdk/exhaustive/additional_init_exports/pyproject.toml
+++ b/seed/python-sdk/exhaustive/additional_init_exports/pyproject.toml
@@ -51,7 +51,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
+pytest = "^9.0.3"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/exhaustive/aliases_with_validation/poetry.lock
+++ b/seed/python-sdk/exhaustive/aliases_with_validation/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "28b2f27f6557e25ed97ac93c05b375557c16d2b86619ef95b310744803b3b417"

--- a/seed/python-sdk/exhaustive/aliases_with_validation/pyproject.toml
+++ b/seed/python-sdk/exhaustive/aliases_with_validation/pyproject.toml
@@ -51,7 +51,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
+pytest = "^9.0.3"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/exhaustive/aliases_without_validation/poetry.lock
+++ b/seed/python-sdk/exhaustive/aliases_without_validation/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "28b2f27f6557e25ed97ac93c05b375557c16d2b86619ef95b310744803b3b417"

--- a/seed/python-sdk/exhaustive/aliases_without_validation/pyproject.toml
+++ b/seed/python-sdk/exhaustive/aliases_without_validation/pyproject.toml
@@ -51,7 +51,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
+pytest = "^9.0.3"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/exhaustive/custom-transport/poetry.lock
+++ b/seed/python-sdk/exhaustive/custom-transport/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "28b2f27f6557e25ed97ac93c05b375557c16d2b86619ef95b310744803b3b417"

--- a/seed/python-sdk/exhaustive/custom-transport/pyproject.toml
+++ b/seed/python-sdk/exhaustive/custom-transport/pyproject.toml
@@ -51,7 +51,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
+pytest = "^9.0.3"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/exhaustive/datetime-milliseconds/poetry.lock
+++ b/seed/python-sdk/exhaustive/datetime-milliseconds/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "28b2f27f6557e25ed97ac93c05b375557c16d2b86619ef95b310744803b3b417"

--- a/seed/python-sdk/exhaustive/datetime-milliseconds/pyproject.toml
+++ b/seed/python-sdk/exhaustive/datetime-milliseconds/pyproject.toml
@@ -51,7 +51,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
+pytest = "^9.0.3"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/exhaustive/eager-imports/poetry.lock
+++ b/seed/python-sdk/exhaustive/eager-imports/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "28b2f27f6557e25ed97ac93c05b375557c16d2b86619ef95b310744803b3b417"

--- a/seed/python-sdk/exhaustive/eager-imports/pyproject.toml
+++ b/seed/python-sdk/exhaustive/eager-imports/pyproject.toml
@@ -51,7 +51,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
+pytest = "^9.0.3"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/exhaustive/extra_dev_dependencies/poetry.lock
+++ b/seed/python-sdk/exhaustive/extra_dev_dependencies/poetry.lock
@@ -1255,20 +1255,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1680,4 +1680,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "cdde23ef42dd3499ec0bb7a747ed4029d24e426bfe00e6819f9b3712c56d4927"
+content-hash = "aa5da99fca94fdbb7238e5b1ce36b4385be7b2b60a377eea10d37b56fa581676"

--- a/seed/python-sdk/exhaustive/extra_dev_dependencies/pyproject.toml
+++ b/seed/python-sdk/exhaustive/extra_dev_dependencies/pyproject.toml
@@ -52,7 +52,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
+pytest = "^9.0.3"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/exhaustive/five-second-timeout/poetry.lock
+++ b/seed/python-sdk/exhaustive/five-second-timeout/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "28b2f27f6557e25ed97ac93c05b375557c16d2b86619ef95b310744803b3b417"

--- a/seed/python-sdk/exhaustive/five-second-timeout/pyproject.toml
+++ b/seed/python-sdk/exhaustive/five-second-timeout/pyproject.toml
@@ -51,7 +51,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
+pytest = "^9.0.3"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/exhaustive/follow_redirects_by_default/poetry.lock
+++ b/seed/python-sdk/exhaustive/follow_redirects_by_default/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "28b2f27f6557e25ed97ac93c05b375557c16d2b86619ef95b310744803b3b417"

--- a/seed/python-sdk/exhaustive/follow_redirects_by_default/pyproject.toml
+++ b/seed/python-sdk/exhaustive/follow_redirects_by_default/pyproject.toml
@@ -51,7 +51,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
+pytest = "^9.0.3"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/exhaustive/import-paths/poetry.lock
+++ b/seed/python-sdk/exhaustive/import-paths/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "28b2f27f6557e25ed97ac93c05b375557c16d2b86619ef95b310744803b3b417"

--- a/seed/python-sdk/exhaustive/import-paths/pyproject.toml
+++ b/seed/python-sdk/exhaustive/import-paths/pyproject.toml
@@ -51,7 +51,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
+pytest = "^9.0.3"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/exhaustive/improved_imports/poetry.lock
+++ b/seed/python-sdk/exhaustive/improved_imports/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "28b2f27f6557e25ed97ac93c05b375557c16d2b86619ef95b310744803b3b417"

--- a/seed/python-sdk/exhaustive/improved_imports/pyproject.toml
+++ b/seed/python-sdk/exhaustive/improved_imports/pyproject.toml
@@ -51,7 +51,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
+pytest = "^9.0.3"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/exhaustive/infinite-timeout/poetry.lock
+++ b/seed/python-sdk/exhaustive/infinite-timeout/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "28b2f27f6557e25ed97ac93c05b375557c16d2b86619ef95b310744803b3b417"

--- a/seed/python-sdk/exhaustive/infinite-timeout/pyproject.toml
+++ b/seed/python-sdk/exhaustive/infinite-timeout/pyproject.toml
@@ -51,7 +51,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
+pytest = "^9.0.3"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/exhaustive/inline-path-params/poetry.lock
+++ b/seed/python-sdk/exhaustive/inline-path-params/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "28b2f27f6557e25ed97ac93c05b375557c16d2b86619ef95b310744803b3b417"

--- a/seed/python-sdk/exhaustive/inline-path-params/pyproject.toml
+++ b/seed/python-sdk/exhaustive/inline-path-params/pyproject.toml
@@ -51,7 +51,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
+pytest = "^9.0.3"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/exhaustive/inline_request_params/poetry.lock
+++ b/seed/python-sdk/exhaustive/inline_request_params/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "28b2f27f6557e25ed97ac93c05b375557c16d2b86619ef95b310744803b3b417"

--- a/seed/python-sdk/exhaustive/inline_request_params/pyproject.toml
+++ b/seed/python-sdk/exhaustive/inline_request_params/pyproject.toml
@@ -51,7 +51,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
+pytest = "^9.0.3"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/exhaustive/no-custom-config/poetry.lock
+++ b/seed/python-sdk/exhaustive/no-custom-config/poetry.lock
@@ -1206,20 +1206,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1611,4 +1611,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "7ac12b5d251e81a278fba2c051cbf4f768fb951f006f23ad0faedb1289539c1a"
+content-hash = "ef16dc9427b6268d92a87a70148ea623679f5adc0e8892f62d993e74711ad6ad"

--- a/seed/python-sdk/exhaustive/no-custom-config/pyproject.toml
+++ b/seed/python-sdk/exhaustive/no-custom-config/pyproject.toml
@@ -51,7 +51,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
+pytest = "^9.0.3"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/exhaustive/package-path/poetry.lock
+++ b/seed/python-sdk/exhaustive/package-path/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "28b2f27f6557e25ed97ac93c05b375557c16d2b86619ef95b310744803b3b417"

--- a/seed/python-sdk/exhaustive/package-path/pyproject.toml
+++ b/seed/python-sdk/exhaustive/package-path/pyproject.toml
@@ -51,7 +51,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
+pytest = "^9.0.3"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/exhaustive/pydantic-extra-fields/poetry.lock
+++ b/seed/python-sdk/exhaustive/pydantic-extra-fields/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "28b2f27f6557e25ed97ac93c05b375557c16d2b86619ef95b310744803b3b417"

--- a/seed/python-sdk/exhaustive/pydantic-extra-fields/pyproject.toml
+++ b/seed/python-sdk/exhaustive/pydantic-extra-fields/pyproject.toml
@@ -51,7 +51,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
+pytest = "^9.0.3"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/exhaustive/pydantic-ignore-fields/poetry.lock
+++ b/seed/python-sdk/exhaustive/pydantic-ignore-fields/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "28b2f27f6557e25ed97ac93c05b375557c16d2b86619ef95b310744803b3b417"

--- a/seed/python-sdk/exhaustive/pydantic-ignore-fields/pyproject.toml
+++ b/seed/python-sdk/exhaustive/pydantic-ignore-fields/pyproject.toml
@@ -51,7 +51,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
+pytest = "^9.0.3"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/exhaustive/pydantic-v1-with-utils/poetry.lock
+++ b/seed/python-sdk/exhaustive/pydantic-v1-with-utils/poetry.lock
@@ -1080,20 +1080,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1419,4 +1419,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "4a8254cfab519b5fdf33c2eb47ede9da99cfc1d411d88660cc116c13edbcddcc"
+content-hash = "8029a71ea1b5b8cf41c9520b20616a9e4e53833f7b4699c0cc4c005221ad51fa"

--- a/seed/python-sdk/exhaustive/pydantic-v1-with-utils/pyproject.toml
+++ b/seed/python-sdk/exhaustive/pydantic-v1-with-utils/pyproject.toml
@@ -51,7 +51,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
+pytest = "^9.0.3"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/exhaustive/pydantic-v1-wrapped/poetry.lock
+++ b/seed/python-sdk/exhaustive/pydantic-v1-wrapped/poetry.lock
@@ -1080,20 +1080,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1419,4 +1419,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "4a8254cfab519b5fdf33c2eb47ede9da99cfc1d411d88660cc116c13edbcddcc"
+content-hash = "8029a71ea1b5b8cf41c9520b20616a9e4e53833f7b4699c0cc4c005221ad51fa"

--- a/seed/python-sdk/exhaustive/pydantic-v1-wrapped/pyproject.toml
+++ b/seed/python-sdk/exhaustive/pydantic-v1-wrapped/pyproject.toml
@@ -51,7 +51,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
+pytest = "^9.0.3"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/exhaustive/pydantic-v1/poetry.lock
+++ b/seed/python-sdk/exhaustive/pydantic-v1/poetry.lock
@@ -1080,20 +1080,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1419,4 +1419,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "4a8254cfab519b5fdf33c2eb47ede9da99cfc1d411d88660cc116c13edbcddcc"
+content-hash = "8029a71ea1b5b8cf41c9520b20616a9e4e53833f7b4699c0cc4c005221ad51fa"

--- a/seed/python-sdk/exhaustive/pydantic-v1/pyproject.toml
+++ b/seed/python-sdk/exhaustive/pydantic-v1/pyproject.toml
@@ -51,7 +51,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
+pytest = "^9.0.3"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/exhaustive/pydantic-v2-wrapped/poetry.lock
+++ b/seed/python-sdk/exhaustive/pydantic-v2-wrapped/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c6bf0f1a4ea5cfca20a9bd8bf6d0af44697939804bef125015305f0f38d7395e"
+content-hash = "23396d9506d2fb2adea87d5747c09d06243bc1389cee6e786f6fd9483f69eef2"

--- a/seed/python-sdk/exhaustive/pydantic-v2-wrapped/pyproject.toml
+++ b/seed/python-sdk/exhaustive/pydantic-v2-wrapped/pyproject.toml
@@ -51,7 +51,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
+pytest = "^9.0.3"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/exhaustive/skip-pydantic-validation/poetry.lock
+++ b/seed/python-sdk/exhaustive/skip-pydantic-validation/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "28b2f27f6557e25ed97ac93c05b375557c16d2b86619ef95b310744803b3b417"

--- a/seed/python-sdk/exhaustive/skip-pydantic-validation/pyproject.toml
+++ b/seed/python-sdk/exhaustive/skip-pydantic-validation/pyproject.toml
@@ -51,7 +51,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
+pytest = "^9.0.3"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/exhaustive/union-utils/poetry.lock
+++ b/seed/python-sdk/exhaustive/union-utils/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "28b2f27f6557e25ed97ac93c05b375557c16d2b86619ef95b310744803b3b417"

--- a/seed/python-sdk/exhaustive/union-utils/pyproject.toml
+++ b/seed/python-sdk/exhaustive/union-utils/pyproject.toml
@@ -51,7 +51,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
+pytest = "^9.0.3"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/exhaustive/wire-tests-custom-client-name/poetry.lock
+++ b/seed/python-sdk/exhaustive/wire-tests-custom-client-name/poetry.lock
@@ -1206,20 +1206,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1611,4 +1611,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "7ac12b5d251e81a278fba2c051cbf4f768fb951f006f23ad0faedb1289539c1a"
+content-hash = "ef16dc9427b6268d92a87a70148ea623679f5adc0e8892f62d993e74711ad6ad"

--- a/seed/python-sdk/exhaustive/wire-tests-custom-client-name/pyproject.toml
+++ b/seed/python-sdk/exhaustive/wire-tests-custom-client-name/pyproject.toml
@@ -51,7 +51,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
+pytest = "^9.0.3"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/extends/poetry.lock
+++ b/seed/python-sdk/extends/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "28b2f27f6557e25ed97ac93c05b375557c16d2b86619ef95b310744803b3b417"

--- a/seed/python-sdk/extends/pyproject.toml
+++ b/seed/python-sdk/extends/pyproject.toml
@@ -51,7 +51,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
+pytest = "^9.0.3"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/extra-properties/poetry.lock
+++ b/seed/python-sdk/extra-properties/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "28b2f27f6557e25ed97ac93c05b375557c16d2b86619ef95b310744803b3b417"

--- a/seed/python-sdk/extra-properties/pyproject.toml
+++ b/seed/python-sdk/extra-properties/pyproject.toml
@@ -51,7 +51,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
+pytest = "^9.0.3"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/file-download/default-chunk-size/poetry.lock
+++ b/seed/python-sdk/file-download/default-chunk-size/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "28b2f27f6557e25ed97ac93c05b375557c16d2b86619ef95b310744803b3b417"

--- a/seed/python-sdk/file-download/default-chunk-size/pyproject.toml
+++ b/seed/python-sdk/file-download/default-chunk-size/pyproject.toml
@@ -51,7 +51,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
+pytest = "^9.0.3"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/file-download/no-custom-config/poetry.lock
+++ b/seed/python-sdk/file-download/no-custom-config/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "28b2f27f6557e25ed97ac93c05b375557c16d2b86619ef95b310744803b3b417"

--- a/seed/python-sdk/file-download/no-custom-config/pyproject.toml
+++ b/seed/python-sdk/file-download/no-custom-config/pyproject.toml
@@ -51,7 +51,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
+pytest = "^9.0.3"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/file-upload-openapi/poetry.lock
+++ b/seed/python-sdk/file-upload-openapi/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "28b2f27f6557e25ed97ac93c05b375557c16d2b86619ef95b310744803b3b417"

--- a/seed/python-sdk/file-upload-openapi/pyproject.toml
+++ b/seed/python-sdk/file-upload-openapi/pyproject.toml
@@ -51,7 +51,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
+pytest = "^9.0.3"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/file-upload/exclude_types_from_init_exports/poetry.lock
+++ b/seed/python-sdk/file-upload/exclude_types_from_init_exports/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "28b2f27f6557e25ed97ac93c05b375557c16d2b86619ef95b310744803b3b417"

--- a/seed/python-sdk/file-upload/exclude_types_from_init_exports/pyproject.toml
+++ b/seed/python-sdk/file-upload/exclude_types_from_init_exports/pyproject.toml
@@ -51,7 +51,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
+pytest = "^9.0.3"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/file-upload/no-custom-config/poetry.lock
+++ b/seed/python-sdk/file-upload/no-custom-config/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "28b2f27f6557e25ed97ac93c05b375557c16d2b86619ef95b310744803b3b417"

--- a/seed/python-sdk/file-upload/no-custom-config/pyproject.toml
+++ b/seed/python-sdk/file-upload/no-custom-config/pyproject.toml
@@ -51,7 +51,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
+pytest = "^9.0.3"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/file-upload/use_typeddict_requests/poetry.lock
+++ b/seed/python-sdk/file-upload/use_typeddict_requests/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "28b2f27f6557e25ed97ac93c05b375557c16d2b86619ef95b310744803b3b417"

--- a/seed/python-sdk/file-upload/use_typeddict_requests/pyproject.toml
+++ b/seed/python-sdk/file-upload/use_typeddict_requests/pyproject.toml
@@ -51,7 +51,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
+pytest = "^9.0.3"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/folders/poetry.lock
+++ b/seed/python-sdk/folders/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "28b2f27f6557e25ed97ac93c05b375557c16d2b86619ef95b310744803b3b417"

--- a/seed/python-sdk/folders/pyproject.toml
+++ b/seed/python-sdk/folders/pyproject.toml
@@ -51,7 +51,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
+pytest = "^9.0.3"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/header-auth-environment-variable/poetry.lock
+++ b/seed/python-sdk/header-auth-environment-variable/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "28b2f27f6557e25ed97ac93c05b375557c16d2b86619ef95b310744803b3b417"

--- a/seed/python-sdk/header-auth-environment-variable/pyproject.toml
+++ b/seed/python-sdk/header-auth-environment-variable/pyproject.toml
@@ -51,7 +51,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
+pytest = "^9.0.3"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/header-auth/poetry.lock
+++ b/seed/python-sdk/header-auth/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "28b2f27f6557e25ed97ac93c05b375557c16d2b86619ef95b310744803b3b417"

--- a/seed/python-sdk/header-auth/pyproject.toml
+++ b/seed/python-sdk/header-auth/pyproject.toml
@@ -51,7 +51,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
+pytest = "^9.0.3"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/http-head/poetry.lock
+++ b/seed/python-sdk/http-head/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "28b2f27f6557e25ed97ac93c05b375557c16d2b86619ef95b310744803b3b417"

--- a/seed/python-sdk/http-head/pyproject.toml
+++ b/seed/python-sdk/http-head/pyproject.toml
@@ -51,7 +51,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
+pytest = "^9.0.3"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/idempotency-headers/poetry.lock
+++ b/seed/python-sdk/idempotency-headers/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "28b2f27f6557e25ed97ac93c05b375557c16d2b86619ef95b310744803b3b417"

--- a/seed/python-sdk/idempotency-headers/pyproject.toml
+++ b/seed/python-sdk/idempotency-headers/pyproject.toml
@@ -51,7 +51,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
+pytest = "^9.0.3"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/imdb/poetry.lock
+++ b/seed/python-sdk/imdb/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "28b2f27f6557e25ed97ac93c05b375557c16d2b86619ef95b310744803b3b417"

--- a/seed/python-sdk/imdb/pyproject.toml
+++ b/seed/python-sdk/imdb/pyproject.toml
@@ -51,7 +51,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
+pytest = "^9.0.3"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/inferred-auth-explicit/poetry.lock
+++ b/seed/python-sdk/inferred-auth-explicit/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "28b2f27f6557e25ed97ac93c05b375557c16d2b86619ef95b310744803b3b417"

--- a/seed/python-sdk/inferred-auth-explicit/pyproject.toml
+++ b/seed/python-sdk/inferred-auth-explicit/pyproject.toml
@@ -51,7 +51,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
+pytest = "^9.0.3"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/inferred-auth-implicit-api-key/poetry.lock
+++ b/seed/python-sdk/inferred-auth-implicit-api-key/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "28b2f27f6557e25ed97ac93c05b375557c16d2b86619ef95b310744803b3b417"

--- a/seed/python-sdk/inferred-auth-implicit-api-key/pyproject.toml
+++ b/seed/python-sdk/inferred-auth-implicit-api-key/pyproject.toml
@@ -51,7 +51,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
+pytest = "^9.0.3"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/inferred-auth-implicit-no-expiry/poetry.lock
+++ b/seed/python-sdk/inferred-auth-implicit-no-expiry/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "28b2f27f6557e25ed97ac93c05b375557c16d2b86619ef95b310744803b3b417"

--- a/seed/python-sdk/inferred-auth-implicit-no-expiry/pyproject.toml
+++ b/seed/python-sdk/inferred-auth-implicit-no-expiry/pyproject.toml
@@ -51,7 +51,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
+pytest = "^9.0.3"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/inferred-auth-implicit-reference/poetry.lock
+++ b/seed/python-sdk/inferred-auth-implicit-reference/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "28b2f27f6557e25ed97ac93c05b375557c16d2b86619ef95b310744803b3b417"

--- a/seed/python-sdk/inferred-auth-implicit-reference/pyproject.toml
+++ b/seed/python-sdk/inferred-auth-implicit-reference/pyproject.toml
@@ -51,7 +51,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
+pytest = "^9.0.3"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/inferred-auth-implicit/poetry.lock
+++ b/seed/python-sdk/inferred-auth-implicit/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "28b2f27f6557e25ed97ac93c05b375557c16d2b86619ef95b310744803b3b417"

--- a/seed/python-sdk/inferred-auth-implicit/pyproject.toml
+++ b/seed/python-sdk/inferred-auth-implicit/pyproject.toml
@@ -51,7 +51,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
+pytest = "^9.0.3"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/license/poetry.lock
+++ b/seed/python-sdk/license/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "28b2f27f6557e25ed97ac93c05b375557c16d2b86619ef95b310744803b3b417"

--- a/seed/python-sdk/license/pyproject.toml
+++ b/seed/python-sdk/license/pyproject.toml
@@ -51,7 +51,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
+pytest = "^9.0.3"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/literal/no-custom-config/poetry.lock
+++ b/seed/python-sdk/literal/no-custom-config/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "28b2f27f6557e25ed97ac93c05b375557c16d2b86619ef95b310744803b3b417"

--- a/seed/python-sdk/literal/no-custom-config/pyproject.toml
+++ b/seed/python-sdk/literal/no-custom-config/pyproject.toml
@@ -51,7 +51,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
+pytest = "^9.0.3"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/literal/use_typeddict_requests/poetry.lock
+++ b/seed/python-sdk/literal/use_typeddict_requests/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "28b2f27f6557e25ed97ac93c05b375557c16d2b86619ef95b310744803b3b417"

--- a/seed/python-sdk/literal/use_typeddict_requests/pyproject.toml
+++ b/seed/python-sdk/literal/use_typeddict_requests/pyproject.toml
@@ -51,7 +51,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
+pytest = "^9.0.3"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/literals-unions/poetry.lock
+++ b/seed/python-sdk/literals-unions/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "28b2f27f6557e25ed97ac93c05b375557c16d2b86619ef95b310744803b3b417"

--- a/seed/python-sdk/literals-unions/pyproject.toml
+++ b/seed/python-sdk/literals-unions/pyproject.toml
@@ -51,7 +51,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
+pytest = "^9.0.3"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/mixed-case/poetry.lock
+++ b/seed/python-sdk/mixed-case/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "28b2f27f6557e25ed97ac93c05b375557c16d2b86619ef95b310744803b3b417"

--- a/seed/python-sdk/mixed-case/pyproject.toml
+++ b/seed/python-sdk/mixed-case/pyproject.toml
@@ -51,7 +51,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
+pytest = "^9.0.3"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/mixed-file-directory/exclude_types_from_init_exports/poetry.lock
+++ b/seed/python-sdk/mixed-file-directory/exclude_types_from_init_exports/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "28b2f27f6557e25ed97ac93c05b375557c16d2b86619ef95b310744803b3b417"

--- a/seed/python-sdk/mixed-file-directory/exclude_types_from_init_exports/pyproject.toml
+++ b/seed/python-sdk/mixed-file-directory/exclude_types_from_init_exports/pyproject.toml
@@ -51,7 +51,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
+pytest = "^9.0.3"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/mixed-file-directory/no-custom-config/poetry.lock
+++ b/seed/python-sdk/mixed-file-directory/no-custom-config/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "28b2f27f6557e25ed97ac93c05b375557c16d2b86619ef95b310744803b3b417"

--- a/seed/python-sdk/mixed-file-directory/no-custom-config/pyproject.toml
+++ b/seed/python-sdk/mixed-file-directory/no-custom-config/pyproject.toml
@@ -51,7 +51,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
+pytest = "^9.0.3"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/multi-line-docs/poetry.lock
+++ b/seed/python-sdk/multi-line-docs/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "28b2f27f6557e25ed97ac93c05b375557c16d2b86619ef95b310744803b3b417"

--- a/seed/python-sdk/multi-line-docs/pyproject.toml
+++ b/seed/python-sdk/multi-line-docs/pyproject.toml
@@ -51,7 +51,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
+pytest = "^9.0.3"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/multi-url-environment-no-default/poetry.lock
+++ b/seed/python-sdk/multi-url-environment-no-default/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "28b2f27f6557e25ed97ac93c05b375557c16d2b86619ef95b310744803b3b417"

--- a/seed/python-sdk/multi-url-environment-no-default/pyproject.toml
+++ b/seed/python-sdk/multi-url-environment-no-default/pyproject.toml
@@ -51,7 +51,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
+pytest = "^9.0.3"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/multi-url-environment-reference/poetry.lock
+++ b/seed/python-sdk/multi-url-environment-reference/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "28b2f27f6557e25ed97ac93c05b375557c16d2b86619ef95b310744803b3b417"

--- a/seed/python-sdk/multi-url-environment-reference/pyproject.toml
+++ b/seed/python-sdk/multi-url-environment-reference/pyproject.toml
@@ -51,7 +51,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
+pytest = "^9.0.3"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/multi-url-environment/poetry.lock
+++ b/seed/python-sdk/multi-url-environment/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "28b2f27f6557e25ed97ac93c05b375557c16d2b86619ef95b310744803b3b417"

--- a/seed/python-sdk/multi-url-environment/pyproject.toml
+++ b/seed/python-sdk/multi-url-environment/pyproject.toml
@@ -51,7 +51,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
+pytest = "^9.0.3"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/multiple-request-bodies/poetry.lock
+++ b/seed/python-sdk/multiple-request-bodies/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "28b2f27f6557e25ed97ac93c05b375557c16d2b86619ef95b310744803b3b417"

--- a/seed/python-sdk/multiple-request-bodies/pyproject.toml
+++ b/seed/python-sdk/multiple-request-bodies/pyproject.toml
@@ -51,7 +51,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
+pytest = "^9.0.3"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/no-content-response/poetry.lock
+++ b/seed/python-sdk/no-content-response/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "28b2f27f6557e25ed97ac93c05b375557c16d2b86619ef95b310744803b3b417"

--- a/seed/python-sdk/no-content-response/pyproject.toml
+++ b/seed/python-sdk/no-content-response/pyproject.toml
@@ -51,7 +51,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
+pytest = "^9.0.3"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/no-environment/poetry.lock
+++ b/seed/python-sdk/no-environment/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "28b2f27f6557e25ed97ac93c05b375557c16d2b86619ef95b310744803b3b417"

--- a/seed/python-sdk/no-environment/pyproject.toml
+++ b/seed/python-sdk/no-environment/pyproject.toml
@@ -51,7 +51,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
+pytest = "^9.0.3"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/no-retries/poetry.lock
+++ b/seed/python-sdk/no-retries/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "28b2f27f6557e25ed97ac93c05b375557c16d2b86619ef95b310744803b3b417"

--- a/seed/python-sdk/no-retries/pyproject.toml
+++ b/seed/python-sdk/no-retries/pyproject.toml
@@ -51,7 +51,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
+pytest = "^9.0.3"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/null-type/poetry.lock
+++ b/seed/python-sdk/null-type/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "28b2f27f6557e25ed97ac93c05b375557c16d2b86619ef95b310744803b3b417"

--- a/seed/python-sdk/null-type/pyproject.toml
+++ b/seed/python-sdk/null-type/pyproject.toml
@@ -51,7 +51,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
+pytest = "^9.0.3"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/nullable-allof-extends/poetry.lock
+++ b/seed/python-sdk/nullable-allof-extends/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "28b2f27f6557e25ed97ac93c05b375557c16d2b86619ef95b310744803b3b417"

--- a/seed/python-sdk/nullable-allof-extends/pyproject.toml
+++ b/seed/python-sdk/nullable-allof-extends/pyproject.toml
@@ -51,7 +51,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
+pytest = "^9.0.3"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/nullable-optional/poetry.lock
+++ b/seed/python-sdk/nullable-optional/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "28b2f27f6557e25ed97ac93c05b375557c16d2b86619ef95b310744803b3b417"

--- a/seed/python-sdk/nullable-optional/pyproject.toml
+++ b/seed/python-sdk/nullable-optional/pyproject.toml
@@ -51,7 +51,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
+pytest = "^9.0.3"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/nullable-request-body/poetry.lock
+++ b/seed/python-sdk/nullable-request-body/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "28b2f27f6557e25ed97ac93c05b375557c16d2b86619ef95b310744803b3b417"

--- a/seed/python-sdk/nullable-request-body/pyproject.toml
+++ b/seed/python-sdk/nullable-request-body/pyproject.toml
@@ -51,7 +51,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
+pytest = "^9.0.3"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/nullable/no-custom-config/poetry.lock
+++ b/seed/python-sdk/nullable/no-custom-config/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "28b2f27f6557e25ed97ac93c05b375557c16d2b86619ef95b310744803b3b417"

--- a/seed/python-sdk/nullable/no-custom-config/pyproject.toml
+++ b/seed/python-sdk/nullable/no-custom-config/pyproject.toml
@@ -51,7 +51,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
+pytest = "^9.0.3"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/nullable/use-typeddict-requests/poetry.lock
+++ b/seed/python-sdk/nullable/use-typeddict-requests/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "28b2f27f6557e25ed97ac93c05b375557c16d2b86619ef95b310744803b3b417"

--- a/seed/python-sdk/nullable/use-typeddict-requests/pyproject.toml
+++ b/seed/python-sdk/nullable/use-typeddict-requests/pyproject.toml
@@ -51,7 +51,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
+pytest = "^9.0.3"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/oauth-client-credentials-custom/poetry.lock
+++ b/seed/python-sdk/oauth-client-credentials-custom/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "28b2f27f6557e25ed97ac93c05b375557c16d2b86619ef95b310744803b3b417"

--- a/seed/python-sdk/oauth-client-credentials-custom/pyproject.toml
+++ b/seed/python-sdk/oauth-client-credentials-custom/pyproject.toml
@@ -51,7 +51,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
+pytest = "^9.0.3"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/oauth-client-credentials-default/poetry.lock
+++ b/seed/python-sdk/oauth-client-credentials-default/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "28b2f27f6557e25ed97ac93c05b375557c16d2b86619ef95b310744803b3b417"

--- a/seed/python-sdk/oauth-client-credentials-default/pyproject.toml
+++ b/seed/python-sdk/oauth-client-credentials-default/pyproject.toml
@@ -51,7 +51,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
+pytest = "^9.0.3"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/oauth-client-credentials-environment-variables/poetry.lock
+++ b/seed/python-sdk/oauth-client-credentials-environment-variables/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "28b2f27f6557e25ed97ac93c05b375557c16d2b86619ef95b310744803b3b417"

--- a/seed/python-sdk/oauth-client-credentials-environment-variables/pyproject.toml
+++ b/seed/python-sdk/oauth-client-credentials-environment-variables/pyproject.toml
@@ -51,7 +51,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
+pytest = "^9.0.3"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/oauth-client-credentials-mandatory-auth/no-custom-config/poetry.lock
+++ b/seed/python-sdk/oauth-client-credentials-mandatory-auth/no-custom-config/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "28b2f27f6557e25ed97ac93c05b375557c16d2b86619ef95b310744803b3b417"

--- a/seed/python-sdk/oauth-client-credentials-mandatory-auth/no-custom-config/pyproject.toml
+++ b/seed/python-sdk/oauth-client-credentials-mandatory-auth/no-custom-config/pyproject.toml
@@ -51,7 +51,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
+pytest = "^9.0.3"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/oauth-client-credentials-nested-root/poetry.lock
+++ b/seed/python-sdk/oauth-client-credentials-nested-root/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "28b2f27f6557e25ed97ac93c05b375557c16d2b86619ef95b310744803b3b417"

--- a/seed/python-sdk/oauth-client-credentials-nested-root/pyproject.toml
+++ b/seed/python-sdk/oauth-client-credentials-nested-root/pyproject.toml
@@ -51,7 +51,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
+pytest = "^9.0.3"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/oauth-client-credentials-openapi/poetry.lock
+++ b/seed/python-sdk/oauth-client-credentials-openapi/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "28b2f27f6557e25ed97ac93c05b375557c16d2b86619ef95b310744803b3b417"

--- a/seed/python-sdk/oauth-client-credentials-openapi/pyproject.toml
+++ b/seed/python-sdk/oauth-client-credentials-openapi/pyproject.toml
@@ -51,7 +51,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
+pytest = "^9.0.3"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/oauth-client-credentials-reference/poetry.lock
+++ b/seed/python-sdk/oauth-client-credentials-reference/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "28b2f27f6557e25ed97ac93c05b375557c16d2b86619ef95b310744803b3b417"

--- a/seed/python-sdk/oauth-client-credentials-reference/pyproject.toml
+++ b/seed/python-sdk/oauth-client-credentials-reference/pyproject.toml
@@ -51,7 +51,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
+pytest = "^9.0.3"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/oauth-client-credentials-with-variables/poetry.lock
+++ b/seed/python-sdk/oauth-client-credentials-with-variables/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "28b2f27f6557e25ed97ac93c05b375557c16d2b86619ef95b310744803b3b417"

--- a/seed/python-sdk/oauth-client-credentials-with-variables/pyproject.toml
+++ b/seed/python-sdk/oauth-client-credentials-with-variables/pyproject.toml
@@ -51,7 +51,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
+pytest = "^9.0.3"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/oauth-client-credentials/poetry.lock
+++ b/seed/python-sdk/oauth-client-credentials/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "28b2f27f6557e25ed97ac93c05b375557c16d2b86619ef95b310744803b3b417"

--- a/seed/python-sdk/oauth-client-credentials/pyproject.toml
+++ b/seed/python-sdk/oauth-client-credentials/pyproject.toml
@@ -51,7 +51,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
+pytest = "^9.0.3"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/object/poetry.lock
+++ b/seed/python-sdk/object/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "28b2f27f6557e25ed97ac93c05b375557c16d2b86619ef95b310744803b3b417"

--- a/seed/python-sdk/object/pyproject.toml
+++ b/seed/python-sdk/object/pyproject.toml
@@ -51,7 +51,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
+pytest = "^9.0.3"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/objects-with-imports/poetry.lock
+++ b/seed/python-sdk/objects-with-imports/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "28b2f27f6557e25ed97ac93c05b375557c16d2b86619ef95b310744803b3b417"

--- a/seed/python-sdk/objects-with-imports/pyproject.toml
+++ b/seed/python-sdk/objects-with-imports/pyproject.toml
@@ -51,7 +51,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
+pytest = "^9.0.3"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/optional/poetry.lock
+++ b/seed/python-sdk/optional/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "28b2f27f6557e25ed97ac93c05b375557c16d2b86619ef95b310744803b3b417"

--- a/seed/python-sdk/optional/pyproject.toml
+++ b/seed/python-sdk/optional/pyproject.toml
@@ -51,7 +51,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
+pytest = "^9.0.3"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/package-yml/poetry.lock
+++ b/seed/python-sdk/package-yml/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "28b2f27f6557e25ed97ac93c05b375557c16d2b86619ef95b310744803b3b417"

--- a/seed/python-sdk/package-yml/pyproject.toml
+++ b/seed/python-sdk/package-yml/pyproject.toml
@@ -51,7 +51,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
+pytest = "^9.0.3"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/pagination-custom/poetry.lock
+++ b/seed/python-sdk/pagination-custom/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "28b2f27f6557e25ed97ac93c05b375557c16d2b86619ef95b310744803b3b417"

--- a/seed/python-sdk/pagination-custom/pyproject.toml
+++ b/seed/python-sdk/pagination-custom/pyproject.toml
@@ -51,7 +51,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
+pytest = "^9.0.3"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/pagination-uri-path/poetry.lock
+++ b/seed/python-sdk/pagination-uri-path/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "28b2f27f6557e25ed97ac93c05b375557c16d2b86619ef95b310744803b3b417"

--- a/seed/python-sdk/pagination-uri-path/pyproject.toml
+++ b/seed/python-sdk/pagination-uri-path/pyproject.toml
@@ -51,7 +51,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
+pytest = "^9.0.3"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/pagination/no-custom-config/poetry.lock
+++ b/seed/python-sdk/pagination/no-custom-config/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "28b2f27f6557e25ed97ac93c05b375557c16d2b86619ef95b310744803b3b417"

--- a/seed/python-sdk/pagination/no-custom-config/pyproject.toml
+++ b/seed/python-sdk/pagination/no-custom-config/pyproject.toml
@@ -51,7 +51,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
+pytest = "^9.0.3"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/pagination/no-inheritance-for-extended-models/poetry.lock
+++ b/seed/python-sdk/pagination/no-inheritance-for-extended-models/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "28b2f27f6557e25ed97ac93c05b375557c16d2b86619ef95b310744803b3b417"

--- a/seed/python-sdk/pagination/no-inheritance-for-extended-models/pyproject.toml
+++ b/seed/python-sdk/pagination/no-inheritance-for-extended-models/pyproject.toml
@@ -51,7 +51,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
+pytest = "^9.0.3"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/pagination/page-index-semantics/poetry.lock
+++ b/seed/python-sdk/pagination/page-index-semantics/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "28b2f27f6557e25ed97ac93c05b375557c16d2b86619ef95b310744803b3b417"

--- a/seed/python-sdk/pagination/page-index-semantics/pyproject.toml
+++ b/seed/python-sdk/pagination/page-index-semantics/pyproject.toml
@@ -51,7 +51,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
+pytest = "^9.0.3"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/path-parameters/poetry.lock
+++ b/seed/python-sdk/path-parameters/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "28b2f27f6557e25ed97ac93c05b375557c16d2b86619ef95b310744803b3b417"

--- a/seed/python-sdk/path-parameters/pyproject.toml
+++ b/seed/python-sdk/path-parameters/pyproject.toml
@@ -51,7 +51,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
+pytest = "^9.0.3"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/plain-text/poetry.lock
+++ b/seed/python-sdk/plain-text/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "28b2f27f6557e25ed97ac93c05b375557c16d2b86619ef95b310744803b3b417"

--- a/seed/python-sdk/plain-text/pyproject.toml
+++ b/seed/python-sdk/plain-text/pyproject.toml
@@ -51,7 +51,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
+pytest = "^9.0.3"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/property-access/poetry.lock
+++ b/seed/python-sdk/property-access/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "28b2f27f6557e25ed97ac93c05b375557c16d2b86619ef95b310744803b3b417"

--- a/seed/python-sdk/property-access/pyproject.toml
+++ b/seed/python-sdk/property-access/pyproject.toml
@@ -51,7 +51,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
+pytest = "^9.0.3"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/public-object/poetry.lock
+++ b/seed/python-sdk/public-object/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "28b2f27f6557e25ed97ac93c05b375557c16d2b86619ef95b310744803b3b417"

--- a/seed/python-sdk/public-object/pyproject.toml
+++ b/seed/python-sdk/public-object/pyproject.toml
@@ -51,7 +51,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
+pytest = "^9.0.3"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/python-backslash-escape/poetry.lock
+++ b/seed/python-sdk/python-backslash-escape/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "28b2f27f6557e25ed97ac93c05b375557c16d2b86619ef95b310744803b3b417"

--- a/seed/python-sdk/python-backslash-escape/pyproject.toml
+++ b/seed/python-sdk/python-backslash-escape/pyproject.toml
@@ -51,7 +51,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
+pytest = "^9.0.3"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/python-mypy-exclude/no-custom-config/poetry.lock
+++ b/seed/python-sdk/python-mypy-exclude/no-custom-config/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "28b2f27f6557e25ed97ac93c05b375557c16d2b86619ef95b310744803b3b417"

--- a/seed/python-sdk/python-mypy-exclude/no-custom-config/pyproject.toml
+++ b/seed/python-sdk/python-mypy-exclude/no-custom-config/pyproject.toml
@@ -51,7 +51,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
+pytest = "^9.0.3"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/python-mypy-exclude/with-mypy-exclude/poetry.lock
+++ b/seed/python-sdk/python-mypy-exclude/with-mypy-exclude/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "28b2f27f6557e25ed97ac93c05b375557c16d2b86619ef95b310744803b3b417"

--- a/seed/python-sdk/python-mypy-exclude/with-mypy-exclude/pyproject.toml
+++ b/seed/python-sdk/python-mypy-exclude/with-mypy-exclude/pyproject.toml
@@ -51,7 +51,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
+pytest = "^9.0.3"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/python-positional-single-property/no-custom-config/poetry.lock
+++ b/seed/python-sdk/python-positional-single-property/no-custom-config/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "28b2f27f6557e25ed97ac93c05b375557c16d2b86619ef95b310744803b3b417"

--- a/seed/python-sdk/python-positional-single-property/no-custom-config/pyproject.toml
+++ b/seed/python-sdk/python-positional-single-property/no-custom-config/pyproject.toml
@@ -51,7 +51,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
+pytest = "^9.0.3"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/python-positional-single-property/with-positional-constructors/poetry.lock
+++ b/seed/python-sdk/python-positional-single-property/with-positional-constructors/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "28b2f27f6557e25ed97ac93c05b375557c16d2b86619ef95b310744803b3b417"

--- a/seed/python-sdk/python-positional-single-property/with-positional-constructors/pyproject.toml
+++ b/seed/python-sdk/python-positional-single-property/with-positional-constructors/pyproject.toml
@@ -51,7 +51,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
+pytest = "^9.0.3"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/python-streaming-parameter-openapi/with-wire-tests/poetry.lock
+++ b/seed/python-sdk/python-streaming-parameter-openapi/with-wire-tests/poetry.lock
@@ -1206,20 +1206,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1611,4 +1611,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "7ac12b5d251e81a278fba2c051cbf4f768fb951f006f23ad0faedb1289539c1a"
+content-hash = "ef16dc9427b6268d92a87a70148ea623679f5adc0e8892f62d993e74711ad6ad"

--- a/seed/python-sdk/python-streaming-parameter-openapi/with-wire-tests/pyproject.toml
+++ b/seed/python-sdk/python-streaming-parameter-openapi/with-wire-tests/pyproject.toml
@@ -51,7 +51,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
+pytest = "^9.0.3"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/query-param-name-conflict/poetry.lock
+++ b/seed/python-sdk/query-param-name-conflict/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "28b2f27f6557e25ed97ac93c05b375557c16d2b86619ef95b310744803b3b417"

--- a/seed/python-sdk/query-param-name-conflict/pyproject.toml
+++ b/seed/python-sdk/query-param-name-conflict/pyproject.toml
@@ -51,7 +51,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
+pytest = "^9.0.3"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/query-parameters-openapi-as-objects/no-custom-config/poetry.lock
+++ b/seed/python-sdk/query-parameters-openapi-as-objects/no-custom-config/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "28b2f27f6557e25ed97ac93c05b375557c16d2b86619ef95b310744803b3b417"

--- a/seed/python-sdk/query-parameters-openapi-as-objects/no-custom-config/pyproject.toml
+++ b/seed/python-sdk/query-parameters-openapi-as-objects/no-custom-config/pyproject.toml
@@ -51,7 +51,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
+pytest = "^9.0.3"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/query-parameters-openapi/no-custom-config/poetry.lock
+++ b/seed/python-sdk/query-parameters-openapi/no-custom-config/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "28b2f27f6557e25ed97ac93c05b375557c16d2b86619ef95b310744803b3b417"

--- a/seed/python-sdk/query-parameters-openapi/no-custom-config/pyproject.toml
+++ b/seed/python-sdk/query-parameters-openapi/no-custom-config/pyproject.toml
@@ -51,7 +51,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
+pytest = "^9.0.3"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/query-parameters/no-custom-config/poetry.lock
+++ b/seed/python-sdk/query-parameters/no-custom-config/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "28b2f27f6557e25ed97ac93c05b375557c16d2b86619ef95b310744803b3b417"

--- a/seed/python-sdk/query-parameters/no-custom-config/pyproject.toml
+++ b/seed/python-sdk/query-parameters/no-custom-config/pyproject.toml
@@ -51,7 +51,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
+pytest = "^9.0.3"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/request-parameters/poetry.lock
+++ b/seed/python-sdk/request-parameters/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "28b2f27f6557e25ed97ac93c05b375557c16d2b86619ef95b310744803b3b417"

--- a/seed/python-sdk/request-parameters/pyproject.toml
+++ b/seed/python-sdk/request-parameters/pyproject.toml
@@ -51,7 +51,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
+pytest = "^9.0.3"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/required-nullable/poetry.lock
+++ b/seed/python-sdk/required-nullable/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "28b2f27f6557e25ed97ac93c05b375557c16d2b86619ef95b310744803b3b417"

--- a/seed/python-sdk/required-nullable/pyproject.toml
+++ b/seed/python-sdk/required-nullable/pyproject.toml
@@ -51,7 +51,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
+pytest = "^9.0.3"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/reserved-keywords/poetry.lock
+++ b/seed/python-sdk/reserved-keywords/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "28b2f27f6557e25ed97ac93c05b375557c16d2b86619ef95b310744803b3b417"

--- a/seed/python-sdk/reserved-keywords/pyproject.toml
+++ b/seed/python-sdk/reserved-keywords/pyproject.toml
@@ -51,7 +51,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
+pytest = "^9.0.3"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/response-property/poetry.lock
+++ b/seed/python-sdk/response-property/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "28b2f27f6557e25ed97ac93c05b375557c16d2b86619ef95b310744803b3b417"

--- a/seed/python-sdk/response-property/pyproject.toml
+++ b/seed/python-sdk/response-property/pyproject.toml
@@ -51,7 +51,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
+pytest = "^9.0.3"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/schemaless-request-body-examples/poetry.lock
+++ b/seed/python-sdk/schemaless-request-body-examples/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "28b2f27f6557e25ed97ac93c05b375557c16d2b86619ef95b310744803b3b417"

--- a/seed/python-sdk/schemaless-request-body-examples/pyproject.toml
+++ b/seed/python-sdk/schemaless-request-body-examples/pyproject.toml
@@ -51,7 +51,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
+pytest = "^9.0.3"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/server-sent-event-examples/poetry.lock
+++ b/seed/python-sdk/server-sent-event-examples/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "28b2f27f6557e25ed97ac93c05b375557c16d2b86619ef95b310744803b3b417"

--- a/seed/python-sdk/server-sent-event-examples/pyproject.toml
+++ b/seed/python-sdk/server-sent-event-examples/pyproject.toml
@@ -51,7 +51,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
+pytest = "^9.0.3"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/server-sent-events-openapi/with-wire-tests/poetry.lock
+++ b/seed/python-sdk/server-sent-events-openapi/with-wire-tests/poetry.lock
@@ -1206,20 +1206,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1611,4 +1611,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "7ac12b5d251e81a278fba2c051cbf4f768fb951f006f23ad0faedb1289539c1a"
+content-hash = "ef16dc9427b6268d92a87a70148ea623679f5adc0e8892f62d993e74711ad6ad"

--- a/seed/python-sdk/server-sent-events-openapi/with-wire-tests/pyproject.toml
+++ b/seed/python-sdk/server-sent-events-openapi/with-wire-tests/pyproject.toml
@@ -51,7 +51,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
+pytest = "^9.0.3"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/server-sent-events/with-wire-tests/poetry.lock
+++ b/seed/python-sdk/server-sent-events/with-wire-tests/poetry.lock
@@ -1206,20 +1206,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1611,4 +1611,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "7ac12b5d251e81a278fba2c051cbf4f768fb951f006f23ad0faedb1289539c1a"
+content-hash = "ef16dc9427b6268d92a87a70148ea623679f5adc0e8892f62d993e74711ad6ad"

--- a/seed/python-sdk/server-sent-events/with-wire-tests/pyproject.toml
+++ b/seed/python-sdk/server-sent-events/with-wire-tests/pyproject.toml
@@ -51,7 +51,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
+pytest = "^9.0.3"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/server-url-templating/no-custom-config/poetry.lock
+++ b/seed/python-sdk/server-url-templating/no-custom-config/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "28b2f27f6557e25ed97ac93c05b375557c16d2b86619ef95b310744803b3b417"

--- a/seed/python-sdk/server-url-templating/no-custom-config/pyproject.toml
+++ b/seed/python-sdk/server-url-templating/no-custom-config/pyproject.toml
@@ -51,7 +51,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
+pytest = "^9.0.3"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/simple-api/poetry.lock
+++ b/seed/python-sdk/simple-api/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "28b2f27f6557e25ed97ac93c05b375557c16d2b86619ef95b310744803b3b417"

--- a/seed/python-sdk/simple-api/pyproject.toml
+++ b/seed/python-sdk/simple-api/pyproject.toml
@@ -51,7 +51,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
+pytest = "^9.0.3"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/simple-fhir/no-inheritance-for-extended-models/poetry.lock
+++ b/seed/python-sdk/simple-fhir/no-inheritance-for-extended-models/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "28b2f27f6557e25ed97ac93c05b375557c16d2b86619ef95b310744803b3b417"

--- a/seed/python-sdk/simple-fhir/no-inheritance-for-extended-models/pyproject.toml
+++ b/seed/python-sdk/simple-fhir/no-inheritance-for-extended-models/pyproject.toml
@@ -51,7 +51,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
+pytest = "^9.0.3"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/single-url-environment-default/poetry.lock
+++ b/seed/python-sdk/single-url-environment-default/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "28b2f27f6557e25ed97ac93c05b375557c16d2b86619ef95b310744803b3b417"

--- a/seed/python-sdk/single-url-environment-default/pyproject.toml
+++ b/seed/python-sdk/single-url-environment-default/pyproject.toml
@@ -51,7 +51,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
+pytest = "^9.0.3"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/single-url-environment-no-default/poetry.lock
+++ b/seed/python-sdk/single-url-environment-no-default/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "28b2f27f6557e25ed97ac93c05b375557c16d2b86619ef95b310744803b3b417"

--- a/seed/python-sdk/single-url-environment-no-default/pyproject.toml
+++ b/seed/python-sdk/single-url-environment-no-default/pyproject.toml
@@ -51,7 +51,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
+pytest = "^9.0.3"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/streaming-parameter/poetry.lock
+++ b/seed/python-sdk/streaming-parameter/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "28b2f27f6557e25ed97ac93c05b375557c16d2b86619ef95b310744803b3b417"

--- a/seed/python-sdk/streaming-parameter/pyproject.toml
+++ b/seed/python-sdk/streaming-parameter/pyproject.toml
@@ -51,7 +51,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
+pytest = "^9.0.3"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/streaming/no-custom-config/poetry.lock
+++ b/seed/python-sdk/streaming/no-custom-config/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "28b2f27f6557e25ed97ac93c05b375557c16d2b86619ef95b310744803b3b417"

--- a/seed/python-sdk/streaming/no-custom-config/pyproject.toml
+++ b/seed/python-sdk/streaming/no-custom-config/pyproject.toml
@@ -51,7 +51,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
+pytest = "^9.0.3"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/streaming/skip-pydantic-validation/poetry.lock
+++ b/seed/python-sdk/streaming/skip-pydantic-validation/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "28b2f27f6557e25ed97ac93c05b375557c16d2b86619ef95b310744803b3b417"

--- a/seed/python-sdk/streaming/skip-pydantic-validation/pyproject.toml
+++ b/seed/python-sdk/streaming/skip-pydantic-validation/pyproject.toml
@@ -51,7 +51,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
+pytest = "^9.0.3"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/trace/poetry.lock
+++ b/seed/python-sdk/trace/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "28b2f27f6557e25ed97ac93c05b375557c16d2b86619ef95b310744803b3b417"

--- a/seed/python-sdk/trace/pyproject.toml
+++ b/seed/python-sdk/trace/pyproject.toml
@@ -51,7 +51,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
+pytest = "^9.0.3"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/undiscriminated-union-with-response-property/poetry.lock
+++ b/seed/python-sdk/undiscriminated-union-with-response-property/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "28b2f27f6557e25ed97ac93c05b375557c16d2b86619ef95b310744803b3b417"

--- a/seed/python-sdk/undiscriminated-union-with-response-property/pyproject.toml
+++ b/seed/python-sdk/undiscriminated-union-with-response-property/pyproject.toml
@@ -51,7 +51,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
+pytest = "^9.0.3"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/undiscriminated-unions/poetry.lock
+++ b/seed/python-sdk/undiscriminated-unions/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "28b2f27f6557e25ed97ac93c05b375557c16d2b86619ef95b310744803b3b417"

--- a/seed/python-sdk/undiscriminated-unions/pyproject.toml
+++ b/seed/python-sdk/undiscriminated-unions/pyproject.toml
@@ -51,7 +51,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
+pytest = "^9.0.3"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/unions-with-local-date/poetry.lock
+++ b/seed/python-sdk/unions-with-local-date/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "28b2f27f6557e25ed97ac93c05b375557c16d2b86619ef95b310744803b3b417"

--- a/seed/python-sdk/unions-with-local-date/pyproject.toml
+++ b/seed/python-sdk/unions-with-local-date/pyproject.toml
@@ -51,7 +51,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
+pytest = "^9.0.3"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/unions/no-custom-config/poetry.lock
+++ b/seed/python-sdk/unions/no-custom-config/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "28b2f27f6557e25ed97ac93c05b375557c16d2b86619ef95b310744803b3b417"

--- a/seed/python-sdk/unions/no-custom-config/pyproject.toml
+++ b/seed/python-sdk/unions/no-custom-config/pyproject.toml
@@ -51,7 +51,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
+pytest = "^9.0.3"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/unions/union-naming-v1-wire-tests/poetry.lock
+++ b/seed/python-sdk/unions/union-naming-v1-wire-tests/poetry.lock
@@ -1206,20 +1206,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1611,4 +1611,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "7ac12b5d251e81a278fba2c051cbf4f768fb951f006f23ad0faedb1289539c1a"
+content-hash = "ef16dc9427b6268d92a87a70148ea623679f5adc0e8892f62d993e74711ad6ad"

--- a/seed/python-sdk/unions/union-naming-v1-wire-tests/pyproject.toml
+++ b/seed/python-sdk/unions/union-naming-v1-wire-tests/pyproject.toml
@@ -51,7 +51,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
+pytest = "^9.0.3"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/unions/union-naming-v1/poetry.lock
+++ b/seed/python-sdk/unions/union-naming-v1/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "28b2f27f6557e25ed97ac93c05b375557c16d2b86619ef95b310744803b3b417"

--- a/seed/python-sdk/unions/union-naming-v1/pyproject.toml
+++ b/seed/python-sdk/unions/union-naming-v1/pyproject.toml
@@ -51,7 +51,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
+pytest = "^9.0.3"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/unions/union-utils/poetry.lock
+++ b/seed/python-sdk/unions/union-utils/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "28b2f27f6557e25ed97ac93c05b375557c16d2b86619ef95b310744803b3b417"

--- a/seed/python-sdk/unions/union-utils/pyproject.toml
+++ b/seed/python-sdk/unions/union-utils/pyproject.toml
@@ -51,7 +51,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
+pytest = "^9.0.3"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/unknown/poetry.lock
+++ b/seed/python-sdk/unknown/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "28b2f27f6557e25ed97ac93c05b375557c16d2b86619ef95b310744803b3b417"

--- a/seed/python-sdk/unknown/pyproject.toml
+++ b/seed/python-sdk/unknown/pyproject.toml
@@ -51,7 +51,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
+pytest = "^9.0.3"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/url-form-encoded/poetry.lock
+++ b/seed/python-sdk/url-form-encoded/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "28b2f27f6557e25ed97ac93c05b375557c16d2b86619ef95b310744803b3b417"

--- a/seed/python-sdk/url-form-encoded/pyproject.toml
+++ b/seed/python-sdk/url-form-encoded/pyproject.toml
@@ -51,7 +51,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
+pytest = "^9.0.3"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/validation/no-custom-config/poetry.lock
+++ b/seed/python-sdk/validation/no-custom-config/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "28b2f27f6557e25ed97ac93c05b375557c16d2b86619ef95b310744803b3b417"

--- a/seed/python-sdk/validation/no-custom-config/pyproject.toml
+++ b/seed/python-sdk/validation/no-custom-config/pyproject.toml
@@ -51,7 +51,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
+pytest = "^9.0.3"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/validation/with-defaults-parameters/poetry.lock
+++ b/seed/python-sdk/validation/with-defaults-parameters/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "28b2f27f6557e25ed97ac93c05b375557c16d2b86619ef95b310744803b3b417"

--- a/seed/python-sdk/validation/with-defaults-parameters/pyproject.toml
+++ b/seed/python-sdk/validation/with-defaults-parameters/pyproject.toml
@@ -51,7 +51,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
+pytest = "^9.0.3"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/validation/with-defaults/poetry.lock
+++ b/seed/python-sdk/validation/with-defaults/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "28b2f27f6557e25ed97ac93c05b375557c16d2b86619ef95b310744803b3b417"

--- a/seed/python-sdk/validation/with-defaults/pyproject.toml
+++ b/seed/python-sdk/validation/with-defaults/pyproject.toml
@@ -51,7 +51,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
+pytest = "^9.0.3"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/variables/poetry.lock
+++ b/seed/python-sdk/variables/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "28b2f27f6557e25ed97ac93c05b375557c16d2b86619ef95b310744803b3b417"

--- a/seed/python-sdk/variables/pyproject.toml
+++ b/seed/python-sdk/variables/pyproject.toml
@@ -51,7 +51,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
+pytest = "^9.0.3"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/version-no-default/poetry.lock
+++ b/seed/python-sdk/version-no-default/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "28b2f27f6557e25ed97ac93c05b375557c16d2b86619ef95b310744803b3b417"

--- a/seed/python-sdk/version-no-default/pyproject.toml
+++ b/seed/python-sdk/version-no-default/pyproject.toml
@@ -51,7 +51,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
+pytest = "^9.0.3"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/version/poetry.lock
+++ b/seed/python-sdk/version/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "28b2f27f6557e25ed97ac93c05b375557c16d2b86619ef95b310744803b3b417"

--- a/seed/python-sdk/version/pyproject.toml
+++ b/seed/python-sdk/version/pyproject.toml
@@ -51,7 +51,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
+pytest = "^9.0.3"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/webhook-audience/poetry.lock
+++ b/seed/python-sdk/webhook-audience/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "28b2f27f6557e25ed97ac93c05b375557c16d2b86619ef95b310744803b3b417"

--- a/seed/python-sdk/webhook-audience/pyproject.toml
+++ b/seed/python-sdk/webhook-audience/pyproject.toml
@@ -51,7 +51,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
+pytest = "^9.0.3"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/webhooks/poetry.lock
+++ b/seed/python-sdk/webhooks/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "28b2f27f6557e25ed97ac93c05b375557c16d2b86619ef95b310744803b3b417"

--- a/seed/python-sdk/webhooks/pyproject.toml
+++ b/seed/python-sdk/webhooks/pyproject.toml
@@ -51,7 +51,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
+pytest = "^9.0.3"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/websocket-bearer-auth/poetry.lock
+++ b/seed/python-sdk/websocket-bearer-auth/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "28b2f27f6557e25ed97ac93c05b375557c16d2b86619ef95b310744803b3b417"

--- a/seed/python-sdk/websocket-bearer-auth/pyproject.toml
+++ b/seed/python-sdk/websocket-bearer-auth/pyproject.toml
@@ -51,7 +51,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
+pytest = "^9.0.3"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/websocket-inferred-auth/poetry.lock
+++ b/seed/python-sdk/websocket-inferred-auth/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "28b2f27f6557e25ed97ac93c05b375557c16d2b86619ef95b310744803b3b417"

--- a/seed/python-sdk/websocket-inferred-auth/pyproject.toml
+++ b/seed/python-sdk/websocket-inferred-auth/pyproject.toml
@@ -51,7 +51,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
+pytest = "^9.0.3"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/websocket-multi-url/poetry.lock
+++ b/seed/python-sdk/websocket-multi-url/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "28b2f27f6557e25ed97ac93c05b375557c16d2b86619ef95b310744803b3b417"

--- a/seed/python-sdk/websocket-multi-url/pyproject.toml
+++ b/seed/python-sdk/websocket-multi-url/pyproject.toml
@@ -51,7 +51,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
+pytest = "^9.0.3"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/websocket/websocket-base/poetry.lock
+++ b/seed/python-sdk/websocket/websocket-base/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "28b2f27f6557e25ed97ac93c05b375557c16d2b86619ef95b310744803b3b417"

--- a/seed/python-sdk/websocket/websocket-base/pyproject.toml
+++ b/seed/python-sdk/websocket/websocket-base/pyproject.toml
@@ -51,7 +51,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
+pytest = "^9.0.3"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/websocket/websocket-with_generated_clients-skip_validation/poetry.lock
+++ b/seed/python-sdk/websocket/websocket-with_generated_clients-skip_validation/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1491,4 +1491,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "9815ecd03f1237ca99fb206d32d23b5885ad0150e8339bb54d3faff4f804b4f7"
+content-hash = "27af33d4794ab5148e00278a1f55e5390623c930226e22e48be87eedbd393e9e"

--- a/seed/python-sdk/websocket/websocket-with_generated_clients-skip_validation/pyproject.toml
+++ b/seed/python-sdk/websocket/websocket-with_generated_clients-skip_validation/pyproject.toml
@@ -52,7 +52,7 @@ websockets = ">=12.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
+pytest = "^9.0.3"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/websocket/websocket-with_generated_clients/poetry.lock
+++ b/seed/python-sdk/websocket/websocket-with_generated_clients/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1491,4 +1491,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "9815ecd03f1237ca99fb206d32d23b5885ad0150e8339bb54d3faff4f804b4f7"
+content-hash = "27af33d4794ab5148e00278a1f55e5390623c930226e22e48be87eedbd393e9e"

--- a/seed/python-sdk/websocket/websocket-with_generated_clients/pyproject.toml
+++ b/seed/python-sdk/websocket/websocket-with_generated_clients/pyproject.toml
@@ -52,7 +52,7 @@ websockets = ">=12.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
+pytest = "^9.0.3"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"

--- a/seed/python-sdk/x-fern-default/poetry.lock
+++ b/seed/python-sdk/x-fern-default/poetry.lock
@@ -1068,20 +1068,20 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.3"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
-    {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
+    {file = "pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9"},
+    {file = "pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c"},
 ]
 
 [package.dependencies]
 colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
-iniconfig = ">=1"
-packaging = ">=20"
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
 pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
@@ -1421,4 +1421,4 @@ aiohttp = ["aiohttp", "httpx-aiohttp"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "c22c549ef574a50fc48074038793033112a025836768a63fcc3749869d1bcc8e"
+content-hash = "28b2f27f6557e25ed97ac93c05b375557c16d2b86619ef95b310744803b3b417"

--- a/seed/python-sdk/x-fern-default/pyproject.toml
+++ b/seed/python-sdk/x-fern-default/pyproject.toml
@@ -51,7 +51,7 @@ typing_extensions = ">= 4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "==1.13.0"
-pytest = "^8.2.0"
+pytest = "^9.0.3"
 pytest-asyncio = "^1.0.0"
 pytest-xdist = "^3.6.1"
 python-dateutil = "^2.9.0"


### PR DESCRIPTION
## Description

Addresses [CVE-2025-71176](https://github.com/advisories/GHSA-6w46-j5rx-g56g) (pytest insecure `/tmp/pytest-of-{user}` handling on UNIX, moderate severity, patched in pytest 9.0.3) for SDKs generated by the Python SDK and Pydantic model generators.

The generated `pyproject.toml` template in `generators/python/src/fern_python/codegen/pyproject_toml.py` is shared between the Python SDK, FastAPI, and Pydantic generators, so updating it here fixes the Dependabot alerts surfaced across all `seed/python-sdk/**/poetry.lock` and `seed/pydantic/**/poetry.lock` files the next time seed fixtures are regenerated.

Python 3.8 projects continue to use `pytest ^7.4.0` because pytest 9 requires Python 3.9+ — there is no fixed version of pytest for Python 3.8.

## Changes Made

- Bump generated `pytest` dev dep from `^8.2.0` → `^9.0.3` for SDKs targeting Python 3.9+ in `generators/python/src/fern_python/codegen/pyproject_toml.py`.
- Add an unreleased changelog entry for the Python SDK generator.
- Add a `1.12.0-rc.1` entry to the Pydantic generator's `versions.yml`.
- [ ] Updated README.md generator (if applicable)

Seed fixture output is intentionally untouched — @davidkonigsberg will regenerate seed fixtures from this branch.

## Testing

- [ ] Unit tests added/updated
- [x] Manual testing completed — verified the only changes to `pyproject_toml.py` are the pytest version string and the surrounding comment; ran `ruff check` against the file and confirmed the one remaining lint error is pre-existing and unrelated.


Link to Devin session: https://app.devin.ai/sessions/a6e58c9e91664a5989bdf64c2ecfa2cd