### PR TITLE
chore(cli): normalize source map paths for Sentry display

### DIFF
--- a/packages/cli/cli/build-utils.mjs
+++ b/packages/cli/cli/build-utils.mjs
@@ -1,5 +1,6 @@
 import { exec } from "child_process";
-import { writeFile } from "fs/promises";
+import { existsSync } from "fs";
+import { readdir, readFile, writeFile } from "fs/promises";
 import path from "path";
 import tsup from "tsup";
 import { fileURLToPath } from "url";
@@ -9,6 +10,42 @@ import packageJson from "./package.json" with { type: "json" };
 const execAsync = promisify(exec);
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(__dirname, "../../..");
+
+/**
+ * Rewrite every .map file in absOutDir so each entry in `sources` is a clean
+ * path relative to the repo root (e.g. "packages/cli/cli/src/cli.ts") instead
+ * of a relative path like "../../src/cli.ts". This gives Sentry a tidy,
+ * already-normalised filename to display and lets a single repo-root-based
+ * code mapping resolve every frame regardless of package depth.
+ */
+async function rewriteSourceMapSources(absOutDir) {
+    if (!existsSync(absOutDir)) {
+        return;
+    }
+    const entries = await readdir(absOutDir, { withFileTypes: true });
+    for (const entry of entries) {
+        if (!entry.isFile() || !entry.name.endsWith(".map")) {
+            continue;
+        }
+        const mapPath = path.join(absOutDir, entry.name);
+        const mapDir = path.dirname(mapPath);
+        const map = JSON.parse(await readFile(mapPath, "utf8"));
+        if (!Array.isArray(map.sources)) {
+            continue;
+        }
+        map.sources = map.sources.map((src) => {
+            if (typeof src !== "string" || src === "" || src.startsWith("<") || src.startsWith("data:")) {
+                return src;
+            }
+            return path.relative(REPO_ROOT, path.resolve(mapDir, src));
+        });
+        if ("sourceRoot" in map) {
+            delete map.sourceRoot;
+        }
+        await writeFile(mapPath, JSON.stringify(map));
+    }
+}
 
 /**
  * Get a dependency version from package.json, preferring dependencies over devDependencies.
@@ -92,6 +129,11 @@ export async function buildCli(config) {
     });
 
     const outDirAbs = path.join(__dirname, outDir);
+
+    // Rewrite source map `sources` to repo-root-relative paths so Sentry
+    // displays clean filenames (e.g. "packages/cli/cli/src/cli.ts") and a
+    // single repo-root-based code mapping resolves every frame.
+    await rewriteSourceMapSources(outDirAbs);
 
     // Collect runtime dependencies
     const dependencies = {};


### PR DESCRIPTION
## Summary

Post-process the CLI bundle's source map so that each entry in `sources`
is a clean repo-root-relative path (e.g. `packages/cli/cli/src/cli.ts`)
instead of the esbuild default (`../../src/cli.ts`).

## Why

Sentry resolves stack frames by looking up the entry in `sources[i]`
pointed to by the bundle's debug ID. It then renders that string
verbatim in the issue header. Because esbuild emits `sources` relative
to each output file's directory, every frame currently shows up as
something like:

```
packages/cli/cli/dist/prod/../../src/cli.ts
packages/cli/cli/dist/prod/../../../workspace/loader/src/loadDocsWorkspace.ts
```

The canonical paths Sentry computes on hover (`app:///packages/...`)
are correct, but the displayed filename is noisy and the varying depth
of `..` segments makes it awkward to write one GitHub code mapping that
covers every package pulled into the bundle.

`sourceRoot` doesn't help on its own: per the source-map spec it's a
URL prefix, and Sentry's display concatenates it with each `sources[i]`
literally rather than normalising the result.

## What

A small post-build step in `buildCli` that, after tsup finishes,
rewrites every `.map` file so that:

- each entry in `sources` is resolved against the map's directory, then
  made relative to the repo root (`packages/cli/cli/src/cli.ts`, ...)
- `sourceRoot` is dropped (no longer needed)

Everything else in the map (`mappings`, `names`, `sourcesContent`,
debug-id metadata that sentry-cli injects later) is preserved as-is.

## Impact

- **Runtime / published `fern-api` package**: zero. The `.map` file is
  not included in the npm package (`files: ["cli.cjs"]`); only Sentry
  (and anyone debugging the bundle locally) ever reads it.
- **Sentry**: stack frames now render as `packages/cli/cli/src/cli.ts`
  directly, and a single GitHub code mapping (`app:///` -> empty root)
  resolves every frame regardless of which package it lives in.
- **Existing uploaded maps**: unaffected. Matching is done via
  debug IDs, so old events continue to resolve against their old maps.

Only the CLI is touched in this PR; the equivalent change for
generators will ship separately.

## Test plan

- [x] `pnpm dist:cli:prod` succeeds
- [x] Resulting `cli.cjs.map` has no `sourceRoot`, no `..` segments in
  any `sources` entry, and includes `packages/cli/cli/src/cli.ts`
- [ ] Upload the rebuilt map with `sentry-cli sourcemaps upload` and
  trigger a test error; confirm the Sentry issue header shows
  `packages/cli/cli/src/cli.ts`

Made with [Cursor](https://cursor.com)