### PR TITLE
fix(python, go, ruby, rust, php): support array query params in wire test verification

### DIFF
--- a/generators/go-v2/sdk/src/wire-tests/WireTestGenerator.ts
+++ b/generators/go-v2/sdk/src/wire-tests/WireTestGenerator.ts
@@ -245,7 +245,7 @@ export class WireTestGenerator {
                     }),
                     go.parameter({
                         name: "queryParams",
-                        type: go.Type.map(go.Type.string(), go.Type.string())
+                        type: go.Type.map(go.Type.string(), go.Type.any())
                     }),
                     go.parameter({
                         name: "expected",
@@ -296,11 +296,39 @@ export class WireTestGenerator {
                     writer.newLine();
                     writer.writeNode(go.codeblock("        reqBody.WriteString(key)"));
                     writer.newLine();
-                    writer.writeNode(go.codeblock('        reqBody.WriteString(`":{"equalTo":"`)'));
+                    writer.writeNode(go.codeblock("        switch v := value.(type) {"));
                     writer.newLine();
-                    writer.writeNode(go.codeblock("        reqBody.WriteString(value)"));
+                    writer.writeNode(go.codeblock("        case string:"));
                     writer.newLine();
-                    writer.writeNode(go.codeblock('        reqBody.WriteString(`"}`)'));
+                    writer.writeNode(go.codeblock('            reqBody.WriteString(`":{"equalTo":"`)'));
+                    writer.newLine();
+                    writer.writeNode(go.codeblock("            reqBody.WriteString(v)"));
+                    writer.newLine();
+                    writer.writeNode(go.codeblock('            reqBody.WriteString(`"}`)'));
+                    writer.newLine();
+                    writer.writeNode(go.codeblock("        case []string:"));
+                    writer.newLine();
+                    writer.writeNode(go.codeblock('            reqBody.WriteString(`":{"hasExactly":[`)'));
+                    writer.newLine();
+                    writer.writeNode(go.codeblock("            for i, item := range v {"));
+                    writer.newLine();
+                    writer.writeNode(go.codeblock("                if i > 0 {"));
+                    writer.newLine();
+                    writer.writeNode(go.codeblock('                    reqBody.WriteString(",")'));
+                    writer.newLine();
+                    writer.writeNode(go.codeblock("                }"));
+                    writer.newLine();
+                    writer.writeNode(go.codeblock('                reqBody.WriteString(`{"equalTo":"`)'));
+                    writer.newLine();
+                    writer.writeNode(go.codeblock("                reqBody.WriteString(item)"));
+                    writer.newLine();
+                    writer.writeNode(go.codeblock('                reqBody.WriteString(`"}`)'));
+                    writer.newLine();
+                    writer.writeNode(go.codeblock("            }"));
+                    writer.newLine();
+                    writer.writeNode(go.codeblock("            reqBody.WriteString(`]}`)"));
+                    writer.newLine();
+                    writer.writeNode(go.codeblock("        }"));
                     writer.newLine();
                     writer.writeNode(go.codeblock("        first = false"));
                     writer.newLine();
@@ -825,21 +853,28 @@ export class WireTestGenerator {
             }
         }
 
+        let hasArrayParam = false;
         const queryParamEntries: string[] = [];
         for (const [paramName, paramValue] of Object.entries(dynamicEndpointExample.queryParameters)) {
             if (paramValue != null) {
                 const key = JSON.stringify(paramName);
-                let stringValue = String(paramValue);
-                // Normalize datetime values to always include milliseconds, matching the
-                // Go SDK's RFC3339Milli format ("2006-01-02T15:04:05.000Z07:00").
-                if (datetimeQueryParams.has(paramName)) {
-                    const date = new Date(stringValue);
-                    if (!isNaN(date.getTime())) {
-                        stringValue = date.toISOString();
+                if (Array.isArray(paramValue) && paramValue.length > 1) {
+                    hasArrayParam = true;
+                    const items = paramValue.map((v: unknown) => JSON.stringify(String(v)));
+                    queryParamEntries.push(`${key}: []string{${items.join(", ")}}`);
+                } else {
+                    let stringValue = String(paramValue);
+                    // Normalize datetime values to always include milliseconds, matching the
+                    // Go SDK's RFC3339Milli format ("2006-01-02T15:04:05.000Z07:00").
+                    if (datetimeQueryParams.has(paramName)) {
+                        const date = new Date(stringValue);
+                        if (!isNaN(date.getTime())) {
+                            stringValue = date.toISOString();
+                        }
                     }
+                    const value = JSON.stringify(stringValue);
+                    queryParamEntries.push(`${key}: ${value}`);
                 }
-                const value = JSON.stringify(stringValue);
-                queryParamEntries.push(`${key}: ${value}`);
             }
         }
 
@@ -847,7 +882,8 @@ export class WireTestGenerator {
             return "nil";
         }
 
-        return `map[string]string{${queryParamEntries.join(", ")}}`;
+        const mapType = hasArrayParam ? "map[string]interface{}" : "map[string]string";
+        return `${mapType}{${queryParamEntries.join(", ")}}`;
     }
 
     private getDynamicEndpointExample(endpoint: FernIr.HttpEndpoint): FernIr.dynamic.EndpointExample | null {

--- a/generators/go-v2/sdk/src/wire-tests/WireTestGenerator.ts
+++ b/generators/go-v2/sdk/src/wire-tests/WireTestGenerator.ts
@@ -853,13 +853,11 @@ export class WireTestGenerator {
             }
         }
 
-        let hasArrayParam = false;
         const queryParamEntries: string[] = [];
         for (const [paramName, paramValue] of Object.entries(dynamicEndpointExample.queryParameters)) {
             if (paramValue != null) {
                 const key = JSON.stringify(paramName);
                 if (Array.isArray(paramValue) && paramValue.length > 1) {
-                    hasArrayParam = true;
                     const items = paramValue.map((v: unknown) => JSON.stringify(String(v)));
                     queryParamEntries.push(`${key}: []string{${items.join(", ")}}`);
                 } else {
@@ -882,8 +880,7 @@ export class WireTestGenerator {
             return "nil";
         }
 
-        const mapType = hasArrayParam ? "map[string]interface{}" : "map[string]string";
-        return `${mapType}{${queryParamEntries.join(", ")}}`;
+        return `map[string]interface{}{${queryParamEntries.join(", ")}}`;
     }
 
     private getDynamicEndpointExample(endpoint: FernIr.HttpEndpoint): FernIr.dynamic.EndpointExample | null {

--- a/generators/go/sdk/changes/unreleased/fix-array-query-params-wire-tests.yml
+++ b/generators/go/sdk/changes/unreleased/fix-array-query-params-wire-tests.yml
@@ -1,0 +1,3 @@
+- summary: |
+    Fix wire test verification for endpoints with multi-value array query parameters.
+  type: fix

--- a/generators/php/sdk/changes/unreleased/fix-array-query-params-wire-tests.yml
+++ b/generators/php/sdk/changes/unreleased/fix-array-query-params-wire-tests.yml
@@ -1,0 +1,3 @@
+- summary: |
+    Fix wire test verification for endpoints with multi-value array query parameters.
+  type: fix

--- a/generators/php/sdk/src/wire-tests/WireTestGenerator.ts
+++ b/generators/php/sdk/src/wire-tests/WireTestGenerator.ts
@@ -398,7 +398,12 @@ export class WireTestGenerator {
 
         for (const [key, value] of Object.entries(queryParams)) {
             if (value !== null && value !== undefined) {
-                entries.push(`'${this.escapeStringForPhp(key)}' => '${this.escapeStringForPhp(String(value))}'`);
+                if (Array.isArray(value) && value.length > 1) {
+                    const items = value.map((v: unknown) => `'${this.escapeStringForPhp(String(v))}'`);
+                    entries.push(`'${this.escapeStringForPhp(key)}' => [${items.join(", ")}]`);
+                } else {
+                    entries.push(`'${this.escapeStringForPhp(key)}' => '${this.escapeStringForPhp(String(value))}'`);
+                }
             }
         }
 

--- a/generators/php/sdk/src/wire-tests/WireTestSetupGenerator.ts
+++ b/generators/php/sdk/src/wire-tests/WireTestSetupGenerator.ts
@@ -156,7 +156,7 @@ abstract class WireMockTestCase extends TestCase
      * @param string $testId The test ID used to filter requests
      * @param string $method The HTTP method (GET, POST, etc.)
      * @param string $urlPath The URL path to match
-     * @param array<string, string>|null $queryParams Query parameters to match
+     * @param array<string, string|array<string>>|null $queryParams Query parameters to match
      * @param int $expected Expected number of requests
      */
     protected function verifyRequestCount(

--- a/generators/php/sdk/src/wire-tests/WireTestSetupGenerator.ts
+++ b/generators/php/sdk/src/wire-tests/WireTestSetupGenerator.ts
@@ -1,6 +1,6 @@
 import { File } from "@fern-api/base-generator";
 import { RelativeFilePath } from "@fern-api/fs-utils";
-import { isEqualToMatcher, WireMock, WireMockStubMapping } from "@fern-api/mock-utils";
+import { WireMock, WireMockStubMapping } from "@fern-api/mock-utils";
 import { FernIr } from "@fern-fern/ir-sdk";
 import { SdkGeneratorContext } from "../SdkGeneratorContext.js";
 
@@ -53,10 +53,13 @@ export class WireTestSetupGenerator {
         for (const mapping of stubMapping.mappings) {
             if (mapping.request.queryParameters) {
                 for (const [, value] of Object.entries(mapping.request.queryParameters)) {
-                    if (!isEqualToMatcher(value)) {
+                    if (!("equalTo" in value)) {
                         continue;
                     }
-                    if (WireTestSetupGenerator.DATETIME_WITH_ZERO_MILLIS_REGEX.test(value.equalTo)) {
+                    if (
+                        value.equalTo != null &&
+                        WireTestSetupGenerator.DATETIME_WITH_ZERO_MILLIS_REGEX.test(value.equalTo)
+                    ) {
                         value.equalTo = value.equalTo.replace(".000", "");
                     }
                 }

--- a/generators/php/sdk/src/wire-tests/WireTestSetupGenerator.ts
+++ b/generators/php/sdk/src/wire-tests/WireTestSetupGenerator.ts
@@ -1,6 +1,6 @@
 import { File } from "@fern-api/base-generator";
 import { RelativeFilePath } from "@fern-api/fs-utils";
-import { WireMock, WireMockStubMapping } from "@fern-api/mock-utils";
+import { isEqualToMatcher, WireMock, WireMockStubMapping } from "@fern-api/mock-utils";
 import { FernIr } from "@fern-fern/ir-sdk";
 import { SdkGeneratorContext } from "../SdkGeneratorContext.js";
 
@@ -53,13 +53,10 @@ export class WireTestSetupGenerator {
         for (const mapping of stubMapping.mappings) {
             if (mapping.request.queryParameters) {
                 for (const [, value] of Object.entries(mapping.request.queryParameters)) {
-                    if (!("equalTo" in value)) {
+                    if (!isEqualToMatcher(value)) {
                         continue;
                     }
-                    if (
-                        value.equalTo != null &&
-                        WireTestSetupGenerator.DATETIME_WITH_ZERO_MILLIS_REGEX.test(value.equalTo)
-                    ) {
+                    if (WireTestSetupGenerator.DATETIME_WITH_ZERO_MILLIS_REGEX.test(value.equalTo)) {
                         value.equalTo = value.equalTo.replace(".000", "");
                     }
                 }

--- a/generators/php/sdk/src/wire-tests/WireTestSetupGenerator.ts
+++ b/generators/php/sdk/src/wire-tests/WireTestSetupGenerator.ts
@@ -53,12 +53,14 @@ export class WireTestSetupGenerator {
         for (const mapping of stubMapping.mappings) {
             if (mapping.request.queryParameters) {
                 for (const [, value] of Object.entries(mapping.request.queryParameters)) {
-                    const paramValue = value as { equalTo: string };
+                    if (!("equalTo" in value)) {
+                        continue;
+                    }
                     if (
-                        paramValue.equalTo != null &&
-                        WireTestSetupGenerator.DATETIME_WITH_ZERO_MILLIS_REGEX.test(paramValue.equalTo)
+                        value.equalTo != null &&
+                        WireTestSetupGenerator.DATETIME_WITH_ZERO_MILLIS_REGEX.test(value.equalTo)
                     ) {
-                        paramValue.equalTo = paramValue.equalTo.replace(".000", "");
+                        value.equalTo = value.equalTo.replace(".000", "");
                     }
                 }
             }
@@ -181,7 +183,15 @@ abstract class WireMockTestCase extends TestCase
         if ($queryParams !== null && $queryParams !== []) {
             $body['queryParameters'] = [];
             foreach ($queryParams as $k => $v) {
-                $body['queryParameters'][$k] = ['equalTo' => (string) $v];
+                if (is_array($v)) {
+                    $matchers = [];
+                    foreach ($v as $item) {
+                        $matchers[] = ['equalTo' => (string) $item];
+                    }
+                    $body['queryParameters'][$k] = ['hasExactly' => $matchers];
+                } else {
+                    $body['queryParameters'][$k] = ['equalTo' => (string) $v];
+                }
             }
         }
 

--- a/generators/python-v2/sdk/src/wire-tests/WireTestGenerator.ts
+++ b/generators/python-v2/sdk/src/wire-tests/WireTestGenerator.ts
@@ -692,9 +692,15 @@ export class WireTestGenerator {
 
         for (const [key, value] of Object.entries(queryParams)) {
             if (value != null) {
-                const isDatetimeTyped = this.isDatetimeTypedQueryParam(endpoint, key);
-                const normalized = this.normalizeDatetimeQueryParamValue(String(value), isDatetimeTyped);
-                entries.push(`"${this.escapeStringForPython(key)}": "${this.escapeStringForPython(normalized)}"`);
+                if (Array.isArray(value) && value.length > 1) {
+                    // Multi-value: emit as Python list
+                    const items = value.map((v: unknown) => `"${this.escapeStringForPython(String(v))}"`);
+                    entries.push(`"${this.escapeStringForPython(key)}": [${items.join(", ")}]`);
+                } else {
+                    const isDatetimeTyped = this.isDatetimeTypedQueryParam(endpoint, key);
+                    const normalized = this.normalizeDatetimeQueryParamValue(String(value), isDatetimeTyped);
+                    entries.push(`"${this.escapeStringForPython(key)}": "${this.escapeStringForPython(normalized)}"`);
+                }
             }
         }
 

--- a/generators/python-v2/sdk/src/wire-tests/WireTestSetupGenerator.ts
+++ b/generators/python-v2/sdk/src/wire-tests/WireTestSetupGenerator.ts
@@ -1,7 +1,7 @@
 import { File, getNameFromWireValue, getWireValue } from "@fern-api/base-generator";
 import { assertNever } from "@fern-api/core-utils";
 import { RelativeFilePath } from "@fern-api/fs-utils";
-import { isEqualToMatcher, WireMock, WireMockStubMapping } from "@fern-api/mock-utils";
+import { WireMock, WireMockStubMapping } from "@fern-api/mock-utils";
 import { PYTHON_CASE_CONVERTER as caseConverter } from "@fern-api/python-base";
 import { FernIr } from "@fern-fern/ir-sdk";
 import { SdkGeneratorContext } from "../SdkGeneratorContext.js";
@@ -54,10 +54,13 @@ export class WireTestSetupGenerator {
             // Strip from query parameters
             if (mapping.request.queryParameters) {
                 for (const [, value] of Object.entries(mapping.request.queryParameters)) {
-                    if (!isEqualToMatcher(value)) {
+                    if (!("equalTo" in value)) {
                         continue;
                     }
-                    if (WireTestSetupGenerator.DATETIME_WITH_ZERO_MILLIS_REGEX.test(value.equalTo)) {
+                    if (
+                        value.equalTo != null &&
+                        WireTestSetupGenerator.DATETIME_WITH_ZERO_MILLIS_REGEX.test(value.equalTo)
+                    ) {
                         value.equalTo = value.equalTo.replace(".000", "");
                     }
                 }

--- a/generators/python-v2/sdk/src/wire-tests/WireTestSetupGenerator.ts
+++ b/generators/python-v2/sdk/src/wire-tests/WireTestSetupGenerator.ts
@@ -54,12 +54,14 @@ export class WireTestSetupGenerator {
             // Strip from query parameters
             if (mapping.request.queryParameters) {
                 for (const [, value] of Object.entries(mapping.request.queryParameters)) {
-                    const paramValue = value as { equalTo: string };
+                    if (!("equalTo" in value)) {
+                        continue;
+                    }
                     if (
-                        paramValue.equalTo != null &&
-                        WireTestSetupGenerator.DATETIME_WITH_ZERO_MILLIS_REGEX.test(paramValue.equalTo)
+                        value.equalTo != null &&
+                        WireTestSetupGenerator.DATETIME_WITH_ZERO_MILLIS_REGEX.test(value.equalTo)
                     ) {
-                        paramValue.equalTo = paramValue.equalTo.replace(".000", "");
+                        value.equalTo = value.equalTo.replace(".000", "");
                     }
                 }
             }
@@ -117,12 +119,14 @@ export class WireTestSetupGenerator {
                 if (datetimeParams.has(paramName)) {
                     continue;
                 }
-                const paramValue = value as { equalTo: string };
+                if (!("equalTo" in value)) {
+                    continue;
+                }
                 if (
-                    paramValue.equalTo != null &&
-                    WireTestSetupGenerator.DATETIME_WITH_ZERO_MILLIS_REGEX.test(paramValue.equalTo)
+                    value.equalTo != null &&
+                    WireTestSetupGenerator.DATETIME_WITH_ZERO_MILLIS_REGEX.test(value.equalTo)
                 ) {
-                    paramValue.equalTo = paramValue.equalTo.replace(".000", "");
+                    value.equalTo = value.equalTo.replace(".000", "");
                 }
             }
         }
@@ -305,7 +309,7 @@ def verify_request_count(
     test_id: str,
     method: str,
     url_path: str,
-    query_params: Optional[Dict[str, str]],
+    query_params: Optional[Dict[str, Any]],
     expected: int,
 ) -> None:
     """Verifies the number of requests made to WireMock filtered by test ID for concurrency safety."""
@@ -316,7 +320,12 @@ def verify_request_count(
         "headers": {"X-Test-Id": {"equalTo": test_id}},
     }
     if query_params:
-        query_parameters = {k: {"equalTo": v} for k, v in query_params.items()}
+        query_parameters = {}
+        for k, v in query_params.items():
+            if isinstance(v, list):
+                query_parameters[k] = {"hasExactly": [{"equalTo": item} for item in v]}
+            else:
+                query_parameters[k] = {"equalTo": v}
         request_body["queryParameters"] = query_parameters
     response = httpx.post(f"{wiremock_admin_url}/requests/find", json=request_body)
     assert response.status_code == 200, "Failed to query WireMock requests"

--- a/generators/python-v2/sdk/src/wire-tests/WireTestSetupGenerator.ts
+++ b/generators/python-v2/sdk/src/wire-tests/WireTestSetupGenerator.ts
@@ -1,7 +1,7 @@
 import { File, getNameFromWireValue, getWireValue } from "@fern-api/base-generator";
 import { assertNever } from "@fern-api/core-utils";
 import { RelativeFilePath } from "@fern-api/fs-utils";
-import { WireMock, WireMockStubMapping } from "@fern-api/mock-utils";
+import { isEqualToMatcher, WireMock, WireMockStubMapping } from "@fern-api/mock-utils";
 import { PYTHON_CASE_CONVERTER as caseConverter } from "@fern-api/python-base";
 import { FernIr } from "@fern-fern/ir-sdk";
 import { SdkGeneratorContext } from "../SdkGeneratorContext.js";
@@ -54,13 +54,10 @@ export class WireTestSetupGenerator {
             // Strip from query parameters
             if (mapping.request.queryParameters) {
                 for (const [, value] of Object.entries(mapping.request.queryParameters)) {
-                    if (!("equalTo" in value)) {
+                    if (!isEqualToMatcher(value)) {
                         continue;
                     }
-                    if (
-                        value.equalTo != null &&
-                        WireTestSetupGenerator.DATETIME_WITH_ZERO_MILLIS_REGEX.test(value.equalTo)
-                    ) {
+                    if (WireTestSetupGenerator.DATETIME_WITH_ZERO_MILLIS_REGEX.test(value.equalTo)) {
                         value.equalTo = value.equalTo.replace(".000", "");
                     }
                 }

--- a/generators/python/sdk/changes/unreleased/fix-array-query-params-wire-tests.yml
+++ b/generators/python/sdk/changes/unreleased/fix-array-query-params-wire-tests.yml
@@ -1,0 +1,3 @@
+- summary: |
+    Fix wire test verification for endpoints with multi-value array query parameters.
+  type: fix

--- a/generators/ruby-v2/sdk/changes/unreleased/fix-array-query-params-wire-tests.yml
+++ b/generators/ruby-v2/sdk/changes/unreleased/fix-array-query-params-wire-tests.yml
@@ -1,0 +1,3 @@
+- summary: |
+    Fix wire test verification for endpoints with multi-value array query parameters.
+  type: fix

--- a/generators/ruby-v2/sdk/src/wire-tests/WireTestGenerator.ts
+++ b/generators/ruby-v2/sdk/src/wire-tests/WireTestGenerator.ts
@@ -446,8 +446,13 @@ export class WireTestGenerator {
             // but prioritize required params to avoid verifying optional params
             if (paramValue != null && requiredQueryParamNames.has(paramName)) {
                 const key = JSON.stringify(paramName);
-                const value = JSON.stringify(String(paramValue));
-                queryParamEntries.push(`${key} => ${value}`);
+                if (Array.isArray(paramValue) && paramValue.length > 1) {
+                    const items = paramValue.map((v: unknown) => JSON.stringify(String(v)));
+                    queryParamEntries.push(`${key} => [${items.join(", ")}]`);
+                } else {
+                    const value = JSON.stringify(String(paramValue));
+                    queryParamEntries.push(`${key} => ${value}`);
+                }
             }
         }
 

--- a/generators/ruby-v2/sdk/src/wire-tests/WireTestSetupGenerator.ts
+++ b/generators/ruby-v2/sdk/src/wire-tests/WireTestSetupGenerator.ts
@@ -1,6 +1,6 @@
 import { File } from "@fern-api/base-generator";
 import { RelativeFilePath } from "@fern-api/fs-utils";
-import { WireMock, WireMockStubMapping } from "@fern-api/mock-utils";
+import { isEqualToMatcher, WireMock, WireMockStubMapping } from "@fern-api/mock-utils";
 import { FernIr } from "@fern-fern/ir-sdk";
 import { SdkGeneratorContext } from "../SdkGeneratorContext.js";
 
@@ -52,13 +52,10 @@ export class WireTestSetupGenerator {
         for (const mapping of stubMapping.mappings) {
             if (mapping.request.queryParameters) {
                 for (const [, value] of Object.entries(mapping.request.queryParameters)) {
-                    if (!("equalTo" in value)) {
+                    if (!isEqualToMatcher(value)) {
                         continue;
                     }
-                    if (
-                        value.equalTo != null &&
-                        WireTestSetupGenerator.DATETIME_WITH_ZERO_MILLIS_REGEX.test(value.equalTo)
-                    ) {
+                    if (WireTestSetupGenerator.DATETIME_WITH_ZERO_MILLIS_REGEX.test(value.equalTo)) {
                         value.equalTo = value.equalTo.replace(".000", "");
                     }
                 }

--- a/generators/ruby-v2/sdk/src/wire-tests/WireTestSetupGenerator.ts
+++ b/generators/ruby-v2/sdk/src/wire-tests/WireTestSetupGenerator.ts
@@ -52,12 +52,14 @@ export class WireTestSetupGenerator {
         for (const mapping of stubMapping.mappings) {
             if (mapping.request.queryParameters) {
                 for (const [, value] of Object.entries(mapping.request.queryParameters)) {
-                    const paramValue = value as { equalTo: string };
+                    if (!("equalTo" in value)) {
+                        continue;
+                    }
                     if (
-                        paramValue.equalTo != null &&
-                        WireTestSetupGenerator.DATETIME_WITH_ZERO_MILLIS_REGEX.test(paramValue.equalTo)
+                        value.equalTo != null &&
+                        WireTestSetupGenerator.DATETIME_WITH_ZERO_MILLIS_REGEX.test(value.equalTo)
                     ) {
-                        paramValue.equalTo = paramValue.equalTo.replace(".000", "");
+                        value.equalTo = value.equalTo.replace(".000", "");
                     }
                 }
             }
@@ -287,7 +289,13 @@ class WireMockTestCase < Minitest::Test
     request_body = { "method" => method, "urlPath" => url_path }
     request_body["headers"] = { "X-Test-Id" => { "equalTo" => test_id } }
     if query_params
-      request_body["queryParameters"] = query_params.transform_values { |v| { "equalTo" => v } }
+      request_body["queryParameters"] = query_params.transform_values do |v|
+        if v.is_a?(Array)
+          { "hasExactly" => v.map { |item| { "equalTo" => item } } }
+        else
+          { "equalTo" => v }
+        end
+      end
     end
 
     post_request.body = request_body.to_json

--- a/generators/ruby-v2/sdk/src/wire-tests/WireTestSetupGenerator.ts
+++ b/generators/ruby-v2/sdk/src/wire-tests/WireTestSetupGenerator.ts
@@ -1,6 +1,6 @@
 import { File } from "@fern-api/base-generator";
 import { RelativeFilePath } from "@fern-api/fs-utils";
-import { isEqualToMatcher, WireMock, WireMockStubMapping } from "@fern-api/mock-utils";
+import { WireMock, WireMockStubMapping } from "@fern-api/mock-utils";
 import { FernIr } from "@fern-fern/ir-sdk";
 import { SdkGeneratorContext } from "../SdkGeneratorContext.js";
 
@@ -52,10 +52,13 @@ export class WireTestSetupGenerator {
         for (const mapping of stubMapping.mappings) {
             if (mapping.request.queryParameters) {
                 for (const [, value] of Object.entries(mapping.request.queryParameters)) {
-                    if (!isEqualToMatcher(value)) {
+                    if (!("equalTo" in value)) {
                         continue;
                     }
-                    if (WireTestSetupGenerator.DATETIME_WITH_ZERO_MILLIS_REGEX.test(value.equalTo)) {
+                    if (
+                        value.equalTo != null &&
+                        WireTestSetupGenerator.DATETIME_WITH_ZERO_MILLIS_REGEX.test(value.equalTo)
+                    ) {
                         value.equalTo = value.equalTo.replace(".000", "");
                     }
                 }

--- a/generators/rust/sdk/changes/unreleased/fix-array-query-params-wire-tests.yml
+++ b/generators/rust/sdk/changes/unreleased/fix-array-query-params-wire-tests.yml
@@ -1,0 +1,3 @@
+- summary: |
+    Fix wire test verification for endpoints with multi-value array query parameters.
+  type: fix

--- a/generators/rust/sdk/src/wire-tests/WireTestGenerator.ts
+++ b/generators/rust/sdk/src/wire-tests/WireTestGenerator.ts
@@ -458,8 +458,13 @@ export class WireTestGenerator {
         for (const [paramName, paramValue] of Object.entries(dynamicEndpointExample.queryParameters)) {
             if (paramValue != null) {
                 const key = JSON.stringify(paramName);
-                const value = JSON.stringify(String(paramValue));
-                queryParamEntries.push(`(${key}.to_string(), ${value}.to_string())`);
+                if (Array.isArray(paramValue) && paramValue.length > 1) {
+                    const items = paramValue.map((v: unknown) => JSON.stringify(String(v)));
+                    queryParamEntries.push(`(${key}.to_string(), json!([${items.join(", ")}]))`);
+                } else {
+                    const value = JSON.stringify(String(paramValue));
+                    queryParamEntries.push(`(${key}.to_string(), json!(${value}))`);
+                }
             }
         }
 

--- a/generators/rust/sdk/src/wire-tests/WireTestSetupGenerator.ts
+++ b/generators/rust/sdk/src/wire-tests/WireTestSetupGenerator.ts
@@ -1,7 +1,7 @@
 import { FernIr } from "@fern-fern/ir-sdk";
 import { File } from "@fern-api/base-generator";
 import { RelativeFilePath } from "@fern-api/fs-utils";
-import { isEqualToMatcher, WireMock, WireMockMapping, WireMockStubMapping } from "@fern-api/mock-utils";
+import { WireMock, WireMockMapping, WireMockStubMapping } from "@fern-api/mock-utils";
 import { RustFile } from "@fern-api/rust-base";
 import { SdkGeneratorContext } from "../SdkGeneratorContext.js";
 
@@ -165,10 +165,13 @@ export class WireTestSetupGenerator {
             // Strip from query parameter matchers
             if (mapping.request.queryParameters) {
                 for (const [_key, matcher] of Object.entries(mapping.request.queryParameters)) {
-                    if (!isEqualToMatcher(matcher)) {
+                    if (!("equalTo" in matcher)) {
                         continue;
                     }
-                    if (WireTestSetupGenerator.DATETIME_WITH_ZERO_MILLIS_REGEX.test(matcher.equalTo)) {
+                    if (
+                        matcher.equalTo &&
+                        WireTestSetupGenerator.DATETIME_WITH_ZERO_MILLIS_REGEX.test(matcher.equalTo)
+                    ) {
                         matcher.equalTo = matcher.equalTo.replace(".000", "");
                     }
                 }

--- a/generators/rust/sdk/src/wire-tests/WireTestSetupGenerator.ts
+++ b/generators/rust/sdk/src/wire-tests/WireTestSetupGenerator.ts
@@ -1,7 +1,7 @@
 import { FernIr } from "@fern-fern/ir-sdk";
 import { File } from "@fern-api/base-generator";
 import { RelativeFilePath } from "@fern-api/fs-utils";
-import { WireMock, WireMockMapping, WireMockStubMapping } from "@fern-api/mock-utils";
+import { isEqualToMatcher, WireMock, WireMockMapping, WireMockStubMapping } from "@fern-api/mock-utils";
 import { RustFile } from "@fern-api/rust-base";
 import { SdkGeneratorContext } from "../SdkGeneratorContext.js";
 
@@ -165,13 +165,10 @@ export class WireTestSetupGenerator {
             // Strip from query parameter matchers
             if (mapping.request.queryParameters) {
                 for (const [_key, matcher] of Object.entries(mapping.request.queryParameters)) {
-                    if (!("equalTo" in matcher)) {
+                    if (!isEqualToMatcher(matcher)) {
                         continue;
                     }
-                    if (
-                        matcher.equalTo &&
-                        WireTestSetupGenerator.DATETIME_WITH_ZERO_MILLIS_REGEX.test(matcher.equalTo)
-                    ) {
+                    if (WireTestSetupGenerator.DATETIME_WITH_ZERO_MILLIS_REGEX.test(matcher.equalTo)) {
                         matcher.equalTo = matcher.equalTo.replace(".000", "");
                     }
                 }

--- a/generators/rust/sdk/src/wire-tests/WireTestSetupGenerator.ts
+++ b/generators/rust/sdk/src/wire-tests/WireTestSetupGenerator.ts
@@ -165,9 +165,14 @@ export class WireTestSetupGenerator {
             // Strip from query parameter matchers
             if (mapping.request.queryParameters) {
                 for (const [_key, matcher] of Object.entries(mapping.request.queryParameters)) {
-                    const m = matcher as { equalTo?: string };
-                    if (m.equalTo && WireTestSetupGenerator.DATETIME_WITH_ZERO_MILLIS_REGEX.test(m.equalTo)) {
-                        m.equalTo = m.equalTo.replace(".000", "");
+                    if (!("equalTo" in matcher)) {
+                        continue;
+                    }
+                    if (
+                        matcher.equalTo &&
+                        WireTestSetupGenerator.DATETIME_WITH_ZERO_MILLIS_REGEX.test(matcher.equalTo)
+                    ) {
+                        matcher.equalTo = matcher.equalTo.replace(".000", "");
                     }
                 }
             }
@@ -501,7 +506,7 @@ pub async fn reset_wiremock_requests() -> Result<(), Box<dyn std::error::Error>>
 pub async fn verify_request_count(
     method: &str,
     url_path: &str,
-    query_params: Option<HashMap<String, String>>,
+    query_params: Option<HashMap<String, serde_json::Value>>,
     expected: usize,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let mut request_body = json!({
@@ -512,7 +517,21 @@ pub async fn verify_request_count(
     if let Some(params) = query_params {
         let query_parameters: Value = params
             .into_iter()
-            .map(|(k, v)| (k, json!({"equalTo": v})))
+            .map(|(k, v)| {
+                let matcher = if v.is_array() {
+                    let items: Vec<Value> = v.as_array().unwrap()
+                        .iter()
+                        .filter_map(|item| item.as_str())
+                        .map(|s| json!({"equalTo": s}))
+                        .collect();
+                    json!({"hasExactly": items})
+                } else if let Some(s) = v.as_str() {
+                    json!({"equalTo": s})
+                } else {
+                    json!({"equalTo": v.to_string()})
+                };
+                (k, matcher)
+            })
             .collect();
         request_body["queryParameters"] = query_parameters;
     }

--- a/packages/cli/cli/changes/unreleased/fix-array-query-params-wire-tests.yml
+++ b/packages/cli/cli/changes/unreleased/fix-array-query-params-wire-tests.yml
@@ -1,0 +1,3 @@
+- summary: |
+    Fix wire test infrastructure to correctly handle array query parameters in WireMock stubs and test verification across all generators with wire test support.
+  type: fix

--- a/packages/commons/mock-utils/index.ts
+++ b/packages/commons/mock-utils/index.ts
@@ -11,10 +11,6 @@ export interface WireMockStubMapping {
 
 export type QueryParameterMatcher = { equalTo: string } | { hasExactly: Array<{ equalTo: string }> };
 
-export function isEqualToMatcher(matcher: QueryParameterMatcher): matcher is { equalTo: string } {
-    return "equalTo" in matcher;
-}
-
 export interface WireMockMapping {
     id: string;
     name: string;

--- a/packages/commons/mock-utils/index.ts
+++ b/packages/commons/mock-utils/index.ts
@@ -11,6 +11,10 @@ export interface WireMockStubMapping {
 
 export type QueryParameterMatcher = { equalTo: string } | { hasExactly: Array<{ equalTo: string }> };
 
+export function isEqualToMatcher(matcher: QueryParameterMatcher): matcher is { equalTo: string } {
+    return "equalTo" in matcher;
+}
+
 export interface WireMockMapping {
     id: string;
     name: string;

--- a/packages/commons/mock-utils/index.ts
+++ b/packages/commons/mock-utils/index.ts
@@ -9,6 +9,8 @@ export interface WireMockStubMapping {
     };
 }
 
+export type QueryParameterMatcher = { equalTo: string } | { hasExactly: Array<{ equalTo: string }> };
+
 export interface WireMockMapping {
     id: string;
     name: string;
@@ -17,7 +19,7 @@ export interface WireMockMapping {
         method: string;
         headers?: Record<string, { matches?: string; equalTo?: string }>;
         pathParameters?: Record<string, { equalTo: string }>;
-        queryParameters?: Record<string, { equalTo: string }>;
+        queryParameters?: Record<string, QueryParameterMatcher>;
         formParameters?: Record<string, unknown>;
         bodyPatterns?: Array<{ matchesJsonPath: string }>;
     };
@@ -178,12 +180,33 @@ export class WireMock {
         }
 
         // Extract query parameters from example
-        const queryParameters: Record<string, { equalTo: string }> = {};
+        const queryParameters: Record<string, QueryParameterMatcher> = {};
         for (const param of example?.queryParameters || []) {
-            const paramValue = this.exampleToQueryOrHeaderValue({ value: param.value });
-            if (paramValue !== undefined) {
-                const paramName = param.name != null ? getWireValue(param.name) : undefined;
-                if (paramName) {
+            const paramName = param.name != null ? getWireValue(param.name) : undefined;
+            if (!paramName) {
+                continue;
+            }
+
+            if (Array.isArray(param.value.jsonExample)) {
+                // Multi-value query param: build hasExactly matcher with one equalTo per element
+                const matchers: Array<{ equalTo: string }> = [];
+                for (const item of param.value.jsonExample) {
+                    const itemStr =
+                        typeof item === "string"
+                            ? item
+                            : typeof item === "number" || typeof item === "boolean"
+                              ? String(item)
+                              : undefined;
+                    if (itemStr !== undefined) {
+                        matchers.push({ equalTo: itemStr });
+                    }
+                }
+                if (matchers.length > 0) {
+                    queryParameters[paramName] = { hasExactly: matchers };
+                }
+            } else {
+                const paramValue = this.exampleToQueryOrHeaderValue({ value: param.value });
+                if (paramValue !== undefined) {
                     queryParameters[paramName] = { equalTo: paramValue };
                 }
             }

--- a/packages/commons/mock-utils/src/index.ts
+++ b/packages/commons/mock-utils/src/index.ts
@@ -11,6 +11,10 @@ export interface WireMockStubMapping {
 
 export type QueryParameterMatcher = { equalTo: string } | { hasExactly: Array<{ equalTo: string }> };
 
+export function isEqualToMatcher(matcher: QueryParameterMatcher): matcher is { equalTo: string } {
+    return "equalTo" in matcher;
+}
+
 export interface WireMockMapping {
     id: string;
     name: string;

--- a/packages/commons/mock-utils/test/convertToWireMock.test.ts
+++ b/packages/commons/mock-utils/test/convertToWireMock.test.ts
@@ -3,7 +3,7 @@ import { FernIr } from "@fern-fern/ir-sdk";
 import { IntermediateRepresentation as IRSerializer } from "@fern-fern/ir-sdk/serialization";
 import { readFileSync } from "fs";
 import { join } from "path";
-import { WireMock } from "../index.js";
+import { WireMock } from "../src/index.js";
 
 const loadIr = (irPath: string): FernIr.IntermediateRepresentation => {
     const irJson = JSON.parse(readFileSync(irPath, "utf-8"));

--- a/packages/commons/mock-utils/tsconfig.json
+++ b/packages/commons/mock-utils/tsconfig.json
@@ -2,8 +2,8 @@
   "extends": "@fern-api/configs/tsconfig/main.json",
   "compilerOptions": {
     "outDir": "lib",
-    "rootDir": "."
+    "rootDir": "src"
   },
-  "include": ["./**/*"],
+  "include": ["src/**/*"],
   "exclude": ["node_modules", "lib", "dist", "test"]
 }

--- a/seed/go-sdk/exhaustive/no-custom-config/.fern/metadata.json
+++ b/seed/go-sdk/exhaustive/no-custom-config/.fern/metadata.json
@@ -7,8 +7,8 @@
   },
   "originGitCommit": "DUMMY",
   "originGitCommitIsDirty": null,
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
+  "ciProvider": null,
   "sdkVersion": "v0.0.1"
 }

--- a/seed/go-sdk/exhaustive/no-custom-config/endpoints/container/endpoints_container_test/endpoints_container_test.go
+++ b/seed/go-sdk/exhaustive/no-custom-config/endpoints/container/endpoints_container_test/endpoints_container_test.go
@@ -21,7 +21,7 @@ func VerifyRequestCount(
 	testId string,
 	method string,
 	urlPath string,
-	queryParams map[string]string,
+	queryParams map[string]any,
 	expected int,
 ) {
 	wiremockURL := os.Getenv("WIREMOCK_URL")
@@ -46,9 +46,23 @@ func VerifyRequestCount(
 			}
 			reqBody.WriteString(`"`)
 			reqBody.WriteString(key)
-			reqBody.WriteString(`":{"equalTo":"`)
-			reqBody.WriteString(value)
-			reqBody.WriteString(`"}`)
+			switch v := value.(type) {
+			case string:
+				reqBody.WriteString(`":{"equalTo":"`)
+				reqBody.WriteString(v)
+				reqBody.WriteString(`"}`)
+			case []string:
+				reqBody.WriteString(`":{"hasExactly":[`)
+				for i, item := range v {
+					if i > 0 {
+						reqBody.WriteString(",")
+					}
+					reqBody.WriteString(`{"equalTo":"`)
+					reqBody.WriteString(item)
+					reqBody.WriteString(`"}`)
+				}
+				reqBody.WriteString(`]}`)
+			}
 			first = false
 		}
 		reqBody.WriteString("}")

--- a/seed/go-sdk/exhaustive/no-custom-config/endpoints/contenttype/endpoints_content_type_test/endpoints_content_type_test.go
+++ b/seed/go-sdk/exhaustive/no-custom-config/endpoints/contenttype/endpoints_content_type_test/endpoints_content_type_test.go
@@ -23,7 +23,7 @@ func VerifyRequestCount(
 	testId string,
 	method string,
 	urlPath string,
-	queryParams map[string]string,
+	queryParams map[string]any,
 	expected int,
 ) {
 	wiremockURL := os.Getenv("WIREMOCK_URL")
@@ -48,9 +48,23 @@ func VerifyRequestCount(
 			}
 			reqBody.WriteString(`"`)
 			reqBody.WriteString(key)
-			reqBody.WriteString(`":{"equalTo":"`)
-			reqBody.WriteString(value)
-			reqBody.WriteString(`"}`)
+			switch v := value.(type) {
+			case string:
+				reqBody.WriteString(`":{"equalTo":"`)
+				reqBody.WriteString(v)
+				reqBody.WriteString(`"}`)
+			case []string:
+				reqBody.WriteString(`":{"hasExactly":[`)
+				for i, item := range v {
+					if i > 0 {
+						reqBody.WriteString(",")
+					}
+					reqBody.WriteString(`{"equalTo":"`)
+					reqBody.WriteString(item)
+					reqBody.WriteString(`"}`)
+				}
+				reqBody.WriteString(`]}`)
+			}
 			first = false
 		}
 		reqBody.WriteString("}")

--- a/seed/go-sdk/exhaustive/no-custom-config/endpoints/enum/endpoints_enum_test/endpoints_enum_test.go
+++ b/seed/go-sdk/exhaustive/no-custom-config/endpoints/enum/endpoints_enum_test/endpoints_enum_test.go
@@ -21,7 +21,7 @@ func VerifyRequestCount(
 	testId string,
 	method string,
 	urlPath string,
-	queryParams map[string]string,
+	queryParams map[string]any,
 	expected int,
 ) {
 	wiremockURL := os.Getenv("WIREMOCK_URL")
@@ -46,9 +46,23 @@ func VerifyRequestCount(
 			}
 			reqBody.WriteString(`"`)
 			reqBody.WriteString(key)
-			reqBody.WriteString(`":{"equalTo":"`)
-			reqBody.WriteString(value)
-			reqBody.WriteString(`"}`)
+			switch v := value.(type) {
+			case string:
+				reqBody.WriteString(`":{"equalTo":"`)
+				reqBody.WriteString(v)
+				reqBody.WriteString(`"}`)
+			case []string:
+				reqBody.WriteString(`":{"hasExactly":[`)
+				for i, item := range v {
+					if i > 0 {
+						reqBody.WriteString(",")
+					}
+					reqBody.WriteString(`{"equalTo":"`)
+					reqBody.WriteString(item)
+					reqBody.WriteString(`"}`)
+				}
+				reqBody.WriteString(`]}`)
+			}
 			first = false
 		}
 		reqBody.WriteString("}")

--- a/seed/go-sdk/exhaustive/no-custom-config/endpoints/httpmethods/endpoints_http_methods_test/endpoints_http_methods_test.go
+++ b/seed/go-sdk/exhaustive/no-custom-config/endpoints/httpmethods/endpoints_http_methods_test/endpoints_http_methods_test.go
@@ -23,7 +23,7 @@ func VerifyRequestCount(
 	testId string,
 	method string,
 	urlPath string,
-	queryParams map[string]string,
+	queryParams map[string]any,
 	expected int,
 ) {
 	wiremockURL := os.Getenv("WIREMOCK_URL")
@@ -48,9 +48,23 @@ func VerifyRequestCount(
 			}
 			reqBody.WriteString(`"`)
 			reqBody.WriteString(key)
-			reqBody.WriteString(`":{"equalTo":"`)
-			reqBody.WriteString(value)
-			reqBody.WriteString(`"}`)
+			switch v := value.(type) {
+			case string:
+				reqBody.WriteString(`":{"equalTo":"`)
+				reqBody.WriteString(v)
+				reqBody.WriteString(`"}`)
+			case []string:
+				reqBody.WriteString(`":{"hasExactly":[`)
+				for i, item := range v {
+					if i > 0 {
+						reqBody.WriteString(",")
+					}
+					reqBody.WriteString(`{"equalTo":"`)
+					reqBody.WriteString(item)
+					reqBody.WriteString(`"}`)
+				}
+				reqBody.WriteString(`]}`)
+			}
 			first = false
 		}
 		reqBody.WriteString("}")

--- a/seed/go-sdk/exhaustive/no-custom-config/endpoints/object/endpoints_object_test/endpoints_object_test.go
+++ b/seed/go-sdk/exhaustive/no-custom-config/endpoints/object/endpoints_object_test/endpoints_object_test.go
@@ -23,7 +23,7 @@ func VerifyRequestCount(
 	testId string,
 	method string,
 	urlPath string,
-	queryParams map[string]string,
+	queryParams map[string]any,
 	expected int,
 ) {
 	wiremockURL := os.Getenv("WIREMOCK_URL")
@@ -48,9 +48,23 @@ func VerifyRequestCount(
 			}
 			reqBody.WriteString(`"`)
 			reqBody.WriteString(key)
-			reqBody.WriteString(`":{"equalTo":"`)
-			reqBody.WriteString(value)
-			reqBody.WriteString(`"}`)
+			switch v := value.(type) {
+			case string:
+				reqBody.WriteString(`":{"equalTo":"`)
+				reqBody.WriteString(v)
+				reqBody.WriteString(`"}`)
+			case []string:
+				reqBody.WriteString(`":{"hasExactly":[`)
+				for i, item := range v {
+					if i > 0 {
+						reqBody.WriteString(",")
+					}
+					reqBody.WriteString(`{"equalTo":"`)
+					reqBody.WriteString(item)
+					reqBody.WriteString(`"}`)
+				}
+				reqBody.WriteString(`]}`)
+			}
 			first = false
 		}
 		reqBody.WriteString("}")

--- a/seed/go-sdk/exhaustive/no-custom-config/endpoints/pagination/endpoints_pagination_test/endpoints_pagination_test.go
+++ b/seed/go-sdk/exhaustive/no-custom-config/endpoints/pagination/endpoints_pagination_test/endpoints_pagination_test.go
@@ -22,7 +22,7 @@ func VerifyRequestCount(
 	testId string,
 	method string,
 	urlPath string,
-	queryParams map[string]string,
+	queryParams map[string]any,
 	expected int,
 ) {
 	wiremockURL := os.Getenv("WIREMOCK_URL")
@@ -47,9 +47,23 @@ func VerifyRequestCount(
 			}
 			reqBody.WriteString(`"`)
 			reqBody.WriteString(key)
-			reqBody.WriteString(`":{"equalTo":"`)
-			reqBody.WriteString(value)
-			reqBody.WriteString(`"}`)
+			switch v := value.(type) {
+			case string:
+				reqBody.WriteString(`":{"equalTo":"`)
+				reqBody.WriteString(v)
+				reqBody.WriteString(`"}`)
+			case []string:
+				reqBody.WriteString(`":{"hasExactly":[`)
+				for i, item := range v {
+					if i > 0 {
+						reqBody.WriteString(",")
+					}
+					reqBody.WriteString(`{"equalTo":"`)
+					reqBody.WriteString(item)
+					reqBody.WriteString(`"}`)
+				}
+				reqBody.WriteString(`]}`)
+			}
 			first = false
 		}
 		reqBody.WriteString("}")

--- a/seed/go-sdk/exhaustive/no-custom-config/endpoints/pagination/endpoints_pagination_test/endpoints_pagination_test.go
+++ b/seed/go-sdk/exhaustive/no-custom-config/endpoints/pagination/endpoints_pagination_test/endpoints_pagination_test.go
@@ -106,5 +106,5 @@ func TestEndpointsPaginationListItemsWithWireMock(
 	)
 
 	require.NoError(t, invocationErr, "Client method call should succeed")
-	VerifyRequestCount(t, "TestEndpointsPaginationListItemsWithWireMock", "GET", "/pagination", map[string]string{"cursor": "cursor", "limit": "1"}, 1)
+	VerifyRequestCount(t, "TestEndpointsPaginationListItemsWithWireMock", "GET", "/pagination", map[string]interface{}{"cursor": "cursor", "limit": "1"}, 1)
 }

--- a/seed/go-sdk/exhaustive/no-custom-config/endpoints/params/endpoints_params_test/endpoints_params_test.go
+++ b/seed/go-sdk/exhaustive/no-custom-config/endpoints/params/endpoints_params_test/endpoints_params_test.go
@@ -21,7 +21,7 @@ func VerifyRequestCount(
 	testId string,
 	method string,
 	urlPath string,
-	queryParams map[string]string,
+	queryParams map[string]any,
 	expected int,
 ) {
 	wiremockURL := os.Getenv("WIREMOCK_URL")
@@ -46,9 +46,23 @@ func VerifyRequestCount(
 			}
 			reqBody.WriteString(`"`)
 			reqBody.WriteString(key)
-			reqBody.WriteString(`":{"equalTo":"`)
-			reqBody.WriteString(value)
-			reqBody.WriteString(`"}`)
+			switch v := value.(type) {
+			case string:
+				reqBody.WriteString(`":{"equalTo":"`)
+				reqBody.WriteString(v)
+				reqBody.WriteString(`"}`)
+			case []string:
+				reqBody.WriteString(`":{"hasExactly":[`)
+				for i, item := range v {
+					if i > 0 {
+						reqBody.WriteString(",")
+					}
+					reqBody.WriteString(`{"equalTo":"`)
+					reqBody.WriteString(item)
+					reqBody.WriteString(`"}`)
+				}
+				reqBody.WriteString(`]}`)
+			}
 			first = false
 		}
 		reqBody.WriteString("}")

--- a/seed/go-sdk/exhaustive/no-custom-config/endpoints/params/endpoints_params_test/endpoints_params_test.go
+++ b/seed/go-sdk/exhaustive/no-custom-config/endpoints/params/endpoints_params_test/endpoints_params_test.go
@@ -147,7 +147,7 @@ func TestEndpointsParamsGetWithQueryWithWireMock(
 	)
 
 	require.NoError(t, invocationErr, "Client method call should succeed")
-	VerifyRequestCount(t, "TestEndpointsParamsGetWithQueryWithWireMock", "GET", "/params", map[string]string{"query": "query", "number": "1"}, 1)
+	VerifyRequestCount(t, "TestEndpointsParamsGetWithQueryWithWireMock", "GET", "/params", map[string]interface{}{"query": "query", "number": "1"}, 1)
 }
 
 func TestEndpointsParamsGetWithQueryWithWireMock2(
@@ -174,7 +174,7 @@ func TestEndpointsParamsGetWithQueryWithWireMock2(
 	)
 
 	require.NoError(t, invocationErr, "Client method call should succeed")
-	VerifyRequestCount(t, "TestEndpointsParamsGetWithQueryWithWireMock2", "GET", "/params", map[string]string{"query": "query", "number": "1"}, 1)
+	VerifyRequestCount(t, "TestEndpointsParamsGetWithQueryWithWireMock2", "GET", "/params", map[string]interface{}{"query": "query", "number": "1"}, 1)
 }
 
 func TestEndpointsParamsGetWithPathAndQueryWithWireMock(
@@ -201,7 +201,7 @@ func TestEndpointsParamsGetWithPathAndQueryWithWireMock(
 	)
 
 	require.NoError(t, invocationErr, "Client method call should succeed")
-	VerifyRequestCount(t, "TestEndpointsParamsGetWithPathAndQueryWithWireMock", "GET", "/params/path-query/param", map[string]string{"query": "query"}, 1)
+	VerifyRequestCount(t, "TestEndpointsParamsGetWithPathAndQueryWithWireMock", "GET", "/params/path-query/param", map[string]interface{}{"query": "query"}, 1)
 }
 
 func TestEndpointsParamsGetWithPathAndQueryWithWireMock2(
@@ -228,7 +228,7 @@ func TestEndpointsParamsGetWithPathAndQueryWithWireMock2(
 	)
 
 	require.NoError(t, invocationErr, "Client method call should succeed")
-	VerifyRequestCount(t, "TestEndpointsParamsGetWithPathAndQueryWithWireMock2", "GET", "/params/path-query/param", map[string]string{"query": "query"}, 1)
+	VerifyRequestCount(t, "TestEndpointsParamsGetWithPathAndQueryWithWireMock2", "GET", "/params/path-query/param", map[string]interface{}{"query": "query"}, 1)
 }
 
 func TestEndpointsParamsModifyWithPathWithWireMock(

--- a/seed/go-sdk/exhaustive/no-custom-config/endpoints/primitive/endpoints_primitive_test/endpoints_primitive_test.go
+++ b/seed/go-sdk/exhaustive/no-custom-config/endpoints/primitive/endpoints_primitive_test/endpoints_primitive_test.go
@@ -22,7 +22,7 @@ func VerifyRequestCount(
 	testId string,
 	method string,
 	urlPath string,
-	queryParams map[string]string,
+	queryParams map[string]any,
 	expected int,
 ) {
 	wiremockURL := os.Getenv("WIREMOCK_URL")
@@ -47,9 +47,23 @@ func VerifyRequestCount(
 			}
 			reqBody.WriteString(`"`)
 			reqBody.WriteString(key)
-			reqBody.WriteString(`":{"equalTo":"`)
-			reqBody.WriteString(value)
-			reqBody.WriteString(`"}`)
+			switch v := value.(type) {
+			case string:
+				reqBody.WriteString(`":{"equalTo":"`)
+				reqBody.WriteString(v)
+				reqBody.WriteString(`"}`)
+			case []string:
+				reqBody.WriteString(`":{"hasExactly":[`)
+				for i, item := range v {
+					if i > 0 {
+						reqBody.WriteString(",")
+					}
+					reqBody.WriteString(`{"equalTo":"`)
+					reqBody.WriteString(item)
+					reqBody.WriteString(`"}`)
+				}
+				reqBody.WriteString(`]}`)
+			}
 			first = false
 		}
 		reqBody.WriteString("}")

--- a/seed/go-sdk/exhaustive/no-custom-config/endpoints/put/endpoints_put_test/endpoints_put_test.go
+++ b/seed/go-sdk/exhaustive/no-custom-config/endpoints/put/endpoints_put_test/endpoints_put_test.go
@@ -21,7 +21,7 @@ func VerifyRequestCount(
 	testId string,
 	method string,
 	urlPath string,
-	queryParams map[string]string,
+	queryParams map[string]any,
 	expected int,
 ) {
 	wiremockURL := os.Getenv("WIREMOCK_URL")
@@ -46,9 +46,23 @@ func VerifyRequestCount(
 			}
 			reqBody.WriteString(`"`)
 			reqBody.WriteString(key)
-			reqBody.WriteString(`":{"equalTo":"`)
-			reqBody.WriteString(value)
-			reqBody.WriteString(`"}`)
+			switch v := value.(type) {
+			case string:
+				reqBody.WriteString(`":{"equalTo":"`)
+				reqBody.WriteString(v)
+				reqBody.WriteString(`"}`)
+			case []string:
+				reqBody.WriteString(`":{"hasExactly":[`)
+				for i, item := range v {
+					if i > 0 {
+						reqBody.WriteString(",")
+					}
+					reqBody.WriteString(`{"equalTo":"`)
+					reqBody.WriteString(item)
+					reqBody.WriteString(`"}`)
+				}
+				reqBody.WriteString(`]}`)
+			}
 			first = false
 		}
 		reqBody.WriteString("}")

--- a/seed/go-sdk/exhaustive/no-custom-config/endpoints/union/endpoints_union_test/endpoints_union_test.go
+++ b/seed/go-sdk/exhaustive/no-custom-config/endpoints/union/endpoints_union_test/endpoints_union_test.go
@@ -21,7 +21,7 @@ func VerifyRequestCount(
 	testId string,
 	method string,
 	urlPath string,
-	queryParams map[string]string,
+	queryParams map[string]any,
 	expected int,
 ) {
 	wiremockURL := os.Getenv("WIREMOCK_URL")
@@ -46,9 +46,23 @@ func VerifyRequestCount(
 			}
 			reqBody.WriteString(`"`)
 			reqBody.WriteString(key)
-			reqBody.WriteString(`":{"equalTo":"`)
-			reqBody.WriteString(value)
-			reqBody.WriteString(`"}`)
+			switch v := value.(type) {
+			case string:
+				reqBody.WriteString(`":{"equalTo":"`)
+				reqBody.WriteString(v)
+				reqBody.WriteString(`"}`)
+			case []string:
+				reqBody.WriteString(`":{"hasExactly":[`)
+				for i, item := range v {
+					if i > 0 {
+						reqBody.WriteString(",")
+					}
+					reqBody.WriteString(`{"equalTo":"`)
+					reqBody.WriteString(item)
+					reqBody.WriteString(`"}`)
+				}
+				reqBody.WriteString(`]}`)
+			}
 			first = false
 		}
 		reqBody.WriteString("}")

--- a/seed/go-sdk/exhaustive/no-custom-config/endpoints/urls/endpoints_urls_test/endpoints_urls_test.go
+++ b/seed/go-sdk/exhaustive/no-custom-config/endpoints/urls/endpoints_urls_test/endpoints_urls_test.go
@@ -20,7 +20,7 @@ func VerifyRequestCount(
 	testId string,
 	method string,
 	urlPath string,
-	queryParams map[string]string,
+	queryParams map[string]any,
 	expected int,
 ) {
 	wiremockURL := os.Getenv("WIREMOCK_URL")
@@ -45,9 +45,23 @@ func VerifyRequestCount(
 			}
 			reqBody.WriteString(`"`)
 			reqBody.WriteString(key)
-			reqBody.WriteString(`":{"equalTo":"`)
-			reqBody.WriteString(value)
-			reqBody.WriteString(`"}`)
+			switch v := value.(type) {
+			case string:
+				reqBody.WriteString(`":{"equalTo":"`)
+				reqBody.WriteString(v)
+				reqBody.WriteString(`"}`)
+			case []string:
+				reqBody.WriteString(`":{"hasExactly":[`)
+				for i, item := range v {
+					if i > 0 {
+						reqBody.WriteString(",")
+					}
+					reqBody.WriteString(`{"equalTo":"`)
+					reqBody.WriteString(item)
+					reqBody.WriteString(`"}`)
+				}
+				reqBody.WriteString(`]}`)
+			}
 			first = false
 		}
 		reqBody.WriteString("}")

--- a/seed/go-sdk/exhaustive/no-custom-config/inlinedrequests/inlined_requests_test/inlined_requests_test.go
+++ b/seed/go-sdk/exhaustive/no-custom-config/inlinedrequests/inlined_requests_test/inlined_requests_test.go
@@ -23,7 +23,7 @@ func VerifyRequestCount(
 	testId string,
 	method string,
 	urlPath string,
-	queryParams map[string]string,
+	queryParams map[string]any,
 	expected int,
 ) {
 	wiremockURL := os.Getenv("WIREMOCK_URL")
@@ -48,9 +48,23 @@ func VerifyRequestCount(
 			}
 			reqBody.WriteString(`"`)
 			reqBody.WriteString(key)
-			reqBody.WriteString(`":{"equalTo":"`)
-			reqBody.WriteString(value)
-			reqBody.WriteString(`"}`)
+			switch v := value.(type) {
+			case string:
+				reqBody.WriteString(`":{"equalTo":"`)
+				reqBody.WriteString(v)
+				reqBody.WriteString(`"}`)
+			case []string:
+				reqBody.WriteString(`":{"hasExactly":[`)
+				for i, item := range v {
+					if i > 0 {
+						reqBody.WriteString(",")
+					}
+					reqBody.WriteString(`{"equalTo":"`)
+					reqBody.WriteString(item)
+					reqBody.WriteString(`"}`)
+				}
+				reqBody.WriteString(`]}`)
+			}
 			first = false
 		}
 		reqBody.WriteString("}")

--- a/seed/go-sdk/exhaustive/no-custom-config/noauth/no_auth_test/no_auth_test.go
+++ b/seed/go-sdk/exhaustive/no-custom-config/noauth/no_auth_test/no_auth_test.go
@@ -20,7 +20,7 @@ func VerifyRequestCount(
 	testId string,
 	method string,
 	urlPath string,
-	queryParams map[string]string,
+	queryParams map[string]any,
 	expected int,
 ) {
 	wiremockURL := os.Getenv("WIREMOCK_URL")
@@ -45,9 +45,23 @@ func VerifyRequestCount(
 			}
 			reqBody.WriteString(`"`)
 			reqBody.WriteString(key)
-			reqBody.WriteString(`":{"equalTo":"`)
-			reqBody.WriteString(value)
-			reqBody.WriteString(`"}`)
+			switch v := value.(type) {
+			case string:
+				reqBody.WriteString(`":{"equalTo":"`)
+				reqBody.WriteString(v)
+				reqBody.WriteString(`"}`)
+			case []string:
+				reqBody.WriteString(`":{"hasExactly":[`)
+				for i, item := range v {
+					if i > 0 {
+						reqBody.WriteString(",")
+					}
+					reqBody.WriteString(`{"equalTo":"`)
+					reqBody.WriteString(item)
+					reqBody.WriteString(`"}`)
+				}
+				reqBody.WriteString(`]}`)
+			}
 			first = false
 		}
 		reqBody.WriteString("}")

--- a/seed/go-sdk/exhaustive/no-custom-config/noreqbody/no_req_body_test/no_req_body_test.go
+++ b/seed/go-sdk/exhaustive/no-custom-config/noreqbody/no_req_body_test/no_req_body_test.go
@@ -20,7 +20,7 @@ func VerifyRequestCount(
 	testId string,
 	method string,
 	urlPath string,
-	queryParams map[string]string,
+	queryParams map[string]any,
 	expected int,
 ) {
 	wiremockURL := os.Getenv("WIREMOCK_URL")
@@ -45,9 +45,23 @@ func VerifyRequestCount(
 			}
 			reqBody.WriteString(`"`)
 			reqBody.WriteString(key)
-			reqBody.WriteString(`":{"equalTo":"`)
-			reqBody.WriteString(value)
-			reqBody.WriteString(`"}`)
+			switch v := value.(type) {
+			case string:
+				reqBody.WriteString(`":{"equalTo":"`)
+				reqBody.WriteString(v)
+				reqBody.WriteString(`"}`)
+			case []string:
+				reqBody.WriteString(`":{"hasExactly":[`)
+				for i, item := range v {
+					if i > 0 {
+						reqBody.WriteString(",")
+					}
+					reqBody.WriteString(`{"equalTo":"`)
+					reqBody.WriteString(item)
+					reqBody.WriteString(`"}`)
+				}
+				reqBody.WriteString(`]}`)
+			}
 			first = false
 		}
 		reqBody.WriteString("}")

--- a/seed/go-sdk/exhaustive/no-custom-config/reqwithheaders/req_with_headers_test/req_with_headers_test.go
+++ b/seed/go-sdk/exhaustive/no-custom-config/reqwithheaders/req_with_headers_test/req_with_headers_test.go
@@ -21,7 +21,7 @@ func VerifyRequestCount(
 	testId string,
 	method string,
 	urlPath string,
-	queryParams map[string]string,
+	queryParams map[string]any,
 	expected int,
 ) {
 	wiremockURL := os.Getenv("WIREMOCK_URL")
@@ -46,9 +46,23 @@ func VerifyRequestCount(
 			}
 			reqBody.WriteString(`"`)
 			reqBody.WriteString(key)
-			reqBody.WriteString(`":{"equalTo":"`)
-			reqBody.WriteString(value)
-			reqBody.WriteString(`"}`)
+			switch v := value.(type) {
+			case string:
+				reqBody.WriteString(`":{"equalTo":"`)
+				reqBody.WriteString(v)
+				reqBody.WriteString(`"}`)
+			case []string:
+				reqBody.WriteString(`":{"hasExactly":[`)
+				for i, item := range v {
+					if i > 0 {
+						reqBody.WriteString(",")
+					}
+					reqBody.WriteString(`{"equalTo":"`)
+					reqBody.WriteString(item)
+					reqBody.WriteString(`"}`)
+				}
+				reqBody.WriteString(`]}`)
+			}
 			first = false
 		}
 		reqBody.WriteString("}")

--- a/seed/go-sdk/exhaustive/omit-empty-request-wrappers/.fern/metadata.json
+++ b/seed/go-sdk/exhaustive/omit-empty-request-wrappers/.fern/metadata.json
@@ -8,8 +8,8 @@
   },
   "originGitCommit": "DUMMY",
   "originGitCommitIsDirty": null,
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
+  "ciProvider": null,
   "sdkVersion": "v0.0.1"
 }

--- a/seed/go-sdk/exhaustive/omit-empty-request-wrappers/endpoints/container/endpoints_container_test/endpoints_container_test.go
+++ b/seed/go-sdk/exhaustive/omit-empty-request-wrappers/endpoints/container/endpoints_container_test/endpoints_container_test.go
@@ -21,7 +21,7 @@ func VerifyRequestCount(
 	testId string,
 	method string,
 	urlPath string,
-	queryParams map[string]string,
+	queryParams map[string]any,
 	expected int,
 ) {
 	wiremockURL := os.Getenv("WIREMOCK_URL")
@@ -46,9 +46,23 @@ func VerifyRequestCount(
 			}
 			reqBody.WriteString(`"`)
 			reqBody.WriteString(key)
-			reqBody.WriteString(`":{"equalTo":"`)
-			reqBody.WriteString(value)
-			reqBody.WriteString(`"}`)
+			switch v := value.(type) {
+			case string:
+				reqBody.WriteString(`":{"equalTo":"`)
+				reqBody.WriteString(v)
+				reqBody.WriteString(`"}`)
+			case []string:
+				reqBody.WriteString(`":{"hasExactly":[`)
+				for i, item := range v {
+					if i > 0 {
+						reqBody.WriteString(",")
+					}
+					reqBody.WriteString(`{"equalTo":"`)
+					reqBody.WriteString(item)
+					reqBody.WriteString(`"}`)
+				}
+				reqBody.WriteString(`]}`)
+			}
 			first = false
 		}
 		reqBody.WriteString("}")

--- a/seed/go-sdk/exhaustive/omit-empty-request-wrappers/endpoints/contenttype/endpoints_content_type_test/endpoints_content_type_test.go
+++ b/seed/go-sdk/exhaustive/omit-empty-request-wrappers/endpoints/contenttype/endpoints_content_type_test/endpoints_content_type_test.go
@@ -23,7 +23,7 @@ func VerifyRequestCount(
 	testId string,
 	method string,
 	urlPath string,
-	queryParams map[string]string,
+	queryParams map[string]any,
 	expected int,
 ) {
 	wiremockURL := os.Getenv("WIREMOCK_URL")
@@ -48,9 +48,23 @@ func VerifyRequestCount(
 			}
 			reqBody.WriteString(`"`)
 			reqBody.WriteString(key)
-			reqBody.WriteString(`":{"equalTo":"`)
-			reqBody.WriteString(value)
-			reqBody.WriteString(`"}`)
+			switch v := value.(type) {
+			case string:
+				reqBody.WriteString(`":{"equalTo":"`)
+				reqBody.WriteString(v)
+				reqBody.WriteString(`"}`)
+			case []string:
+				reqBody.WriteString(`":{"hasExactly":[`)
+				for i, item := range v {
+					if i > 0 {
+						reqBody.WriteString(",")
+					}
+					reqBody.WriteString(`{"equalTo":"`)
+					reqBody.WriteString(item)
+					reqBody.WriteString(`"}`)
+				}
+				reqBody.WriteString(`]}`)
+			}
 			first = false
 		}
 		reqBody.WriteString("}")

--- a/seed/go-sdk/exhaustive/omit-empty-request-wrappers/endpoints/enum/endpoints_enum_test/endpoints_enum_test.go
+++ b/seed/go-sdk/exhaustive/omit-empty-request-wrappers/endpoints/enum/endpoints_enum_test/endpoints_enum_test.go
@@ -21,7 +21,7 @@ func VerifyRequestCount(
 	testId string,
 	method string,
 	urlPath string,
-	queryParams map[string]string,
+	queryParams map[string]any,
 	expected int,
 ) {
 	wiremockURL := os.Getenv("WIREMOCK_URL")
@@ -46,9 +46,23 @@ func VerifyRequestCount(
 			}
 			reqBody.WriteString(`"`)
 			reqBody.WriteString(key)
-			reqBody.WriteString(`":{"equalTo":"`)
-			reqBody.WriteString(value)
-			reqBody.WriteString(`"}`)
+			switch v := value.(type) {
+			case string:
+				reqBody.WriteString(`":{"equalTo":"`)
+				reqBody.WriteString(v)
+				reqBody.WriteString(`"}`)
+			case []string:
+				reqBody.WriteString(`":{"hasExactly":[`)
+				for i, item := range v {
+					if i > 0 {
+						reqBody.WriteString(",")
+					}
+					reqBody.WriteString(`{"equalTo":"`)
+					reqBody.WriteString(item)
+					reqBody.WriteString(`"}`)
+				}
+				reqBody.WriteString(`]}`)
+			}
 			first = false
 		}
 		reqBody.WriteString("}")

--- a/seed/go-sdk/exhaustive/omit-empty-request-wrappers/endpoints/httpmethods/endpoints_http_methods_test/endpoints_http_methods_test.go
+++ b/seed/go-sdk/exhaustive/omit-empty-request-wrappers/endpoints/httpmethods/endpoints_http_methods_test/endpoints_http_methods_test.go
@@ -23,7 +23,7 @@ func VerifyRequestCount(
 	testId string,
 	method string,
 	urlPath string,
-	queryParams map[string]string,
+	queryParams map[string]any,
 	expected int,
 ) {
 	wiremockURL := os.Getenv("WIREMOCK_URL")
@@ -48,9 +48,23 @@ func VerifyRequestCount(
 			}
 			reqBody.WriteString(`"`)
 			reqBody.WriteString(key)
-			reqBody.WriteString(`":{"equalTo":"`)
-			reqBody.WriteString(value)
-			reqBody.WriteString(`"}`)
+			switch v := value.(type) {
+			case string:
+				reqBody.WriteString(`":{"equalTo":"`)
+				reqBody.WriteString(v)
+				reqBody.WriteString(`"}`)
+			case []string:
+				reqBody.WriteString(`":{"hasExactly":[`)
+				for i, item := range v {
+					if i > 0 {
+						reqBody.WriteString(",")
+					}
+					reqBody.WriteString(`{"equalTo":"`)
+					reqBody.WriteString(item)
+					reqBody.WriteString(`"}`)
+				}
+				reqBody.WriteString(`]}`)
+			}
 			first = false
 		}
 		reqBody.WriteString("}")

--- a/seed/go-sdk/exhaustive/omit-empty-request-wrappers/endpoints/object/endpoints_object_test/endpoints_object_test.go
+++ b/seed/go-sdk/exhaustive/omit-empty-request-wrappers/endpoints/object/endpoints_object_test/endpoints_object_test.go
@@ -23,7 +23,7 @@ func VerifyRequestCount(
 	testId string,
 	method string,
 	urlPath string,
-	queryParams map[string]string,
+	queryParams map[string]any,
 	expected int,
 ) {
 	wiremockURL := os.Getenv("WIREMOCK_URL")
@@ -48,9 +48,23 @@ func VerifyRequestCount(
 			}
 			reqBody.WriteString(`"`)
 			reqBody.WriteString(key)
-			reqBody.WriteString(`":{"equalTo":"`)
-			reqBody.WriteString(value)
-			reqBody.WriteString(`"}`)
+			switch v := value.(type) {
+			case string:
+				reqBody.WriteString(`":{"equalTo":"`)
+				reqBody.WriteString(v)
+				reqBody.WriteString(`"}`)
+			case []string:
+				reqBody.WriteString(`":{"hasExactly":[`)
+				for i, item := range v {
+					if i > 0 {
+						reqBody.WriteString(",")
+					}
+					reqBody.WriteString(`{"equalTo":"`)
+					reqBody.WriteString(item)
+					reqBody.WriteString(`"}`)
+				}
+				reqBody.WriteString(`]}`)
+			}
 			first = false
 		}
 		reqBody.WriteString("}")

--- a/seed/go-sdk/exhaustive/omit-empty-request-wrappers/endpoints/pagination/endpoints_pagination_test/endpoints_pagination_test.go
+++ b/seed/go-sdk/exhaustive/omit-empty-request-wrappers/endpoints/pagination/endpoints_pagination_test/endpoints_pagination_test.go
@@ -22,7 +22,7 @@ func VerifyRequestCount(
 	testId string,
 	method string,
 	urlPath string,
-	queryParams map[string]string,
+	queryParams map[string]any,
 	expected int,
 ) {
 	wiremockURL := os.Getenv("WIREMOCK_URL")
@@ -47,9 +47,23 @@ func VerifyRequestCount(
 			}
 			reqBody.WriteString(`"`)
 			reqBody.WriteString(key)
-			reqBody.WriteString(`":{"equalTo":"`)
-			reqBody.WriteString(value)
-			reqBody.WriteString(`"}`)
+			switch v := value.(type) {
+			case string:
+				reqBody.WriteString(`":{"equalTo":"`)
+				reqBody.WriteString(v)
+				reqBody.WriteString(`"}`)
+			case []string:
+				reqBody.WriteString(`":{"hasExactly":[`)
+				for i, item := range v {
+					if i > 0 {
+						reqBody.WriteString(",")
+					}
+					reqBody.WriteString(`{"equalTo":"`)
+					reqBody.WriteString(item)
+					reqBody.WriteString(`"}`)
+				}
+				reqBody.WriteString(`]}`)
+			}
 			first = false
 		}
 		reqBody.WriteString("}")

--- a/seed/go-sdk/exhaustive/omit-empty-request-wrappers/endpoints/pagination/endpoints_pagination_test/endpoints_pagination_test.go
+++ b/seed/go-sdk/exhaustive/omit-empty-request-wrappers/endpoints/pagination/endpoints_pagination_test/endpoints_pagination_test.go
@@ -106,5 +106,5 @@ func TestEndpointsPaginationListItemsWithWireMock(
 	)
 
 	require.NoError(t, invocationErr, "Client method call should succeed")
-	VerifyRequestCount(t, "TestEndpointsPaginationListItemsWithWireMock", "GET", "/pagination", map[string]string{"cursor": "cursor", "limit": "1"}, 1)
+	VerifyRequestCount(t, "TestEndpointsPaginationListItemsWithWireMock", "GET", "/pagination", map[string]interface{}{"cursor": "cursor", "limit": "1"}, 1)
 }

--- a/seed/go-sdk/exhaustive/omit-empty-request-wrappers/endpoints/params/endpoints_params_test/endpoints_params_test.go
+++ b/seed/go-sdk/exhaustive/omit-empty-request-wrappers/endpoints/params/endpoints_params_test/endpoints_params_test.go
@@ -21,7 +21,7 @@ func VerifyRequestCount(
 	testId string,
 	method string,
 	urlPath string,
-	queryParams map[string]string,
+	queryParams map[string]any,
 	expected int,
 ) {
 	wiremockURL := os.Getenv("WIREMOCK_URL")
@@ -46,9 +46,23 @@ func VerifyRequestCount(
 			}
 			reqBody.WriteString(`"`)
 			reqBody.WriteString(key)
-			reqBody.WriteString(`":{"equalTo":"`)
-			reqBody.WriteString(value)
-			reqBody.WriteString(`"}`)
+			switch v := value.(type) {
+			case string:
+				reqBody.WriteString(`":{"equalTo":"`)
+				reqBody.WriteString(v)
+				reqBody.WriteString(`"}`)
+			case []string:
+				reqBody.WriteString(`":{"hasExactly":[`)
+				for i, item := range v {
+					if i > 0 {
+						reqBody.WriteString(",")
+					}
+					reqBody.WriteString(`{"equalTo":"`)
+					reqBody.WriteString(item)
+					reqBody.WriteString(`"}`)
+				}
+				reqBody.WriteString(`]}`)
+			}
 			first = false
 		}
 		reqBody.WriteString("}")

--- a/seed/go-sdk/exhaustive/omit-empty-request-wrappers/endpoints/params/endpoints_params_test/endpoints_params_test.go
+++ b/seed/go-sdk/exhaustive/omit-empty-request-wrappers/endpoints/params/endpoints_params_test/endpoints_params_test.go
@@ -147,7 +147,7 @@ func TestEndpointsParamsGetWithQueryWithWireMock(
 	)
 
 	require.NoError(t, invocationErr, "Client method call should succeed")
-	VerifyRequestCount(t, "TestEndpointsParamsGetWithQueryWithWireMock", "GET", "/params", map[string]string{"query": "query", "number": "1"}, 1)
+	VerifyRequestCount(t, "TestEndpointsParamsGetWithQueryWithWireMock", "GET", "/params", map[string]interface{}{"query": "query", "number": "1"}, 1)
 }
 
 func TestEndpointsParamsGetWithQueryWithWireMock2(
@@ -174,7 +174,7 @@ func TestEndpointsParamsGetWithQueryWithWireMock2(
 	)
 
 	require.NoError(t, invocationErr, "Client method call should succeed")
-	VerifyRequestCount(t, "TestEndpointsParamsGetWithQueryWithWireMock2", "GET", "/params", map[string]string{"query": "query", "number": "1"}, 1)
+	VerifyRequestCount(t, "TestEndpointsParamsGetWithQueryWithWireMock2", "GET", "/params", map[string]interface{}{"query": "query", "number": "1"}, 1)
 }
 
 func TestEndpointsParamsGetWithPathAndQueryWithWireMock(
@@ -201,7 +201,7 @@ func TestEndpointsParamsGetWithPathAndQueryWithWireMock(
 	)
 
 	require.NoError(t, invocationErr, "Client method call should succeed")
-	VerifyRequestCount(t, "TestEndpointsParamsGetWithPathAndQueryWithWireMock", "GET", "/params/path-query/param", map[string]string{"query": "query"}, 1)
+	VerifyRequestCount(t, "TestEndpointsParamsGetWithPathAndQueryWithWireMock", "GET", "/params/path-query/param", map[string]interface{}{"query": "query"}, 1)
 }
 
 func TestEndpointsParamsGetWithPathAndQueryWithWireMock2(
@@ -228,7 +228,7 @@ func TestEndpointsParamsGetWithPathAndQueryWithWireMock2(
 	)
 
 	require.NoError(t, invocationErr, "Client method call should succeed")
-	VerifyRequestCount(t, "TestEndpointsParamsGetWithPathAndQueryWithWireMock2", "GET", "/params/path-query/param", map[string]string{"query": "query"}, 1)
+	VerifyRequestCount(t, "TestEndpointsParamsGetWithPathAndQueryWithWireMock2", "GET", "/params/path-query/param", map[string]interface{}{"query": "query"}, 1)
 }
 
 func TestEndpointsParamsModifyWithPathWithWireMock(

--- a/seed/go-sdk/exhaustive/omit-empty-request-wrappers/endpoints/primitive/endpoints_primitive_test/endpoints_primitive_test.go
+++ b/seed/go-sdk/exhaustive/omit-empty-request-wrappers/endpoints/primitive/endpoints_primitive_test/endpoints_primitive_test.go
@@ -22,7 +22,7 @@ func VerifyRequestCount(
 	testId string,
 	method string,
 	urlPath string,
-	queryParams map[string]string,
+	queryParams map[string]any,
 	expected int,
 ) {
 	wiremockURL := os.Getenv("WIREMOCK_URL")
@@ -47,9 +47,23 @@ func VerifyRequestCount(
 			}
 			reqBody.WriteString(`"`)
 			reqBody.WriteString(key)
-			reqBody.WriteString(`":{"equalTo":"`)
-			reqBody.WriteString(value)
-			reqBody.WriteString(`"}`)
+			switch v := value.(type) {
+			case string:
+				reqBody.WriteString(`":{"equalTo":"`)
+				reqBody.WriteString(v)
+				reqBody.WriteString(`"}`)
+			case []string:
+				reqBody.WriteString(`":{"hasExactly":[`)
+				for i, item := range v {
+					if i > 0 {
+						reqBody.WriteString(",")
+					}
+					reqBody.WriteString(`{"equalTo":"`)
+					reqBody.WriteString(item)
+					reqBody.WriteString(`"}`)
+				}
+				reqBody.WriteString(`]}`)
+			}
 			first = false
 		}
 		reqBody.WriteString("}")

--- a/seed/go-sdk/exhaustive/omit-empty-request-wrappers/endpoints/put/endpoints_put_test/endpoints_put_test.go
+++ b/seed/go-sdk/exhaustive/omit-empty-request-wrappers/endpoints/put/endpoints_put_test/endpoints_put_test.go
@@ -21,7 +21,7 @@ func VerifyRequestCount(
 	testId string,
 	method string,
 	urlPath string,
-	queryParams map[string]string,
+	queryParams map[string]any,
 	expected int,
 ) {
 	wiremockURL := os.Getenv("WIREMOCK_URL")
@@ -46,9 +46,23 @@ func VerifyRequestCount(
 			}
 			reqBody.WriteString(`"`)
 			reqBody.WriteString(key)
-			reqBody.WriteString(`":{"equalTo":"`)
-			reqBody.WriteString(value)
-			reqBody.WriteString(`"}`)
+			switch v := value.(type) {
+			case string:
+				reqBody.WriteString(`":{"equalTo":"`)
+				reqBody.WriteString(v)
+				reqBody.WriteString(`"}`)
+			case []string:
+				reqBody.WriteString(`":{"hasExactly":[`)
+				for i, item := range v {
+					if i > 0 {
+						reqBody.WriteString(",")
+					}
+					reqBody.WriteString(`{"equalTo":"`)
+					reqBody.WriteString(item)
+					reqBody.WriteString(`"}`)
+				}
+				reqBody.WriteString(`]}`)
+			}
 			first = false
 		}
 		reqBody.WriteString("}")

--- a/seed/go-sdk/exhaustive/omit-empty-request-wrappers/endpoints/union/endpoints_union_test/endpoints_union_test.go
+++ b/seed/go-sdk/exhaustive/omit-empty-request-wrappers/endpoints/union/endpoints_union_test/endpoints_union_test.go
@@ -21,7 +21,7 @@ func VerifyRequestCount(
 	testId string,
 	method string,
 	urlPath string,
-	queryParams map[string]string,
+	queryParams map[string]any,
 	expected int,
 ) {
 	wiremockURL := os.Getenv("WIREMOCK_URL")
@@ -46,9 +46,23 @@ func VerifyRequestCount(
 			}
 			reqBody.WriteString(`"`)
 			reqBody.WriteString(key)
-			reqBody.WriteString(`":{"equalTo":"`)
-			reqBody.WriteString(value)
-			reqBody.WriteString(`"}`)
+			switch v := value.(type) {
+			case string:
+				reqBody.WriteString(`":{"equalTo":"`)
+				reqBody.WriteString(v)
+				reqBody.WriteString(`"}`)
+			case []string:
+				reqBody.WriteString(`":{"hasExactly":[`)
+				for i, item := range v {
+					if i > 0 {
+						reqBody.WriteString(",")
+					}
+					reqBody.WriteString(`{"equalTo":"`)
+					reqBody.WriteString(item)
+					reqBody.WriteString(`"}`)
+				}
+				reqBody.WriteString(`]}`)
+			}
 			first = false
 		}
 		reqBody.WriteString("}")

--- a/seed/go-sdk/exhaustive/omit-empty-request-wrappers/endpoints/urls/endpoints_urls_test/endpoints_urls_test.go
+++ b/seed/go-sdk/exhaustive/omit-empty-request-wrappers/endpoints/urls/endpoints_urls_test/endpoints_urls_test.go
@@ -20,7 +20,7 @@ func VerifyRequestCount(
 	testId string,
 	method string,
 	urlPath string,
-	queryParams map[string]string,
+	queryParams map[string]any,
 	expected int,
 ) {
 	wiremockURL := os.Getenv("WIREMOCK_URL")
@@ -45,9 +45,23 @@ func VerifyRequestCount(
 			}
 			reqBody.WriteString(`"`)
 			reqBody.WriteString(key)
-			reqBody.WriteString(`":{"equalTo":"`)
-			reqBody.WriteString(value)
-			reqBody.WriteString(`"}`)
+			switch v := value.(type) {
+			case string:
+				reqBody.WriteString(`":{"equalTo":"`)
+				reqBody.WriteString(v)
+				reqBody.WriteString(`"}`)
+			case []string:
+				reqBody.WriteString(`":{"hasExactly":[`)
+				for i, item := range v {
+					if i > 0 {
+						reqBody.WriteString(",")
+					}
+					reqBody.WriteString(`{"equalTo":"`)
+					reqBody.WriteString(item)
+					reqBody.WriteString(`"}`)
+				}
+				reqBody.WriteString(`]}`)
+			}
 			first = false
 		}
 		reqBody.WriteString("}")

--- a/seed/go-sdk/exhaustive/omit-empty-request-wrappers/inlinedrequests/inlined_requests_test/inlined_requests_test.go
+++ b/seed/go-sdk/exhaustive/omit-empty-request-wrappers/inlinedrequests/inlined_requests_test/inlined_requests_test.go
@@ -23,7 +23,7 @@ func VerifyRequestCount(
 	testId string,
 	method string,
 	urlPath string,
-	queryParams map[string]string,
+	queryParams map[string]any,
 	expected int,
 ) {
 	wiremockURL := os.Getenv("WIREMOCK_URL")
@@ -48,9 +48,23 @@ func VerifyRequestCount(
 			}
 			reqBody.WriteString(`"`)
 			reqBody.WriteString(key)
-			reqBody.WriteString(`":{"equalTo":"`)
-			reqBody.WriteString(value)
-			reqBody.WriteString(`"}`)
+			switch v := value.(type) {
+			case string:
+				reqBody.WriteString(`":{"equalTo":"`)
+				reqBody.WriteString(v)
+				reqBody.WriteString(`"}`)
+			case []string:
+				reqBody.WriteString(`":{"hasExactly":[`)
+				for i, item := range v {
+					if i > 0 {
+						reqBody.WriteString(",")
+					}
+					reqBody.WriteString(`{"equalTo":"`)
+					reqBody.WriteString(item)
+					reqBody.WriteString(`"}`)
+				}
+				reqBody.WriteString(`]}`)
+			}
 			first = false
 		}
 		reqBody.WriteString("}")

--- a/seed/go-sdk/exhaustive/omit-empty-request-wrappers/noauth/no_auth_test/no_auth_test.go
+++ b/seed/go-sdk/exhaustive/omit-empty-request-wrappers/noauth/no_auth_test/no_auth_test.go
@@ -20,7 +20,7 @@ func VerifyRequestCount(
 	testId string,
 	method string,
 	urlPath string,
-	queryParams map[string]string,
+	queryParams map[string]any,
 	expected int,
 ) {
 	wiremockURL := os.Getenv("WIREMOCK_URL")
@@ -45,9 +45,23 @@ func VerifyRequestCount(
 			}
 			reqBody.WriteString(`"`)
 			reqBody.WriteString(key)
-			reqBody.WriteString(`":{"equalTo":"`)
-			reqBody.WriteString(value)
-			reqBody.WriteString(`"}`)
+			switch v := value.(type) {
+			case string:
+				reqBody.WriteString(`":{"equalTo":"`)
+				reqBody.WriteString(v)
+				reqBody.WriteString(`"}`)
+			case []string:
+				reqBody.WriteString(`":{"hasExactly":[`)
+				for i, item := range v {
+					if i > 0 {
+						reqBody.WriteString(",")
+					}
+					reqBody.WriteString(`{"equalTo":"`)
+					reqBody.WriteString(item)
+					reqBody.WriteString(`"}`)
+				}
+				reqBody.WriteString(`]}`)
+			}
 			first = false
 		}
 		reqBody.WriteString("}")

--- a/seed/go-sdk/exhaustive/omit-empty-request-wrappers/noreqbody/no_req_body_test/no_req_body_test.go
+++ b/seed/go-sdk/exhaustive/omit-empty-request-wrappers/noreqbody/no_req_body_test/no_req_body_test.go
@@ -20,7 +20,7 @@ func VerifyRequestCount(
 	testId string,
 	method string,
 	urlPath string,
-	queryParams map[string]string,
+	queryParams map[string]any,
 	expected int,
 ) {
 	wiremockURL := os.Getenv("WIREMOCK_URL")
@@ -45,9 +45,23 @@ func VerifyRequestCount(
 			}
 			reqBody.WriteString(`"`)
 			reqBody.WriteString(key)
-			reqBody.WriteString(`":{"equalTo":"`)
-			reqBody.WriteString(value)
-			reqBody.WriteString(`"}`)
+			switch v := value.(type) {
+			case string:
+				reqBody.WriteString(`":{"equalTo":"`)
+				reqBody.WriteString(v)
+				reqBody.WriteString(`"}`)
+			case []string:
+				reqBody.WriteString(`":{"hasExactly":[`)
+				for i, item := range v {
+					if i > 0 {
+						reqBody.WriteString(",")
+					}
+					reqBody.WriteString(`{"equalTo":"`)
+					reqBody.WriteString(item)
+					reqBody.WriteString(`"}`)
+				}
+				reqBody.WriteString(`]}`)
+			}
 			first = false
 		}
 		reqBody.WriteString("}")

--- a/seed/go-sdk/exhaustive/omit-empty-request-wrappers/reqwithheaders/req_with_headers_test/req_with_headers_test.go
+++ b/seed/go-sdk/exhaustive/omit-empty-request-wrappers/reqwithheaders/req_with_headers_test/req_with_headers_test.go
@@ -21,7 +21,7 @@ func VerifyRequestCount(
 	testId string,
 	method string,
 	urlPath string,
-	queryParams map[string]string,
+	queryParams map[string]any,
 	expected int,
 ) {
 	wiremockURL := os.Getenv("WIREMOCK_URL")
@@ -46,9 +46,23 @@ func VerifyRequestCount(
 			}
 			reqBody.WriteString(`"`)
 			reqBody.WriteString(key)
-			reqBody.WriteString(`":{"equalTo":"`)
-			reqBody.WriteString(value)
-			reqBody.WriteString(`"}`)
+			switch v := value.(type) {
+			case string:
+				reqBody.WriteString(`":{"equalTo":"`)
+				reqBody.WriteString(v)
+				reqBody.WriteString(`"}`)
+			case []string:
+				reqBody.WriteString(`":{"hasExactly":[`)
+				for i, item := range v {
+					if i > 0 {
+						reqBody.WriteString(",")
+					}
+					reqBody.WriteString(`{"equalTo":"`)
+					reqBody.WriteString(item)
+					reqBody.WriteString(`"}`)
+				}
+				reqBody.WriteString(`]}`)
+			}
 			first = false
 		}
 		reqBody.WriteString("}")

--- a/seed/php-sdk/basic-auth/wire-tests/.fern/metadata.json
+++ b/seed/php-sdk/basic-auth/wire-tests/.fern/metadata.json
@@ -7,8 +7,8 @@
   },
   "originGitCommit": "DUMMY",
   "originGitCommitIsDirty": null,
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
+  "ciProvider": null,
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/basic-auth/wire-tests/tests/Wire/WireMockTestCase.php
+++ b/seed/php-sdk/basic-auth/wire-tests/tests/Wire/WireMockTestCase.php
@@ -21,7 +21,7 @@ abstract class WireMockTestCase extends TestCase
      * @param string $testId The test ID used to filter requests
      * @param string $method The HTTP method (GET, POST, etc.)
      * @param string $urlPath The URL path to match
-     * @param array<string, string>|null $queryParams Query parameters to match
+     * @param array<string, string|array<string>>|null $queryParams Query parameters to match
      * @param int $expected Expected number of requests
      */
     protected function verifyRequestCount(
@@ -45,7 +45,15 @@ abstract class WireMockTestCase extends TestCase
         if ($queryParams !== null && $queryParams !== []) {
             $body['queryParameters'] = [];
             foreach ($queryParams as $k => $v) {
-                $body['queryParameters'][$k] = ['equalTo' => (string) $v];
+                if (is_array($v)) {
+                    $matchers = [];
+                    foreach ($v as $item) {
+                        $matchers[] = ['equalTo' => (string) $item];
+                    }
+                    $body['queryParameters'][$k] = ['hasExactly' => $matchers];
+                } else {
+                    $body['queryParameters'][$k] = ['equalTo' => (string) $v];
+                }
             }
         }
 

--- a/seed/php-sdk/exhaustive/no-custom-config/.fern/metadata.json
+++ b/seed/php-sdk/exhaustive/no-custom-config/.fern/metadata.json
@@ -4,8 +4,8 @@
   "generatorVersion": "local",
   "originGitCommit": "DUMMY",
   "originGitCommitIsDirty": null,
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
+  "ciProvider": null,
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/exhaustive/wire-tests/.fern/metadata.json
+++ b/seed/php-sdk/exhaustive/wire-tests/.fern/metadata.json
@@ -7,8 +7,8 @@
   },
   "originGitCommit": "DUMMY",
   "originGitCommitIsDirty": null,
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
+  "ciProvider": null,
   "sdkVersion": "0.0.1"
 }

--- a/seed/php-sdk/exhaustive/wire-tests/tests/Wire/WireMockTestCase.php
+++ b/seed/php-sdk/exhaustive/wire-tests/tests/Wire/WireMockTestCase.php
@@ -45,7 +45,15 @@ abstract class WireMockTestCase extends TestCase
         if ($queryParams !== null && $queryParams !== []) {
             $body['queryParameters'] = [];
             foreach ($queryParams as $k => $v) {
-                $body['queryParameters'][$k] = ['equalTo' => (string) $v];
+                if (is_array($v)) {
+                    $matchers = [];
+                    foreach ($v as $item) {
+                        $matchers[] = ['equalTo' => (string) $item];
+                    }
+                    $body['queryParameters'][$k] = ['hasExactly' => $matchers];
+                } else {
+                    $body['queryParameters'][$k] = ['equalTo' => (string) $v];
+                }
             }
         }
 

--- a/seed/php-sdk/exhaustive/wire-tests/tests/Wire/WireMockTestCase.php
+++ b/seed/php-sdk/exhaustive/wire-tests/tests/Wire/WireMockTestCase.php
@@ -21,7 +21,7 @@ abstract class WireMockTestCase extends TestCase
      * @param string $testId The test ID used to filter requests
      * @param string $method The HTTP method (GET, POST, etc.)
      * @param string $urlPath The URL path to match
-     * @param array<string, string>|null $queryParams Query parameters to match
+     * @param array<string, string|array<string>>|null $queryParams Query parameters to match
      * @param int $expected Expected number of requests
      */
     protected function verifyRequestCount(

--- a/seed/python-sdk/exhaustive/additional_init_exports/.fern/metadata.json
+++ b/seed/python-sdk/exhaustive/additional_init_exports/.fern/metadata.json
@@ -15,8 +15,8 @@
   },
   "originGitCommit": "DUMMY",
   "originGitCommitIsDirty": null,
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
+  "ciProvider": null,
   "sdkVersion": "0.0.1"
 }

--- a/seed/python-sdk/exhaustive/aliases_with_validation/.fern/metadata.json
+++ b/seed/python-sdk/exhaustive/aliases_with_validation/.fern/metadata.json
@@ -9,8 +9,8 @@
   },
   "originGitCommit": "DUMMY",
   "originGitCommitIsDirty": null,
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
+  "ciProvider": null,
   "sdkVersion": "0.0.1"
 }

--- a/seed/python-sdk/exhaustive/aliases_without_validation/.fern/metadata.json
+++ b/seed/python-sdk/exhaustive/aliases_without_validation/.fern/metadata.json
@@ -10,8 +10,8 @@
   },
   "originGitCommit": "DUMMY",
   "originGitCommitIsDirty": null,
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
+  "ciProvider": null,
   "sdkVersion": "0.0.1"
 }

--- a/seed/python-sdk/exhaustive/custom-transport/.fern/metadata.json
+++ b/seed/python-sdk/exhaustive/custom-transport/.fern/metadata.json
@@ -7,8 +7,8 @@
   },
   "originGitCommit": "DUMMY",
   "originGitCommitIsDirty": null,
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
+  "ciProvider": null,
   "sdkVersion": "0.0.1"
 }

--- a/seed/python-sdk/exhaustive/datetime-milliseconds/.fern/metadata.json
+++ b/seed/python-sdk/exhaustive/datetime-milliseconds/.fern/metadata.json
@@ -7,8 +7,8 @@
   },
   "originGitCommit": "DUMMY",
   "originGitCommitIsDirty": null,
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
+  "ciProvider": null,
   "sdkVersion": "0.0.1"
 }

--- a/seed/python-sdk/exhaustive/deps_with_min_python_version/.fern/metadata.json
+++ b/seed/python-sdk/exhaustive/deps_with_min_python_version/.fern/metadata.json
@@ -21,8 +21,8 @@
   },
   "originGitCommit": "DUMMY",
   "originGitCommitIsDirty": null,
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
+  "ciProvider": null,
   "sdkVersion": "0.0.1"
 }

--- a/seed/python-sdk/exhaustive/deps_with_min_python_version/poetry.lock
+++ b/seed/python-sdk/exhaustive/deps_with_min_python_version/poetry.lock
@@ -700,17 +700,17 @@ httpx = ">=0.27.0"
 
 [[package]]
 name = "idna"
-version = "3.12"
+version = "3.11"
 description = "Internationalized Domain Names in Applications (IDNA)"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "idna-3.12-py3-none-any.whl", hash = "sha256:60ffaa1858fac94c9c124728c24fcde8160f3fb4a7f79aa8cdd33a9d1af60a67"},
-    {file = "idna-3.12.tar.gz", hash = "sha256:724e9952cc9e2bd7550ea784adb098d837ab5267ef67a1ab9cf7846bdbdd8254"},
+    {file = "idna-3.11-py3-none-any.whl", hash = "sha256:771a87f49d9defaf64091e6e6fe9c18d4833f140bd19464795bc32d966ca37ea"},
+    {file = "idna-3.11.tar.gz", hash = "sha256:795dafcc9c04ed0c1fb032c2aa73654d8e8c5023a7df64a53f39190ada629902"},
 ]
 
 [package.extras]
-all = ["mypy (>=1.11.2)", "pytest (>=8.3.2)", "ruff (>=0.6.2)"]
+all = ["flake8 (>=7.1.1)", "mypy (>=1.11.2)", "pytest (>=8.3.2)", "ruff (>=0.6.2)"]
 
 [[package]]
 name = "iniconfig"
@@ -935,13 +935,13 @@ uuid-utils = ">=0.12.0,<1.0"
 
 [[package]]
 name = "langchain-openai"
-version = "1.1.16"
+version = "1.1.15"
 description = "An integration package connecting OpenAI and LangChain"
 optional = false
 python-versions = "<4.0.0,>=3.10.0"
 files = [
-    {file = "langchain_openai-1.1.16-py3-none-any.whl", hash = "sha256:648becb4fb86d24d56b9292e01878a05cca932bb475909bb8fb85b8c82dd1a02"},
-    {file = "langchain_openai-1.1.16.tar.gz", hash = "sha256:306f1c7f66f47bd39655e645fd1f9445d65473465a59347fa7d716596e28dfe0"},
+    {file = "langchain_openai-1.1.15-py3-none-any.whl", hash = "sha256:069022b6cba2108fac2450d3bf6c888e20a2af92bf89b493638456ef4db0d900"},
+    {file = "langchain_openai-1.1.15.tar.gz", hash = "sha256:16ddb7481853991fd00691dfd01bcc5cdf60cb36aa6962b38c8a4939f0538ba0"},
 ]
 
 [package.dependencies]
@@ -951,13 +951,13 @@ tiktoken = ">=0.7.0,<1.0.0"
 
 [[package]]
 name = "langgraph"
-version = "1.1.9"
+version = "1.1.8"
 description = "Building stateful, multi-actor applications with LLMs"
 optional = false
 python-versions = ">=3.10"
 files = [
-    {file = "langgraph-1.1.9-py3-none-any.whl", hash = "sha256:7db13ceecde4ea643df6c097dcc9e534895dcd9fcc6500eeff2f2cde0fab16b2"},
-    {file = "langgraph-1.1.9.tar.gz", hash = "sha256:bc5a49d5a5e71fda1f9c53c06c62f4caec9a95545b739d130a58b6ab3269e274"},
+    {file = "langgraph-1.1.8-py3-none-any.whl", hash = "sha256:3278c7e335da25eac3327bb474c502d4cab94ae6dcc685fbf93be2bbf7664cd5"},
+    {file = "langgraph-1.1.8.tar.gz", hash = "sha256:a97b8248129f2e007b81eef8277009ad1e1280b75fa2175889ab5aff5dcc4578"},
 ]
 
 [package.dependencies]

--- a/seed/python-sdk/exhaustive/eager-imports/.fern/metadata.json
+++ b/seed/python-sdk/exhaustive/eager-imports/.fern/metadata.json
@@ -7,8 +7,8 @@
   },
   "originGitCommit": "DUMMY",
   "originGitCommitIsDirty": null,
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
+  "ciProvider": null,
   "sdkVersion": "0.0.1"
 }

--- a/seed/python-sdk/exhaustive/extra_dependencies/.fern/metadata.json
+++ b/seed/python-sdk/exhaustive/extra_dependencies/.fern/metadata.json
@@ -21,8 +21,8 @@
   },
   "originGitCommit": "DUMMY",
   "originGitCommitIsDirty": null,
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
+  "ciProvider": null,
   "sdkVersion": "0.0.1"
 }

--- a/seed/python-sdk/exhaustive/extra_dev_dependencies/.fern/metadata.json
+++ b/seed/python-sdk/exhaustive/extra_dev_dependencies/.fern/metadata.json
@@ -12,8 +12,8 @@
   },
   "originGitCommit": "DUMMY",
   "originGitCommitIsDirty": null,
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
+  "ciProvider": null,
   "sdkVersion": "0.0.1"
 }

--- a/seed/python-sdk/exhaustive/five-second-timeout/.fern/metadata.json
+++ b/seed/python-sdk/exhaustive/five-second-timeout/.fern/metadata.json
@@ -7,8 +7,8 @@
   },
   "originGitCommit": "DUMMY",
   "originGitCommitIsDirty": null,
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
+  "ciProvider": null,
   "sdkVersion": "0.0.1"
 }

--- a/seed/python-sdk/exhaustive/follow_redirects_by_default/.fern/metadata.json
+++ b/seed/python-sdk/exhaustive/follow_redirects_by_default/.fern/metadata.json
@@ -7,8 +7,8 @@
   },
   "originGitCommit": "DUMMY",
   "originGitCommitIsDirty": null,
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
+  "ciProvider": null,
   "sdkVersion": "0.0.1"
 }

--- a/seed/python-sdk/exhaustive/import-paths/.fern/metadata.json
+++ b/seed/python-sdk/exhaustive/import-paths/.fern/metadata.json
@@ -10,8 +10,8 @@
   },
   "originGitCommit": "DUMMY",
   "originGitCommitIsDirty": null,
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
+  "ciProvider": null,
   "sdkVersion": "0.0.1"
 }

--- a/seed/python-sdk/exhaustive/improved_imports/.fern/metadata.json
+++ b/seed/python-sdk/exhaustive/improved_imports/.fern/metadata.json
@@ -7,8 +7,8 @@
   },
   "originGitCommit": "DUMMY",
   "originGitCommitIsDirty": null,
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
+  "ciProvider": null,
   "sdkVersion": "0.0.1"
 }

--- a/seed/python-sdk/exhaustive/infinite-timeout/.fern/metadata.json
+++ b/seed/python-sdk/exhaustive/infinite-timeout/.fern/metadata.json
@@ -7,8 +7,8 @@
   },
   "originGitCommit": "DUMMY",
   "originGitCommitIsDirty": null,
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
+  "ciProvider": null,
   "sdkVersion": "0.0.1"
 }

--- a/seed/python-sdk/exhaustive/inline-path-params/.fern/metadata.json
+++ b/seed/python-sdk/exhaustive/inline-path-params/.fern/metadata.json
@@ -8,8 +8,8 @@
   },
   "originGitCommit": "DUMMY",
   "originGitCommitIsDirty": null,
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
+  "ciProvider": null,
   "sdkVersion": "0.0.1"
 }

--- a/seed/python-sdk/exhaustive/inline_request_params/.fern/metadata.json
+++ b/seed/python-sdk/exhaustive/inline_request_params/.fern/metadata.json
@@ -7,8 +7,8 @@
   },
   "originGitCommit": "DUMMY",
   "originGitCommitIsDirty": null,
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
+  "ciProvider": null,
   "sdkVersion": "0.0.1"
 }

--- a/seed/python-sdk/exhaustive/no-custom-config/.fern/metadata.json
+++ b/seed/python-sdk/exhaustive/no-custom-config/.fern/metadata.json
@@ -7,8 +7,8 @@
   },
   "originGitCommit": "DUMMY",
   "originGitCommitIsDirty": null,
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
+  "ciProvider": null,
   "sdkVersion": "0.0.1"
 }

--- a/seed/python-sdk/exhaustive/no-custom-config/tests/wire/conftest.py
+++ b/seed/python-sdk/exhaustive/no-custom-config/tests/wire/conftest.py
@@ -60,7 +60,7 @@ def verify_request_count(
     test_id: str,
     method: str,
     url_path: str,
-    query_params: Optional[Dict[str, str]],
+    query_params: Optional[Dict[str, Any]],
     expected: int,
 ) -> None:
     """Verifies the number of requests made to WireMock filtered by test ID for concurrency safety."""
@@ -71,7 +71,12 @@ def verify_request_count(
         "headers": {"X-Test-Id": {"equalTo": test_id}},
     }
     if query_params:
-        query_parameters = {k: {"equalTo": v} for k, v in query_params.items()}
+        query_parameters = {}
+        for k, v in query_params.items():
+            if isinstance(v, list):
+                query_parameters[k] = {"hasExactly": [{"equalTo": item} for item in v]}
+            else:
+                query_parameters[k] = {"equalTo": v}
         request_body["queryParameters"] = query_parameters
     response = httpx.post(f"{wiremock_admin_url}/requests/find", json=request_body)
     assert response.status_code == 200, "Failed to query WireMock requests"

--- a/seed/python-sdk/exhaustive/package-path/.fern/metadata.json
+++ b/seed/python-sdk/exhaustive/package-path/.fern/metadata.json
@@ -7,8 +7,8 @@
   },
   "originGitCommit": "DUMMY",
   "originGitCommitIsDirty": null,
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
+  "ciProvider": null,
   "sdkVersion": "0.0.1"
 }

--- a/seed/python-sdk/exhaustive/pydantic-extra-fields/.fern/metadata.json
+++ b/seed/python-sdk/exhaustive/pydantic-extra-fields/.fern/metadata.json
@@ -9,8 +9,8 @@
   },
   "originGitCommit": "DUMMY",
   "originGitCommitIsDirty": null,
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
+  "ciProvider": null,
   "sdkVersion": "0.0.1"
 }

--- a/seed/python-sdk/exhaustive/pydantic-ignore-fields/.fern/metadata.json
+++ b/seed/python-sdk/exhaustive/pydantic-ignore-fields/.fern/metadata.json
@@ -9,8 +9,8 @@
   },
   "originGitCommit": "DUMMY",
   "originGitCommitIsDirty": null,
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
+  "ciProvider": null,
   "sdkVersion": "0.0.1"
 }

--- a/seed/python-sdk/exhaustive/pydantic-v1-with-utils/.fern/metadata.json
+++ b/seed/python-sdk/exhaustive/pydantic-v1-with-utils/.fern/metadata.json
@@ -10,8 +10,8 @@
   },
   "originGitCommit": "DUMMY",
   "originGitCommitIsDirty": null,
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
+  "ciProvider": null,
   "sdkVersion": "0.0.1"
 }

--- a/seed/python-sdk/exhaustive/pydantic-v1-wrapped/.fern/metadata.json
+++ b/seed/python-sdk/exhaustive/pydantic-v1-wrapped/.fern/metadata.json
@@ -10,8 +10,8 @@
   },
   "originGitCommit": "DUMMY",
   "originGitCommitIsDirty": null,
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
+  "ciProvider": null,
   "sdkVersion": "0.0.1"
 }

--- a/seed/python-sdk/exhaustive/pydantic-v1/.fern/metadata.json
+++ b/seed/python-sdk/exhaustive/pydantic-v1/.fern/metadata.json
@@ -9,8 +9,8 @@
   },
   "originGitCommit": "DUMMY",
   "originGitCommitIsDirty": null,
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
+  "ciProvider": null,
   "sdkVersion": "0.0.1"
 }

--- a/seed/python-sdk/exhaustive/pydantic-v2-wrapped/.fern/metadata.json
+++ b/seed/python-sdk/exhaustive/pydantic-v2-wrapped/.fern/metadata.json
@@ -10,8 +10,8 @@
   },
   "originGitCommit": "DUMMY",
   "originGitCommitIsDirty": null,
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
+  "ciProvider": null,
   "sdkVersion": "0.0.1"
 }

--- a/seed/python-sdk/exhaustive/pyproject_extras/.fern/metadata.json
+++ b/seed/python-sdk/exhaustive/pyproject_extras/.fern/metadata.json
@@ -16,8 +16,8 @@
   },
   "originGitCommit": "DUMMY",
   "originGitCommitIsDirty": null,
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
+  "ciProvider": null,
   "sdkVersion": "0.0.1"
 }

--- a/seed/python-sdk/exhaustive/skip-pydantic-validation/.fern/metadata.json
+++ b/seed/python-sdk/exhaustive/skip-pydantic-validation/.fern/metadata.json
@@ -9,8 +9,8 @@
   },
   "originGitCommit": "DUMMY",
   "originGitCommitIsDirty": null,
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
+  "ciProvider": null,
   "sdkVersion": "0.0.1"
 }

--- a/seed/python-sdk/exhaustive/union-utils/.fern/metadata.json
+++ b/seed/python-sdk/exhaustive/union-utils/.fern/metadata.json
@@ -9,8 +9,8 @@
   },
   "originGitCommit": "DUMMY",
   "originGitCommitIsDirty": null,
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
+  "ciProvider": null,
   "sdkVersion": "0.0.1"
 }

--- a/seed/python-sdk/exhaustive/wire-tests-custom-client-name/.fern/metadata.json
+++ b/seed/python-sdk/exhaustive/wire-tests-custom-client-name/.fern/metadata.json
@@ -10,8 +10,8 @@
   },
   "originGitCommit": "DUMMY",
   "originGitCommitIsDirty": null,
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
+  "ciProvider": null,
   "sdkVersion": "0.0.1"
 }

--- a/seed/python-sdk/exhaustive/wire-tests-custom-client-name/tests/wire/conftest.py
+++ b/seed/python-sdk/exhaustive/wire-tests-custom-client-name/tests/wire/conftest.py
@@ -60,7 +60,7 @@ def verify_request_count(
     test_id: str,
     method: str,
     url_path: str,
-    query_params: Optional[Dict[str, str]],
+    query_params: Optional[Dict[str, Any]],
     expected: int,
 ) -> None:
     """Verifies the number of requests made to WireMock filtered by test ID for concurrency safety."""
@@ -71,7 +71,12 @@ def verify_request_count(
         "headers": {"X-Test-Id": {"equalTo": test_id}},
     }
     if query_params:
-        query_parameters = {k: {"equalTo": v} for k, v in query_params.items()}
+        query_parameters = {}
+        for k, v in query_params.items():
+            if isinstance(v, list):
+                query_parameters[k] = {"hasExactly": [{"equalTo": item} for item in v]}
+            else:
+                query_parameters[k] = {"equalTo": v}
         request_body["queryParameters"] = query_parameters
     response = httpx.post(f"{wiremock_admin_url}/requests/find", json=request_body)
     assert response.status_code == 200, "Failed to query WireMock requests"

--- a/seed/ruby-sdk-v2/exhaustive/wire-tests/.fern/metadata.json
+++ b/seed/ruby-sdk-v2/exhaustive/wire-tests/.fern/metadata.json
@@ -10,8 +10,8 @@
   },
   "originGitCommit": "DUMMY",
   "originGitCommitIsDirty": null,
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
+  "ciProvider": null,
   "sdkVersion": "0.0.1"
 }

--- a/seed/ruby-sdk-v2/exhaustive/wire-tests/test/wire/wiremock_test_case.rb
+++ b/seed/ruby-sdk-v2/exhaustive/wire-tests/test/wire/wiremock_test_case.rb
@@ -37,7 +37,15 @@ class WireMockTestCase < Minitest::Test
 
     request_body = { "method" => method, "urlPath" => url_path }
     request_body["headers"] = { "X-Test-Id" => { "equalTo" => test_id } }
-    request_body["queryParameters"] = query_params.transform_values { |v| { "equalTo" => v } } if query_params
+    if query_params
+      request_body["queryParameters"] = query_params.transform_values do |v|
+        if v.is_a?(Array)
+          { "hasExactly" => v.map { |item| { "equalTo" => item } } }
+        else
+          { "equalTo" => v }
+        end
+      end
+    end
 
     post_request.body = request_body.to_json
     response = http.request(post_request)

--- a/seed/rust-sdk/exhaustive/.fern/metadata.json
+++ b/seed/rust-sdk/exhaustive/.fern/metadata.json
@@ -7,8 +7,8 @@
   },
   "originGitCommit": "DUMMY",
   "originGitCommitIsDirty": null,
-  "invokedBy": "ci",
+  "invokedBy": "manual",
   "requestedVersion": "0.0.1",
-  "ciProvider": "github",
+  "ciProvider": null,
   "sdkVersion": "0.0.1"
 }

--- a/seed/rust-sdk/exhaustive/tests/endpoints_pagination_test.rs
+++ b/seed/rust-sdk/exhaustive/tests/endpoints_pagination_test.rs
@@ -35,8 +35,8 @@ async fn test_endpoints_pagination_list_items_with_wiremock() {
         "GET",
         "/pagination",
         Some(HashMap::from([
-            ("cursor".to_string(), "cursor".to_string()),
-            ("limit".to_string(), "1".to_string()),
+            ("cursor".to_string(), json!("cursor")),
+            ("limit".to_string(), json!("1")),
         ])),
         1,
     )

--- a/seed/rust-sdk/exhaustive/tests/endpoints_params_test.rs
+++ b/seed/rust-sdk/exhaustive/tests/endpoints_params_test.rs
@@ -88,8 +88,8 @@ async fn test_endpoints_params_get_with_query_with_wiremock() {
         "GET",
         "/params",
         Some(HashMap::from([
-            ("query".to_string(), "query".to_string()),
-            ("number".to_string(), "1".to_string()),
+            ("query".to_string(), json!("query")),
+            ("number".to_string(), json!("1")),
         ])),
         1,
     )
@@ -129,8 +129,8 @@ async fn test_endpoints_params_get_with_allow_multiple_query_with_wiremock() {
         "GET",
         "/params",
         Some(HashMap::from([
-            ("query".to_string(), "query".to_string()),
-            ("number".to_string(), "1".to_string()),
+            ("query".to_string(), json!("query")),
+            ("number".to_string(), json!("1")),
         ])),
         1,
     )
@@ -169,7 +169,7 @@ async fn test_endpoints_params_get_with_path_and_query_with_wiremock() {
     wire_test_utils::verify_request_count(
         "GET",
         "/params/path-query/param",
-        Some(HashMap::from([("query".to_string(), "query".to_string())])),
+        Some(HashMap::from([("query".to_string(), json!("query"))])),
         1,
     )
     .await
@@ -207,7 +207,7 @@ async fn test_endpoints_params_get_with_inline_path_and_query_with_wiremock() {
     wire_test_utils::verify_request_count(
         "GET",
         "/params/path-query/param",
-        Some(HashMap::from([("query".to_string(), "query".to_string())])),
+        Some(HashMap::from([("query".to_string(), json!("query"))])),
         1,
     )
     .await

--- a/seed/rust-sdk/exhaustive/tests/wire_test_utils.rs
+++ b/seed/rust-sdk/exhaustive/tests/wire_test_utils.rs
@@ -140,7 +140,7 @@ pub async fn reset_wiremock_requests() -> Result<(), Box<dyn std::error::Error>>
 pub async fn verify_request_count(
     method: &str,
     url_path: &str,
-    query_params: Option<HashMap<String, String>>,
+    query_params: Option<HashMap<String, serde_json::Value>>,
     expected: usize,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let mut request_body = json!({
@@ -151,7 +151,23 @@ pub async fn verify_request_count(
     if let Some(params) = query_params {
         let query_parameters: Value = params
             .into_iter()
-            .map(|(k, v)| (k, json!({"equalTo": v})))
+            .map(|(k, v)| {
+                let matcher = if v.is_array() {
+                    let items: Vec<Value> = v
+                        .as_array()
+                        .unwrap()
+                        .iter()
+                        .filter_map(|item| item.as_str())
+                        .map(|s| json!({"equalTo": s}))
+                        .collect();
+                    json!({"hasExactly": items})
+                } else if let Some(s) = v.as_str() {
+                    json!({"equalTo": s})
+                } else {
+                    json!({"equalTo": v.to_string()})
+                };
+                (k, matcher)
+            })
             .collect();
         request_body["queryParameters"] = query_parameters;
     }


### PR DESCRIPTION
## Summary

- Fix wire test infrastructure so array query parameters are correctly represented in WireMock stubs and test verification across all 5 generators with wire test support (Python, Go, PHP, Ruby, Rust).

## Problem

When a query parameter accepts an array (e.g., `grouping=["deployment", "line_item"]`), three components disagree:

| Component | Behavior |
|-----------|----------|
| SDK runtime (`encode_query`) | `grouping=deployment&grouping=line_item` (correct) |
| Wire test verification (`buildQueryParamsCode`) | `"grouping": "deployment,line_item"` (wrong — JS `String()` on array) |
| WireMock stub (`mock-utils`) | *(silently drops array params entirely)* |

Single-element arrays work by coincidence (`String(["x"])` = `"x"`). The bug manifests with 2+ elements.

## Fix

- **mock-utils**: Use WireMock's `hasExactly` matcher for array query params instead of dropping them. Export `QueryParameterMatcher` union type and `isEqualToMatcher` type guard.
- **Each generator**: Emit language-native array literals for multi-element query params in test verification code, and branch on list vs scalar when constructing WireMock matcher JSON.
- **Datetime stripping**: Add type guards to skip `hasExactly` entries (array elements won't be datetimes).

## Example

Generated Python conftest now handles lists:
```python
if isinstance(v, list):
    query_parameters[k] = {"hasExactly": [{"equalTo": item} for item in v]}
else:
    query_parameters[k] = {"equalTo": v}
```

WireMock stubs now include array params:
```json
{"queryParameters": {"grouping": {"hasExactly": [{"equalTo": "deployment"}, {"equalTo": "line_item"}]}}}
```

## Test plan

- [x] `pnpm seed test --generator python-sdk --fixture exhaustive --skip-scripts` (28/28 pass)
- [x] `pnpm seed test --generator go-sdk --fixture exhaustive --skip-scripts` (2/2 pass)
- [x] `pnpm seed test --generator php-sdk --fixture exhaustive --skip-scripts` (2/2 pass)
- [x] `pnpm seed test --generator ruby-sdk-v2 --fixture exhaustive --skip-scripts` (1/1 pass)
- [x] `pnpm seed test --generator rust-sdk --fixture exhaustive --skip-scripts` (1/1 pass)
- [x] mock-utils compiles cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)