### PR TITLE
fix(ci): drop retired generators from validate-all-changelogs list

### DIFF
--- a/.github/workflows/validate-changelog.yml
+++ b/.github/workflows/validate-changelog.yml
@@ -9,6 +9,8 @@ on:
       - "packages/cli/cli/versions.yml"
       - "packages/generator-cli/versions.yml"
       - "generators/**/versions.yml"
+      - "scripts/validate-all-changelogs.sh"
+      - ".github/workflows/validate-changelog.yml"
   pull_request:
     branches:
       - main
@@ -17,6 +19,8 @@ on:
       - "packages/cli/cli/versions.yml"
       - "packages/generator-cli/versions.yml"
       - "generators/**/versions.yml"
+      - "scripts/validate-all-changelogs.sh"
+      - ".github/workflows/validate-changelog.yml"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/scripts/validate-all-changelogs.sh
+++ b/scripts/validate-all-changelogs.sh
@@ -5,23 +5,20 @@
 
 set -e
 
-# Run all validations in parallel and collect errors
+# Run all validations in parallel and collect errors.
+# Retired generators (pydantic v1 and the standalone *-model generators) are
+# marked `disabled: true` in their seed.yml and are intentionally omitted here
+# so the seed CLI does not error with "Generators X not found".
 generators=(
     ruby-sdk-v2
-    pydantic
     python-sdk
     openapi
     java-sdk
-    java-model
     ts-sdk
-    go-model
     go-sdk
-    csharp-model
     csharp-sdk
-    php-model
     php-sdk
     swift-sdk
-    rust-model
     rust-sdk
 )
 


### PR DESCRIPTION
## Description
Linear ticket: Refs

Fixes the `Validate Changelogs` workflow that was red on every push to `main` that touches `generators/**/versions.yml` (e.g. the release commit for `chore(cli): release 4.80.1` — run [24700007257](https://github.com/fern-api/fern/actions/runs/24700007257/job/72241018804)).

**Why it was failing:** `scripts/validate-all-changelogs.sh` iterates over a hardcoded list of generators and runs `pnpm seed validate generator <name>` for each. The list still contained 6 retired generators — `pydantic`, `java-model`, `go-model`, `csharp-model`, `php-model`, `rust-model` — whose `seed.yml` files are marked `disabled: true`. Inside the seed CLI, `loadGeneratorWorkspaces()` intentionally filters out any workspace with `disabled: true` (logging `Skipping X: disabled in seed.yml`), so the `validate generator` subcommand's `throwIfGeneratorDoesNotExist` safety check sees the name as unknown and errors with `Generators X not found. Please make sure that there is a folder with those names in the seed directory.`, exiting 1 for each. The shell script then aggregates those as failures and the job fails.

Each of those 6 `seed.yml` files has a "no longer actively supported… seed tests, publishing, and builds are skipped" comment, so they should not be validated.

## Changes Made
- Remove the 6 retired generators (`pydantic`, `java-model`, `go-model`, `csharp-model`, `php-model`, `rust-model`) from the `generators` array in `scripts/validate-all-changelogs.sh` and add an inline comment explaining why retired (disabled) generators are intentionally omitted.
- Add `scripts/validate-all-changelogs.sh` and `.github/workflows/validate-changelog.yml` to the workflow's `paths` filter so future changes to the script or workflow are exercised in CI (including this PR, which now runs the workflow itself as a direct smoke test of the fix).
- [ ] Updated README.md generator (if applicable)

## Testing
- [ ] Unit tests added/updated
- [x] Manual testing completed — confirmed all 6 failures in the original run are the same `Generators X not found` error produced by `throwIfGeneratorDoesNotExist` after `loadGeneratorWorkspaces` filtered the `disabled: true` workspaces out. The remaining 10 generators in the list passed in that same run. With the path-filter change, the `Validate Changelogs` workflow now runs on this PR itself and should be green.

Link to Devin session: https://app.devin.ai/sessions/670bcf0a7ca3464b8dd7acc73573b96e
Requested by: @Ryan-Amirthan