### PR TITLE
fix(ci): drop retired generators from update-seed matrix list

### DIFF
--- a/.github/workflows/update-seed.yml
+++ b/.github/workflows/update-seed.yml
@@ -309,8 +309,13 @@ jobs:
         run: |
           SELECTED_FIXTURE="${{ needs.setup.outputs.selected-fixture }}"
           
-          # List of all generators
-          GENERATORS="ruby-sdk-v2 pydantic python-sdk openapi java-sdk java-model ts-sdk go-model go-sdk csharp-model csharp-sdk php-model php-sdk swift-sdk rust-model rust-sdk"
+          # List of all generators.
+          # Retired generators (pydantic v1 and the standalone *-model generators) are
+          # marked `disabled: true` in their seed.yml and are intentionally omitted here
+          # so the seed CLI does not error with "Generators X not found" when building
+          # the test matrix. Their per-generator seed-update jobs below are already
+          # gated with `if: false # generator not actively supported`.
+          GENERATORS="ruby-sdk-v2 python-sdk openapi java-sdk ts-sdk go-sdk csharp-sdk php-sdk swift-sdk rust-sdk"
           
           # Process each generator and set its output
           for GEN in $GENERATORS; do


### PR DESCRIPTION
## Description

Follow-up to [#15197](https://github.com/fern-api/fern/pull/15197). The `Update Seed` workflow's `get-all-test-matrices` job was still iterating over the 6 retired generators (`pydantic`, `java-model`, `go-model`, `csharp-model`, `php-model`, `rust-model`) when building the dynamic test matrix, producing the same `Generators X not found` failure as the validate-changelog job ([example run](https://github.com/fern-api/fern/actions/runs/24723766674/job/72319169846)).

Each of those generators is marked `disabled: true` in its `seed.yml`, and `loadGeneratorWorkspaces()` drops them from the workspace list, so `seed list-test-fixtures --generator <name>` throws and exits 1, failing the matrix step.

The per-generator `*-seed-update` jobs for all 6 retired generators are already gated with `if: false # generator not actively supported`, so omitting them from the matrix list is safe — nothing downstream consumes those outputs anymore.

## Changes Made
- Remove `pydantic`, `java-model`, `go-model`, `csharp-model`, `php-model`, and `rust-model` from the `GENERATORS` list in the `Create Dynamic Matrix` step of `.github/workflows/update-seed.yml`.
- Add a comment explaining why they are intentionally omitted.

## Testing
- [ ] Unit tests added/updated
- [x] Manual testing completed — CI on this PR exercises the updated matrix step.


Link to Devin session: https://app.devin.ai/sessions/670bcf0a7ca3464b8dd7acc73573b96e
Requested by: @Ryan-Amirthan