### PR TITLE
chore(cli): scaffold AutoVersionStep and extend pipeline types

### DIFF
--- a/packages/generator-cli/src/__test__/auto-version-step.test.ts
+++ b/packages/generator-cli/src/__test__/auto-version-step.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
-import { AutoVersionStep } from "../pipeline/steps/AutoVersionStep.js";
 import type { AutoVersionStepConfig, PipelineContext, PipelineLogger } from "../pipeline/index.js";
 import { PostGenerationPipeline } from "../pipeline/index.js";
+import { AutoVersionStep } from "../pipeline/steps/AutoVersionStep.js";
 
 const silentLogger: PipelineLogger = {
     debug: () => undefined,

--- a/packages/generator-cli/src/__test__/auto-version-step.test.ts
+++ b/packages/generator-cli/src/__test__/auto-version-step.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "vitest";
+import { AutoVersionStep } from "../pipeline/steps/AutoVersionStep.js";
+import type { AutoVersionStepConfig, PipelineContext, PipelineLogger } from "../pipeline/index.js";
+import { PostGenerationPipeline } from "../pipeline/index.js";
+
+const silentLogger: PipelineLogger = {
+    debug: () => undefined,
+    info: () => undefined,
+    warn: () => undefined,
+    error: () => undefined
+};
+
+const emptyContext: PipelineContext = {
+    previousStepResults: {}
+};
+
+const baseConfig: AutoVersionStepConfig = {
+    enabled: true,
+    language: "typescript",
+    fernToken: "test-token"
+};
+
+describe("AutoVersionStep", () => {
+    it("has name 'autoVersion' matching the pipeline dispatch key", () => {
+        const step = new AutoVersionStep("/tmp/fake", silentLogger, baseConfig);
+        expect(step.name).toBe("autoVersion");
+    });
+
+    it("execute() is a no-op that reports executed + success", async () => {
+        const step = new AutoVersionStep("/tmp/fake", silentLogger, baseConfig);
+        const result = await step.execute(emptyContext);
+        expect(result).toEqual({ executed: true, success: true });
+    });
+});
+
+describe("PostGenerationPipeline autoVersion wiring", () => {
+    it("short-circuits when autoVersion config is omitted", async () => {
+        const pipeline = new PostGenerationPipeline({ outputDir: "/tmp/fake" }, silentLogger);
+        const result = await pipeline.run();
+        expect(result.steps.autoVersion).toBeUndefined();
+        expect(result.success).toBe(true);
+    });
+
+    it("short-circuits when autoVersion.enabled is false", async () => {
+        const pipeline = new PostGenerationPipeline(
+            {
+                outputDir: "/tmp/fake",
+                autoVersion: { ...baseConfig, enabled: false }
+            },
+            silentLogger
+        );
+        const result = await pipeline.run();
+        expect(result.steps.autoVersion).toBeUndefined();
+        expect(result.success).toBe(true);
+    });
+
+    it("runs the no-op step and records its result when autoVersion.enabled is true", async () => {
+        const pipeline = new PostGenerationPipeline(
+            {
+                outputDir: "/tmp/fake",
+                autoVersion: baseConfig
+            },
+            silentLogger
+        );
+        const result = await pipeline.run();
+        expect(result.steps.autoVersion).toEqual({ executed: true, success: true });
+        expect(result.success).toBe(true);
+    });
+});

--- a/packages/generator-cli/src/pipeline/PostGenerationPipeline.ts
+++ b/packages/generator-cli/src/pipeline/PostGenerationPipeline.ts
@@ -2,10 +2,12 @@ import { extractErrorMessage } from "@fern-api/core-utils";
 import { execFileSync } from "child_process";
 import { FERN_BOT_EMAIL, FERN_BOT_NAME } from "./github/constants";
 import { consolePipelineLogger, type PipelineLogger } from "./PipelineLogger";
+import { AutoVersionStep } from "./steps/AutoVersionStep";
 import { BaseStep } from "./steps/BaseStep";
 import { GithubStep } from "./steps/GithubStep";
 import { ReplayStep } from "./steps/ReplayStep";
 import type {
+    AutoVersionStepResult,
     FernignoreStepResult,
     GithubStepResult,
     PipelineConfig,
@@ -28,6 +30,14 @@ export class PostGenerationPipeline {
                 "Replay is not supported with GitHub push mode. Disabling replay to prevent force push to base branch."
             );
             config.replay.enabled = false;
+        }
+
+        // Runs between the generation commit and replay detect/apply so the autoversion diff
+        // sees only pure generator output on both sides (see FER-9978). Today the generation
+        // commit is made inside ReplayStep; FER-9980 extracts it so AutoVersionStep sits
+        // cleanly between them.
+        if (config.autoVersion?.enabled) {
+            this.steps.push(new AutoVersionStep(config.outputDir, this.logger, config.autoVersion));
         }
 
         if (config.replay?.enabled) {
@@ -81,6 +91,9 @@ export class PostGenerationPipeline {
                 if (step.name === "replay") {
                     result.steps.replay = stepResult as ReplayStepResult;
                     pipelineContext.previousStepResults.replay = stepResult as ReplayStepResult;
+                } else if (step.name === "autoVersion") {
+                    result.steps.autoVersion = stepResult as AutoVersionStepResult;
+                    pipelineContext.previousStepResults.autoVersion = stepResult as AutoVersionStepResult;
                 } else if (step.name === "fernignore") {
                     result.steps.fernignore = stepResult as FernignoreStepResult;
                 } else if (step.name === "github") {

--- a/packages/generator-cli/src/pipeline/index.ts
+++ b/packages/generator-cli/src/pipeline/index.ts
@@ -2,6 +2,8 @@ export { consolePipelineLogger, type PipelineLogger } from "./PipelineLogger";
 export { PostGenerationPipeline } from "./PostGenerationPipeline";
 export { formatReplayPrBody, logReplaySummary } from "./replay-summary";
 export type {
+    AutoVersionStepConfig,
+    AutoVersionStepResult,
     FernignoreStepConfig,
     FernignoreStepResult,
     GithubStepConfig,

--- a/packages/generator-cli/src/pipeline/steps/AutoVersionStep.ts
+++ b/packages/generator-cli/src/pipeline/steps/AutoVersionStep.ts
@@ -1,0 +1,33 @@
+import type { PipelineLogger } from "../PipelineLogger";
+import type { AutoVersionStepConfig, AutoVersionStepResult, PipelineContext } from "../types";
+import { BaseStep } from "./BaseStep";
+
+/**
+ * Runs SDK autoversioning inside the replay pipeline, between the `[fern-generated]` commit
+ * and replay detect/apply. Diffs prev vs new `[fern-generated]` sha (both pure generator output),
+ * calls FAI to determine the bump and changelog, rewrites the placeholder version, appends
+ * to changelog.md, and commits `[fern-autoversion]`.
+ *
+ * This scaffold is a no-op — `execute()` logic lands in FER-9980.
+ */
+export class AutoVersionStep extends BaseStep {
+    readonly name = "autoVersion";
+
+    constructor(
+        outputDir: string,
+        logger: PipelineLogger,
+        private readonly config: AutoVersionStepConfig
+    ) {
+        super(outputDir, logger);
+    }
+
+    async execute(_context: PipelineContext): Promise<AutoVersionStepResult> {
+        this.logger.info(
+            `AutoVersionStep: no-op scaffold for language=${this.config.language} (logic lands in FER-9980)`
+        );
+        return {
+            executed: true,
+            success: true
+        };
+    }
+}

--- a/packages/generator-cli/src/pipeline/types.ts
+++ b/packages/generator-cli/src/pipeline/types.ts
@@ -3,6 +3,7 @@ export interface PipelineConfig {
 
     // Step configs (optional, modular)
     replay?: ReplayStepConfig;
+    autoVersion?: AutoVersionStepConfig;
     fernignore?: FernignoreStepConfig; // PHASE 2: not implemented yet
     github?: GithubStepConfig;
 
@@ -15,6 +16,7 @@ export interface PipelineConfig {
 export interface PipelineContext {
     previousStepResults: {
         replay?: ReplayStepResult;
+        autoVersion?: AutoVersionStepResult;
         fernignore?: FernignoreStepResult;
     };
 }
@@ -23,6 +25,18 @@ export interface ReplayStepConfig {
     enabled: boolean;
     stageOnly?: boolean;
     skipApplication?: boolean;
+}
+
+export interface AutoVersionStepConfig {
+    enabled: boolean;
+    /** Generator language: typescript | python | java | go | ruby | csharp | php | swift | rust | kotlin */
+    language: string;
+    /** Existing changelog content passed to the AI for context. */
+    priorChangelog?: string;
+    /** Fallback version when no prior generation exists (first run). */
+    baseVersion?: string;
+    /** Fern token used to authorize the FAI (AnalyzeSdkDiff) call. */
+    fernToken: string;
 }
 
 export interface FernignoreStepConfig {
@@ -81,6 +95,7 @@ export interface PipelineResult {
     success: boolean;
     steps: {
         replay?: ReplayStepResult;
+        autoVersion?: AutoVersionStepResult;
         fernignore?: FernignoreStepResult;
         github?: GithubStepResult;
     };
@@ -114,6 +129,25 @@ export interface ReplayStepResult extends StepResult {
 
 export interface FernignoreStepResult extends StepResult {
     pathsPreserved?: string[];
+}
+
+export interface AutoVersionStepResult extends StepResult {
+    /** The new version to use (e.g. "1.2.3"). Field name matches fiddle's Java AutoVersionResult DTO. */
+    version?: string;
+    /** Commit subject for the `[fern-autoversion]` commit. */
+    commitMessage?: string;
+    /** User-facing changelog entry appended to changelog.md. */
+    changelogEntry?: string;
+    /** Prior SDK version before this change (e.g. "1.2.2"). */
+    previousVersion?: string;
+    /** The version bump level determined by FAI. */
+    versionBump?: "MAJOR" | "MINOR" | "PATCH" | "NO_CHANGE";
+    /** Structured PR description with Before/After code fences for breaking changes. */
+    prDescription?: string;
+    /** One-sentence justification for WHY the version bump was chosen. */
+    versionBumpReason?: string;
+    /** SHA of the `[fern-autoversion]` commit once it's been made. TS-only; no fiddle counterpart. */
+    commitSha?: string;
 }
 
 export interface GithubStepResult extends StepResult {


### PR DESCRIPTION
## Description
Linear ticket: Closes [FER-9979](https://linear.app/buildwithfern/issue/FER-9979/scaffold-autoversionstep-and-extend-pipelineconfig-pipelineresult)

Parent epic: [FER-9978](https://linear.app/buildwithfern/issue/FER-9978/epic-move-sdk-autoversioning-into-the-replay-pipeline) — move SDK autoversioning into the replay pipeline so the diff sees only pure generator output on both sides (today fiddle diffs a tree contaminated with replay-applied customizations, producing false major bumps and lying changelogs).

This PR is the **type surface and no-op step class only**. No behavior change. Actual `execute()` logic lands in FER-9980; fiddle wire-up in FER-9982.

## Changes Made
- `packages/generator-cli/src/pipeline/types.ts` — new `AutoVersionStepConfig` and `AutoVersionStepResult`; `autoVersion?` added to `PipelineConfig`, `PipelineContext.previousStepResults`, `PipelineResult.steps`.
- `packages/generator-cli/src/pipeline/steps/AutoVersionStep.ts` (new) — extends `BaseStep` with `name = "autoVersion"`. `execute()` logs once and returns `{ executed: true, success: true }`.
- `packages/generator-cli/src/pipeline/PostGenerationPipeline.ts` — pushes `AutoVersionStep` before `ReplayStep` when `config.autoVersion?.enabled`; adds dispatch branch in `run()` writing both `result.steps.autoVersion` and `pipelineContext.previousStepResults.autoVersion`.
- `packages/generator-cli/src/pipeline/index.ts` — re-exports the two new types.
- [ ] Updated README.md generator — n/a

### Design decisions worth calling out
- **Result field name is `version`, not `newVersion`** — matches fiddle-coordinator's Java `AutoVersionResult` DTO so FER-9982's wire integration is a straight passthrough. `GithubStepConfig.newVersion` is untouched; the local-workspace-runner adapter in FER-9980 will map `autoVersion.version → github.newVersion`.
- **`commitSha` is optional and TS-only** — Java's DTO has no equivalent (fiddle doesn't make the commit). FER-9980 populates after the `[fern-autoversion]` commit.
- **Step order: before `ReplayStep`** — today the generation commit is embedded inside `ReplayStep`, so AutoVersion is a no-op here anyway. FER-9980 will extract the generation commit so AutoVersionStep sits cleanly between `[fern-generated]` and replay detect/apply, per the epic's target architecture.
- **No `@fern-api/generator-cli` version bump** — no behavior shipped. FER-9980 will bump when real logic lands.

## Testing
- [x] Unit tests added — 5 vitest cases in `src/__test__/auto-version-step.test.ts`: step `name`, direct `execute()` no-op, pipeline with no `autoVersion` config, `enabled: false`, `enabled: true`.
- [x] `pnpm turbo run compile --filter @fern-api/generator-cli` — clean
- [x] `pnpm turbo run test --filter @fern-api/generator-cli` — 183 passed (5 new + 178 existing)
- [x] `pnpm turbo run compile --filter @fern-api/local-workspace-runner` — 73 packages clean, no downstream drift
- [x] `pnpm format` / `pnpm lint:biome packages/generator-cli/src/` — clean