### PR TITLE
fix(ci): write Dependabot alerts to a file to avoid E2BIG in security workflow

### DIFF
--- a/.github/workflows/security-scanning-and-remediation.yml
+++ b/.github/workflows/security-scanning-and-remediation.yml
@@ -50,11 +50,15 @@ jobs:
       - name: Fetch Dependabot alerts
         id: fetch-alerts
         uses: actions/github-script@v8
+        env:
+          ALERTS_FILE: ${{ runner.temp }}/dependabot-alerts.json
         with:
           github-token: ${{ secrets.FERN_GITHUB_TOKEN }}
           script: |
+            const fs = require('fs');
             const owner = context.repo.owner;
             const repo = context.repo.repo;
+            const alertsFile = process.env.ALERTS_FILE;
 
             // Fetch all open Dependabot alerts using FERN_GITHUB_TOKEN
             let alerts = [];
@@ -73,23 +77,23 @@ jobs:
                 console.log('2. The token does not have the required `security_events` scope');
                 console.log('');
                 console.log('To fix: Ensure FERN_GITHUB_TOKEN is a PAT (classic) with `security_events` scope');
-                core.setOutput('alerts_json', '[]');
+                fs.writeFileSync(alertsFile, '[]');
+                core.setOutput('alerts_count', '0');
                 return;
               }
               throw error;
             }
 
-            if (alerts.length === 0) {
-              console.log('No open Dependabot alerts found.');
-              core.setOutput('alerts_json', '[]');
-              return;
-            }
-
-            console.log(`Found ${alerts.length} open Dependabot alerts.`);
-            core.setOutput('alerts_json', JSON.stringify(alerts));
+            // Persist alerts to a file on disk rather than passing the JSON
+            // through step outputs/env vars. The full alert payload can exceed
+            // the OS exec arg/env size limit (E2BIG "Argument list too long")
+            // when there are many alerts or long advisory descriptions.
+            fs.writeFileSync(alertsFile, JSON.stringify(alerts));
+            console.log(`Found ${alerts.length} open Dependabot alerts. Wrote to ${alertsFile}.`);
+            core.setOutput('alerts_count', String(alerts.length));
       - name: Create PRs and send Slack notifications
         id: create-prs
-        if: ${{ steps.fetch-alerts.outputs.alerts_json != '[]' && inputs.scan_only != true }}
+        if: ${{ steps.fetch-alerts.outputs.alerts_count != '0' && inputs.scan_only != true }}
         uses: actions/github-script@v8
         env:
           # ============================================================
@@ -110,11 +114,12 @@ jobs:
             8. Update the PR title, if needed, to pass CI checks
 
             **Alert Details:**
-          ALERTS_JSON: ${{ steps.fetch-alerts.outputs.alerts_json }}
+          ALERTS_FILE: ${{ runner.temp }}/dependabot-alerts.json
           SLACK_TOKEN: ${{ secrets.DEVIN_AI_PR_BOT_SLACK_TOKEN }}
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
+            const fs = require('fs');
             const devinPrompt = process.env.DEVIN_PROMPT;
             const slackToken = process.env.SLACK_TOKEN;
             const slackChannelId = 'C0A23CZEFNF';
@@ -123,7 +128,10 @@ jobs:
             const repo = context.repo.repo;
             const baseBranch = 'main';
 
-            const alerts = JSON.parse(process.env.ALERTS_JSON || '[]');
+            const alertsFile = process.env.ALERTS_FILE;
+            const alerts = fs.existsSync(alertsFile)
+              ? JSON.parse(fs.readFileSync(alertsFile, 'utf8'))
+              : [];
             if (alerts.length === 0) {
               console.log('No alerts to process.');
               return;


### PR DESCRIPTION
## Description
The `Check Dependabot alerts` job in `.github/workflows/security-scanning-and-remediation.yml` was failing with:

```
##[error]An error occurred trying to start process '.../node24/bin/node' with working directory '/home/runner/work/fern/fern'. Argument list too long
```

Reproduced in [this run](https://github.com/fern-api/fern/actions/runs/24664951213/job/72120103141).

Root cause: the `Fetch Dependabot alerts` step serialized the full `listAlertsForRepo` response into the `alerts_json` step output, and the next step read it back via the `ALERTS_JSON` env var. With ~100 alerts and long advisory descriptions the payload grew to ~670 KB, which exceeds the OS exec argument/env size limit (`E2BIG`) when `actions/github-script` spawns its child node process.

## Changes Made
- Persist the alerts payload to a file under `${{ runner.temp }}` in the fetch step instead of passing it through step outputs.
- Replace `alerts_json` with an `alerts_count` step output used only for the conditional guard.
- Load the alerts from disk in the create-PRs step.

## Testing
- YAML validated locally with `python -c "import yaml; yaml.safe_load(...)"`.
- No logic changes to PR creation / Slack notification flow — only the transport for the alerts payload changed.


Link to Devin session: https://app.devin.ai/sessions/1e015381860d4c5881f1e67a677cb19c
Requested by: @davidkonigsberg