### PR TITLE
chore(java): bump bundled bouncycastle jars to 1.84 to address CVE-2026-3505

### DIFF
--- a/generators/java/sdk/Dockerfile
+++ b/generators/java/sdk/Dockerfile
@@ -40,6 +40,22 @@ RUN rm -f /opt/gradle/lib/jackson-core-*.jar && \
       -o /opt/gradle/lib/jackson-core-2.18.6.jar && \
     echo "e7e1bfa50f0a79db37e6aa37db111cf03aebf4a484b359d21127ab43ab2398c6  /opt/gradle/lib/jackson-core-2.18.6.jar" | sha256sum -c -
 
+# Replace vulnerable Bouncy Castle jars in Gradle distribution to fix CVE-2026-3505
+# (bcpg unbounded PGP AEAD chunk size leads to pre-auth resource exhaustion; fixed in 1.84).
+# bcprov and bcutil are upgraded in lockstep since bcpg 1.78+ requires a matching bcutil.
+RUN rm -f /opt/gradle/lib/plugins/bcpg-jdk18on-*.jar \
+          /opt/gradle/lib/plugins/bcprov-jdk18on-*.jar \
+          /opt/gradle/lib/plugins/bcutil-jdk18on-*.jar && \
+    curl -sL https://repo1.maven.org/maven2/org/bouncycastle/bcpg-jdk18on/1.84/bcpg-jdk18on-1.84.jar \
+      -o /opt/gradle/lib/plugins/bcpg-jdk18on-1.84.jar && \
+    echo "c0e6303a0d7589040f400950ecee87a14b81312e84ed15e5390ebb0c4566ddab  /opt/gradle/lib/plugins/bcpg-jdk18on-1.84.jar" | sha256sum -c - && \
+    curl -sL https://repo1.maven.org/maven2/org/bouncycastle/bcprov-jdk18on/1.84/bcprov-jdk18on-1.84.jar \
+      -o /opt/gradle/lib/plugins/bcprov-jdk18on-1.84.jar && \
+    echo "64d6c5a6121fcd927152dd182cbed39afe0fda641a970d9bcc0c9cb1858b2731  /opt/gradle/lib/plugins/bcprov-jdk18on-1.84.jar" | sha256sum -c - && \
+    curl -sL https://repo1.maven.org/maven2/org/bouncycastle/bcutil-jdk18on/1.84/bcutil-jdk18on-1.84.jar \
+      -o /opt/gradle/lib/plugins/bcutil-jdk18on-1.84.jar && \
+    echo "b374e16963421fb9cfb01cc20d7ad8fd2f8b8188e3eef0ec0a8965e245f7619a  /opt/gradle/lib/plugins/bcutil-jdk18on-1.84.jar" | sha256sum -c -
+
 # Update packages to get latest security fixes and remove unnecessary packages
 # Amazon Linux 2023 uses dnf instead of apt-get
 # Note: Amazon Linux 2023 has fewer pre-installed packages than Ubuntu, so we only

--- a/generators/java/sdk/changes/unreleased/bump-bouncycastle-cve-2026-3505.yml
+++ b/generators/java/sdk/changes/unreleased/bump-bouncycastle-cve-2026-3505.yml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=../../../../../fern-changes-yml.schema.json
+
+- summary: |
+    Bump Bouncy Castle jars bundled with the Gradle base image from 1.78.1 to
+    1.84 to address CVE-2026-3505 (unbounded PGP AEAD chunk size in bcpg leading
+    to pre-auth resource exhaustion).
+  type: chore


### PR DESCRIPTION
## Description
Linear ticket: n/a

The `fernapi/fern-java-sdk` generator container is built on top of `gradle:jdk11-corretto`, which ships Bouncy Castle 1.78.1 jars (`bcpg-jdk18on`, `bcprov-jdk18on`, `bcutil-jdk18on`) in `/opt/gradle/lib/plugins/`. [CVE-2026-3505](https://nvd.nist.gov/vuln/detail/CVE-2026-3505) reports an unbounded PGP AEAD chunk size in `bcpg` that can cause pre-auth resource exhaustion; the fix lands in Bouncy Castle 1.84.

This PR follows the existing pattern already used in `generators/java/sdk/Dockerfile` for `plexus-utils` and `jackson-core`: remove the vulnerable jars shipped with the base image and replace them with the fixed 1.84 jars from Maven Central, with pinned SHA-256 verification. `bcprov` and `bcutil` are upgraded in lockstep since `bcpg` 1.78+ requires a matching `bcutil` (see [bcgit/bc-java#1619](https://github.com/bcgit/bc-java/issues/1619)).

## Changes Made
- Update `generators/java/sdk/Dockerfile` to remove `/opt/gradle/lib/plugins/bcpg-jdk18on-*.jar`, `bcprov-jdk18on-*.jar`, and `bcutil-jdk18on-*.jar`, and download + checksum-verify the 1.84 replacements from Maven Central.
- Add a changelog entry under `generators/java/sdk/changes/unreleased/`.
- [ ] Updated README.md generator (if applicable)

## Testing
- [ ] Unit tests added/updated
- [x] Manual testing completed

Ran the Dockerfile's new `RUN` block inside a fresh `gradle:jdk11-corretto` container to verify the remove/download/checksum-verify sequence succeeds and that `gradle --version` still reports `Gradle 8.14.4` after the replacement:

```
/opt/gradle/lib/plugins/bcpg-jdk18on-1.84.jar: OK
/opt/gradle/lib/plugins/bcprov-jdk18on-1.84.jar: OK
/opt/gradle/lib/plugins/bcutil-jdk18on-1.84.jar: OK
...
Gradle 8.14.4
```


Link to Devin session: https://app.devin.ai/sessions/a3edb33705fc403e92a659bd6deaecf5
Requested by: @davidkonigsberg
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fern-api/fern/pull/15162" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
