### PR TITLE
feat(internal): add generator error taxonomy and sentry routing

### DIFF
--- a/generators/base/src/AbstractGeneratorCli.ts
+++ b/generators/base/src/AbstractGeneratorCli.ts
@@ -9,6 +9,7 @@ import {
 import { assertNever } from "@fern-api/core-utils";
 import { RelativeFilePath } from "@fern-api/fs-utils";
 import { readFile } from "fs/promises";
+import { GeneratorError, resolveErrorCode, shouldReportToSentry } from "./GeneratorError.js";
 import { SentryClient } from "./telemetry/SentryClient.js";
 
 export declare namespace AbstractGeneratorCli {
@@ -77,12 +78,16 @@ export abstract class AbstractGeneratorCli<
                 FernGeneratorExec.GeneratorUpdate.exitStatusUpdate(FernGeneratorExec.ExitStatusUpdate.successful({}))
             );
         } catch (e) {
-            await sentryClient?.captureException(e);
+            const errorCode = resolveErrorCode(e);
+            if (shouldReportToSentry(e)) {
+                await sentryClient?.captureException(e);
+            }
             if (generatorNotificationService != null) {
+                const exitMessage = e instanceof Error ? e.message : "Encountered error";
                 await generatorNotificationService.sendUpdate(
                     FernGeneratorExec.GeneratorUpdate.exitStatusUpdate(
                         FernGeneratorExec.ExitStatusUpdate.error({
-                            message: e instanceof Error ? e.message : "Encountered error"
+                            message: exitMessage
                         })
                     )
                 );
@@ -151,7 +156,7 @@ export abstract class AbstractGeneratorCli<
 async function getGeneratorConfig(): Promise<FernGeneratorExec.GeneratorConfig> {
     const pathToConfig = process.argv[process.argv.length - 1];
     if (pathToConfig == null) {
-        throw new Error("No argument for config filepath was provided.");
+        throw GeneratorError.environmentError("No argument for config filepath was provided.");
     }
     const rawConfig = await readFile(pathToConfig);
     console.log(`Reading ${pathToConfig}`);
@@ -161,7 +166,7 @@ async function getGeneratorConfig(): Promise<FernGeneratorExec.GeneratorConfig> 
         unrecognizedObjectKeys: "passthrough"
     });
     if (!validatedConfig.ok) {
-        throw new Error(
+        throw GeneratorError.validationError(
             `The generator config failed to pass validation. ${validatedConfig.errors.map((e) => (typeof e === "object" ? JSON.stringify(e) : String(e))).join(", ")}`
         );
     }

--- a/generators/base/src/GeneratorError.ts
+++ b/generators/base/src/GeneratorError.ts
@@ -1,0 +1,95 @@
+export declare namespace GeneratorError {
+    /**
+     * Error codes used by generator runtimes to distinguish user-facing errors
+     * from internal Fern bugs.
+     */
+    export type Code =
+        | "INTERNAL_ERROR"
+        | "RESOLUTION_ERROR"
+        | "IR_CONVERSION_ERROR"
+        | "CONTAINER_ERROR"
+        | "VERSION_ERROR"
+        | "PARSE_ERROR"
+        | "ENVIRONMENT_ERROR"
+        | "REFERENCE_ERROR"
+        | "VALIDATION_ERROR"
+        | "NETWORK_ERROR"
+        | "AUTH_ERROR"
+        | "CONFIG_ERROR";
+}
+
+const SENTRY_REPORTABLE_CODES: ReadonlySet<GeneratorError.Code> = new Set<GeneratorError.Code>([
+    "INTERNAL_ERROR",
+    "RESOLUTION_ERROR",
+    "IR_CONVERSION_ERROR",
+    "CONTAINER_ERROR",
+    "VERSION_ERROR"
+]);
+
+export class GeneratorError extends Error {
+    public readonly code: GeneratorError.Code;
+
+    constructor({ message, code }: { message: string; code: GeneratorError.Code }) {
+        super(message);
+        this.code = code;
+    }
+
+    public static internalError(message: string): GeneratorError {
+        return new GeneratorError({ message, code: "INTERNAL_ERROR" });
+    }
+
+    public static resolutionError(message: string): GeneratorError {
+        return new GeneratorError({ message, code: "RESOLUTION_ERROR" });
+    }
+
+    public static irConversionError(message: string): GeneratorError {
+        return new GeneratorError({ message, code: "IR_CONVERSION_ERROR" });
+    }
+
+    public static containerError(message: string): GeneratorError {
+        return new GeneratorError({ message, code: "CONTAINER_ERROR" });
+    }
+
+    public static versionError(message: string): GeneratorError {
+        return new GeneratorError({ message, code: "VERSION_ERROR" });
+    }
+
+    public static parseError(message: string): GeneratorError {
+        return new GeneratorError({ message, code: "PARSE_ERROR" });
+    }
+
+    public static environmentError(message: string): GeneratorError {
+        return new GeneratorError({ message, code: "ENVIRONMENT_ERROR" });
+    }
+
+    public static referenceError(message: string): GeneratorError {
+        return new GeneratorError({ message, code: "REFERENCE_ERROR" });
+    }
+
+    public static validationError(message: string): GeneratorError {
+        return new GeneratorError({ message, code: "VALIDATION_ERROR" });
+    }
+
+    public static networkError(message: string): GeneratorError {
+        return new GeneratorError({ message, code: "NETWORK_ERROR" });
+    }
+
+    public static authError(message: string): GeneratorError {
+        return new GeneratorError({ message, code: "AUTH_ERROR" });
+    }
+
+    public static configError(message: string): GeneratorError {
+        return new GeneratorError({ message, code: "CONFIG_ERROR" });
+    }
+}
+
+export function resolveErrorCode(error: unknown): GeneratorError.Code {
+    if (error instanceof GeneratorError) {
+        return error.code;
+    }
+    return "INTERNAL_ERROR";
+}
+
+export function shouldReportToSentry(error: unknown): boolean {
+    return SENTRY_REPORTABLE_CODES.has(resolveErrorCode(error));
+}

--- a/generators/base/src/SourceFetcher.ts
+++ b/generators/base/src/SourceFetcher.ts
@@ -5,6 +5,7 @@ import { createWriteStream } from "fs";
 import { mkdir, readdir } from "fs/promises";
 import { pipeline } from "stream";
 import { promisify } from "util";
+import { GeneratorError } from "./GeneratorError.js";
 
 const LOCAL_FILE_SCHEME = "file:///";
 const PROTOBUF_ZIP_FILENAME = "proto.zip";
@@ -136,7 +137,9 @@ export class SourceFetcher {
         this.context.logger.debug(`Downloading ${downloadURL} to ${destinationPath}`);
         const response = await fetch(downloadURL);
         if (!response.ok) {
-            throw new Error(`Failed to download source. Status: ${response.status}, ${response.statusText}`);
+            throw GeneratorError.networkError(
+                `Failed to download source. Status: ${response.status}, ${response.statusText}`
+            );
         }
         const fileStream = createWriteStream(destinationPath);
 

--- a/generators/base/src/__test__/GeneratorError.test.ts
+++ b/generators/base/src/__test__/GeneratorError.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+import { GeneratorError, resolveErrorCode, shouldReportToSentry } from "../GeneratorError.js";
+
+describe("GeneratorError", () => {
+    it("defaults unknown errors to INTERNAL_ERROR", () => {
+        expect(resolveErrorCode(new Error("boom"))).toBe("INTERNAL_ERROR");
+    });
+
+    it("does not report user-facing config errors to sentry", () => {
+        expect(shouldReportToSentry(GeneratorError.configError("bad config"))).toBe(false);
+    });
+
+    it("reports internal errors to sentry", () => {
+        expect(shouldReportToSentry(GeneratorError.internalError("bug"))).toBe(true);
+    });
+});

--- a/generators/base/src/__test__/SentryClient.test.ts
+++ b/generators/base/src/__test__/SentryClient.test.ts
@@ -22,6 +22,7 @@ vi.mock("@sentry/node", () => ({
     setTag: mockSentrySetTag
 }));
 
+import { GeneratorError } from "../GeneratorError.js";
 import { SentryClient } from "../telemetry/SentryClient.js";
 
 const DEFAULT_ARGS = {
@@ -102,5 +103,16 @@ describe("SentryClient (base-generator)", () => {
                 release: "fern-go-sdk:2.1.0"
             })
         );
+    });
+
+    it("sets the provided error_code tag when capturing exception", async () => {
+        const client = new SentryClient(DEFAULT_ARGS);
+
+        await client.captureException(new GeneratorError({ message: "bad config", code: "CONFIG_ERROR" }), {
+            errorCode: "CONFIG_ERROR"
+        });
+
+        expect(mockSentrySetTag).toHaveBeenCalledWith("error_code", "CONFIG_ERROR");
+        expect(mockSentryCaptureException).toHaveBeenCalledOnce();
     });
 });

--- a/generators/base/src/index.ts
+++ b/generators/base/src/index.ts
@@ -1,6 +1,7 @@
 export * from "./AbstractGeneratorAgent.js";
 export * from "./AbstractGeneratorCli.js";
 export * from "./browserCompatibleExports.js";
+export * from "./GeneratorError.js";
 export * from "./project/index.js";
 export * from "./readme/index.js";
 export * from "./reference/index.js";

--- a/generators/base/src/readme/AbstractReadmeSnippetBuilder.ts
+++ b/generators/base/src/readme/AbstractReadmeSnippetBuilder.ts
@@ -1,5 +1,6 @@
 import { FernGeneratorExec } from "@fern-api/browser-compatible-base-generator";
 import { camelCase } from "lodash-es";
+import { GeneratorError } from "../GeneratorError.js";
 
 export abstract class AbstractReadmeSnippetBuilder {
     private endpointSnippets: FernGeneratorExec.Endpoint[];
@@ -18,12 +19,14 @@ export abstract class AbstractReadmeSnippetBuilder {
         if (defaultEndpoint == null) {
             const firstEndpoint = this.endpointSnippets[0];
             if (firstEndpoint == null) {
-                throw new Error("Internal error; no endpoint snippets were provided");
+                throw GeneratorError.internalError("Internal error; no endpoint snippets were provided");
             }
             defaultEndpoint = firstEndpoint;
         }
         if (defaultEndpoint.id.identifierOverride == null) {
-            throw new Error("Internal error; all endpoints must define an endpoint id to generate README.md");
+            throw GeneratorError.internalError(
+                "Internal error; all endpoints must define an endpoint id to generate README.md"
+            );
         }
         return defaultEndpoint.id.identifierOverride;
     }

--- a/generators/base/src/telemetry/SentryClient.ts
+++ b/generators/base/src/telemetry/SentryClient.ts
@@ -1,4 +1,5 @@
 import * as Sentry from "@sentry/node";
+import { resolveErrorCode } from "../GeneratorError.js";
 
 export class SentryClient {
     private readonly sentry: Sentry.NodeClient | undefined;
@@ -64,11 +65,12 @@ export class SentryClient {
         }
     }
 
-    public async captureException(error: unknown): Promise<void> {
+    public async captureException(error: unknown, { errorCode }: { errorCode?: string } = {}): Promise<void> {
         if (this.sentry == null) {
             return;
         }
         try {
+            Sentry.setTag("error_code", errorCode ?? resolveErrorCode(error));
             this.sentry.captureException(error);
         } catch {
             // no-op

--- a/generators/base/src/utils/GitHubConfig.ts
+++ b/generators/base/src/utils/GitHubConfig.ts
@@ -1,5 +1,6 @@
 import { isNonNullish } from "@fern-api/core-utils";
 import { Logger } from "@fern-api/logger";
+import { GeneratorError } from "../GeneratorError.js";
 
 /**
  * The configuration used to interact with a GitHub repository.
@@ -30,17 +31,17 @@ export function resolveGitHubConfig({
 }): ResolvedGithubConfig {
     if (rawGithubConfig.type == null) {
         logger.error("Publishing config is missing");
-        throw new Error("Publishing config is required for GitHub actions");
+        throw GeneratorError.configError("Publishing config is required for GitHub actions");
     }
 
     if (rawGithubConfig.type !== "github") {
         logger.error(`Publishing type ${rawGithubConfig.type} is not supported`);
-        throw new Error("Only GitHub publishing is supported");
+        throw GeneratorError.configError("Only GitHub publishing is supported");
     }
 
     if (!(isNonNullish(rawGithubConfig.uri) && isNonNullish(rawGithubConfig.token))) {
         logger.error("GitHub URI or token is missing in publishing config");
-        throw new Error("GitHub URI and token are required in publishing config");
+        throw GeneratorError.configError("GitHub URI and token are required in publishing config");
     }
 
     return {

--- a/generators/base/src/utils/parseGeneratorConfig.ts
+++ b/generators/base/src/utils/parseGeneratorConfig.ts
@@ -1,5 +1,6 @@
 import { FernGeneratorExec, GeneratorExecParsing } from "@fern-api/browser-compatible-base-generator";
 import { readFile } from "fs/promises";
+import { GeneratorError } from "../GeneratorError.js";
 
 export async function parseGeneratorConfig(pathToConfig: string): Promise<FernGeneratorExec.GeneratorConfig> {
     const configStr = await readFile(pathToConfig);
@@ -13,7 +14,7 @@ export async function parseGeneratorConfig(pathToConfig: string): Promise<FernGe
     if (!parsedConfig.ok) {
         // biome-ignore lint/suspicious/noConsole: allow console
         console.log(`Failed to parse ${pathToConfig}`);
-        throw new Error("Failed to parse the generator configuration");
+        throw GeneratorError.parseError("Failed to parse the generator configuration");
     }
 
     return parsedConfig.value;

--- a/generators/base/src/utils/parseIR.ts
+++ b/generators/base/src/utils/parseIR.ts
@@ -1,5 +1,6 @@
 import { AbsoluteFilePath, streamObjectFromFile } from "@fern-api/fs-utils";
 import { readFile, stat } from "fs/promises";
+import { GeneratorError } from "../GeneratorError.js";
 
 export declare namespace parseIR {
     export interface Args<IntermediateRepresentation> {
@@ -99,7 +100,7 @@ export async function parseIR<IR>({ absolutePathToIR, parse }: parseIR.Args<IR>)
     if (!parsedIR.ok) {
         // biome-ignore lint/suspicious/noConsole: allow console
         console.log(`Failed to parse ${absolutePathToIR}`);
-        throw new Error(`Failed to parse IR: ${JSON.stringify(parsedIR.errors, null, 4)}`);
+        throw GeneratorError.parseError(`Failed to parse IR: ${JSON.stringify(parsedIR.errors, null, 4)}`);
     }
 
     return parsedIR.value;

--- a/generators/typescript/utils/abstract-generator-cli/src/AbstractGeneratorCli.ts
+++ b/generators/typescript/utils/abstract-generator-cli/src/AbstractGeneratorCli.ts
@@ -1,10 +1,13 @@
 import {
     FernGeneratorExec,
+    GeneratorError,
     GeneratorNotificationService,
     NopGeneratorNotificationService,
     parseGeneratorConfig,
     parseIR,
-    SentryClient
+    resolveErrorCode,
+    SentryClient,
+    shouldReportToSentry
 } from "@fern-api/base-generator";
 import { assertNever } from "@fern-api/core-utils";
 import { AbsoluteFilePath, join, RelativeFilePath } from "@fern-api/fs-utils";
@@ -49,7 +52,7 @@ export abstract class AbstractGeneratorCli<CustomConfig> {
     public async runCli(options?: AbstractGeneratorCli.Options): Promise<void> {
         const pathToConfig = process.argv[process.argv.length - 1];
         if (pathToConfig == null) {
-            throw new Error("No argument for config filepath.");
+            throw GeneratorError.environmentError("No argument for config filepath.");
         }
         await this.run(pathToConfig, options);
     }
@@ -126,7 +129,7 @@ export abstract class AbstractGeneratorCli<CustomConfig> {
             });
             logger.debug(`[TIMING] code generation took ${Date.now() - codeGenStartTime}ms`);
             if (!generatorContext.didSucceed()) {
-                throw new Error("Failed to generate TypeScript project.");
+                throw GeneratorError.internalError("Failed to generate TypeScript project.");
             }
 
             const destinationPath = join(
@@ -261,7 +264,7 @@ export abstract class AbstractGeneratorCli<CustomConfig> {
                     });
                 },
                 _other: ({ type }) => {
-                    throw new Error(`${type} mode is not implemented`);
+                    throw GeneratorError.internalError(`${type} mode is not implemented`);
                 }
             });
 
@@ -275,10 +278,14 @@ export abstract class AbstractGeneratorCli<CustomConfig> {
             // biome-ignore lint/suspicious/noConsole: allow console
             console.log("Sent success event to coordinator");
         } catch (e) {
+            const errorCode = resolveErrorCode(e);
+            if (shouldReportToSentry(e)) {
+                await sentryClient?.captureException(e, { errorCode });
+            }
+
             // This call tears down generator service
             // TODO: if using in conjunction with MCP server generator, MCP server generator to tear down the service?
             // SEE: go-v2
-            await sentryClient?.captureException(e);
             await generatorNotificationService.sendUpdate(
                 FernGeneratorExec.GeneratorUpdate.exitStatusUpdate(
                     FernGeneratorExec.ExitStatusUpdate.error({


### PR DESCRIPTION
## Description

Introduce a shared `GeneratorError` taxonomy for generator runtimes so that
`generators/base` and language-specific generators can distinguish user-facing
errors (config, validation, network, auth, etc.) from internal Fern bugs, and
route only the "our fault" errors to Sentry. Mirrors the `CliError` /
`shouldReportToSentry` pattern already in the CLI.

## Changes Made

- Add `generators/base/src/GeneratorError.ts` with the error class, typed
`Code` union, static factories (`internalError`, `resolutionError`,
`irConversionError`, `containerError`, `versionError`, `parseError`,
`environmentError`, `referenceError`, `validationError`, `networkError`,
`authError`, `configError`), plus `resolveErrorCode` and
`shouldReportToSentry` helpers.
- Sentry-reportable set limited to `INTERNAL_ERROR`, `RESOLUTION_ERROR`,
`IR_CONVERSION_ERROR`, `CONTAINER_ERROR`, `VERSION_ERROR` — user-fixable
failures (parse/validation/env/auth/config/network) are no longer reported.
- Gate Sentry reporting in `AbstractGeneratorCli` (both `generators/base` and
the browser-compatible variant) behind `shouldReportToSentry(e)` so only
reportable codes are sent, and propagate the existing exit message through
unchanged.
- Migrate `generators/base` internals to throw typed `GeneratorError`s:
`parseGeneratorConfig`, `parseIR`, `SourceFetcher`, `GitHubConfig`, the
`AbstractReadmeSnippetBuilder`, and the CLI entrypoints.
- Add unit tests for `GeneratorError` code resolution / Sentry gating and the
generator-side `SentryClient`.

## Testing

- [x] Unit tests added (`GeneratorError.test.ts`, `SentryClient.test.ts`)
- [x] `pnpm turbo run test --filter @fern-api/base-generator` passes