### PR TITLE
chore(ruby): bump ruby-v2 generator to publish new version

### DIFF
--- a/generators/ruby-v2/sdk/changes/unreleased/bump-version.yml
+++ b/generators/ruby-v2/sdk/changes/unreleased/bump-version.yml
@@ -1,3 +1,3 @@
 - summary: |
-    Release ruby-v2 generator.
+    Publish new ruby-v2 generator version.
   type: chore


### PR DESCRIPTION
## Description

Bump the ruby-v2 generator to trigger a new patch release. The previous PR (#15180) was merged but the release automation skipped it because the commit message matched the `chore(<scope>): release ...` pattern used by automated release commits.

## Changes Made

- Updated the unreleased changelog entry summary to re-trigger the release workflow

## Testing

- No code changes; this is a version bump only


Link to Devin session: https://app.devin.ai/sessions/8f307e5c2b0041e4860709989d33850e
Requested by: @iamnamananand996