### PR TITLE
fix(cli): resolve file-local $ref pointers in AsyncAPI bundler

### DIFF
--- a/packages/cli/cli/changes/unreleased/fix-asyncapi-file-local-refs.yml
+++ b/packages/cli/cli/changes/unreleased/fix-asyncapi-file-local-refs.yml
@@ -1,0 +1,5 @@
+- summary: |
+    Fix AsyncAPI bundler silently degrading typed models to `unknown` when
+    multi-file specs use file-local `$ref` pointers (e.g. `$ref: '#/Sibling'`)
+    inside schemas that are inlined from external files.
+  type: fix

--- a/packages/cli/workspace/lazy-fern-workspace/src/__test__/loadAsyncAPI.test.ts
+++ b/packages/cli/workspace/lazy-fern-workspace/src/__test__/loadAsyncAPI.test.ts
@@ -733,6 +733,150 @@ describe("loadAsyncAPI — external $ref resolution", () => {
         ).rejects.toThrow(/Circular \$ref detected/);
     });
 
+    it("rewrites file-local refs in inlined content via registry", async () => {
+        // Reproduces the Deepgram pattern: a schema file defines messages that
+        // use file-local #/Sibling refs to sibling definitions in the same file.
+        // When the message is inlined into the main doc, those file-local refs
+        // must be rewritten to #/components/schemas/Sibling (via registry).
+        await mkdir(join(tempDir, "schemas"), { recursive: true });
+        await mkdir(join(tempDir, "channels"), { recursive: true });
+
+        // schemas/schemas.listen.yml — message + sibling schemas
+        await writeFile(
+            join(tempDir, "schemas", "schemas.listen.yml"),
+            yaml.dump({
+                EagerEotThreshold: {
+                    type: "number",
+                    description: "Eager EOT threshold"
+                },
+                ListenConfigure: {
+                    name: "ListenConfigure",
+                    payload: {
+                        type: "object",
+                        properties: {
+                            type: { type: "string", const: "Configure" },
+                            threshold: { $ref: "#/EagerEotThreshold" }
+                        }
+                    }
+                }
+            })
+        );
+
+        // channels/listen.yml — references the message from the schemas file
+        await writeFile(
+            join(tempDir, "channels", "listen.yml"),
+            yaml.dump({
+                Listen: {
+                    messages: {
+                        ListenConfigure: {
+                            $ref: "../schemas/schemas.listen.yml#/ListenConfigure"
+                        }
+                    }
+                }
+            })
+        );
+
+        // Main doc — registers EagerEotThreshold in components.schemas and
+        // the channel via external refs
+        const doc = {
+            asyncapi: "3.0.0",
+            info: { title: "Test", version: "1.0.0" },
+            channels: {
+                Listen: { $ref: "./channels/listen.yml#/Listen" }
+            },
+            components: {
+                schemas: {
+                    EagerEotThreshold: {
+                        $ref: "./schemas/schemas.listen.yml#/EagerEotThreshold"
+                    }
+                }
+            }
+        };
+        await writeFile(join(tempDir, "asyncapi.yml"), yaml.dump(doc));
+
+        const result = (await loadAsyncAPI({
+            context,
+            absoluteFilePath: AbsoluteFilePath.of(join(tempDir, "asyncapi.yml")),
+            absoluteFilePathToOverrides: undefined
+        })) as unknown as Record<string, unknown>;
+
+        // The channel message should be inlined, and the file-local
+        // #/EagerEotThreshold ref inside it should be rewritten to the
+        // registry path #/components/schemas/EagerEotThreshold
+        const channels = result["channels"] as Record<string, unknown>;
+        const listen = channels["Listen"] as Record<string, unknown>;
+        const messages = listen["messages"] as Record<string, unknown>;
+        const configure = messages["ListenConfigure"] as Record<string, unknown>;
+        const payload = configure["payload"] as Record<string, unknown>;
+        const properties = payload["properties"] as Record<string, unknown>;
+        const threshold = properties["threshold"] as Record<string, unknown>;
+
+        expect(threshold["$ref"]).toBe("#/components/schemas/EagerEotThreshold");
+    });
+
+    it("inlines file-local refs when target is not in registry", async () => {
+        // When a file-local ref points to a sibling that is NOT registered in
+        // components.schemas (or any other registry section), the bundler should
+        // inline the content from the source file rather than leaving a dangling ref.
+        await mkdir(join(tempDir, "schemas"), { recursive: true });
+
+        await writeFile(
+            join(tempDir, "schemas", "types.yml"),
+            yaml.dump({
+                HelperType: {
+                    type: "string",
+                    description: "A helper type not registered in main doc"
+                },
+                MainType: {
+                    type: "object",
+                    properties: {
+                        helper: { $ref: "#/HelperType" }
+                    }
+                }
+            })
+        );
+
+        const doc = {
+            asyncapi: "2.6.0",
+            info: { title: "Test", version: "1.0.0" },
+            channels: {
+                "/data": {
+                    publish: {
+                        message: {
+                            payload: { $ref: "./schemas/types.yml#/MainType" }
+                        }
+                    }
+                }
+            }
+        };
+        await writeFile(join(tempDir, "asyncapi.yml"), yaml.dump(doc));
+
+        const result = (await loadAsyncAPI({
+            context,
+            absoluteFilePath: AbsoluteFilePath.of(join(tempDir, "asyncapi.yml")),
+            absoluteFilePathToOverrides: undefined
+        })) as unknown as Record<string, unknown>;
+
+        const channels = result["channels"] as Record<string, unknown>;
+        const payload = (
+            ((channels["/data"] as Record<string, unknown>)["publish"] as Record<string, unknown>)["message"] as Record<
+                string,
+                unknown
+            >
+        )["payload"] as Record<string, unknown>;
+
+        // MainType should be inlined
+        expect(payload["$ref"]).toBeUndefined();
+        expect(payload["type"]).toBe("object");
+
+        // The file-local #/HelperType ref should also be fully inlined
+        const properties = payload["properties"] as Record<string, unknown>;
+        const helper = properties["helper"] as Record<string, unknown>;
+        expect(helper["$ref"]).toBeUndefined();
+        expect(helper["type"]).toBe("string");
+        expect(helper["description"]).toBe("A helper type not registered in main doc");
+    });
+
     it("leaves HTTP/HTTPS $ref values untouched for downstream resolution", async () => {
         const doc = {
             asyncapi: "3.0.0",

--- a/packages/cli/workspace/lazy-fern-workspace/src/utils/resolveExternalRefs.ts
+++ b/packages/cli/workspace/lazy-fern-workspace/src/utils/resolveExternalRefs.ts
@@ -107,6 +107,62 @@ function isExternalRefValue(value: unknown): boolean {
     return typeof ref === "string" && ref.length > 0 && !ref.startsWith("#") && !isUrlRef(ref);
 }
 
+interface SiblingResult {
+    siblingProperties: Record<string, unknown>;
+    hasSiblings: boolean;
+}
+
+/** Extract all properties from a $ref object other than `$ref` itself. */
+function collectSiblingProperties(record: Record<string, unknown>): SiblingResult {
+    const siblingProperties: Record<string, unknown> = {};
+    let hasSiblings = false;
+    for (const [key, value] of Object.entries(record)) {
+        if (key !== "$ref") {
+            siblingProperties[key] = value;
+            hasSiblings = true;
+        }
+    }
+    return { siblingProperties, hasSiblings };
+}
+
+/** Walk a parsed document to the node at the given JSON Pointer. */
+function navigateJsonPointer(root: unknown, pointer: string, filePath: string): unknown {
+    if (pointer === "") {
+        return root;
+    }
+    const segments = pointer.split("/").filter((k) => k !== "");
+    let current: unknown = root;
+    for (const segment of segments) {
+        const decodedKey = segment.replace(/~1/g, "/").replace(/~0/g, "~");
+        if (typeof current !== "object" || current == null) {
+            throw new Error(
+                `Cannot navigate JSON Pointer "${pointer}" in "${filePath}": ` +
+                    `expected an object but found ${typeof current} at key "${decodedKey}"`
+            );
+        }
+        const next = (current as Record<string, unknown>)[decodedKey];
+        if (next === undefined) {
+            throw new Error(
+                `Cannot navigate JSON Pointer "${pointer}" in "${filePath}": ` + `key "${decodedKey}" not found`
+            );
+        }
+        current = next;
+    }
+    return current;
+}
+
+/** Merge sibling properties onto resolved content (siblings take precedence). */
+function mergeWithSiblings(
+    resolved: unknown,
+    siblingProperties: Record<string, unknown>,
+    hasSiblings: boolean
+): unknown {
+    if (hasSiblings && resolved != null && typeof resolved === "object" && !Array.isArray(resolved)) {
+        return { ...(resolved as Record<string, unknown>), ...siblingProperties };
+    }
+    return resolved;
+}
+
 /**
  * Given a resolved absolute ref path + JSON pointer, check whether it should
  * become an internal `#/…` ref rather than be inlined:
@@ -162,7 +218,10 @@ function findInternalRef(
  * similar) document.
  *
  * **Behaviour**
- * - Internal refs (`#/…`) are always left unchanged.
+ * - Internal refs (`#/…`) in the main document are left unchanged.
+ * - Internal refs (`#/…`) inside content inlined from an external file are
+ *   rewritten via the registry (or inlined from the source file) because they
+ *   are file-local to the source, not the main document.
  * - External refs (`./foo.yml#/Bar`) are handled based on `applyRegistry`:
  *   - When `false` (top-level processing of the main document): always inline.
  *   - When `true` (inside a loaded external file): first try to convert to an
@@ -170,13 +229,16 @@ function findInternalRef(
  * - Transitive external refs inside loaded files are resolved recursively with
  *   `applyRegistry = true`.
  *
- * @param obj             - Document fragment to process
- * @param baseDir         - Absolute directory for resolving relative file refs
- * @param mainFileAbsPath - Absolute path to the root document being bundled
- * @param registry        - Ref registry built by `buildExternalRefRegistry`
- * @param applyRegistry   - Whether to attempt registry-based ref conversion
- * @param visited         - Cycle-detection set (do not pass externally)
- * @param fileCache       - Per-call file cache (do not pass externally)
+ * @param obj                - Document fragment to process
+ * @param baseDir            - Absolute directory for resolving relative file refs
+ * @param mainFileAbsPath    - Absolute path to the root document being bundled
+ * @param registry           - Ref registry built by `buildExternalRefRegistry`
+ * @param applyRegistry      - Whether to attempt registry-based ref conversion
+ * @param visited            - Cycle-detection set (do not pass externally)
+ * @param fileCache          - Per-call file cache (do not pass externally)
+ * @param sourceFileAbsPath  - When set, we are inside content inlined from this
+ *                             external file; file-local `#/` refs are resolved
+ *                             against it rather than left unchanged.
  */
 export async function resolveExternalRefs(
     obj: unknown,
@@ -185,7 +247,8 @@ export async function resolveExternalRefs(
     registry: Map<string, string>,
     applyRegistry = false,
     visited: Set<string> = new Set(),
-    fileCache: Map<string, unknown> = new Map()
+    fileCache: Map<string, unknown> = new Map(),
+    sourceFileAbsPath?: string
 ): Promise<unknown> {
     if (obj == null || typeof obj !== "object") {
         return obj;
@@ -194,7 +257,16 @@ export async function resolveExternalRefs(
     if (Array.isArray(obj)) {
         return Promise.all(
             obj.map((item) =>
-                resolveExternalRefs(item, baseDir, mainFileAbsPath, registry, applyRegistry, visited, fileCache)
+                resolveExternalRefs(
+                    item,
+                    baseDir,
+                    mainFileAbsPath,
+                    registry,
+                    applyRegistry,
+                    visited,
+                    fileCache,
+                    sourceFileAbsPath
+                )
             )
         );
     }
@@ -202,21 +274,48 @@ export async function resolveExternalRefs(
     const record = obj as Record<string, unknown>;
 
     const ref = record["$ref"];
+
+    // When inside content inlined from an external file, file-local refs
+    // (#/Foo) point to siblings in the *source* file, not the main document.
+    // Rewrite them via the registry or inline from the source file.
+    if (typeof ref === "string" && ref.startsWith("#") && sourceFileAbsPath != null) {
+        const pointer = ref.substring(1);
+        const { siblingProperties, hasSiblings } = collectSiblingProperties(record);
+
+        const internalRef = findInternalRef(sourceFileAbsPath, pointer, mainFileAbsPath, registry);
+        if (internalRef !== null) {
+            return hasSiblings ? { $ref: internalRef, ...siblingProperties } : { $ref: internalRef };
+        }
+
+        const cacheKey = `${sourceFileAbsPath}#${pointer}`;
+        if (visited.has(cacheKey)) {
+            throw new Error(`Circular $ref detected: "${ref}" (resolved to "${cacheKey}")`);
+        }
+        const newVisited = new Set(visited);
+        newVisited.add(cacheKey);
+
+        const fileContent = await readAndParseFile(sourceFileAbsPath, fileCache);
+        const parsed = navigateJsonPointer(fileContent, pointer, sourceFileAbsPath);
+
+        const refDir = dirname(sourceFileAbsPath);
+        const resolved = await resolveExternalRefs(
+            parsed,
+            refDir,
+            mainFileAbsPath,
+            registry,
+            true,
+            newVisited,
+            fileCache,
+            sourceFileAbsPath
+        );
+
+        return mergeWithSiblings(resolved, siblingProperties, hasSiblings);
+    }
+
     if (typeof ref === "string" && !ref.startsWith("#") && !isUrlRef(ref)) {
         const { jsonPointer, absolutePath: absoluteRefPath } = parseExternalRef(ref, baseDir);
+        const { siblingProperties, hasSiblings } = collectSiblingProperties(record);
 
-        // Collect sibling properties (keys other than $ref). AsyncAPI 3.x and
-        // OpenAPI 3.1+ allow meaningful sibling keywords alongside $ref (e.g.
-        // "description" overriding the referenced schema's description).
-        const siblingProperties: Record<string, unknown> = {};
-        for (const [key, value] of Object.entries(record)) {
-            if (key !== "$ref") {
-                siblingProperties[key] = value;
-            }
-        }
-        const hasSiblings = Object.keys(siblingProperties).length > 0;
-
-        // When inside a loaded file, prefer converting to an internal ref
         if (applyRegistry) {
             const internalRef = findInternalRef(absoluteRefPath, jsonPointer, mainFileAbsPath, registry);
             if (internalRef !== null) {
@@ -224,7 +323,6 @@ export async function resolveExternalRefs(
             }
         }
 
-        // Inline the referenced content
         const cacheKey = `${absoluteRefPath}#${jsonPointer}`;
         if (visited.has(cacheKey)) {
             throw new Error(`Circular $ref detected: "${ref}" (resolved to "${cacheKey}")`);
@@ -232,32 +330,9 @@ export async function resolveExternalRefs(
         const newVisited = new Set(visited);
         newVisited.add(cacheKey);
 
-        let parsed: unknown = await readAndParseFile(absoluteRefPath, fileCache);
+        const fileContent = await readAndParseFile(absoluteRefPath, fileCache);
+        const parsed = navigateJsonPointer(fileContent, jsonPointer, absoluteRefPath);
 
-        if (jsonPointer !== "") {
-            const keys = jsonPointer.split("/").filter((k) => k !== "");
-            let current: unknown = parsed;
-            for (const key of keys) {
-                const decodedKey = key.replace(/~1/g, "/").replace(/~0/g, "~");
-                if (typeof current !== "object" || current == null) {
-                    throw new Error(
-                        `Cannot navigate JSON Pointer "${jsonPointer}" in "${absoluteRefPath}": ` +
-                            `expected an object but found ${typeof current} at key "${decodedKey}"`
-                    );
-                }
-                const next = (current as Record<string, unknown>)[decodedKey];
-                if (next === undefined) {
-                    throw new Error(
-                        `Cannot navigate JSON Pointer "${jsonPointer}" in "${absoluteRefPath}": ` +
-                            `key "${decodedKey}" not found`
-                    );
-                }
-                current = next;
-            }
-            parsed = current;
-        }
-
-        // Recursively resolve the loaded content, now with registry active
         const refDir = dirname(absoluteRefPath);
         const resolved = await resolveExternalRefs(
             parsed,
@@ -266,15 +341,11 @@ export async function resolveExternalRefs(
             registry,
             true,
             newVisited,
-            fileCache
+            fileCache,
+            absoluteRefPath
         );
 
-        // Merge sibling properties onto the resolved content. Sibling props
-        // take precedence (they act as overrides per AsyncAPI 3.x / OAS 3.1).
-        if (hasSiblings && resolved != null && typeof resolved === "object" && !Array.isArray(resolved)) {
-            return { ...(resolved as Record<string, unknown>), ...siblingProperties };
-        }
-        return resolved;
+        return mergeWithSiblings(resolved, siblingProperties, hasSiblings);
     }
 
     // No external $ref — recursively process every property value
@@ -287,7 +358,8 @@ export async function resolveExternalRefs(
             registry,
             applyRegistry,
             visited,
-            fileCache
+            fileCache,
+            sourceFileAbsPath
         );
     }
     return result;


### PR DESCRIPTION
Fix AsyncAPI bundler silently breaking `$ref`erences when multi-file specs use file-local `$ref` pointers (i.e., those that start with `#/`) inside schemas inlined from external files.

## Example

A schema file with sibling `$ref`s like:

```yaml
# schemas/schemas.listen.v2.yml
ListenV2Configure:
  payload:
    properties:
      thresholds:
        properties:
          eager_eot_threshold:
            $ref: '#/ListenV2EagerEotThreshold'   # sibling in same file
```

When inlined into the main document, the bundler left `#/ListenV2EagerEotThreshold` as-is. That ref is file-local to the source file and doesn't exist at the root of the bundled document — causing the downstream schema converter to fall back to `unknown`.

**Before:** `send_configure(self, message: typing.Any)`
**After:** `send_configure(self, message: ListenV2Configure)`

The fix adds `sourceFileAbsPath` tracking to `resolveExternalRefs` so that file-local `#/` refs inside inlined content are rewritten via the registry (or inlined from the source file).

## Test plan

- [x] New unit tests: "rewrites file-local refs in inlined content via registry" and "inlines file-local refs when target is not in registry"
- [x] All 21 `loadAsyncAPI` tests pass
- [x] End-to-end: `pnpm seed run --generator python-sdk --path <deepgram-fern-config>/fern` produces typed `ListenV2Configure` and `ListenV2ConfigureSuccess` models

🤖 Generated with [Claude Code](https://claude.com/claude-code)