### PR TITLE
feat(cli): harden Sentry config with additional integrations

### DIFF
--- a/packages/cli/cli/src/telemetry/SentryClient.ts
+++ b/packages/cli/cli/src/telemetry/SentryClient.ts
@@ -20,9 +20,33 @@ export class SentryClient {
                 dsn: sentryDsn,
                 release,
                 environment: sentryEnvironment,
+                // Opt out of every built-in integration (HTTP tracing, local
+                // variables, console breadcrumbs, etc.) — error capture is all
+                // we need.
                 defaultIntegrations: false,
-                integrations: [Sentry.rewriteFramesIntegration()],
-                tracesSampleRate: 0
+                // Rewrite absolute frame paths to repo-root-relative paths so
+                // they align with the source maps uploaded at publish time.
+                // onUncaughtException / onUnhandledRejection catch errors that
+                // escape the CLI's top-level handler (fire-and-forget callbacks,
+                // unhandled rejections in background work, etc.).
+                // linkedErrors chains .cause so wrapped errors stay traceable.
+                // nodeContext adds Node.js version and OS to every event.
+                integrations: [
+                    Sentry.rewriteFramesIntegration(),
+                    Sentry.onUncaughtExceptionIntegration(),
+                    Sentry.onUnhandledRejectionIntegration(),
+                    Sentry.linkedErrorsIntegration(),
+                    Sentry.nodeContextIntegration()
+                ],
+                // The CLI doesn't emit transactions; disable performance
+                // sampling entirely.
+                tracesSampleRate: 0,
+                // Always attach a stack trace, even when the thrown value is
+                // not an Error instance (e.g. a plain string or object).
+                attachStacktrace: true,
+                // Suppress the client-report envelope Sentry sends when events
+                // are dropped (e.g. due to rate limits).
+                sendClientReports: false
             });
             setSentryRunIdTags();
         }

--- a/packages/cli/cli/src/telemetry/__test__/SentryClient.test.ts
+++ b/packages/cli/cli/src/telemetry/__test__/SentryClient.test.ts
@@ -14,6 +14,10 @@ const { mockSentryCaptureException, mockSentryFlush, mockSentryInit } = vi.hoist
 vi.mock("@sentry/node", () => ({
     init: mockSentryInit,
     rewriteFramesIntegration: vi.fn().mockReturnValue({}),
+    onUncaughtExceptionIntegration: vi.fn().mockReturnValue({}),
+    onUnhandledRejectionIntegration: vi.fn().mockReturnValue({}),
+    linkedErrorsIntegration: vi.fn().mockReturnValue({}),
+    nodeContextIntegration: vi.fn().mockReturnValue({}),
     setTag: vi.fn()
 }));
 


### PR DESCRIPTION
## Summary

Hardens the CLI's Sentry initialisation by opting into four additional integrations and two config flags that were previously missing.

## Changes

- **`onUncaughtExceptionIntegration` / `onUnhandledRejectionIntegration`** — catches errors and promise rejections that escape the CLI's top-level handler (fire-and-forget callbacks, unhandled rejections from background work, etc.). More impactful here than in a generator container because the CLI is long-lived, runs on arbitrary user machines, and has a larger async surface area.
- **`linkedErrorsIntegration`** — follows the `.cause` chain on wrapped errors so both the original and the wrapper appear in Sentry, rather than just the outermost exception.
- **`nodeContextIntegration`** — attaches Node.js version, OS name/version, and architecture to every event. Useful for diagnosing environment-specific failures.
- **`attachStacktrace: true`** — forces a stack trace even when the thrown value is not an `Error` instance (plain string, object, etc.).
- **`sendClientReports: false`** — suppresses the client-report envelope Sentry sends when events are dropped due to rate limiting.

`defaultIntegrations: false` and `tracesSampleRate: 0` are kept as-is — HTTP tracing, local-variable capture, and performance sampling are not needed for a CLI.

Made with [Cursor](https://cursor.com)