### PR TITLE
feat(cli): forward telemetry opt-out to local generator containers

### DIFF
--- a/packages/cli/cli-v2/src/sdk/generator/LegacyLocalGenerationRunner.ts
+++ b/packages/cli/cli-v2/src/sdk/generator/LegacyLocalGenerationRunner.ts
@@ -187,7 +187,8 @@ export class LegacyLocalGenerationRunner {
             inspect: false,
             ai: undefined,
             skipFernignore: args.skipFernignore,
-            requireEnvVars: args.requireEnvVars
+            requireEnvVars: args.requireEnvVars,
+            disableTelemetry: !this.context.telemetry.isTelemetryEnabled()
         });
 
         if (taskContext.getResult() === TaskResult.Failure) {
@@ -228,7 +229,8 @@ export class LegacyLocalGenerationRunner {
         const executionEnvironment = new ContainerExecutionEnvironment({
             containerImage,
             keepContainer: args.keepContainer ?? false,
-            runner: args.containerEngine
+            runner: args.containerEngine,
+            disableTelemetry: !this.context.telemetry.isTelemetryEnabled()
         });
 
         const runner = new GenerationRunner(executionEnvironment);

--- a/packages/cli/cli-v2/src/telemetry/TelemetryClient.ts
+++ b/packages/cli/cli-v2/src/telemetry/TelemetryClient.ts
@@ -179,13 +179,13 @@ export class TelemetryClient {
     }
 
     /**
-     * Returns true if telemetry should be disabled.
+     * Returns true if telemetry is enabled.
      *
      * Priority:
      *  1. FERN_TELEMETRY_DISABLED env var (any non-empty value)
      *  2. telemetry.enabled: false in ~/.fernrc
      */
-    private isTelemetryEnabled(): boolean {
+    public isTelemetryEnabled(): boolean {
         const envDisabled = process.env["FERN_TELEMETRY_DISABLED"];
         if (envDisabled != null && envDisabled.length > 0) {
             return false;

--- a/packages/cli/cli/changes/unreleased/forward-telemetry-setting-to-generators.yml
+++ b/packages/cli/cli/changes/unreleased/forward-telemetry-setting-to-generators.yml
@@ -1,0 +1,9 @@
+# yaml-language-server: $schema=../../../../../fern-changes-yml.schema.json
+
+- summary: |
+    Forward the CLI's telemetry setting to local generator containers. When the CLI
+    has telemetry disabled (via FERN_DISABLE_TELEMETRY, FERN_TELEMETRY_DISABLED, or
+    `fern telemetry disable`), `fern generate --local` now sets
+    FERN_DISABLE_TELEMETRY=true inside the generator container so the generator
+    runtime's Sentry client is disabled too. Remote generation is unaffected.
+  type: feat

--- a/packages/cli/cli/src/commands/generate/generateAPIWorkspace.ts
+++ b/packages/cli/cli/src/commands/generate/generateAPIWorkspace.ts
@@ -149,7 +149,8 @@ export async function generateWorkspace({
                         requireEnvVars,
                         skipFernignore,
                         automationMode,
-                        autoMerge
+                        autoMerge,
+                        disableTelemetry: process.env.FERN_DISABLE_TELEMETRY === "true"
                     });
                 } else if (token != null) {
                     await runRemoteGenerationForAPIWorkspace({

--- a/packages/cli/cli/src/commands/generate/generateAPIWorkspace.ts
+++ b/packages/cli/cli/src/commands/generate/generateAPIWorkspace.ts
@@ -15,6 +15,7 @@ import { FernFiddle } from "@fern-fern/fiddle-sdk";
 import chalk from "chalk";
 
 import { GROUP_CLI_OPTION } from "../../constants.js";
+import { isTelemetryDisabled } from "../../telemetry/isTelemetryDisabled.js";
 import { filterGenerators } from "./filterGenerators.js";
 import { GenerationMode } from "./generateAPIWorkspaces.js";
 import { resolveGroupAlias } from "./resolveGroupAlias.js";
@@ -150,7 +151,7 @@ export async function generateWorkspace({
                         skipFernignore,
                         automationMode,
                         autoMerge,
-                        disableTelemetry: process.env.FERN_DISABLE_TELEMETRY === "true"
+                        disableTelemetry: isTelemetryDisabled()
                     });
                 } else if (token != null) {
                     await runRemoteGenerationForAPIWorkspace({

--- a/packages/cli/cli/src/commands/sdk-preview/sdkPreview.ts
+++ b/packages/cli/cli/src/commands/sdk-preview/sdkPreview.ts
@@ -14,6 +14,7 @@ import fs from "fs/promises";
 import { CliContext } from "../../cli-context/CliContext.js";
 import { loadProjectAndRegisterWorkspacesWithContext } from "../../cliCommons.js";
 import { GROUP_CLI_OPTION } from "../../constants.js";
+import { isTelemetryDisabled } from "../../telemetry/isTelemetryDisabled.js";
 import { computePreviewVersion } from "./computePreviewVersion.js";
 import { getPreviewId } from "./getPreviewId.js";
 import {
@@ -357,7 +358,7 @@ export async function sdkPreview({
                             validateWorkspace: true,
                             publishToRegistry,
                             isPreview: true,
-                            disableTelemetry: process.env.FERN_DISABLE_TELEMETRY === "true"
+                            disableTelemetry: isTelemetryDisabled()
                         });
                     });
                 }

--- a/packages/cli/cli/src/commands/sdk-preview/sdkPreview.ts
+++ b/packages/cli/cli/src/commands/sdk-preview/sdkPreview.ts
@@ -356,7 +356,8 @@ export async function sdkPreview({
                             noReplay: true,
                             validateWorkspace: true,
                             publishToRegistry,
-                            isPreview: true
+                            isPreview: true,
+                            disableTelemetry: process.env.FERN_DISABLE_TELEMETRY === "true"
                         });
                     });
                 }

--- a/packages/cli/cli/src/telemetry/SentryClient.ts
+++ b/packages/cli/cli/src/telemetry/SentryClient.ts
@@ -2,13 +2,14 @@ import { setSentryRunIdTags } from "@fern-api/cli-telemetry";
 import { CliError } from "@fern-api/task-context";
 import * as Sentry from "@sentry/node";
 
+import { isTelemetryDisabled } from "./isTelemetryDisabled.js";
+
 export class SentryClient {
     private readonly sentry: Sentry.NodeClient | undefined;
 
     constructor({ release }: { release: string }) {
-        const isTelemetryEnabled = process.env.FERN_DISABLE_TELEMETRY !== "true";
         const sentryDsn = process.env.SENTRY_DSN;
-        if (isTelemetryEnabled && sentryDsn != null && sentryDsn.length > 0) {
+        if (!isTelemetryDisabled() && sentryDsn != null && sentryDsn.length > 0) {
             const sentryEnvironment = process.env.SENTRY_ENVIRONMENT;
             if (sentryEnvironment == null || sentryEnvironment.length === 0) {
                 throw new CliError({

--- a/packages/cli/cli/src/telemetry/isTelemetryDisabled.ts
+++ b/packages/cli/cli/src/telemetry/isTelemetryDisabled.ts
@@ -1,0 +1,11 @@
+/**
+ * Returns true when the user has opted out of CLI telemetry via the
+ * `FERN_DISABLE_TELEMETRY` environment variable.
+ *
+ * This only applies to the legacy CLI. The new CLI (cli-v2) uses a combination of
+ * a new environment variable (`FERN_TELEMETRY_DISABLED`) and a setting in the `~/.fernrc`
+ * file to determine whether telemetry is disabled.
+ */
+export function isTelemetryDisabled(): boolean {
+    return process.env.FERN_DISABLE_TELEMETRY === "true";
+}

--- a/packages/cli/generation/local-generation/local-workspace-runner/src/ContainerExecutionEnvironment.ts
+++ b/packages/cli/generation/local-generation/local-workspace-runner/src/ContainerExecutionEnvironment.ts
@@ -15,17 +15,21 @@ export class ContainerExecutionEnvironment implements ExecutionEnvironment {
     private readonly containerImage: string;
     private readonly keepContainer: boolean;
     private readonly runner?: ContainerRunner;
+    private readonly disableTelemetry: boolean;
 
     constructor({
         containerImage,
         keepContainer,
         runner,
+        disableTelemetry,
         dockerImage,
         keepDocker
     }: {
         containerImage?: string;
         keepContainer?: boolean;
         runner?: ContainerRunner;
+        /** When true, disables telemetry collection inside the generator container. */
+        disableTelemetry?: boolean;
         /** @deprecated Use containerImage instead */
         dockerImage?: string;
         /** @deprecated Use keepContainer instead */
@@ -34,6 +38,7 @@ export class ContainerExecutionEnvironment implements ExecutionEnvironment {
         this.containerImage = containerImage ?? dockerImage ?? "";
         this.keepContainer = keepContainer ?? keepDocker ?? false;
         this.runner = runner;
+        this.disableTelemetry = disableTelemetry ?? false;
     }
 
     public async execute({
@@ -77,6 +82,9 @@ export class ContainerExecutionEnvironment implements ExecutionEnvironment {
         if (inspect) {
             envVars["NODE_OPTIONS"] = `--inspect-brk=0.0.0.0:${DEFAULT_NODE_DEBUG_PORT}`;
             ports[DEFAULT_NODE_DEBUG_PORT] = DEFAULT_NODE_DEBUG_PORT;
+        }
+        if (this.disableTelemetry) {
+            envVars["FERN_DISABLE_TELEMETRY"] = "true";
         }
 
         await runContainer({

--- a/packages/cli/generation/local-generation/local-workspace-runner/src/runGenerator.ts
+++ b/packages/cli/generation/local-generation/local-workspace-runner/src/runGenerator.ts
@@ -80,7 +80,8 @@ export async function writeFilesToDiskAndRunGenerator({
     ai,
     autoVersioningCache,
     absolutePathToSpecRepo,
-    skipFernignore
+    skipFernignore,
+    disableTelemetry
 }: {
     organization: string;
     absolutePathToFernConfig: AbsoluteFilePath | undefined;
@@ -110,6 +111,7 @@ export async function writeFilesToDiskAndRunGenerator({
     autoVersioningCache?: AutoVersioningCache;
     absolutePathToSpecRepo: AbsoluteFilePath | undefined;
     skipFernignore?: boolean;
+    disableTelemetry?: boolean;
 }): Promise<{
     ir: IntermediateRepresentation;
     generatorConfig: FernGeneratorExec.GeneratorConfig;
@@ -175,7 +177,8 @@ export async function writeFilesToDiskAndRunGenerator({
             containerImage: generatorInvocation.containerImage
                 ? `${generatorInvocation.containerImage}:${generatorInvocation.version}`
                 : `${generatorInvocation.name}:${generatorInvocation.version}`,
-            keepContainer: keepDocker
+            keepContainer: keepDocker,
+            disableTelemetry
         });
 
     const paths = environment.usesContainerPaths

--- a/packages/cli/generation/local-generation/local-workspace-runner/src/runLocalGenerationForWorkspace.ts
+++ b/packages/cli/generation/local-generation/local-workspace-runner/src/runLocalGenerationForWorkspace.ts
@@ -56,7 +56,8 @@ export async function runLocalGenerationForWorkspace({
     publishToRegistry,
     isPreview: isPreviewOverride,
     automationMode,
-    autoMerge
+    autoMerge,
+    disableTelemetry
 }: {
     token: FernToken | undefined;
     projectConfig: fernConfigJson.ProjectConfig;
@@ -78,6 +79,7 @@ export async function runLocalGenerationForWorkspace({
     isPreview?: boolean;
     automationMode?: boolean;
     autoMerge?: boolean;
+    disableTelemetry?: boolean;
 }): Promise<void> {
     // Fail fast: check all generators for version conflicts BEFORE starting any IR generation.
     // This avoids wasted work when one generator would fail the version check.
@@ -365,7 +367,8 @@ export async function runLocalGenerationForWorkspace({
                     ai,
                     autoVersioningCache,
                     absolutePathToSpecRepo: dirname(workspace.absoluteFilePath),
-                    skipFernignore
+                    skipFernignore,
+                    disableTelemetry
                 });
 
                 interactiveTaskContext.logger.info(chalk.green("Wrote files to " + absolutePathToLocalOutput));


### PR DESCRIPTION
## Summary

- When the CLI has telemetry disabled (via `FERN_DISABLE_TELEMETRY`, `FERN_TELEMETRY_DISABLED`, or `fern telemetry disable`), `fern generate --local` now injects `FERN_DISABLE_TELEMETRY=true` into the generator container environment
- This ensures the generator runtime's own telemetry client (Sentry, PostHog) is also silenced — previously the generator container would collect telemetry independently regardless of the user's opt-out
- Remote generation is unaffected
- `TelemetryClient.isTelemetryEnabled()` in cli-v2 is changed from `private` to `public` to allow `LegacyLocalGenerationRunner` to read the setting without duplicating the logic

## Test plan

- [ ] Build old CLI and verify: `FERN_DISABLE_TELEMETRY=true pnpm fern:local generate --local --keep-docker` → inspect stopped container with `docker inspect $(docker ps -lq) --format '{{range .Config.Env}}{{println .}}{{end}}'` — `FERN_DISABLE_TELEMETRY=true` should appear
- [ ] Build cli-v2 and verify: `FERN_TELEMETRY_DISABLED=1 pnpm fern-v2-dev:local generate --local --keep-container` → same container inspection
- [ ] Without any telemetry env var set, the container env should NOT contain `FERN_DISABLE_TELEMETRY`


Made with [Cursor](https://cursor.com)