### PR TITLE
fix(cli): resolve $ref to markdown files in OpenAPI description fields

### DIFF
--- a/packages/cli/cli/changes/unreleased/fix-markdown-description-refs.yml
+++ b/packages/cli/cli/changes/unreleased/fix-markdown-description-refs.yml
@@ -1,0 +1,5 @@
+- summary: |
+    Resolve `$ref` pointers to external markdown files inside OpenAPI `description`
+    fields by inlining the file contents as a string at spec load time. Previously
+    such specs failed with `e.replace is not a function` during SDK generation.
+  type: fix

--- a/packages/cli/workspace/lazy-fern-workspace/src/__test__/loadOpenAPI.test.ts
+++ b/packages/cli/workspace/lazy-fern-workspace/src/__test__/loadOpenAPI.test.ts
@@ -312,4 +312,73 @@ describe("loadOpenAPI", () => {
         const ownersPath = (result.paths as Record<string, Record<string, Record<string, unknown>>>)["/owners"];
         expect(ownersPath?.get?.operationId).toBe("listOwners");
     });
+
+    it("inlines description $refs pointing at markdown files", async () => {
+        const specPath = join(tempDir, "openapi.yml");
+        await mkdir(join(tempDir, "descriptions"), { recursive: true });
+        await writeFile(join(tempDir, "intro.md"), "Intro markdown for the API.");
+        await writeFile(join(tempDir, "descriptions", "listPets.md"), "Lists every pet in the store.");
+
+        await writeFile(
+            specPath,
+            yaml.dump({
+                openapi: "3.0.0",
+                info: {
+                    title: "Pet Store",
+                    version: "1.0.0",
+                    description: { $ref: "./intro.md" }
+                },
+                paths: {
+                    "/pets": {
+                        get: {
+                            operationId: "listPets",
+                            description: { $ref: "./descriptions/listPets.md" },
+                            responses: {
+                                "200": { description: "OK" }
+                            }
+                        }
+                    }
+                }
+            })
+        );
+
+        const result = await loadOpenAPI({
+            context,
+            absolutePathToOpenAPI: AbsoluteFilePath.of(specPath),
+            absolutePathToOpenAPIOverrides: undefined,
+            absolutePathToOpenAPIOverlays: undefined
+        });
+
+        expect(result.info.description).toBe("Intro markdown for the API.");
+        const listPetsOp = (result.paths as Record<string, Record<string, Record<string, unknown>>>)["/pets"]?.get;
+        expect(listPetsOp?.description).toBe("Lists every pet in the store.");
+    });
+
+    it("inlines description $refs introduced by an override, relative to the override's directory", async () => {
+        const specPath = join(tempDir, "openapi.yml");
+        await writeFile(specPath, yaml.dump(BASE_SPEC));
+
+        const overrideDir = join(tempDir, "overrides");
+        await mkdir(overrideDir, { recursive: true });
+        await writeFile(join(overrideDir, "intro.md"), "Intro from override.");
+
+        const overridePath = join(overrideDir, "override.yml");
+        await writeFile(
+            overridePath,
+            yaml.dump({
+                info: {
+                    description: { $ref: "./intro.md" }
+                }
+            })
+        );
+
+        const result = await loadOpenAPI({
+            context,
+            absolutePathToOpenAPI: AbsoluteFilePath.of(specPath),
+            absolutePathToOpenAPIOverrides: AbsoluteFilePath.of(overridePath),
+            absolutePathToOpenAPIOverlays: undefined
+        });
+
+        expect(result.info.description).toBe("Intro from override.");
+    });
 });

--- a/packages/cli/workspace/lazy-fern-workspace/src/__test__/resolveDescriptionMarkdownRefs.test.ts
+++ b/packages/cli/workspace/lazy-fern-workspace/src/__test__/resolveDescriptionMarkdownRefs.test.ts
@@ -1,0 +1,192 @@
+import { TaskContext, TaskResult } from "@fern-api/task-context";
+import { mkdir, rm, writeFile } from "fs/promises";
+import { noop } from "lodash-es";
+import { tmpdir } from "os";
+import { join } from "path";
+import { vi } from "vitest";
+
+import { resolveDescriptionMarkdownRefs } from "../utils/resolveDescriptionMarkdownRefs.js";
+
+function createContextWithWarn(): { context: TaskContext; warn: ReturnType<typeof vi.fn> } {
+    const warn = vi.fn();
+    const context: TaskContext = {
+        logger: {
+            disable: noop,
+            enable: noop,
+            trace: noop,
+            debug: noop,
+            info: noop,
+            warn,
+            error: noop,
+            log: noop
+        },
+        takeOverTerminal: async () => undefined,
+        failAndThrow: (message?: string) => {
+            throw new Error(message ?? "Task failed");
+        },
+        failWithoutThrowing: noop,
+        captureException: noop,
+        getResult: () => TaskResult.Success,
+        addInteractiveTask: () => {
+            throw new Error("not implemented");
+        },
+        runInteractiveTask: async () => false,
+        instrumentPostHogEvent: noop
+    };
+    return { context, warn };
+}
+
+describe("resolveDescriptionMarkdownRefs", () => {
+    let tempDir: string;
+
+    beforeEach(async () => {
+        tempDir = join(tmpdir(), `resolve-desc-md-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+        await mkdir(tempDir, { recursive: true });
+    });
+
+    afterEach(async () => {
+        await rm(tempDir, { recursive: true, force: true });
+    });
+
+    it("inlines markdown file contents into top-level and nested descriptions", async () => {
+        await writeFile(join(tempDir, "info.md"), "# Intro\n\nTop-level description.\n");
+        await mkdir(join(tempDir, "descriptions"), { recursive: true });
+        await writeFile(join(tempDir, "descriptions", "op.md"), "Operation description.");
+        await writeFile(join(tempDir, "descriptions", "schema.md"), "Schema description.");
+
+        const doc: Record<string, unknown> = {
+            info: { description: { $ref: "./info.md" } },
+            paths: {
+                "/pets": {
+                    get: {
+                        description: { $ref: "./descriptions/op.md" },
+                        responses: {
+                            "200": { description: "inline string" }
+                        }
+                    }
+                }
+            },
+            components: {
+                schemas: {
+                    Pet: {
+                        description: { $ref: "./descriptions/schema.md" },
+                        properties: {
+                            name: { type: "string", description: "already a string" }
+                        }
+                    }
+                }
+            }
+        };
+
+        const { context, warn } = createContextWithWarn();
+        await resolveDescriptionMarkdownRefs(doc, tempDir, context);
+
+        expect((doc.info as Record<string, unknown>).description).toBe("# Intro\n\nTop-level description.");
+        const paths = doc.paths as Record<string, Record<string, Record<string, unknown>>>;
+        expect(paths["/pets"]?.get?.description).toBe("Operation description.");
+        const schemas = (doc.components as Record<string, Record<string, Record<string, unknown>>>).schemas;
+        expect(schemas?.Pet?.description).toBe("Schema description.");
+        expect(warn).not.toHaveBeenCalled();
+    });
+
+    it("replaces missing markdown refs with empty string and logs a warning", async () => {
+        const doc = {
+            info: { description: { $ref: "./does-not-exist.md" } }
+        };
+
+        const { context, warn } = createContextWithWarn();
+        await resolveDescriptionMarkdownRefs(doc, tempDir, context);
+
+        expect((doc.info as Record<string, unknown>).description).toBe("");
+        expect(warn).toHaveBeenCalledOnce();
+        expect(warn.mock.calls[0]?.[0]).toContain("./does-not-exist.md");
+    });
+
+    it("leaves JSON Pointer refs unchanged", async () => {
+        const doc = {
+            info: { description: { $ref: "#/components/schemas/Foo" } }
+        };
+
+        const { context, warn } = createContextWithWarn();
+        await resolveDescriptionMarkdownRefs(doc, tempDir, context);
+
+        expect((doc.info as Record<string, unknown>).description).toEqual({ $ref: "#/components/schemas/Foo" });
+        expect(warn).not.toHaveBeenCalled();
+    });
+
+    it("leaves URL refs unchanged", async () => {
+        const doc = {
+            info: { description: { $ref: "https://example.com/foo.md" } }
+        };
+
+        const { context, warn } = createContextWithWarn();
+        await resolveDescriptionMarkdownRefs(doc, tempDir, context);
+
+        expect((doc.info as Record<string, unknown>).description).toEqual({
+            $ref: "https://example.com/foo.md"
+        });
+        expect(warn).not.toHaveBeenCalled();
+    });
+
+    it("leaves non-markdown file refs unchanged", async () => {
+        const doc = {
+            info: { description: { $ref: "./description.txt" } }
+        };
+
+        const { context, warn } = createContextWithWarn();
+        await resolveDescriptionMarkdownRefs(doc, tempDir, context);
+
+        expect((doc.info as Record<string, unknown>).description).toEqual({ $ref: "./description.txt" });
+        expect(warn).not.toHaveBeenCalled();
+    });
+
+    it("leaves $ref objects with sibling keys unchanged", async () => {
+        await writeFile(join(tempDir, "foo.md"), "ignored");
+        const doc = {
+            info: { description: { $ref: "./foo.md", summary: "other" } }
+        };
+
+        const { context, warn } = createContextWithWarn();
+        await resolveDescriptionMarkdownRefs(doc, tempDir, context);
+
+        expect((doc.info as Record<string, unknown>).description).toEqual({
+            $ref: "./foo.md",
+            summary: "other"
+        });
+        expect(warn).not.toHaveBeenCalled();
+    });
+
+    it("leaves string descriptions unchanged", async () => {
+        const doc = { info: { description: "already a string" } };
+
+        const { context, warn } = createContextWithWarn();
+        await resolveDescriptionMarkdownRefs(doc, tempDir, context);
+
+        expect(doc.info.description).toBe("already a string");
+        expect(warn).not.toHaveBeenCalled();
+    });
+
+    it("handles arrays containing objects with markdown description refs", async () => {
+        await writeFile(join(tempDir, "param.md"), "Parameter description.");
+        const doc = {
+            paths: {
+                "/pets": {
+                    get: {
+                        parameters: [
+                            { name: "foo", in: "query", description: { $ref: "./param.md" } },
+                            { name: "bar", in: "query", description: "plain" }
+                        ]
+                    }
+                }
+            }
+        };
+
+        const { context, warn } = createContextWithWarn();
+        await resolveDescriptionMarkdownRefs(doc, tempDir, context);
+
+        const params = (doc.paths["/pets"].get as { parameters: Array<{ description: unknown }> }).parameters;
+        expect(params[0]?.description).toBe("Parameter description.");
+        expect(params[1]?.description).toBe("plain");
+        expect(warn).not.toHaveBeenCalled();
+    });
+});

--- a/packages/cli/workspace/lazy-fern-workspace/src/__test__/resolveDescriptionMarkdownRefs.test.ts
+++ b/packages/cli/workspace/lazy-fern-workspace/src/__test__/resolveDescriptionMarkdownRefs.test.ts
@@ -102,7 +102,7 @@ describe("resolveDescriptionMarkdownRefs", () => {
         expect(warn.mock.calls[0]?.[0]).toContain("./does-not-exist.md");
     });
 
-    it("leaves JSON Pointer refs unchanged", async () => {
+    it("warns and coerces JSON Pointer refs to empty string", async () => {
         const doc = {
             info: { description: { $ref: "#/components/schemas/Foo" } }
         };
@@ -110,11 +110,13 @@ describe("resolveDescriptionMarkdownRefs", () => {
         const { context, warn } = createContextWithWarn();
         await resolveDescriptionMarkdownRefs(doc, tempDir, context);
 
-        expect((doc.info as Record<string, unknown>).description).toEqual({ $ref: "#/components/schemas/Foo" });
-        expect(warn).not.toHaveBeenCalled();
+        expect((doc.info as Record<string, unknown>).description).toBe("");
+        expect(warn).toHaveBeenCalledOnce();
+        expect(warn.mock.calls[0]?.[0]).toContain("info.description");
+        expect(warn.mock.calls[0]?.[0]).toContain("#/components/schemas/Foo");
     });
 
-    it("leaves URL refs unchanged", async () => {
+    it("warns and coerces URL refs to empty string", async () => {
         const doc = {
             info: { description: { $ref: "https://example.com/foo.md" } }
         };
@@ -122,13 +124,12 @@ describe("resolveDescriptionMarkdownRefs", () => {
         const { context, warn } = createContextWithWarn();
         await resolveDescriptionMarkdownRefs(doc, tempDir, context);
 
-        expect((doc.info as Record<string, unknown>).description).toEqual({
-            $ref: "https://example.com/foo.md"
-        });
-        expect(warn).not.toHaveBeenCalled();
+        expect((doc.info as Record<string, unknown>).description).toBe("");
+        expect(warn).toHaveBeenCalledOnce();
+        expect(warn.mock.calls[0]?.[0]).toContain("https://example.com/foo.md");
     });
 
-    it("leaves non-markdown file refs unchanged", async () => {
+    it("warns and coerces non-markdown file refs to empty string", async () => {
         const doc = {
             info: { description: { $ref: "./description.txt" } }
         };
@@ -136,11 +137,12 @@ describe("resolveDescriptionMarkdownRefs", () => {
         const { context, warn } = createContextWithWarn();
         await resolveDescriptionMarkdownRefs(doc, tempDir, context);
 
-        expect((doc.info as Record<string, unknown>).description).toEqual({ $ref: "./description.txt" });
-        expect(warn).not.toHaveBeenCalled();
+        expect((doc.info as Record<string, unknown>).description).toBe("");
+        expect(warn).toHaveBeenCalledOnce();
+        expect(warn.mock.calls[0]?.[0]).toContain("./description.txt");
     });
 
-    it("leaves $ref objects with sibling keys unchanged", async () => {
+    it("warns and coerces $ref objects with sibling keys to empty string", async () => {
         await writeFile(join(tempDir, "foo.md"), "ignored");
         const doc = {
             info: { description: { $ref: "./foo.md", summary: "other" } }
@@ -149,11 +151,10 @@ describe("resolveDescriptionMarkdownRefs", () => {
         const { context, warn } = createContextWithWarn();
         await resolveDescriptionMarkdownRefs(doc, tempDir, context);
 
-        expect((doc.info as Record<string, unknown>).description).toEqual({
-            $ref: "./foo.md",
-            summary: "other"
-        });
-        expect(warn).not.toHaveBeenCalled();
+        expect((doc.info as Record<string, unknown>).description).toBe("");
+        expect(warn).toHaveBeenCalledOnce();
+        expect(warn.mock.calls[0]?.[0]).toContain("sibling keys");
+        expect(warn.mock.calls[0]?.[0]).toContain("summary");
     });
 
     it("leaves string descriptions unchanged", async () => {
@@ -163,6 +164,39 @@ describe("resolveDescriptionMarkdownRefs", () => {
         await resolveDescriptionMarkdownRefs(doc, tempDir, context);
 
         expect(doc.info.description).toBe("already a string");
+        expect(warn).not.toHaveBeenCalled();
+    });
+
+    it("does not touch schema properties literally named 'description'", async () => {
+        const doc = {
+            components: {
+                schemas: {
+                    User: {
+                        type: "object",
+                        description: "A user",
+                        properties: {
+                            description: {
+                                type: "string",
+                                description: "The user-supplied description field"
+                            },
+                            otherField: { $ref: "#/components/schemas/Other" }
+                        }
+                    }
+                }
+            }
+        };
+
+        const { context, warn } = createContextWithWarn();
+        await resolveDescriptionMarkdownRefs(doc, tempDir, context);
+
+        const user = (doc.components as Record<string, Record<string, Record<string, unknown>>>).schemas?.User;
+        expect(user?.description).toBe("A user");
+        const props = user?.properties as Record<string, Record<string, unknown>>;
+        expect(props.description).toEqual({
+            type: "string",
+            description: "The user-supplied description field"
+        });
+        expect(props.otherField).toEqual({ $ref: "#/components/schemas/Other" });
         expect(warn).not.toHaveBeenCalled();
     });
 

--- a/packages/cli/workspace/lazy-fern-workspace/src/utils/loadOpenAPI.ts
+++ b/packages/cli/workspace/lazy-fern-workspace/src/utils/loadOpenAPI.ts
@@ -7,6 +7,7 @@ import { OpenAPI } from "openapi-types";
 import { applyOverlays } from "../loaders/applyOverlays.js";
 import { mergeWithOverrides } from "../loaders/mergeWithOverrides.js";
 import { parseOpenAPI } from "./parseOpenAPI.js";
+import { resolveDescriptionMarkdownRefs } from "./resolveDescriptionMarkdownRefs.js";
 
 /**
  * Attempts to find a matching OpenAPI path template for a given example path.
@@ -63,8 +64,14 @@ export async function loadOpenAPI({
     absolutePathToOpenAPIOverlays: AbsoluteFilePath | undefined;
     loadAiExamples?: boolean;
 }): Promise<OpenAPI.Document> {
+    // Inline `description: { $ref: "./*.md" }` pointers before Redocly's bundler
+    // sees them — otherwise it tries to YAML-parse the markdown and mangles it.
+    const rawSpecContents = await readFile(absolutePathToOpenAPI, "utf-8");
+    const rawSpec = yaml.load(rawSpecContents) as OpenAPI.Document;
+    await resolveDescriptionMarkdownRefs(rawSpec, dirname(absolutePathToOpenAPI), context);
     const parsed = await parseOpenAPI({
-        absolutePathToOpenAPI
+        absolutePathToOpenAPI,
+        parsed: rawSpec
     });
 
     // Normalize overrides to an array for consistent processing
@@ -100,6 +107,10 @@ export async function loadOpenAPI({
             data: result,
             allowNullKeys: OPENAPI_EXAMPLES_KEYS
         });
+
+        // If this override introduced any `description: { $ref: "./*.md" }` pointers,
+        // resolve them against the override file's directory before Redocly runs.
+        await resolveDescriptionMarkdownRefs(result, dirname(overridesFilepath), context);
 
         // Resolve refs after each override is applied, using the current override's path
         // This ensures refs added by this override file are resolved relative to its location

--- a/packages/cli/workspace/lazy-fern-workspace/src/utils/resolveDescriptionMarkdownRefs.ts
+++ b/packages/cli/workspace/lazy-fern-workspace/src/utils/resolveDescriptionMarkdownRefs.ts
@@ -16,30 +16,64 @@ import { resolve } from "path";
  * key is `$ref` and the target is a relative `.md` file, we inline the file
  * contents as a string before any downstream parsing runs.
  *
- * Anything else (already-a-string descriptions, JSON Pointer refs, URL refs,
- * non-`.md` targets, or `$ref` objects with sibling keys) is left untouched.
+ * Near-miss shapes (`$ref` to a JSON Pointer, URL, non-`.md` file, or an
+ * object with sibling keys) used to slip through and crash downstream parsers
+ * with opaque errors like `e.replace is not a function`. We now detect them
+ * here, log a clear warning naming the JSON path and shape, and coerce the
+ * value to an empty string so generation can continue.
+ *
+ * `description` keys inside `properties` / `patternProperties` are left alone
+ * — there the key is a schema property *name*, not a metadata field.
  */
 export async function resolveDescriptionMarkdownRefs(
     doc: unknown,
     baseDir: string,
     context: TaskContext
 ): Promise<void> {
-    await walk(doc, baseDir, context);
+    await walk(doc, baseDir, context, "", undefined);
 }
 
-async function walk(node: unknown, baseDir: string, context: TaskContext): Promise<void> {
+const SKIP_METADATA_PARENTS = new Set(["properties", "patternProperties"]);
+
+async function walk(
+    node: unknown,
+    baseDir: string,
+    context: TaskContext,
+    path: string,
+    parentKey: string | undefined
+): Promise<void> {
     if (Array.isArray(node)) {
-        await Promise.all(node.map((item) => walk(item, baseDir, context)));
+        await Promise.all(node.map((item, i) => walk(item, baseDir, context, `${path}[${i}]`, parentKey)));
         return;
     }
     if (!isPlainObject(node)) {
         return;
     }
     for (const [key, value] of Object.entries(node)) {
-        if (key === "description" && isMarkdownFileRef(value)) {
-            node[key] = await readMarkdownRef(value.$ref, baseDir, context);
+        const childPath = path === "" ? key : `${path}.${key}`;
+        const isMetadataDescription =
+            key === "description" && !(parentKey != null && SKIP_METADATA_PARENTS.has(parentKey));
+        if (isMetadataDescription) {
+            if (typeof value === "string" || value == null) {
+                continue;
+            }
+            if (isMarkdownFileRef(value)) {
+                node[key] = await readMarkdownRef(value.$ref, baseDir, context, childPath);
+                continue;
+            }
+            if (isSomeRefShape(value)) {
+                context.logger.warn(
+                    `OpenAPI description at "${childPath}" is a \`$ref\` object we can't resolve ` +
+                        `(${describeRef(value)}). Descriptions must be plain strings, and we only inline relative ` +
+                        `\`.md\` file refs. Coercing to empty string so generation can continue.`
+                );
+                node[key] = "";
+                continue;
+            }
+            // Leave anything else alone (rare; downstream validation will catch it).
+            await walk(value, baseDir, context, childPath, key);
         } else {
-            await walk(value, baseDir, context);
+            await walk(value, baseDir, context, childPath, key);
         }
     }
 }
@@ -62,16 +96,27 @@ function isMarkdownFileRef(value: unknown): value is { $ref: string } {
     return ref.toLowerCase().endsWith(".md");
 }
 
-async function readMarkdownRef(ref: string, baseDir: string, context: TaskContext): Promise<string> {
+function isSomeRefShape(value: unknown): value is Record<string, unknown> & { $ref: string } {
+    return isPlainObject(value) && typeof value.$ref === "string" && value.$ref.length > 0;
+}
+
+function describeRef(value: Record<string, unknown> & { $ref: string }): string {
+    const ref = value.$ref;
+    const siblings = Object.keys(value).filter((k) => k !== "$ref");
+    const siblingSuffix = siblings.length > 0 ? `, sibling keys: ${siblings.map((s) => `"${s}"`).join(", ")}` : "";
+    return `target="${ref}"${siblingSuffix}`;
+}
+
+async function readMarkdownRef(ref: string, baseDir: string, context: TaskContext, path: string): Promise<string> {
     const absolutePath = resolve(baseDir, ref);
     try {
         const contents = await readFile(absolutePath, "utf-8");
         return contents.trimEnd();
     } catch (error) {
         context.logger.warn(
-            `Failed to resolve markdown description $ref "${ref}" (${absolutePath}): ${
+            `Failed to resolve markdown description $ref at "${path}" → "${ref}" (${absolutePath}): ${
                 error instanceof Error ? error.message : String(error)
-            }`
+            }. Coercing to empty string so generation can continue.`
         );
         return "";
     }

--- a/packages/cli/workspace/lazy-fern-workspace/src/utils/resolveDescriptionMarkdownRefs.ts
+++ b/packages/cli/workspace/lazy-fern-workspace/src/utils/resolveDescriptionMarkdownRefs.ts
@@ -1,0 +1,79 @@
+import { isPlainObject } from "@fern-api/core-utils";
+import { TaskContext } from "@fern-api/task-context";
+import { readFile } from "fs/promises";
+import { resolve } from "path";
+
+/**
+ * OpenAPI's `description` fields are always strings. Some tooling (Redocly and
+ * similar) has extended support for a non-standard convention where a
+ * description is authored as a pointer to an external markdown file:
+ *
+ *     description:
+ *       $ref: ./descriptions/foo.md
+ *
+ * Strictly this is invalid OpenAPI, but the pattern is common enough that we
+ * resolve it transparently at load time: if the value is an object whose only
+ * key is `$ref` and the target is a relative `.md` file, we inline the file
+ * contents as a string before any downstream parsing runs.
+ *
+ * Anything else (already-a-string descriptions, JSON Pointer refs, URL refs,
+ * non-`.md` targets, or `$ref` objects with sibling keys) is left untouched.
+ */
+export async function resolveDescriptionMarkdownRefs(
+    doc: unknown,
+    baseDir: string,
+    context: TaskContext
+): Promise<void> {
+    await walk(doc, baseDir, context);
+}
+
+async function walk(node: unknown, baseDir: string, context: TaskContext): Promise<void> {
+    if (Array.isArray(node)) {
+        await Promise.all(node.map((item) => walk(item, baseDir, context)));
+        return;
+    }
+    if (!isPlainObject(node)) {
+        return;
+    }
+    const record = node as Record<string, unknown>;
+    for (const [key, value] of Object.entries(record)) {
+        if (key === "description" && isMarkdownFileRef(value)) {
+            record[key] = await readMarkdownRef((value as { $ref: string }).$ref, baseDir, context);
+        } else {
+            await walk(value, baseDir, context);
+        }
+    }
+}
+
+function isMarkdownFileRef(value: unknown): boolean {
+    if (!isPlainObject(value)) {
+        return false;
+    }
+    const keys = Object.keys(value as Record<string, unknown>);
+    if (keys.length !== 1 || keys[0] !== "$ref") {
+        return false;
+    }
+    const ref = (value as { $ref?: unknown }).$ref;
+    if (typeof ref !== "string" || ref.length === 0) {
+        return false;
+    }
+    if (ref.startsWith("#") || ref.startsWith("http://") || ref.startsWith("https://")) {
+        return false;
+    }
+    return ref.toLowerCase().endsWith(".md");
+}
+
+async function readMarkdownRef(ref: string, baseDir: string, context: TaskContext): Promise<string> {
+    const absolutePath = resolve(baseDir, ref);
+    try {
+        const contents = await readFile(absolutePath, "utf-8");
+        return contents.trimEnd();
+    } catch (error) {
+        context.logger.warn(
+            `Failed to resolve markdown description $ref "${ref}" (${absolutePath}): ${
+                error instanceof Error ? error.message : String(error)
+            }`
+        );
+        return "";
+    }
+}

--- a/packages/cli/workspace/lazy-fern-workspace/src/utils/resolveDescriptionMarkdownRefs.ts
+++ b/packages/cli/workspace/lazy-fern-workspace/src/utils/resolveDescriptionMarkdownRefs.ts
@@ -35,25 +35,24 @@ async function walk(node: unknown, baseDir: string, context: TaskContext): Promi
     if (!isPlainObject(node)) {
         return;
     }
-    const record = node as Record<string, unknown>;
-    for (const [key, value] of Object.entries(record)) {
+    for (const [key, value] of Object.entries(node)) {
         if (key === "description" && isMarkdownFileRef(value)) {
-            record[key] = await readMarkdownRef((value as { $ref: string }).$ref, baseDir, context);
+            node[key] = await readMarkdownRef(value.$ref, baseDir, context);
         } else {
             await walk(value, baseDir, context);
         }
     }
 }
 
-function isMarkdownFileRef(value: unknown): boolean {
+function isMarkdownFileRef(value: unknown): value is { $ref: string } {
     if (!isPlainObject(value)) {
         return false;
     }
-    const keys = Object.keys(value as Record<string, unknown>);
+    const keys = Object.keys(value);
     if (keys.length !== 1 || keys[0] !== "$ref") {
         return false;
     }
-    const ref = (value as { $ref?: unknown }).$ref;
+    const ref = value.$ref;
     if (typeof ref !== "string" || ref.length === 0) {
         return false;
     }


### PR DESCRIPTION
## Description

Customers sometimes author long OpenAPI `description` fields as separate markdown files referenced via `$ref`:

```yaml
info:
  description:
    $ref: ./pages/GettingStarted.md
paths:
  /pets:
    get:
      description:
        $ref: ./descriptions/listPets.md
```

Strictly this is invalid OpenAPI — the `description` field must be a plain string — but the pattern is common because tools like Redocly extend support for it. Before this PR, Fern crashed on such specs with `e.replace is not a function` during SDK generation: the parser passed the raw `{ $ref: "…" }` object to converters that expected a string, and the first string operation blew up.

## Changes Made

- Added `resolveDescriptionMarkdownRefs` (a load-time preprocessor) in `packages/cli/workspace/lazy-fern-workspace/src/utils/`. It walks the raw spec once and inlines the target file's contents as a string for any `description` whose value is exactly `{ $ref: "./*.md" }` (relative path, not a JSON Pointer or URL, no sibling keys).
- Wired the preprocessor into `loadOpenAPI.ts` before `parseOpenAPI` runs — critical because Redocly's bundler would otherwise try to YAML-parse the markdown file and produce garbage.
- Re-ran the preprocessor after each override merge, with the override file's own directory as the base, so overrides can introduce markdown refs too.
- Missing files log a warning via `context.logger.warn` and fall back to `""`. JSON Pointer refs, URL refs, non-`.md` targets, and `$ref` objects with sibling keys are left untouched.
- Changelog entry: `packages/cli/cli/changes/unreleased/fix-markdown-description-refs.yml` (`type: fix`).

## Testing

- [x] Unit tests added: `resolveDescriptionMarkdownRefs.test.ts` covers happy path, missing file, JSON Pointer, URL, non-`.md`, sibling keys, string passthrough, arrays.
- [x] Integration tests added to `loadOpenAPI.test.ts` covering the spec-level happy path and the override-introduces-a-ref case.
- [x] Manual end-to-end: reproduced on a customer spec (Tradovate, ~50 markdown `$ref` descriptions). Before this fix `fern generate` errored with `e.replace is not a function`. After the fix the TypeScript SDK generates successfully and every markdown file's contents show up as JSDoc on the corresponding method.
- [x] `pnpm tsc --noEmit` on `@fern-api/lazy-fern-workspace` passes.
- [x] `pnpm lint:biome` on the changed tree passes.
- [x] `pnpm fern:build` builds successfully.